### PR TITLE
Pin requests to <2.12.0 to avoid the strict IDNA2008 validation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ if version_info[0] == 2 or (version_info[0] == 3 and version_info[1] < 4):
 if (version_info[0] == 2 and version_info[1] == 6 and version_info[2] < 3):
     deps.append("requests>=1.0,<2.0")
 else:
-    deps.append("requests>=1.0,<3.0")
+    # requests >2.12.0 currently has strict IDNA2008 parsing that breaks on some non-compliant URIs (YouTube)
+    deps.append("requests>=1.0,<2.12.0")
 
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.


### PR DESCRIPTION
Currently `requests>=2.12.0` has strict validation for IDNA2008. This means that some URIs that are in use (specifically by YouTube) will not validate and thus will not work in `streamlink`. This PR pins `requests` to a version before `2.12.0`. We can use a later version if YouTube fix their non-compliant URIs or `requests` gives to option to use a less strict IDNA parer. 

This is documented in #169.

> If I understand it correctly, IDNA was extended to reverse xx--. UTS-46 defines the criteria for valid IDNA encoded unicode characters.
> 
> > The first 5 criteria are from [IDNA2008]. Criterion #2 in particular is meant to allow for future label extensions beyond just xn--, such as for future versions of IDNA. Some implementations appear to consider such extentions unlikely, and allow labels such as "r3---sn-apo3qvuoxuxbt-j5pe".