### PR TITLE
Modify release for streamlink

### DIFF
--- a/src/streamlink/__init__.py
+++ b/src/streamlink/__init__.py
@@ -12,7 +12,7 @@ Full documentation is available at http://docs.streamlink.io/.
 
 
 __title__ = "streamlink"
-__version__ = "1.14.0-rc1"
+__version__ = "0.0.1"
 __license__ = "Simplified BSD"
 __author__ = "Christopher Rosell"
 __copyright__ = "Copyright 2011-2015 Christopher Rosell"


### PR DESCRIPTION
Fixes #38, I also noticed this is present here: https://github.com/streamlink/streamlink/blob/9bc8949ca300572d6fb14042e1f013e024d20b7f/win32/livestreamer-win32-installer.nsi#L12 but I don't think it's worth fixing since we're modifying how the Windows build works.