### PR TITLE
Fix for plugin.livestream courtesy of @intact 

### DIFF
--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -22,7 +22,10 @@ _stream_config_schema = validate.Schema({
             ),
         }, None)
     },
-    validate.optional("playerUri"): validate.text
+    validate.optional("playerUri"): validate.text,
+    validate.optional("viewerPlusSwfUrl"): validate.url(scheme="http"),
+    validate.optional("lsPlayerSwfUrl"): validate.text,
+    validate.optional("hdPlayerSwfUrl"): validate.text
 })
 _smil_schema = validate.Schema(validate.union({
     "http_base": validate.all(
@@ -93,7 +96,7 @@ class Livestream(Plugin):
 
         play_url = stream_info.get("play_url")
         if play_url:
-            swf_url = info.get("playerUri")
+            swf_url = info.get("playerUri") or info.get("hdPlayerSwfUrl") or info.get("lsPlayerSwfUrl") or info.get("viewerPlusSwfUrl")
             if swf_url:
                 if not swf_url.startswith("http"):
                     swf_url = "http://" + swf_url


### PR DESCRIPTION
Latest fix from @intact for the livestream plugin (chrippa/livestreamer/pull/1277), without squashing previous `streamlink` fixes. Could fix #182, but needs to be tested on a Raspberry Pi. 