### PR TITLE
Picarto plugin: multistream workaround (fixes #50)

### DIFF
--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -13,7 +13,7 @@ _url_re = re.compile(r"""
 """, re.VERBOSE)
 
 _channel_casing_re = re.compile(r"""
-    <script>placeStreamChannelFlash\('(?P<channel>[^']+)',[^,]+,[^,]+,'(?P<visibility>[^']+)',[^,]+\);</script>
+    <script>placeStreamChannel(Flash)?\('(?P<channel>[^']+)',[^,]+,[^,]+,'(?P<visibility>[^']+)'(,[^,]+)?\);</script>
 """, re.VERBOSE)
 
 


### PR DESCRIPTION
This works for both multistream and individual streams as long as
it isn't a multistream where the primary streamer is offline.

If you go to a page linked to a multistream but the primary streamer
is offline, then this will incorrectly match the secondary or tertiary
stream and record them instead of (correctly) reporting the stream
offline.