### PR TITLE
Add metadata to Windows installer

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -55,6 +55,7 @@ installer_name=${dist_dir}/${STREAMLINK_INSTALLER}.exe
 EOF
 
 cat >"${build_dir}/installer_tmpl.nsi" <<EOF
+!include "FileFunc.nsh"
 !include "TextFunc.nsh"
 [% extends "pyapp_msvcrt.nsi" %]
 
@@ -100,6 +101,16 @@ cat >"${build_dir}/installer_tmpl.nsi" <<EOF
     SetOverwrite ifnewer
     SetOutPath -
     SetShellVarContext all
+
+    ; Add metadata
+    ; hijack the install_files block for this
+    WriteRegStr HKLM "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\${PRODUCT_NAME}" "DisplayVersion" "${STREAMLINK_VERSION}"
+    WriteRegStr HKLM "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\${PRODUCT_NAME}" "Publisher" "Streamlink"
+    WriteRegStr HKLM "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\${PRODUCT_NAME}" "URLInfoAbout" "https://streamlink.github.io/"
+    WriteRegStr HKLM "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\${PRODUCT_NAME}" "HelpLink" "https://streamlink.github.io/"
+	\${GetSize} "\$INSTDIR" "/S=0K" \$0 \$1 \$2
+	IntFmt \$0 "0x%08X" \$0
+	WriteRegDWORD HKLM "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\\${PRODUCT_NAME}" "EstimatedSize" "\$0"
 [% endblock %]
 
 [% block install_shortcuts %]


### PR DESCRIPTION
Resolves #277 

Added version, publisher, about-url, help-url and estimated-size data.

![virtualbox_win7_08_12_2016_23_07_04](https://cloud.githubusercontent.com/assets/467294/21029943/5880599a-bd9c-11e6-8a36-20e3b89fdbe2.png)
