### PR TITLE
Modify the browser redirect

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -533,7 +533,7 @@ def authenticate_twitch_oauth():
        access to their Twitch account."""
 
     client_id = TWITCH_CLIENT_ID
-    redirect_uri = "http://streamlink.tanuki.se/en/develop/twitch_oauth.html"
+    redirect_uri = "https://streamlink.github.io/twitch_oauth.html"
     url = ("https://api.twitch.tv/kraken/oauth2/authorize/"
            "?response_type=token&client_id={0}&redirect_uri="
            "{1}&scope=user_read+user_subscriptions").format(client_id, redirect_uri)


### PR DESCRIPTION
This simply ensures we're doing the redirect to https://streamlink.github.io/twitch_oauth.html instead of Chrippa's site. Fixes #190.