### PR TITLE
Fix stream quality naming issue with py2 vs. py3, fixing #89

### DIFF
--- a/src/streamlink/plugins/itvplayer.py
+++ b/src/streamlink/plugins/itvplayer.py
@@ -112,7 +112,7 @@ class ITVPlayer(Plugin):
                     params['live'] = True
 
                 bitrate = int(mediafile.attrib['bitrate']) / 1000
-                quality = "{0}k".format(bitrate)
+                quality = "{0:d}k".format(int(bitrate))
                 streams[quality] = RTMPStream(self.session, params)
 
         # Parse HDS streams

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -103,7 +103,7 @@ class Livestream(Plugin):
 
             qualities = stream_info["qualities"]
             for bitrate, stream in self._parse_smil(play_url, swf_url):
-                name = "{0}k".format(bitrate / 1000)
+                name = "{0:d}k".format(int(bitrate / 1000))
                 for quality in qualities:
                     if quality["bitrate"] == bitrate:
                         name = "{0}p".format(quality["height"])


### PR DESCRIPTION
py2 and py3 handle integer division differently, in py2 1800000 / 1000 would be 1800, however in py3 it would be 1800.0. This means that for some plugins (itv, and livestream at least) the quality could be named 1800.0k, which is not handled as expected.