### PR TITLE
twitch.tv: add option to disable hosting

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -904,6 +904,13 @@ plugin.add_argument(
     """
 )
 plugin.add_argument(
+    "--twitch-disable-hosting",
+    action="store_true",
+    help="""
+    Do not open the stream if the target channel is hosting another channel.
+    """
+)
+plugin.add_argument(
     "--ustream-password",
     metavar="PASSWORD",
     help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -773,6 +773,10 @@ def setup_plugin_options():
         streamlink.set_plugin_option("twitch", "oauth_token",
                                        args.twitch_oauth_token)
 
+    if args.twitch_disable_hosting:
+        streamlink.set_plugin_option("twitch", "disable_hosting",
+                                       args.twitch_disable_hosting)
+
     if args.ustream_password:
         streamlink.set_plugin_option("ustreamtv", "password",
                                        args.ustream_password)


### PR DESCRIPTION
This PR is a fix for #41.

Example output without the option:
> (streamlink) simon@desktop:~/projects/streamlink$ streamlink https://www.twitch.tv/ster best
[cli][info] Found matching plugin twitch for URL https://www.twitch.tv/ster
[plugin.twitch][info] ster is hosting overwatchopen
[plugin.twitch][info] switching to overwatchopen
[cli][info] Available streams: audio, mobile (worst), low, medium, high, source (best)
[cli][info] Opening stream: source (hls)
[cli][info] Starting player: /usr/bin/vlc

This is the output with the `--twitch-disable-hosting` option
> (streamlink) simon@desktop:~/projects/streamlink$ streamlink https://www.twitch.tv/ster best --twitch-disable-hosting
[cli][info] Found matching plugin twitch for URL https://www.twitch.tv/ster
[plugin.twitch][info] ster is hosting overwatchopen
[plugin.twitch][info] hosting was disabled by command line option
error: No streams found on this URL: https://www.twitch.tv/ster

cc @larryhastings