### PR TITLE
Retrying hosted streams with hosting disabled will always retry

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -403,9 +403,9 @@ def fetch_streams_infinite(plugin, interval):
 
     if not streams:
         console.logger.info("Waiting for streams, retrying every {0} "
-                            "second(s)", args.retry_streams)
+                            "second(s)", interval)
     while not streams:
-        sleep(args.retry_streams)
+        sleep(interval)
 
         try:
             streams = fetch_streams(plugin)


### PR DESCRIPTION
This PR fixes #82

There was a bug in the way that `Twitch._check_for_host` worked in that it would update the `channel_id` to the hosted channel (if the requested channel was hosting), and as such on the next retry it would see that hosted channel (now stored in `channel_id`) was not hosting and would play the hosted channel.

This fix updates `Twitch._check_for_host`so that it does not modify the object state and moves that logic in to the calling method `Twitch._get_hls_streams`.

It also fixes a bug where if you had one channel hosting another channel, that was hosting a different channel, eg. channel_a -> channel_b -> channel_c, you would not find the streams for channel_c. It will also detect cycles and stop eg. channel_a -> channel_b -> channel_a would create an infinite loop :)