### PR TITLE
Fix for erroneous escape coding the livecoding plugin. Fixes #106

### DIFF
--- a/src/streamlink/plugins/livecodingtv.py
+++ b/src/streamlink/plugins/livecodingtv.py
@@ -1,12 +1,21 @@
 import re
 from streamlink.plugin import Plugin
+from streamlink.stream import HLSStream
 from streamlink.stream import RTMPStream, HTTPStream
 from streamlink.plugin.api import http
 
 
-_vod_re = re.compile('\"(http(s)?://.*\.mp4\?t=.*)\"')
-_rtmp_re = re.compile('rtmp://[^"]+/(?P<channel>\w+)+[^/"]+')
+_streams_re = re.compile(r"""
+    src:\s+"(
+        rtmp://.*?\?t=.*?|                      # RTMP stream
+        https?://.*?playlist.m3u8.*?\?t=.*?|    # HLS stream
+        https?://.*?manifest.mpd.*?\?t=.*?|     # DASH stream
+        https?://.*?.mp4\?t=.*?                 # HTTP stream
+        )".*?
+     type:\s+"(.*?)"                            # which stream type it is
+     """, re.M | re.DOTALL | re.VERBOSE)
 _url_re = re.compile(r"http(s)?://(?:\w+\.)?livecoding\.tv")
+
 
 class LivecodingTV(Plugin):
     @classmethod
@@ -15,18 +24,19 @@ class LivecodingTV(Plugin):
 
     def _get_streams(self):
         res = http.get(self.url)
-        match = _rtmp_re.search(res.content.decode('utf-8'))
-        if match:
-            params = {
-                "rtmp": match.group(0),
-                "pageUrl": self.url,
-                "live": True,
-            }
-            yield 'live', RTMPStream(self.session, params)
-            return
-
-        match = _vod_re.search(res.content.decode('utf-8'))
-        if match:
-            yield 'vod', HTTPStream(self.session, match.group(1))
+        match = _streams_re.findall(res.content.decode('utf-8'))
+        for url, stream_type in match:
+            if stream_type == "rtmp/mp4" and RTMPStream.is_usable(self.session):
+                params = {
+                    "rtmp": url,
+                    "pageUrl": self.url,
+                    "live": True,
+                }
+                yield 'live', RTMPStream(self.session, params)
+            elif stream_type == "application/x-mpegURL":
+                for s in HLSStream.parse_variant_playlist(self.session, url).items():
+                    yield s
+            elif stream_type == "video/mp4":
+                yield 'vod', HTTPStream(self.session, url)
 
 __plugin__ = LivecodingTV

--- a/src/streamlink/plugins/livecodingtv.py
+++ b/src/streamlink/plugins/livecodingtv.py
@@ -6,8 +6,7 @@ from streamlink.plugin.api import http
 
 _vod_re = re.compile('\"(http(s)?://.*\.mp4\?t=.*)\"')
 _rtmp_re = re.compile('rtmp://[^"]+/(?P<channel>\w+)+[^/"]+')
-_url_re = re.compile('http(s)?://(?:\w+.)?\livecoding\.tv')
-
+_url_re = re.compile(r"http(s)?://(?:\w+\.)?livecoding\.tv")
 
 class LivecodingTV(Plugin):
     @classmethod


### PR DESCRIPTION
A per the suggestion by @intact. It removed the bad `\l` escape code in the regex. 
Also fixes the plugin so that it finds the streams again. 