### PR TITLE
Use pycryptodome inplace of pyCrypto

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -147,7 +147,7 @@ Name                                 Notes
 **Optional**
 --------------------------------------------------------------------------------
 `RTMPDump`_                          Required to play RTMP streams.
-`PyCrypto`_                          Required to play some encrypted streams.
+`PyCrypto`_                          Required to play some encrypted streams (`pycryptodome`_ is a compatible alternative).
 `python-librtmp`_                    Required by the *ustreamtv* plugin to be
                                      able to use non-mobile streams.
 ==================================== ===========================================
@@ -160,6 +160,7 @@ Name                                 Notes
 .. _python-singledispatch: http://pypi.python.org/pypi/singledispatch
 .. _RTMPDump: http://rtmpdump.mplayerhq.hu/
 .. _PyCrypto: https://www.dlitz.net/software/pycrypto/
+.. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
 .. _python-librtmp: https://github.com/chrippa/python-librtmp
 
 

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -19,6 +19,7 @@ format=bundled
 packages=requests
          streamlink
          streamlink_cli
+pypi_wheels=pycryptodome==3.4.3
 
 files=../win32/rtmpdump > \$INSTDIR
 

--- a/src/streamlink/plugins/beattv.py
+++ b/src/streamlink/plugins/beattv.py
@@ -262,7 +262,7 @@ class BeatStream(Stream):
     def open(self):
         if not CAN_DECRYPT:
             raise StreamError(
-                "pyCrypto needs to be installed to decrypt this stream"
+                "pyCrypto or pycryptodome needs to be installed to decrypt this stream"
             )
 
         reader = BeatStreamReader(self)

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -160,7 +160,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
             self.logger.debug("Segments in this playlist are encrypted")
 
             if not CAN_DECRYPT:
-                raise StreamError("Need pyCrypto installed to decrypt this stream")
+                raise StreamError("Need pyCrypto or pycryptodome installed to decrypt this stream")
 
         self.playlist_changed = ([s.num for s in self.playlist_sequences] !=
                                  [s.num for s in sequences])


### PR DESCRIPTION
`pycryptodome` is a fork of `pyCrypto` and can be used as a drop-in replacement for `pyCrypto`, either package can be used. 

The advantage of `pycryptodome` over `pyCrypto` is that it has wheels available on PyPi for Windows, which makes it easier for Windows users to install and for us to include in the NSIS installer. I have updated the installer script to include `pycryptodome`. 