### PR TITLE
Fix zdf_mediathek TypeError

### DIFF
--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -91,7 +91,7 @@ class zdf_mediathek(Plugin):
 
         res = http.get(stream_request_url)
         res = http.json(res, schema=_schema)
-        formatList = res["priorityList"]["formitaeten"]
+        formatList = res["priorityList"][0]["formitaeten"]
 
         streams = {}
         for format_ in formatList:


### PR DESCRIPTION
  File "C:\Python35\lib\site-packages\streamlink-0.0.2-py3.5.egg\streamlink\plugins\zdf_mediathek.py", line 95, in _get_streams
    formatList = res["priorityList"]["formitaeten"]
TypeError: list indices must be integers or slices, not str