### PR TITLE
plugins.ustream: improved plugin 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
     deps.append("requests>=1.0,<3.0")
 
 deps.append("websocket-client==0.37.0")
-deps.append("pymp4==1.0.0")
+deps.append("pymp4==1.0.1")
 
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ if (version_info[0] == 2 and version_info[1] == 6 and version_info[2] < 3):
 else:
     deps.append("requests>=1.0,<3.0")
 
+deps.append("websocket-client==0.37.0")
+deps.append("pymp4==1.0.0")
+
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.
 if environ.get("NO_DEPS"):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
     deps.append("requests>=1.0,<3.0")
 
 deps.append("websocket-client==0.37.0")
-deps.append("pymp4==1.0.1")
+deps.append("pymp4==1.0.2")
 
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -21,12 +21,12 @@ elif is_py3:
 
 try:
     from urllib.parse import (
-        urlparse, urlunparse, urljoin, quote, unquote, parse_qsl
+        urlparse, urlunparse, urljoin, quote, unquote, parse_qsl, urlencode
     )
     import queue
 except ImportError:
     from urlparse import urlparse, urlunparse, urljoin, parse_qsl
-    from urllib import quote, unquote
+    from urllib import quote, unquote, urlencode
     import Queue as queue
 
 __all__ = ["is_py2", "is_py3", "is_py33", "is_win32", "str", "bytes",

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -60,7 +60,7 @@ class UHSDesktopClient(WebSocket):
         if data[u"cmd"] in self._callbacks:
             return self._callbacks[data[u"cmd"]](self, **data)
         else:
-            self.logger.warn("No handler for command: {0}".format(data[u"cmd"]))
+            self.logger.warning("No handler for command: {0}".format(data[u"cmd"]))
 
     @property
     def rsid(self):
@@ -450,9 +450,9 @@ class UHSSegmentedMP4Stream(UHSStream):
 
 class UStreamTV(Plugin):
     _url_re = re.compile("""
-        http(s)?://(www\.)?ustream.tv
+        http(?:s)?://(?:www\.)?ustream.tv
         (?:
-            (/embed/|/channel/id/)(?P<channel_id>\d+)
+            (?:/embed/|/channel/id/)(?P<channel_id>\d+)
         )?
         (?:
             /recorded/(?P<video_id>\d+)
@@ -485,10 +485,14 @@ class UStreamTV(Plugin):
         return weight, group
 
     def _get_channel_id(self):
-        res = http.get(self.url)
-        match = UStreamTV._channel_id_re.search(res.text)
-        if match:
-            return int(match.group(1))
+        channel_id, _ = UStreamTV._url_re.match(self.url).groups()
+        if not channel_id:
+            res = http.get(self.url)
+            match = UStreamTV._channel_id_re.search(res.text)
+            if match:
+                return int(match.group(1))
+        else:
+            return int(channel_id)
 
     def _get_desktop_streams(self, channel_id):
         streams = {}

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -1,240 +1,282 @@
+#!/usr/bin/env python
+import json
+import logging
 import re
-
 from collections import namedtuple
 from functools import partial
+from operator import itemgetter
 from random import randint
+
+from io import BytesIO
 from time import sleep
 
-from streamlink.compat import urlparse, urljoin, range
-from streamlink.exceptions import StreamError, PluginError, NoStreamsError
+from streamlink import StreamError
+from streamlink.compat import urljoin, urlencode
+from pymp4.tools.mux import MP4Muxer
 from streamlink.plugin import Plugin, PluginOptions
 from streamlink.plugin.api import http, validate
-from streamlink.stream import RTMPStream, HLSStream, HTTPStream, Stream
+from streamlink.stream import HLSStream
+from streamlink.stream import Stream
 from streamlink.stream.flvconcat import FLVTagConcat
-from streamlink.stream.segmented import (
-    SegmentedStreamReader, SegmentedStreamWriter, SegmentedStreamWorker
-)
+from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
+from websocket import WebSocket
 
-try:
-    import librtmp
-    HAS_LIBRTMP = True
-except ImportError:
-    HAS_LIBRTMP = False
+log = logging.getLogger(__name__)
 
-_url_re = re.compile("""
-    http(s)?://(www\.)?ustream.tv
-    (?:
-        (/embed/|/channel/id/)(?P<channel_id>\d+)
-    )?
-    (?:
-        /recorded/(?P<video_id>\d+)
-    )?
-""", re.VERBOSE)
-_channel_id_re = re.compile("\"channelId\":(\d+)")
-
-HLS_PLAYLIST_URL = (
-    "http://iphone-streaming.ustream.tv"
-    "/uhls/{0}/streams/live/iphone/playlist.m3u8"
-)
-RECORDED_URL = "http://tcdn.ustream.tv/video/{0}"
-RTMP_URL = "rtmp://r{0}-1-{1}-channel-live.ums.ustream.tv:1935/ustream"
-SWF_URL = "http://static-cdn1.ustream.tv/swf/live/viewer.rsl:505.swf"
-
-_module_info_schema = validate.Schema(
-    list,
-    validate.length(1),
-    validate.get(0),
-    dict
-)
-_amf3_array = validate.Schema(
-    validate.any(
-        validate.all(
-            {int: object},
-            validate.transform(lambda a: list(a.values())),
-        ),
-        list
-    )
-)
-_recorded_schema = validate.Schema({
-    validate.optional("stream"): validate.all(
-        _amf3_array,
-        [{
-            "name": validate.text,
-            "streams": validate.all(
-                _amf3_array,
-                [{
-                    "streamName": validate.text,
-                    "bitrate": float,
-                }],
-            ),
-            validate.optional("url"): validate.text,
-        }]
-    )
-})
-_stream_schema = validate.Schema(
-    validate.any({
-        "name": validate.text,
-        "url": validate.text,
-        "streams": validate.all(
-            _amf3_array,
-            [{
-                "chunkId": validate.any(int, float),
-                "chunkRange": {validate.text: validate.text},
-                "chunkTime": validate.any(int, float),
-                "offset": validate.any(int, float),
-                "offsetInMs": validate.any(int, float),
-                "streamName": validate.text,
-                validate.optional("bitrate"): validate.any(int, float),
-                validate.optional("height"): validate.any(int, float),
-                validate.optional("description"): validate.text,
-                validate.optional("isTranscoded"): bool
-            }],
-        )
-    },
-    {
-        "name": validate.text,
-        "varnishUrl": validate.text
-    })
-)
-_channel_schema = validate.Schema({
-    validate.optional("stream"): validate.any(
-        validate.all(
-            _amf3_array,
-            [_stream_schema],
-        ),
-        "offline"
-    )
-})
-
-Chunk = namedtuple("Chunk", "num url offset")
+FLVChunk = namedtuple("FLVChunk", "num url offset")
+MP4Chunk = namedtuple("MP4Chunk", "num url type is_header")
 
 
-if HAS_LIBRTMP:
-    from io import BytesIO
-    from time import time
+class UHSDesktopClient(WebSocket):
+    WS_URL = "ws://r{0}-1-{1}-channel-live.ums.ustream.tv:1935/1/ustream"
+    APP_ID, APP_VERSION = 3, 1
 
-    from librtmp.rtmp import RTMPTimeoutError, PACKET_TYPE_INVOKE
-    from streamlink.packages.flashmedia.types import AMF0Value
+    def __init__(self, **options):
+        super(UHSDesktopClient, self).__init__(**options)
+        self._callbacks = {}
+        self.channel_id = options.pop("channel_id", None)
+        self.url = options.pop("url", None)
+        self._rsid_a = None
+        self._rpin = None
 
-    def decode_amf(body):
-        def generator():
-            fd = BytesIO(body)
-            while True:
-                try:
-                    yield AMF0Value.read(fd)
-                except IOError:
-                    break
+    def connect(self, **options):
+        options.pop("url", None)
+        super(UHSDesktopClient, self).connect(self.ws_url, **options)
+        self.send_command("connect",
+                          {"type": "viewer", "appId": self.APP_ID, "appVersion": self.APP_VERSION, "rsid": self.rsid,
+                           "rpin": self.rpin, "referrer": self.url or "unknown", "media": str(self.channel_id),
+                           "application": "channel"}
+                          )
+        return self
 
-        return list(generator())
+    def __setitem__(self, cmd, f):
+        self._callbacks[cmd] = f
+        return self
 
-    class FlashmediaRTMP(librtmp.RTMP):
-        """RTMP connection using python-flashmedia's AMF decoder.
+    register = __setitem__
 
-        TODO: Move to python-librtmp instead.
+    def recv_command(self):
+        data = json.loads(super(UHSDesktopClient, self).recv())
+        if data[u"cmd"] in self._callbacks:
+            return self._callbacks[data[u"cmd"]](self, **data)
+        else:
+            log.warn("No handler for command: {0}".format(data[u"cmd"]))
+
+    @property
+    def rsid(self):
+        self._rsid_a = self._rsid_a or randint(0, 1e10)
+        return "{0:x}:{1:x}".format(self._rsid_a, randint(0, 1e10))
+
+    @property
+    def rpin(self):
+        self._rpin = self._rpin or randint(0, 1e15)
+        return "_rpin.{0:x}".format(self._rpin)
+
+    def send_command(self, command, *args):
+        msg = json.dumps({"cmd": command, "args": list(args)}).encode("utf-8")
+        self.send(msg)
+
+    @property
+    def ws_url(self):
+        return self.WS_URL.format(randint(0, 0xffffff), self.channel_id)
+
+
+class UHSStreamWorker(SegmentedStreamWorker):
+    def __init__(self, *args, **kwargs):
+        SegmentedStreamWorker.__init__(self, *args, **kwargs)
+
+        self.chunk_id = None
+        self.chunk_id_max = None
+        self.hashes = {}
+        self.providers = []
+        self.file_pattern = None
+        self.chunk_offsets = {}
+
+        self.stream.client.register("moduleInfo", self.handle_module_info)
+        self.stream.client.connect()
+
+    def handle_module_info(self, client, cmd, args):
+        raise NotImplementedError
+
+    def drop_old_hashes(self):
         """
+        Drop any hashes that are for chunkId ranges that are unused
+        """
+        chunk_starts = sorted(self.hashes.keys())
+        for i, chunk_start in enumerate(chunk_starts[:-1]):
+            # if the current chunk id is greater than this chunk start,
+            # then it needs to be dropped if the next chunk start is
+            # also less than current chunk id
+            if self.chunk_id > chunk_start and self.chunk_id > chunk_starts[i + 1]:
+                self.hashes.pop(chunk_start)
 
-        def process_packets(self, transaction_id=None, invoked_method=None,
-                            timeout=None):
-            start = time()
+    def get_chunk_hash(self, chunk_id):
+        for chunk_start, chunk_hash in sorted(self.hashes.items(), key=itemgetter(0), reverse=True):
+            if chunk_id >= chunk_start:
+                return chunk_hash
 
-            while self.connected and transaction_id not in self._invoke_results:
-                if timeout and (time() - start) >= timeout:
-                    raise RTMPTimeoutError("Timeout")
+    def get_chunk_url(self, chunk_id, file_pattern, preferred_provider=None, **params):
+        """
+        Get the URL for the chunk using the first provider, or prefer a particular provider
+        :param file_pattern:
+        :param chunk_id:
+        :param preferred_provider:
+        :return:
+        """
+        provider_index = 0
+        if preferred_provider:
+            for i, provider in enumerate(self.providers):
+                if provider["name"] == preferred_provider:
+                    provider_index = i
 
-                packet = self.read_packet()
-                if packet.type == PACKET_TYPE_INVOKE:
-                    try:
-                        decoded = decode_amf(packet.body)
-                    except IOError:
-                        continue
+        purl = self.providers[provider_index][u"url"]
 
-                    try:
-                        method, transaction_id_, obj = decoded[:3]
-                        args = decoded[3:]
-                    except ValueError:
-                        continue
-
-                    if method == "_result":
-                        if len(args) > 0:
-                            result = args[0]
-                        else:
-                            result = None
-
-                        self._invoke_results[transaction_id_] = result
-                    else:
-                        handler = self._invoke_handlers.get(method)
-                        if handler:
-                            res = handler(*args)
-                            if res is not None:
-                                self.call("_result", res,
-                                          transaction_id=transaction_id_)
-
-                        if method == invoked_method:
-                            self._invoke_args[invoked_method] = args
-                            break
-
-                    if transaction_id_ == 1.0:
-                        self._connect_result = packet
-                    else:
-                        self.handle_packet(packet)
-                else:
-                    self.handle_packet(packet)
-
-            if transaction_id:
-                result = self._invoke_results.pop(transaction_id, None)
-
-                return result
-
-            if invoked_method:
-                args = self._invoke_args.pop(invoked_method, None)
-
-                return args
+        return urljoin(purl,
+                       file_pattern.replace("%", "%s") % (chunk_id, self.get_chunk_hash(chunk_id))) \
+            + "?" + urlencode(params)
 
 
-def create_ums_connection(app, media_id, page_url, password,
-                          exception=PluginError):
-    url = RTMP_URL.format(randint(0, 0xffffff), media_id)
-    params = {
-        "application": app,
-        "media": str(media_id),
-        "password": password
-    }
-    conn = FlashmediaRTMP(url,
-                          swfurl=SWF_URL,
-                          pageurl=page_url,
-                          connect_data=params)
+class UHSSegmentedFLVStreamWorker(UHSStreamWorker):
+    """
+    FLV Stream information is formatted differently that MP4 Stream information
 
-    try:
-        conn.connect()
-    except librtmp.RTMPError:
-        raise exception("Failed to connect to RTMP server")
+    """
+    _moduleInfoSchema = [
+        {
+            validate.optional(u"stream"): {
+                u"hashes": [validate.all({validate.text: validate.text},
+                                         validate.transform(lambda x: dict(map(partial(map, int), x.items())))
+                                         )],
+                u'keyframe': [{u'chunkId': int,
+                               u'offset': int,
+                               u'offsetInMs': int}],
+                u'providers': [{u'name': validate.text,
+                                validate.optional(u'url'): validate.url(),
+                                validate.optional(u'varnishUrl'): validate.url()}],
+                u'streamType': u'flv/segmented',
+                u'streams': [{u'bitrate': int,
+                              u'chunkTime': int,
+                              u'height': int,
+                              u'isTranscoded': bool,
+                              u'streamName': [validate.text],
+                              u'videoCodec': validate.text,
+                              u'width': int}]
+            }
+        }
+    ]
 
-    return conn
+    def __init__(self, *args, **kwargs):
+        super(UHSSegmentedFLVStreamWorker, self).__init__(*args, **kwargs)
+        self.key_frame_offset = 0
+
+    def handle_module_info(self, client, cmd, args):
+        data = validate.validate(self._moduleInfoSchema, args)
+        if u"stream" in data[0]:
+            stream = data[0]["stream"]
+
+            # update the hashes for the chunk id
+            self.hashes.update(stream.get(u"hashes")[self.stream.stream_index])
+
+            # set the max chunk id to the latest id in the hashes
+            self.chunk_id_max = self.chunk_id or sorted(self.hashes)[-1]
+
+            # the first chunk is the keyframe chunk, it also has an offset
+            self.chunk_id = stream[u"keyframe"][self.stream.stream_index][u"chunkId"]
+            # ignoring keyframe offset for now
+
+            self.providers = stream.get("providers", self.providers)
+            self.file_pattern = stream["streams"][self.stream.stream_index]["streamName"][0]
+
+    def iter_segments(self):
+        while not self.closed:
+            # wait for a command from the web socket server
+            self.stream.client.recv_command()
+            while self.chunk_id <= self.chunk_id_max:
+                self.logger.debug("Adding chunk {0} to queue", self.chunk_id)
+
+                yield FLVChunk(self.chunk_id,
+                               self.get_chunk_url(self.chunk_id, self.file_pattern),
+                               self.chunk_offsets.pop(self.chunk_id, 0))
+                self.chunk_id += 1
 
 
-class UHSStreamWriter(SegmentedStreamWriter):
+class UHSSegmentedMP4StreamWorker(UHSStreamWorker):
+    _moduleInfoSchema = [
+        {
+            validate.optional(u"stream"): {
+                u"chunkId": int,
+                u"hashes": validate.all({validate.text: validate.text},
+                                        validate.transform(
+                                            lambda x: dict(map(lambda y: (int(y[0]), y[1]), x.items())))),
+                u'providers': [
+                    {u'name': validate.text, u'url': validate.url(), validate.optional(u'varnishUrl'): validate.url()}],
+                u'streamType': u'mp4/segmented',
+                u'streams': [validate.any(
+                    {u'bitrate': int,
+                     u'codec': validate.text,
+                     u'contentType': u'video/mp4',
+                     u'height': int,
+                     u'initUrl': validate.text,
+                     u'segmentUrl': validate.text,
+                     u'width': int},
+                    {u'bitrate': int,
+                     u'codec': validate.text,
+                     u'contentType': u'audio/mp4',
+                     u'initUrl': validate.text,
+                     u'segmentUrl': validate.text},
+                )]
+            }
+        }
+    ]
+
+    def __init__(self, *args, **kwargs):
+        super(UHSSegmentedMP4StreamWorker, self).__init__(*args, **kwargs)
+        self.stream_info = {}
+
+    def handle_module_info(self, client, cmd, args):
+        data = validate.validate(self._moduleInfoSchema, args)
+        if u"stream" in data[0]:
+            stream = data[0]["stream"]
+            # update the hashes for the chunk id
+            self.hashes.update(stream.get(u"hashes"))
+
+            # if the current chunk id is unknown then use the lowest available according to the hashes
+            self.chunk_id = self.chunk_id or stream["chunkId"]
+            # chunkId is the same for all streams
+            self.chunk_id_max = stream["chunkId"]
+
+            self.providers = stream.get("providers", self.providers)
+            self.stream_info["audio"] = stream["streams"][self.stream.audio_stream_index]
+            self.stream_info["video"] = stream["streams"][self.stream.video_stream_index]
+
+    def iter_segments(self):
+        init = True
+        while not self.closed:
+            # wait for a command from the web socket server
+            self.stream.client.recv_command()
+            while self.chunk_id <= self.chunk_id_max:
+                self.logger.debug("Adding {}chunk {} to queue", "init " if init else "", self.chunk_id)
+                url_style = "segmentUrl" if not init else "initUrl"
+
+                yield MP4Chunk(self.chunk_id,
+                               self.get_chunk_url(self.chunk_id, self.stream_info["video"][url_style]),
+                               "video",
+                               init)
+                yield MP4Chunk(self.chunk_id,
+                               self.get_chunk_url(self.chunk_id, self.stream_info["audio"][url_style]),
+                               "audio",
+                               init)
+                if not init:  # the first video segment has the same chunk id as the first header chunk
+                    self.chunk_id += 1
+                init = False
+
+
+class UHSSegmentedFLVStreamWriter(SegmentedStreamWriter):
     def __init__(self, *args, **kwargs):
         SegmentedStreamWriter.__init__(self, *args, **kwargs)
 
         self.concater = FLVTagConcat(flatten_timestamps=True,
                                      sync_headers=True)
-
-    def fetch(self, chunk, retries=None):
-        if not retries or self.closed:
-            return
-
-        try:
-            params = {}
-            if chunk.offset:
-                params["start"] = chunk.offset
-
-            return http.get(chunk.url,
-                            timeout=self.timeout,
-                            params=params,
-                            exception=StreamError)
-        except StreamError as err:
-            self.logger.error("Failed to open chunk {0}: {1}", chunk.num, err)
-            return self.fetch(chunk, retries - 1)
 
     def write(self, chunk, res, chunk_size=8192):
         try:
@@ -249,176 +291,176 @@ class UHSStreamWriter(SegmentedStreamWriter):
         except IOError as err:
             self.logger.error("Failed to read chunk {0}: {1}", chunk.num, err)
 
-
-class UHSStreamWorker(SegmentedStreamWorker):
-    def __init__(self, *args, **kwargs):
-        SegmentedStreamWorker.__init__(self, *args, **kwargs)
-
-        self.chunk_ranges = {}
-        self.chunk_id = None
-        self.chunk_id_max = None
-        self.chunks = []
-        self.filename_format = ""
-        self.module_info_reload_time = 2
-        self.process_module_info()
-
-    def fetch_module_info(self):
-        self.logger.debug("Fetching module info")
-        conn = create_ums_connection("channel",
-                                     self.stream.channel_id,
-                                     self.stream.page_url,
-                                     self.stream.password,
-                                     exception=StreamError)
-
-        try:
-            result = conn.process_packets(invoked_method="moduleInfo",
-                                          timeout=10)
-        except (IOError, librtmp.RTMPError) as err:
-            raise StreamError("Failed to get module info: {0}".format(err))
-        finally:
-            conn.close()
-
-        result = _module_info_schema.validate(result)
-        return _channel_schema.validate(result, "module info")
-
-    def process_module_info(self):
+    def fetch(self, chunk, retries=0):
         if self.closed:
             return
 
         try:
-            result = self.fetch_module_info()
-        except PluginError as err:
-            self.logger.error("{0}", err)
-            return
+            params = {}
+            if chunk.offset:
+                params["start"] = chunk.offset
 
-        providers = result.get("stream")
-        if not providers or providers == "offline":
-            self.logger.debug("Stream went offline")
-            self.close()
-            return
+            return http.get(chunk.url,
+                            timeout=self.timeout,
+                            params=params,
+                            exception=StreamError)
+        except StreamError as err:
+            self.logger.error("Failed to open chunk {0}: {1}", chunk.num, err)
+            retries -= 1
+            if retries <= 0:
+                raise
+            return self.fetch(chunk, retries)
 
-        for provider in providers:
-            if provider.get("name") == self.stream.provider:
-                break
-        else:
+
+class UHSSegmentedMP4StreamWriter(SegmentedStreamWriter):
+    def __init__(self, reader):
+        super(UHSSegmentedMP4StreamWriter, self).__init__(reader)
+        self.mp4muxer = MP4Muxer(reader.buffer)
+
+        self.done_init = False
+        self.chunk_num = 0
+
+    def write(self, chunk, result, chunk_size=8192):
+        try:
+            stream_id = {"video": 1, "audio": 2}[chunk.type]
+            if chunk.is_header:
+                self.mp4muxer.add_header(BytesIO(result.content), stream_id)
+            else:
+                if not self.done_init:
+                    self.mp4muxer.finalise_header()
+                    self.done_init = True
+                elif chunk.num > self.chunk_num:
+                    # chunk number has changed, write the new data
+                    self.mp4muxer.finalise_content()
+                    self.logger.debug("Writing completed chunk to the output buffer: {}".format(self.chunk_num))
+
+                self.mp4muxer.add_content(BytesIO(result.content), stream_id)
+
+            self.chunk_num = chunk.num
+
+            self.logger.debug("Download of {0} for chunk {1} complete", chunk.type, chunk.num)
+        except IOError as err:
+            self.logger.error("Failed to read {0} chunk {1}: {2}", chunk.type, chunk.num, err)
+
+    def fetch(self, chunk, retries=0):
+        if self.closed:
             return
 
         try:
-            stream = provider["streams"][self.stream.stream_index]
-        except IndexError:
-            self.logger.error("Stream index not in result")
-            return
-
-        filename_format = stream["streamName"].replace("%", "%s")
-        filename_format = urljoin(provider["url"], filename_format)
-
-        self.filename_format = filename_format
-        self.update_chunk_info(stream)
-
-    def update_chunk_info(self, result):
-        chunk_range = result["chunkRange"]
-        if not chunk_range:
-            return
-
-        chunk_id = int(result["chunkId"])
-        chunk_offset = int(result["offset"])
-        chunk_range = dict(map(partial(map, int), chunk_range.items()))
-
-        self.chunk_ranges.update(chunk_range)
-        self.chunk_id_min = sorted(chunk_range)[0]
-        self.chunk_id_max = int(result["chunkId"])
-        self.chunks = [Chunk(i, self.format_chunk_url(i),
-                             not self.chunk_id and i == chunk_id and chunk_offset)
-                       for i in range(self.chunk_id_min, self.chunk_id_max + 1)]
-
-        if self.chunk_id is None and self.chunks:
-            self.chunk_id = chunk_id
-
-    def format_chunk_url(self, chunk_id):
-        chunk_hash = ""
-        for chunk_start in sorted(self.chunk_ranges):
-            if chunk_id >= chunk_start:
-                chunk_hash = self.chunk_ranges[chunk_start]
-
-        return self.filename_format % (chunk_id, chunk_hash)
-
-    def valid_chunk(self, chunk):
-        return self.chunk_id and chunk.num >= self.chunk_id
-
-    def iter_segments(self):
-        while not self.closed:
-            for chunk in filter(self.valid_chunk, self.chunks):
-                self.logger.debug("Adding chunk {0} to queue", chunk.num)
-                yield chunk
-
-                # End of stream
-                if self.closed:
-                    return
-
-                self.chunk_id = chunk.num + 1
-
-            if self.wait(self.module_info_reload_time):
-                try:
-                    self.process_module_info()
-                except StreamError as err:
-                    self.logger.warning("Failed to process module info: {0}", err)
+            # grab all the URLs for the chunk
+            return http.get(chunk.url, timeout=self.timeout, exception=StreamError)
+        except StreamError as err:
+            self.logger.error("Failed to open chunk {0}: {1}", chunk.num, err)
+            retries -= 1
+            if retries <= 0:
+                raise
+            sleep(1)  # a short delay between retries
+            return self.fetch(chunk, retries)
 
 
-class UHSStreamReader(SegmentedStreamReader):
-    __worker__ = UHSStreamWorker
-    __writer__ = UHSStreamWriter
+class UHSSegmentedFLVStreamReader(SegmentedStreamReader):
+    __worker__ = UHSSegmentedFLVStreamWorker
+    __writer__ = UHSSegmentedFLVStreamWriter
 
     def __init__(self, stream, *args, **kwargs):
-        self.logger = stream.session.logger.new_module("stream.uhs")
+        self.logger = stream.session.logger.new_module("stream.uhs.flv")
+        SegmentedStreamReader.__init__(self, stream, *args, **kwargs)
 
+
+class UHSSegmentedMP4StreamReader(SegmentedStreamReader):
+    __worker__ = UHSSegmentedMP4StreamWorker
+    __writer__ = UHSSegmentedMP4StreamWriter
+
+    def __init__(self, stream, *args, **kwargs):
+        self.logger = stream.session.logger.new_module("stream.uhs.mp4")
         SegmentedStreamReader.__init__(self, stream, *args, **kwargs)
 
 
 class UHSStream(Stream):
     __shortname__ = "uhs"
+    __reader__ = None
 
-    def __init__(self, session, channel_id, page_url, provider,
-                 stream_index, password=""):
+    def __init__(self, session, url, channel_id, *args, **kwargs):
         Stream.__init__(self, session)
-
+        self.url = url
         self.channel_id = channel_id
-        self.page_url = page_url
-        self.provider = provider
-        self.stream_index = stream_index
-        self.password = password
+        self.client = UHSDesktopClient(channel_id=channel_id, url=url)
 
     def __repr__(self):
-        return "<UHSStream({0!r}, {1!r}, {2!r}, {3!r}, {4!r})>".format(
-            self.channel_id, self.page_url, self.provider,
-            self.stream_index, self.password
-        )
+        return "<{0}({1!r}, {2!r})>".format(self.__class__.__name__, self.url, self.channel_id)
 
     def __json__(self):
-        json = Stream.__json__(self)
-        json.update({
-            "channel_id": self.channel_id,
-            "page_url": self.page_url,
-            "provider": self.provider,
-            "stream_index": self.stream_index,
-            "password": self.password
+        jsond = Stream.__json__(self)
+        jsond.update({
+            "url": self.url,
+            "channel_id": self.channel_id
         })
-        return json
+        return jsond
 
     def open(self):
-        reader = UHSStreamReader(self)
-        reader.open()
+        if self.__reader__:
+            reader = self.__reader__(self)
+            reader.open()
 
-        return reader
+            return reader
+        else:
+            raise NotImplementedError
+
+
+class UHSSegmentedFLVStream(UHSStream):
+    __shortname__ = "uhs.flv/segmented"
+    __reader__ = UHSSegmentedFLVStreamReader
+
+    def __init__(self, session, url, channel_id, stream_index, *args, **kwargs):
+        super(UHSSegmentedFLVStream, self).__init__(session, url, channel_id)
+        self.stream_index = stream_index
+
+    def __json__(self):
+        jsond = super(UHSSegmentedFLVStream, self).__json__()
+        jsond.update({
+            "stream_index": self.stream_index
+        })
+        return jsond
+
+
+class UHSSegmentedMP4Stream(UHSStream):
+    __shortname__ = "uhs.mp4/segmented"
+    __reader__ = UHSSegmentedMP4StreamReader
+
+    def __init__(self, session, url, channel_id, video_stream_index, audio_stream_index, *args, **kwargs):
+        super(UHSSegmentedMP4Stream, self).__init__(session, url, channel_id)
+        self.video_stream_index = video_stream_index
+        self.audio_stream_index = audio_stream_index
+
+    def __json__(self):
+        jsond = super(UHSSegmentedMP4Stream, self).__json__()
+        jsond.update({
+            "video_stream_index": self.video_stream_index,
+            "audio_stream_index": self.audio_stream_index,
+        })
 
 
 class UStreamTV(Plugin):
+    _url_re = re.compile("""
+        http(s)?://(www\.)?ustream.tv
+        (?:
+            (/embed/|/channel/id/)(?P<channel_id>\d+)
+        )?
+        (?:
+            /recorded/(?P<video_id>\d+)
+        )?
+    """, re.VERBOSE)
+
+    _channel_id_re = re.compile("\"channelId\":(\d+)")
+    _iphone_stream_url = "http://iphone-streaming.ustream.tv/uhls/{channel_id}/streams/live/iphone/playlist.m3u8"
+
     options = PluginOptions({
         "password": ""
     })
 
     @classmethod
     def can_handle_url(cls, url):
-        return _url_re.match(url)
+        return UStreamTV._url_re.match(url)
 
     @classmethod
     def stream_weight(cls, stream):
@@ -436,191 +478,60 @@ class UStreamTV(Plugin):
 
     def _get_channel_id(self):
         res = http.get(self.url)
-        match = _channel_id_re.search(res.text)
+        match = UStreamTV._channel_id_re.search(res.text)
         if match:
             return int(match.group(1))
 
-    def _get_hls_streams(self, channel_id, wait_for_transcode=False):
-        # HLS streams are created on demand, so we may have to wait
-        # for a transcode to be started.
-        attempts = wait_for_transcode and 10 or 1
-        playlist_url = HLS_PLAYLIST_URL.format(channel_id)
-        streams = {}
-        while attempts and not streams:
-            try:
-                streams = HLSStream.parse_variant_playlist(self.session,
-                                                           playlist_url,
-                                                           nameprefix="mobile_")
-            except IOError:
-                # Channel is probably offline
-                break
-
-            attempts -= 1
-            sleep(3)
-
-        return streams
-
-    def _create_rtmp_stream(self, cdn, stream_name):
-        parsed = urlparse(cdn)
-        params = {
-            "rtmp": cdn,
-            "app": parsed.path[1:],
-            "playpath": stream_name,
-            "pageUrl": self.url,
-            "swfUrl": SWF_URL,
-            "live": True
-        }
-
-        return RTMPStream(self.session, params)
-
-    def _get_module_info(self, app, media_id, password="", schema=None):
-        self.logger.debug("Waiting for moduleInfo invoke")
-        conn = create_ums_connection(app, media_id, self.url, password)
-
-        attempts = 3
-        while conn.connected and attempts:
-            try:
-                result = conn.process_packets(invoked_method="moduleInfo",
-                                              timeout=10)
-            except (IOError, librtmp.RTMPError) as err:
-                raise PluginError("Failed to get stream info: {0}".format(err))
-
-            try:
-                result = _module_info_schema.validate(result)
-                break
-            except PluginError:
-                attempts -= 1
-
-        conn.close()
-
-        if schema:
-            result = schema.validate(result)
-
-        return result
-
     def _get_desktop_streams(self, channel_id):
-        password = self.options.get("password")
-        channel = self._get_module_info("channel", channel_id, password,
-                                        schema=_channel_schema)
-
-        if not isinstance(channel.get("stream"), list):
-            raise NoStreamsError(self.url)
-
         streams = {}
-        for provider in channel["stream"]:
-            if provider["name"] == u"uhs_akamai":  # not heavily tested, but got a stream working
-                continue
-            provider_url = provider["url"]
-            provider_name = provider["name"]
-            for stream_index, stream_info in enumerate(provider["streams"]):
-                stream = None
-                stream_height = int(stream_info.get("height", 0))
-                stream_name = stream_info.get("description")
-                if not stream_name:
-                    if stream_height > 0:
-                        if not stream_info.get("isTranscoded"):
-                            stream_name = "{0}p+".format(stream_height)
-                        else:
-                            stream_name = "{0}p".format(stream_height)
-                    else:
-                        stream_name = "live"
 
-                if stream_name in streams:
-                    provider_name_clean = provider_name.replace("uhs_", "")
-                    stream_name += "_alt_{0}".format(provider_name_clean)
+        def handle_module_info(client, cmd, args):
+            if len(args) and u"stream" in args[0]:
+                stream_metadata = args[0][u"stream"]
+                stream_type = stream_metadata.get("streamType")
+                if stream_metadata == u"offline":
+                    self.logger.warning("This stream is currently offline")
+                    return
+                # generate streams for the flv stream type
+                elif stream_type == "flv/segmented":
+                    for stream_index, stream in enumerate(stream_metadata["streams"]):
+                        desc = "{0}p".format(stream.get("height"))
+                        streams[desc] = UHSSegmentedFLVStream(self.session, client.url, client.channel_id,
+                                                              stream_index=stream_index)
+                elif stream_type == "mp4/segmented":
+                    audio_stream_index = None
+                    for au_i, audio_stream in enumerate(stream_metadata["streams"]):
+                        if (audio_stream[u"contentType"].startswith(u"audio") and
+                                (audio_stream_index is None or
+                                         audio_stream[u"bitrate"] > stream_metadata["streams"][audio_stream_index][
+                                         u"bitrate"])):
+                            audio_stream_index = au_i
 
-                if provider_name.startswith("uhs_"):
-                    stream = UHSStream(self.session, channel_id,
-                                       self.url, provider_name,
-                                       stream_index, password)
-                elif provider_url.startswith("rtmp"):
-                        playpath = stream_info["streamName"]
-                        stream = self._create_rtmp_stream(provider_url,
-                                                          playpath)
+                    for video_stream_index, video_stream in enumerate(stream_metadata["streams"]):
+                        if video_stream[u"contentType"].startswith(u"video"):
+                            desc = "{0}p".format(video_stream["height"])
+                            streams[desc] = UHSSegmentedMP4Stream(self.session, client.url, client.channel_id,
+                                                                  video_stream_index, audio_stream_index)
+                else:
+                    self.logger.warning("Unsupported streamType={0}".format(stream_type))
 
-                if stream:
-                    streams[stream_name] = stream
+        ws = UHSDesktopClient(channel_id=channel_id, url=self.url).register("moduleInfo", handle_module_info)
+        ws.connect().recv_command()
+        ws.close()
 
         return streams
 
-    def _get_live_streams(self, channel_id):
-        has_desktop_streams = False
-        if HAS_LIBRTMP:
-            try:
-                streams = self._get_desktop_streams(channel_id)
-                # TODO: Replace with "yield from" when dropping Python 2.
-                for stream in streams.items():
-                    has_desktop_streams = True
-                    yield stream
-            except PluginError as err:
-                self.logger.error("Unable to fetch desktop streams: {0}", err)
-            except NoStreamsError:
-                pass
-        else:
-            self.logger.warning(
-                "python-librtmp is not installed, but is needed to access "
-                "the desktop streams"
-            )
-
-        try:
-            streams = self._get_hls_streams(channel_id,
-                                            wait_for_transcode=not has_desktop_streams)
-
-            # TODO: Replace with "yield from" when dropping Python 2.
-            for stream in streams.items():
-                yield stream
-        except PluginError as err:
-            self.logger.error("Unable to fetch mobile streams: {0}", err)
-        except NoStreamsError:
-            pass
-
-    def _get_recorded_streams(self, video_id):
-        if HAS_LIBRTMP:
-            recording = self._get_module_info("recorded", video_id,
-                                              schema=_recorded_schema)
-
-            if not isinstance(recording.get("stream"), list):
-                return
-
-            for provider in recording["stream"]:
-                base_url = provider.get("url")
-                for stream_info in provider["streams"]:
-                    bitrate = int(stream_info.get("bitrate", 0))
-                    stream_name = (bitrate > 0 and "{0}k".format(bitrate) or
-                                   "recorded")
-
-                    url = stream_info["streamName"]
-                    if base_url:
-                        url = base_url + url
-
-                    if url.startswith("http"):
-                        yield stream_name, HTTPStream(self.session, url)
-                    elif url.startswith("rtmp"):
-                        params = dict(rtmp=url, pageUrl=self.url)
-                        yield stream_name, RTMPStream(self.session, params)
-
-        else:
-            self.logger.warning(
-                "The proper API could not be used without python-librtmp "
-                "installed. Stream URL is not guaranteed to be valid"
-            )
-
-            url = RECORDED_URL.format(video_id)
-            random_hash = "{0:02x}{1:02x}".format(randint(0, 255),
-                                                  randint(0, 255))
-            params = dict(hash=random_hash)
-            stream = HTTPStream(self.session, url, params=params)
-            yield "recorded", stream
+    def _get_mobile_streams(self, channel_id):
+        playlist_url = self._iphone_stream_url.format(channel_id=channel_id)
+        for name, stream in HLSStream.parse_variant_playlist(self.session, playlist_url).items():
+            yield "mobile_{}".format(name), stream
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
+        channel_id = self._get_channel_id()
+        streams = self._get_desktop_streams(channel_id)
+        streams.update(self._get_mobile_streams(channel_id))
 
-        video_id = match.group("video_id")
-        if video_id:
-            return self._get_recorded_streams(video_id)
+        return streams
 
-        channel_id = match.group("channel_id") or self._get_channel_id()
-        if channel_id:
-            return self._get_live_streams(channel_id)
 
 __plugin__ = UStreamTV

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -519,12 +519,12 @@ class UStreamTV(Plugin):
         def handle_module_info(client, cmd, args):
             if len(args) and u"stream" in args[0]:
                 stream_metadata = args[0][u"stream"]
-                stream_type = stream_metadata.get("streamType")
                 if stream_metadata == u"offline":
                     self.logger.warning("This stream is currently offline")
                     return
+                stream_type = stream_metadata.get("streamType")
                 # generate streams for the flv stream type
-                elif stream_type == "flv/segmented":
+                if stream_type == "flv/segmented":
                     for stream_index, stream in enumerate(stream_metadata["streams"]):
                         desc = "{0}p".format(stream.get("height"))
                         streams[desc] = UHSSegmentedFLVStream(self.session, client.url, client.media_id,


### PR DESCRIPTION
This is a new and improved plugin for ustream.com.
Changes include:

- switched to websockets client, and no longer depends on `python-librtmp`
- support for desktop streams, including fragmented mp4

**Note to maintainers:** this patch introduces two new dependencies `websocket-client==0.37.0` and `pymp4==1.0.0`. `websocket-client` is used to connect to the websockets service for ustream, and `pymp4` (maintained by myself) is used to mux the fragmented mp4 fragments. _I don't know how this may affect the Windows installer._

It would be good to have some other people test this out. 
Note that if you simply replace your existing `ustream.py` you will need to install two python packages: `websocket-client==0.37.0` and `pymp4==1.0.0`. If you use the Windows installer I am not sure how you can install these packages, if you installed `streamlink` with `pip` you can simply use `pip` to install these new dependencies:
```
pip install websocket-client==0.37.0 pymp4==1.0.0
```

This PR is intended to fix #58, #57, and #110. 