### PR TITLE
TVPlayer.com: fix for 400 error, correctly set the platform parameter

### DIFF
--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -11,7 +11,7 @@ class TVPlayer(Plugin):
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/43.0.2357.65 Safari/537.36")
     API_URL = "http://api.tvplayer.com/api/v2/stream/live"
-    _url_re = re.compile(r"http://(?:www.)?tvplayer.com/watch/(.+)")
+    _url_re = re.compile(r"https?://(?:www.)?tvplayer.com/(:?watch/?|watch/(.+)?)")
     _stream_attrs_ = re.compile(r'var\s+(validate|platform|resourceId)\s+=\s*(.*?);', re.S)
     _stream_schema = validate.Schema({
         "tvplayer": validate.Schema({
@@ -25,10 +25,11 @@ class TVPlayer(Plugin):
     @classmethod
     def can_handle_url(cls, url):
         match = TVPlayer._url_re.match(url)
-        return match
+        return match is not None
 
     def _get_streams(self):
         # find the list of channels from the html in the page
+        self.url = self.url.replace("https", "http")  # https redirects to http
         res = http.get(self.url, headers={"User-Agent": TVPlayer._user_agent})
         stream_attrs = dict((k, v.strip('"')) for k, v in TVPlayer._stream_attrs_.findall(res.text))
 

--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -29,7 +29,7 @@ class TVPlayer(Plugin):
 
     def _get_streams(self):
         # find the list of channels from the html in the page
-        res = http.get(self.url)
+        res = http.get(self.url, headers={"User-Agent": TVPlayer._user_agent})
         stream_attrs = dict((k, v.strip('"')) for k, v in TVPlayer._stream_attrs_.findall(res.text))
 
         # get the stream urls

--- a/tests/test_plugin_tvplayer.py
+++ b/tests/test_plugin_tvplayer.py
@@ -1,0 +1,21 @@
+import unittest
+
+from streamlink.plugins.tvplayer import TVPlayer
+
+
+class TestPluginTVPlayer(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/watch/"))
+        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/watch/"))
+        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/watch"))
+        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/watch"))
+        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/watch/dave"))
+        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/watch/itv"))
+        self.assertTrue(TVPlayer.can_handle_url("https://www.tvplayer.com/watch/itv"))
+        self.assertTrue(TVPlayer.can_handle_url("https://tvplayer.com/watch/itv"))
+
+        # shouldn't match
+        self.assertFalse(TVPlayer.can_handle_url("http://www.tvplayer.com/"))
+        self.assertFalse(TVPlayer.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(TVPlayer.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
The User-Agent header needs to be sent for the page to fill in the correct platform variable. 