### PR TITLE
Don't delete everything if docs build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,14 @@
 language: python
-
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-
 sudo: false
 
-env:
-  - BUILD_DOCS=yes
+matrix:
+  include:
+  - python: "2.6"
+  - python: "2.7"
+  - python: "3.3"
+  - python: "3.4"
+  - python: "3.5"
+    env: BUILD_DOCS=yes
 
 before_install:
   - pip install pytest pytest-cov codecov coverage

--- a/script/makedocs.sh
+++ b/script/makedocs.sh
@@ -9,16 +9,20 @@ fi
 DOCS_REPO_PATH="$1"
 
 pip install sphinx
-make --directory=docs html
+if make --directory=docs html ; then
+    # remove old files
+    rm "$DOCS_REPO_PATH/"*.html -f
+    rm "$DOCS_REPO_PATH/"*.js -f
+    rm "$DOCS_REPO_PATH/"*.inv -f
+    rm "$DOCS_REPO_PATH/_sources" -fr
+    rm "$DOCS_REPO_PATH/_static" -fr
 
-# remove old files
-rm "$DOCS_REPO_PATH/"*.html -f
-rm "$DOCS_REPO_PATH/"*.js -f
-rm "$DOCS_REPO_PATH/"*.inv -f
-rm "$DOCS_REPO_PATH/_sources" -fr
-rm "$DOCS_REPO_PATH/_static" -fr
+    # copy new files
+    cp -R docs/_build/html/* "$DOCS_REPO_PATH/"
 
-# copy new files
-cp -R docs/_build/html/* "$DOCS_REPO_PATH/"
-
-echo "All the files were successfully built and copied."
+    echo "All the files were successfully built and copied."
+    exit 0
+else
+    echo "An error occured during the docs' build."
+    exit 1
+fi

--- a/script/pushdocs.sh
+++ b/script/pushdocs.sh
@@ -17,16 +17,18 @@ ssh-add "$DOCS_KEY"
 
 # clone the repo
 git clone "$DOCS_REPO_URL" "$DOCS_REPO_NAME"
-bash script/makedocs.sh "$DOCS_REPO_NAME"
+if bash script/makedocs.sh "$DOCS_REPO_NAME" ; then
+    # git config
+    cd "$DOCS_REPO_NAME"
+    git config user.name "$DOCS_USER"
+    git config user.email "<>"
+    git add --all
+    # Check if anythhing changed, and if it's the case, push to origin/master.
+    if git commit -m 'update docs' -m "Commit: https://github.com/streamlink/streamlink/commit/$TRAVIS_COMMIT" ; then
+        git push origin master
+    fi
 
-# git config
-cd "$DOCS_REPO_NAME"
-git config user.name "$DOCS_USER"
-git config user.email "<>"
-git add --all
-# Check if anythhing changed, and if it's the case, push to origin/master.
-if git commit -m 'update docs' -m "Commit: https://github.com/streamlink/streamlink/commit/$TRAVIS_COMMIT" ; then
-    git push origin master
+    exit 0
+else
+    exit 1
 fi
-
-exit 0


### PR DESCRIPTION
In the last merge, the docs' build just failed randomly, and all the docs got removed. This is an attempt to fix it.