### PR TITLE
Include Visual Studio 2015 Runtime in the installer

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -176,6 +176,11 @@ instead.
 Windows binaries
 ----------------
 
+.. important::
+
+    Windows XP is not supported.
+    Windows Vista requires at least SP2 to be installed. 
+
 You can download the latest stable Windows installer `here <https://github.com/streamlink/streamlink/releases>`_.
 
 You can download the latest nightly Windows installer `here <https://streamlink-builds.s3.amazonaws.com/nightly/windows/streamlink-latest.exe>`_.

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -55,7 +55,7 @@ EOF
 
 cat >"${build_dir}/installer_tmpl.nsi" <<EOF
 !include "TextFunc.nsh"
-[% extends "pyapp.nsi" %]
+[% extends "pyapp_msvcrt.nsi" %]
 
 [% block modernui %]
     ; let the user review all changes being made to the system first
@@ -90,7 +90,6 @@ cat >"${build_dir}/installer_tmpl.nsi" <<EOF
 
 [% block install_files %]
     [[ super() ]]
-
     ; Install config file
     SetShellVarContext current # install the config file for the current user
     SetOverwrite off # config file we don't want to overwrite


### PR DESCRIPTION
As pointed out by @scowalt in #246, the Visual Studio 2015 Runtimes are required for some versions Windows. I have modified the installer to install the VC runtimes if they aren't already installed. The [Python Embedded Distribution](https://docs.python.org/3.5/using/windows.html#embedded-distribution) page also points out that the runtimes are not included and should be installed by the installer. This is possibly an oversight of `pynsist`, but we can fix it ourselves :)

I tested this out of a vanilla Windows Vista 32bit VM, it would be good if @scowalt could test it out on the Chocolatey test environment and if some other people could test it out :)

I have build a version of the installer that people can use to test this out: [streamlink-0.1.0-vcredist-7a50314.exe](https://s3.amazonaws.com/streamlink-builds/beardypig/streamlink-0.1.0-vcredist-7a50314.exe).