### PR TITLE
Support for relative paths for rtmpdump

### DIFF
--- a/src/streamlink/stream/rtmpdump.py
+++ b/src/streamlink/stream/rtmpdump.py
@@ -1,4 +1,5 @@
 import re
+import os.path
 
 from time import sleep
 
@@ -22,7 +23,7 @@ class RTMPStream(StreamProcess):
     def __init__(self, session, params, redirect=False):
         StreamProcess.__init__(self, session, params)
 
-        self.cmd = self.session.options.get("rtmp-rtmpdump")
+        self.cmd = os.path.realpath(self.session.options.get("rtmp-rtmpdump"))
         self.timeout = self.session.options.get("rtmp-timeout")
         self.redirect = redirect
         self.logger = session.logger.new_module("stream.rtmp")

--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -47,8 +47,8 @@
 # Show console output from the video player
 #verbose-player
 
-# RTMP streams are downloaded using rtmpdump. Full path to the rtmpdump exe
-# should be specified here.
+# RTMP streams are downloaded using rtmpdump. Full path or relative path
+# to the rtmpdump exe should be specified here.
 #rtmpdump=C:\Program Files (x86)\Streamlink\rtmpdump\rtmpdump.exe
 
 # Log level, default is info


### PR DESCRIPTION
This patch allows the path to `rtmpdump(.exe)` to be specified as a relative path or as an absolute path. 

FYI @RosadinTV, this patch might break the current version of your portable builder (see my [comment](https://github.com/streamlink/streamlink/issues/155#issuecomment-260892115) on #155).