### PR TITLE
Disable docs on pull requests

### DIFF
--- a/script/pushdocs.sh
+++ b/script/pushdocs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "$TRAVIS_BRANCH" != "master" ] || [ "$BUILD_DOCS" != "yes" ] || [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] ; then
+if [ "$TRAVIS_BRANCH" != "master" ] || [ "$BUILD_DOCS" != "yes" ] || [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] || [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     exit 0
 fi
 


### PR DESCRIPTION
This is a tiny tweak to the `pushdocs.sh` script, if a pull request was made from a branch inside this repo, it would have built and pushed the docs from that PR. We need to wait a merge to master before updating the docs!