### PR TITLE
Fix ORF TVthek plugin

### DIFF
--- a/src/streamlink/plugins/orf_tvthek.py
+++ b/src/streamlink/plugins/orf_tvthek.py
@@ -11,42 +11,42 @@ _json_re = re.compile(r'initializeAdworx\(\[(?P<json>.+)\]\);')
 MODE_STREAM, MODE_VOD = 0, 1
 
 class ORFTVThek(Plugin):
-	@classmethod
-	def can_handle_url(self, url):
-		return _stream_url_re.match(url) or _vod_url_re.match(url)
+    @classmethod
+    def can_handle_url(self, url):
+        return _stream_url_re.match(url) or _vod_url_re.match(url)
 
-	def _get_streams(self):
-		if _stream_url_re.match(self.url):
-			mode = MODE_STREAM
-		else:
-			mode = MODE_VOD
+    def _get_streams(self):
+        if _stream_url_re.match(self.url):
+            mode = MODE_STREAM
+        else:
+            mode = MODE_VOD
 
-		res = http.get(self.url)
-		match = _json_re.search(res.text)
-		if match:
-			data = json.loads(_json_re.search(res.text).group('json'))
-		else:
-			raise PluginError("Could not extract JSON metadata")
+        res = http.get(self.url)
+        match = _json_re.search(res.text)
+        if match:
+            data = json.loads(_json_re.search(res.text).group('json'))
+        else:
+            raise PluginError("Could not extract JSON metadata")
 
-		streams = {}
-		try:
-			if mode == MODE_STREAM:
-				sources = data['values']['episode']['livestream_playlist_data']['videos'][0]['sources']
-			elif mode == MODE_VOD:
-				sources = data['values']['segment']['playlist_item_array']['sources']
-		except (KeyError, IndexError):
-			raise PluginError("Could not extract sources")
+        streams = {}
+        try:
+            if mode == MODE_STREAM:
+                sources = data['values']['episode']['livestream_playlist_data']['videos'][0]['sources']
+            elif mode == MODE_VOD:
+                sources = data['values']['segment']['playlist_item_array']['sources']
+        except (KeyError, IndexError):
+            raise PluginError("Could not extract sources")
 
-		for source in sources: 
-			try:
-				if source['delivery'] != 'hls':
-					continue
-				url = source['src'].replace('\/', '/')
-			except KeyError:
-				continue
-			stream = HLSStream.parse_variant_playlist(self.session, url)
-			streams.update(stream)
+        for source in sources:
+            try:
+                if source['delivery'] != 'hls':
+                    continue
+                url = source['src'].replace('\/', '/')
+            except KeyError:
+                continue
+            stream = HLSStream.parse_variant_playlist(self.session, url)
+            streams.update(stream)
 
-		return streams
+        return streams
 
 __plugin__ = ORFTVThek


### PR DESCRIPTION
The way stream metadata (such as HLS playlist URLs) is embedded into the ORF TVthek website has changed. As a result, streamlink was unable to extract any stream sources. This PR adapts the plugin to these changes and restores previous functionality.

Additionally, tabs have been converted to spaces as spaces seem customary across the project.