### PR TITLE
Automated Windows nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,18 @@
 language: python
-sudo: false
+sudo: required
 
 matrix:
   include:
-  - python: "2.6"
-  - python: "2.7"
-  - python: "3.3"
-  - python: "3.4"
-  - python: "3.5"
-    env: BUILD_DOCS=yes
+  - python: '2.6'
+  - python: '2.7'
+  - python: '3.3'
+  - python: '3.4'
+  - python: '3.5'
+    env: BUILD_DOCS=yes BUILD_INSTALLER=yes STREAMLINK_INSTALLER_DIST_DIR=$TRAVIS_BUILD_DIR/dist/nsis
 
 before_install:
-  - pip install pytest pytest-cov codecov coverage mock
+  - pip install pytest pytest-cov codecov coverage mock pynsist
+  - sudo pip install s3cmd
 
 install:
   - python setup.py install
@@ -20,6 +21,26 @@ script:
   - python -m pytest tests/
   - coverage run setup.py test
   - bash script/pushdocs.sh
+  - if [[ $BUILD_INSTALLER == 'yes' ]]; then ./script/makeinstaller.sh; fi
 
 after_success:
   - codecov
+
+addons:
+  apt:
+    packages:
+    - nsis
+
+deploy:
+  provider: s3
+  skip_cleanup: true
+  local_dir: $STREAMLINK_INSTALLER_DIST_DIR
+  bucket: streamlink-builds
+  upload-dir: nightly/windows
+  on:
+    branch: master
+    condition: $BUILD_INSTALLER = yes
+  secret_access_key:
+    secure: 3abBcpXNxhWDJyznMA/wDmQ+lUSaJVwi62aXHjFxA7Zrz/CidbHmXkNedViWTOivMyVcM4Ypej4JD1V74Uo78GN09TICRbSc9fTF08O8Hu+hKiAcVWepfmuV54nyoQHY5mcxBPwgUZwnTwSYLzKXCqDEmQXrUrM313m4f2cbDSQgo6VPoCqE+U7JTVaUI6asutsErvK7vfw9EqGSumndRNjQdD0triubs5kh6WPv5STpKrkUNWX95fjBbkuf5hy+DIQN22hLpHYwqV3DoTnhWzbPy8/OnCKoUjEAspLehkjr86brwuls1UfR1uC2uG53O2Rb3CCYkZSVC7GKdEw0SnbLNVfbhy500a8AiPbWC0AV75PidXNEe+1zye4n/xKdx0KA8aRXr7v/89x7KibHNpwf6rdpx7axYhlsWcFcyfoOTZJ3thhu7ib9QYJZ7gkRVGWbawZU6I370I5sMJLIwmzBXgZ2y8jFk7LUNbb2GUS3LKcw5gRYOqo+ZEHFdiLpPYXFHUslTkpaMNoPCNUR7Tsa2JPfJ29yEDMsdDs2lJbP+Km8hAnpkyJfpfPcVUcl8Ootd1cTe8iPdD1nqt3KvIy4sCjkCxvQFnmGOTWFqXY/UDD+Yqo3IVOG1aLPR3UxhzHtPX6M5FxtNB22kv8hrbN/QxhBEo/SfNhGIGZJNdI=
+  access_key_id:
+    secure: sjjc1tM756TvFbD8+0VCs/MOLFRhY+VZv/lq7pvNldtbGdv21lcJguvgg0gUwUZ7SihceyL1YagfUlDU2vWS1N5Si04z0VUcHO4lbj9nUJ4CXy27pMNFuk92HmblxYQ4bJw/xVqzsrT9Zeh4tIrbV+F3lYXtg7FDqjpm5bqrUJ5ULyWbhax31s2k8JRVnG2fxVmJiU+j4zwgzCqeZJXQkvXsfdzSe88mLyIrl7Otfjlp1rySocxStQ8qlmkvRAmsYmsKriUq+VgtX21HFAIJqHQp4WbL15eh0aFFzbmORf7OMIKmsmkyeYYeM6xp+Jm9m7ZcWHZ+7siplVM/9ksmumN3+CGp6pogduZ5zFH4BtRQa9o8N2SWnPiPvMrpoyLbHbQhg/uhcMJkYI1yrzj/s9MEH7DVnDEMmgc/UKsyTC2PRwZcgqYYPHxqRVWXzvBWDUe1wtxdNyaXWWKdD/1E7u8XF2+zPTPaUNAYAF1rSi5GNF38uRNMC+QSuEm8wZ/32KXFN4m+RW3NtpT9YHI8MCo4ofVxpRUMcEUwPDF/jV5zW7Krz7LEeL5/zcHMcNay/Ls8e3eApQShAcLAx1jZo+EjznVGXtlRbH9ABXmPO5AcxUH5+20tMiMoj0q6hJen03X8Jx+OMmcDNDufDgPikSym3KVC3Lvj65lG4G9pAyY=

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -202,7 +202,9 @@ instead.
 Windows binaries
 ----------------
 
-You can download the latest Windows installer `here <https://github.com/streamlink/streamlink/releases>`_.
+You can download the latest stable Windows installer `here <https://github.com/streamlink/streamlink/releases>`_.
+
+You can download the latest nightly Windows installer `here <https://streamlink-builds.s3.amazonaws.com/nightly/windows/streamlink-latest.exe>`_.
 
 This is a installer which contains:
 

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -1,14 +1,28 @@
 #!/usr/bin/env bash
 # Execute this at the base of the streamlink repo.
 
-STREAMLINK_VERSION=$(python -c 'import streamlink; print(streamlink.__version__)')
+set -e # stop on error
 
-mkdir -p build
+STREAMLINK_VERSION=$(python -c 'import streamlink; print(streamlink.__version__)')
+STREAMLINK_INSTALLER="streamlink-${STREAMLINK_VERSION}"
+
+# For travis nightly builds generate a version number with commit hash
+if [ -n "${TRAVIS_BRANCH}" ] && [ -z "${TRAVIS_TAG}" ]; then
+    STREAMLINK_INSTALLER="streamlink-${STREAMLINK_VERSION}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}"
+    STREAMLINK_VERSION="${STREAMLINK_VERSION}+${TRAVIS_COMMIT:0:7}"
+fi
+
+build_dir="$(pwd)/build"
+# get the dist directory from an environment variable, but default to the build/nsis directory
+dist_dir="${STREAMLINK_INSTALLER_DIST_DIR:-$(pwd)/build/nsis}"
+mkdir -p "${build_dir}" "${dist_dir}"
+
+echo "Building ${STREAMLINK_INSTALLER} (v${STREAMLINK_VERSION})..." 1>&2
 
 cat > build/streamlink.cfg <<EOF
 [Application]
 name=Streamlink
-version=$STREAMLINK_VERSION
+version=${STREAMLINK_VERSION}
 entry_point=streamlink_cli.main:main
 
 [Python]
@@ -27,11 +41,16 @@ entry_point=streamlink_cli.main:main
 
 [Build]
 directory=nsis
-installer_name=streamlink-$STREAMLINK_VERSION.exe
+installer_name=${dist_dir}/${STREAMLINK_INSTALLER}.exe
 EOF
 
-echo "Building Python 3 installer"
+echo "Building Python 3 installer" 1>&2
 pynsist build/streamlink.cfg
 
-echo "Success!"
-echo "The installer should be in `pwd`/build/nsis."
+# Make a copy of this build for the "latest" nightly
+if [ -n "${TRAVIS_BRANCH}" ] && [ -z "${TRAVIS_TAG}" ]; then
+    cp "${dist_dir}/${STREAMLINK_INSTALLER}.exe" "${dist_dir}/streamlink-latest.exe"
+fi
+
+echo "Success!" 1>&2
+echo "The installer should be in ${dist_dir}." 1>&2


### PR DESCRIPTION
As requested, this PR adds automated nightly (actually build on each commit to master) for the Streamlink NSIS Windows installer, and pushes them to S3. 

The releases are listed [on S3](https://streamlink-builds.s3.amazonaws.com/index.html), and the latest build is always available here [streamlink-latest.exe](https://streamlink-builds.s3.amazonaws.com/nightly/windows/streamlink-latest.exe).

Nightly builds are automatically removed from S3 after 60 days. 

For nightly builds, the version number is constructed out of the current release version (eg. 0.0.2) and the current short commit hash (eg. ba92efb), so they become `0.0.2+ba92efb`. The file name is generated with the build number also (`streamlink-0.0.2-34-ba92efb.exe`), this is so the most recent file can easily be identified and the files will sort in a useful order. 
For release builds (tagged commits) the version number is constructed just using the current release version, so the version would be `0.0.2` and the file name would be `streamlink-0.0.2.exe`. 

@cdrage If you want I can set travis to automatically add the result of tagged builds (ie. only when the commit has a tag) to the GitHub releases to make releasing a bit easier. 