### PR TITLE
Work-around to fix broken --version-check option

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -851,8 +851,14 @@ def check_version(force=False):
     if force or not latest_version:
         res = requests.get("https://pypi.python.org/pypi/streamlink/json")
         data = res.json()
-        latest_version = data.get("info").get("version")
-        cache.set("latest_version", latest_version, (60 * 60 * 24))
+        versions = sorted([StrictVersion(version)
+                           for version, info
+                           in data.get("releases", {}).items()
+                           if len(info)],
+                          reverse=True)
+        if len(versions):
+            latest_version = str(versions[0])
+            cache.set("latest_version", latest_version, (60 * 60 * 24))
 
     version_info_printed = cache.get("version_info_printed")
     if not force and version_info_printed:


### PR DESCRIPTION
This PR provides a work-around for #94. 

The version number is incorrect in the PyPi JSON info endpoint: https://pypi.python.org/pypi/streamlink/json. It reports the version as `1.14.0rc1`, this could be related to and old publish attempt before the `setup.py` had been fully fixed? 

This is only intended to be merged if a solution cannot be found for fixing the version number in PyPi. Another solution would be to release a version greater than `1.14.0rc1`, which is probably not what is wanted given the version number reset before :)
