### PR TITLE
Install the streamlinkrc file in to the users %APPDATA% directory

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -3,6 +3,9 @@
 
 set -e # stop on error
 
+command -v makensis > /dev/null 2>&1 || { echo >&2 "makensis is required to build the installer. Aborting."; exit 1; }
+command -v pynsist > /dev/null 2>&1 || { echo >&2 "pynsist is required to build the installer. Aborting."; exit 1; }
+
 STREAMLINK_VERSION=$(python -c 'import streamlink; print(streamlink.__version__)')
 STREAMLINK_INSTALLER="streamlink-${STREAMLINK_VERSION}"
 
@@ -13,13 +16,14 @@ if [ -n "${TRAVIS_BRANCH}" ] && [ -z "${TRAVIS_TAG}" ]; then
 fi
 
 build_dir="$(pwd)/build"
+nsis_dir="${build_dir}/nsis"
 # get the dist directory from an environment variable, but default to the build/nsis directory
-dist_dir="${STREAMLINK_INSTALLER_DIST_DIR:-$(pwd)/build/nsis}"
-mkdir -p "${build_dir}" "${dist_dir}"
+dist_dir="${STREAMLINK_INSTALLER_DIST_DIR:-$nsis_dir}"
+mkdir -p "${build_dir}" "${dist_dir}" "${nsis_dir}"
 
 echo "Building ${STREAMLINK_INSTALLER} (v${STREAMLINK_VERSION})..." 1>&2
 
-cat > build/streamlink.cfg <<EOF
+cat > "${build_dir}/streamlink.cfg" <<EOF
 [Application]
 name=Streamlink
 version=${STREAMLINK_VERSION}
@@ -42,10 +46,35 @@ entry_point=streamlink_cli.main:main
 
 [Build]
 directory=nsis
+nsi_template=installer_tmpl.nsi
 installer_name=${dist_dir}/${STREAMLINK_INSTALLER}.exe
 EOF
 
+cat >"${build_dir}/installer_tmpl.nsi" <<EOF
+!include "TextFunc.nsh"
+[% extends "pyapp.nsi" %]
+
+[% block install_files %]
+    [[ super() ]]
+
+    ; Install config file
+    SetShellVarContext current # install the config file for the current user
+    SetOverwrite off # config file we don't want to overwrite
+    SetOutPath \$APPDATA\streamlink
+    File /r "streamlinkrc"
+    \${ConfigWrite} "\$APPDATA\streamlink\streamlinkrc" "rtmpdump=" "\$INSTDIR\rtmpdump\rtmpdump.exe" \$R0
+    SetOverwrite ifnewer
+    SetOutPath -
+    SetShellVarContext all
+
+[% endblock %]
+EOF
+
 echo "Building Python 3 installer" 1>&2
+
+# copy the streamlinkrc file to the build dir, we cannot use the Include.files property in the config file
+# because those files will always overwrite, and for a config file we do not want to overwrite
+cp "win32/streamlinkrc" "${nsis_dir}/streamlinkrc"
 pynsist build/streamlink.cfg
 
 # Make a copy of this build for the "latest" nightly

--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -50,6 +50,7 @@
 # RTMP streams are downloaded using rtmpdump. Full path or relative path
 # to the rtmpdump exe should be specified here.
 #rtmpdump=C:\Program Files (x86)\Streamlink\rtmpdump\rtmpdump.exe
+rtmpdump=
 
 # Log level, default is info
 #loglevel=debug


### PR DESCRIPTION
I believe this PR fixes #81 and thus unblocks #116. 

This patch adds an extended nsi template that includes the `streamlinkrc` config file in the installer. The config file is only installed _if_ there is no pre-existing config file in the users `%APPDATA%\streamlink` directory. After the config file has been installed the path to `rtmpdump` is _always_ updated to point to the `rtmpdump.exe` included with the `streamlink` install.

I replaced the newlines in the `win32/streamlinkrc` file with Windows line endings, so that it is more friendly for Windows users to edit in notepad :) 