### PR TITLE
stream.rtmpdump: fixed the rtmpdump path issue, introduced in 6bf7fd7

### DIFF
--- a/src/streamlink/packages/shutil_which.py
+++ b/src/streamlink/packages/shutil_which.py
@@ -1,0 +1,77 @@
+"""Backport of shutil.which from Python 3.5
+
+The function is included unmodified from Python stdlib 3.5.1,
+and is (C) Python
+"""
+
+import os
+import sys
+
+__version__ = '3.5.1'
+
+def backport_which(cmd, mode=os.F_OK | os.X_OK, path=None):
+    """Given a command, mode, and a PATH string, return the path which
+    conforms to the given mode on the PATH, or None if there is no such
+    file.
+
+    `mode` defaults to os.F_OK | os.X_OK. `path` defaults to the result
+    of os.environ.get("PATH"), or can be overridden with a custom search
+    path.
+
+    """
+    # Check that a given file can be accessed with the correct mode.
+    # Additionally check that `file` is not a directory, as on Windows
+    # directories pass the os.access check.
+    def _access_check(fn, mode):
+        return (os.path.exists(fn) and os.access(fn, mode)
+                and not os.path.isdir(fn))
+
+    # If we're given a path with a directory part, look it up directly rather
+    # than referring to PATH directories. This includes checking relative to the
+    # current directory, e.g. ./script
+    if os.path.dirname(cmd):
+        if _access_check(cmd, mode):
+            return cmd
+        return None
+
+    if path is None:
+        path = os.environ.get("PATH", os.defpath)
+    if not path:
+        return None
+    path = path.split(os.pathsep)
+
+    if sys.platform == "win32":
+        # The current directory takes precedence on Windows.
+        if not os.curdir in path:
+            path.insert(0, os.curdir)
+
+        # PATHEXT is necessary to check on Windows.
+        pathext = os.environ.get("PATHEXT", "").split(os.pathsep)
+        # See if the given file matches any of the expected path extensions.
+        # This will allow us to short circuit when given "python.exe".
+        # If it does match, only test that one, otherwise we have to try
+        # others.
+        if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
+            files = [cmd]
+        else:
+            files = [cmd + ext for ext in pathext]
+    else:
+        # On other platforms you don't have things like PATHEXT to tell you
+        # what file suffixes are executable, so just pass on cmd as-is.
+        files = [cmd]
+
+    seen = set()
+    for dir in path:
+        normdir = os.path.normcase(dir)
+        if not normdir in seen:
+            seen.add(normdir)
+            for thefile in files:
+                name = os.path.join(dir, thefile)
+                if _access_check(name, mode):
+                    return name
+    return None
+
+try:
+    from shutil import which
+except ImportError:
+    which = backport_which

--- a/src/streamlink/stream/rtmpdump.py
+++ b/src/streamlink/stream/rtmpdump.py
@@ -1,5 +1,4 @@
 import re
-import os.path
 
 from time import sleep
 
@@ -23,7 +22,7 @@ class RTMPStream(StreamProcess):
     def __init__(self, session, params, redirect=False):
         StreamProcess.__init__(self, session, params)
 
-        self.cmd = os.path.realpath(self.session.options.get("rtmp-rtmpdump"))
+        self.cmd = self.session.options.get("rtmp-rtmpdump")
         self.timeout = self.session.options.get("rtmp-timeout")
         self.redirect = redirect
         self.logger = session.logger.new_module("stream.rtmp")

--- a/src/streamlink/stream/streamprocess.py
+++ b/src/streamlink/stream/streamprocess.py
@@ -3,10 +3,12 @@ from .wrappers import StreamIOThreadWrapper
 from ..compat import str
 from ..exceptions import StreamError
 from ..packages import pbs as sh
+from ..packages.shutil_which import which
 
 import os
 import time
 import tempfile
+
 
 class StreamProcessIO(StreamIOThreadWrapper):
     def __init__(self, session, process, **kwargs):
@@ -68,7 +70,7 @@ class StreamProcess(Stream):
 
     def _check_cmd(self):
         try:
-            cmd = sh.create_command(self.cmd)
+            cmd = sh.create_command(which(self.cmd) or self.cmd)
         except sh.CommandNotFound as err:
             raise StreamError("Unable to find {0} command".format(err))
 
@@ -82,7 +84,7 @@ class StreamProcess(Stream):
     @classmethod
     def is_usable(cls, cmd):
         try:
-            cmd = sh.create_command(cmd)
+            cmd = sh.create_command(which(cmd) or cmd)
         except sh.CommandNotFound:
             return False
 


### PR DESCRIPTION
This fixes the issue reported by @mmetak.

That was my bad, missed testing on linux :| 

This patch uses `shutil.which` (introduced in Python 3.3, with included backport) to find the command on the PATH