### PR TITLE
Remove shortcut from previous releases on Windows

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -100,7 +100,12 @@ cat >"${build_dir}/installer_tmpl.nsi" <<EOF
 [% endblock %]
 
 [% block install_shortcuts %]
-    ; remove unnecessary shortcut
+    ; Remove shortcut from previous releases
+    Delete "\$SMPROGRAMS\Streamlink.lnk"
+[% endblock %]
+
+[% block uninstall_shortcuts %]
+    ; no shortcuts to be removed...
 [% endblock %]
 EOF
 


### PR DESCRIPTION
Follow up of #174 

- Remove old start menu shortcut when installing streamlink >= 0.0.3
- Don't try to remove shortcuts when uninstalling (shortcuts are not being created anymore)