### PR TITLE
Automatically determine the encoding when parsing JSON with HTTPSession

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     env: BUILD_DOCS=yes
 
 before_install:
-  - pip install pytest pytest-cov codecov coverage
+  - pip install pytest pytest-cov codecov coverage mock
 
 install:
   - python setup.py install

--- a/tests/test_plugin_api_http_session.py
+++ b/tests/test_plugin_api_http_session.py
@@ -1,4 +1,12 @@
+# coding=utf-8
 import unittest
+
+import requests
+
+try:
+    from unittest.mock import patch, PropertyMock
+except ImportError:
+    from mock import patch, PropertyMock
 
 from streamlink.exceptions import PluginError
 from streamlink.plugin.api.http_session import HTTPSession
@@ -15,6 +23,27 @@ class TestPluginAPIHTTPSession(unittest.TestCase):
 
 
         self.assertRaises(PluginError, stream_data)
+
+    def test_json_encoding(self):
+        json_str = u"{\"test\": \"Α and Ω\"}"
+
+        # encode the json string with each encoding and assert that the correct one is detected
+        for encoding in ["UTF-32BE", "UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"]:
+            with patch('requests.Response.content', new_callable=PropertyMock) as mock_content:
+                mock_content.return_value = json_str.encode(encoding)
+                res = requests.Response()
+
+                self.assertEqual(HTTPSession.json(res), {u"test": u"\u0391 and \u03a9"})
+
+    def test_json_encoding_override(self):
+        json_text = u"{\"test\": \"Α and Ω\"}".encode("cp949")
+
+        with patch('requests.Response.content', new_callable=PropertyMock) as mock_content:
+            mock_content.return_value = json_text
+            res = requests.Response()
+            res.encoding = "cp949"
+
+            self.assertEqual(HTTPSession.json(res), {u"test": u"\u0391 and \u03a9"})
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This should fix #120 and if I understand #19 it should fix that too. 

According to [RFC4627: The application/json Media Type for JavaScript Object Notation (JSON)
](http://www.ietf.org/rfc/rfc4627.txt) JSON is always encoded as Unicode (see section 3.  Encoding) and the specific Unicode encoding can be determined by looking at the pattern of NULL bytes in the first 4 bytes. 

I have added a method that implements this pattern matching and added a couple of tests for it, the tests use `unittest.mock` which is not available in Python 2 - I added `mock` to the `before_install` command for travis. 

Props to @cyluss 👍 