### PR TITLE
Tweaks and updates for Turkish streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -74,6 +74,7 @@ nos                 nos.nl               Yes   Yes   Streams may be geo-restrict
 npo                 npo.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.
 nrk                 - tv.nrk.no          Yes   Yes   Streams may be geo-restricted to Norway.
                     - radio.nrk.no
+ntv                 ntv.com.tr           Yes   No
 oldlivestream       original.liv... [3]_ Yes   No    Only mobile streams are supported.
 openrectv           openrec.tv           Yes   Yes
 orf_tvthek          tvthek.orf.at        Yes   Yes

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -21,7 +21,8 @@ antenna             antenna.gr           --    Yes
 ard_live            live.daserste.de     Yes   --    Streams may be geo-restricted to Germany.
 ard_mediathek       ardmediathek.de      Yes   Yes   Streams may be geo-restricted to Germany.
 artetv              arte.tv              Yes   Yes
-atv                 atv.com.tr           Yes   No
+atv                 - atv.com.tr         Yes   No
+                    - a2tv.com.tr
 azubutv             azubu.tv             Yes   No
 bambuser            bambuser.com         Yes   Yes
 beam                beam.pro             Yes   No

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -40,6 +40,10 @@ dingittv            dingit.tv            Yes   Yes
 disney_de           - video.disney.de    Yes   Yes   Streams may be geo-restricted to Germany.
                     - disneychannel.de
 dmcloud             api.dmcloud.net      Yes   --
+dogan               - teve2.com.tr       Yes   Yes   VOD is supported for teve2 and kanald
+                    - kanald.com.tr
+                    - dreamtv.com.tr
+                    - cnnturk.com
 dommune             dommune.com          Yes   --
 douyutv             douyutv.com          Yes   --
 dplay               - dplay.se           --    Yes   Streams may be geo-restricted.

--- a/src/streamlink/plugins/atv.py
+++ b/src/streamlink/plugins/atv.py
@@ -8,25 +8,35 @@ from streamlink.stream import HLSStream
 
 class ATV(Plugin):
     """
-    Plugin to support ATV Live stream from http://www.atv.com.tr/webtv/canli-yayin
+    Plugin to support ATV/A2TV Live streams from www.atv.com.tr and www.a2tv.com.tr
     """
 
-    _url_re = re.compile(r"http://www.atv.com.tr/webtv/canli-yayin")
-    _hls_url = "http://trkvz-live.ercdn.net/atvhd/atvhd.m3u8"
+    _url_re = re.compile(r"http://www.(a2?tv).com.tr/webtv/canli-yayin")
+    _hls_url = "http://trkvz-live.ercdn.net/{channel}/{channel}.m3u8"
     _token_url = "http://videotoken.tmgrup.com.tr/webtv/secure"
-    _token_schema = validate.Schema({
-        "Success": True,
-        "Url": validate.url(),
-    })
+    _token_schema = validate.Schema(validate.all(
+        {
+            "Success": True,
+            "Url": validate.url(),
+        },
+        validate.get("Url"))
+    )
 
     @classmethod
     def can_handle_url(cls, url):
         return cls._url_re.match(url) is not None
 
     def _get_streams(self):
-        res = http.get(self._token_url, params={"url": self._hls_url})
-        data = http.json(res, schema=self._token_schema)
-        return HLSStream.parse_variant_playlist(self.session, data["Url"])
+        domain = self._url_re.match(self.url).group(1)
+        # remap the domain to channel
+        channel = {"atv": "atvhd"}.get(domain, domain)
+
+        hls_url = self._hls_url.format(channel=channel)
+        # get the secure HLS URL
+        res = http.get(self._token_url, params={"url": hls_url})
+        secure_hls_url = http.json(res, schema=self._token_schema)
+
+        return HLSStream.parse_variant_playlist(self.session, secure_hls_url)
 
 
 __plugin__ = ATV

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+from __future__ import print_function
+import xml.etree.ElementTree as ET
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.compat import urljoin
+
+
+class Dogan(Plugin):
+    """
+    Support for the live streams from Doğan Media Group channels
+    """
+    url_re = re.compile(r"""
+        https?://(?:www.)?
+        (?:teve2.com.tr/(?:canli-yayin|filmler/.*|programlar/.*)|
+           kanald.com.tr/.*|
+           cnnturk.com/canli-yayin|
+           dreamtv.com.tr/canli-yayin)
+    """, re.VERBOSE)
+    playerctrl_re = re.compile(r'''<div[^>]*?ng-controller=(?P<quote>["'])(?:Live)?PlayerCtrl(?P=quote).*?>''', re.DOTALL)
+    data_id_re = re.compile(r'''data-id=(?P<quote>["'])(?P<id>\w+)(?P=quote)''')
+    content_id_re = re.compile(r'"contentId", "(\w+)"')
+    content_api = "/actions/content/media/{id}"
+    alt_content_api = "/action/media/{id}"
+    content_api_schema = validate.Schema({
+        "Id": validate.text,
+        "Media": {
+            "Link": {
+                "DefaultServiceUrl": validate.url(),
+                validate.optional("ServiceUrl"): validate.url(),
+                "SecurePath": validate.text,
+            }
+        }
+    })
+
+    @classmethod
+    def can_handle_url(cls, url):
+        print(url)
+        return cls.url_re.match(url) is not None
+
+    def _get_content_id(self):
+        res = http.get(self.url)
+        # find the PlayerCtrl div
+        player_ctrl_m = self.playerctrl_re.search(res.text)
+        if player_ctrl_m:
+            # extract the content id from the player control data
+            player_ctrl_div = player_ctrl_m.group(0)
+            content_id_m = self.data_id_re.search(player_ctrl_div)
+            if content_id_m:
+                return content_id_m.group("id")
+
+        # use the fall back regex
+        content_id_m = self.content_id_re.search(res.text)
+        return content_id_m and content_id_m.group(1)
+
+    def _get_hls_url(self, content_id):
+        # make the api url relative to the current domain
+        if "cnnturk" in self.url:
+            self.logger.debug("Using alternative content API url")
+            api_url = urljoin(self.url, self.alt_content_api.format(id=content_id))
+        else:
+            api_url = urljoin(self.url, self.content_api.format(id=content_id))
+
+        apires = http.get(api_url)
+
+        stream_data = http.json(apires, schema=self.content_api_schema)
+        d = stream_data["Media"]["Link"]
+        return urljoin((d["ServiceUrl"] or d["DefaultServiceUrl"]), d["SecurePath"])
+
+    def _get_streams(self):
+        content_id = self._get_content_id()
+        if content_id:
+            self.logger.debug(u"Loading content: {}", content_id)
+            hls_url = self._get_hls_url(content_id)
+            return HLSStream.parse_variant_playlist(self.session, hls_url)
+        else:
+            self.logger.error(u"Could not find the contentId for this stream")
+
+
+__plugin__ = Dogan

--- a/src/streamlink/plugins/foxtr.py
+++ b/src/streamlink/plugins/foxtr.py
@@ -6,6 +6,7 @@ from streamlink.plugin.api import http
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
+
 class FoxTR(Plugin):
     """
     Support for Turkish Fox live stream: http://www.fox.com.tr/canli-yayin

--- a/src/streamlink/plugins/kralmuzik.py
+++ b/src/streamlink/plugins/kralmuzik.py
@@ -1,25 +1,25 @@
 from __future__ import print_function
+
 import re
 
-from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
-from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.plugins.startv import StarTVBase
 
 
-class KralMuzik(Plugin):
+class KralMuzik(StarTVBase):
     url_re = re.compile(r"https?://www.kralmuzik.com.tr/tv/kral-tv")
-    stream_url_re = re.compile(r"(?P<quote>[\"'])(?P<url>https?://[^ ]*?/live/hls/[^ ]*?\?token=[^ ]*?)(?P=quote);")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
+    mobile_url_re = re.compile(r"(?P<quote>[\"'])(?P<url>https?://[^ ]*?/live/hls/[^ ]*?\?token=[^ ]*?)(?P=quote);")
+    desktop_url_re = re.compile(r"(?P<quote>[\"'])(?P<url>https?://[^ ]*?/live/hds/[^ ]*?\?token=[^ ]*?)(?P=quote);")
 
     def _get_streams(self):
         res = http.get(self.url)
-        match = self.stream_url_re.search(res.text)
-        if match:
-            return HLSStream.parse_variant_playlist(self.session, match.group("url"))
+        mobile_match = self.mobile_url_re.search(res.text)
+        desktop_match = self.desktop_url_re.search(res.text)
+
+        mobile_url = mobile_match.group("url") if mobile_match else None
+        desktop_url = desktop_match.group("url") if desktop_match else None
+
+        return self._get_star_streams(desktop_url, mobile_url)
 
 
 __plugin__ = KralMuzik

--- a/src/streamlink/plugins/ntv.py
+++ b/src/streamlink/plugins/ntv.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+
+import re
+
+from streamlink.plugin.api import http
+from streamlink.plugins.startv import StarTVBase
+
+
+class NTR(StarTVBase):
+    """
+    Support for live streams from http://www.ntv.com.tr/, very similar to StarTV
+    """
+    url_re = re.compile(r"https?://www.ntv.com.tr/canli-yayin/ntv")
+    token_re = re.compile(r"data-player-token[ ]*=[ ]*(?P<quote>[\"'])(?P<token>.*?)(?P=quote)")
+    player_src = re.compile(r"data-player-src[ ]*=[ ]*(?P<quote>[\"'])(?P<url>.*?)(?P=quote)")
+    player_mobile_src = re.compile(r"data-player-mobile[ ]*=[ ]*(?P<quote>[\"'])(?P<url>.*?)(?P=quote)")
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        token_m = self.token_re.search(res.text)
+        desktop_player_m = self.player_src.search(res.text)
+        mobile_player_m = self.player_mobile_src.search(res.text)
+        desktop_url, mobile_url = None, None
+
+        if token_m and desktop_player_m:  # desktop stream
+            desktop_url = desktop_player_m.group("url") + token_m.group("token")
+
+        if token_m and mobile_player_m:  # mobile stream
+            mobile_url = mobile_player_m.group("url") + token_m.group("token")
+
+        return self._get_star_streams(desktop_url, mobile_url)
+
+
+__plugin__ = NTR

--- a/src/streamlink/plugins/startv.py
+++ b/src/streamlink/plugins/startv.py
@@ -1,49 +1,67 @@
 from __future__ import print_function
 
-import json
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
 from streamlink.plugin.api import validate
+from streamlink.stream import HDSStream
 from streamlink.stream import HLSStream
 
 
-class StarTV(Plugin):
+class StarTVBase(Plugin):
     """
-    Support for the Live Stream from www.startv.com.tr, only the mobile stream (HLS) is supported as the HDS stream
-    has some kind of token authentication.
-
-    TODO: support HDS streams
+    Base class for all StarTV streams
     """
-    url_re = re.compile(r"http://www.startv.com.tr/canli-yayin")
-    playervars_re = re.compile(r"mobileUrl: \"(.*?)\"")
-    token_schema = validate.Schema(
-        validate.transform(playervars_re.search),  # search the playerArray variable
-        validate.any(
-            None,
-            validate.all(
-                validate.get(1),  # get the first match
-                validate.url(),
-            )
-        )
-    )
-    api_schema = validate.Schema(validate.all(
+    url_re = None
+    hds_schema = validate.Schema(validate.all(
         {
             "success": True,
-            "xtra": {"url": validate.url()}
+            "xtra": {
+                "url": validate.url(),
+                "use_akamai": bool
+            }
         },
-        validate.get("xtra"), validate.get("url")
+        validate.get("xtra")
     ))
+    SWF_URL = "http://dygassets.akamaized.net/player2/plugins/flowplayer/flowplayer.httpstreaming-3.2.11.swf"
 
     @classmethod
     def can_handle_url(cls, url):
+        if not cls.url_re:
+            raise NotImplementedError
         return cls.url_re.match(url) is not None
+
+    def _get_star_streams(self, desktop_url, mobile_url):
+        if mobile_url:
+            for s in HLSStream.parse_variant_playlist(self.session,
+                                                         mobile_url,
+                                                         headers={"Referer": self.url}).items():
+                yield s
+        if desktop_url:
+            # get the HDS stream URL
+            res = http.get(desktop_url)
+            stream_data = http.json(res, schema=self.hds_schema)
+            for s in HDSStream.parse_manifest(self.session,
+                                                 stream_data["url"],
+                                                 pvswf=self.SWF_URL,
+                                                 is_akamai=stream_data["use_akamai"],
+                                                 headers={"Referer": self.url}).items():
+                yield s
+
+
+class StarTV(StarTVBase):
+    """
+    Support for the Live Stream from www.startv.com.tr, both HLS and HDS streams
+    """
+    url_re = re.compile(r"http://www.startv.com.tr/canli-yayin")
+    mobile_player = re.compile(r"mobileUrl: \"(.*?)\"")
+    desktop_player = re.compile(r"flashUrl: \"(.*?)\"")
 
     def _get_streams(self):
         res = http.get(self.url)
-        mobile_url = self.token_schema.validate(res.text)
-        if mobile_url:
-            return HLSStream.parse_variant_playlist(self.session, mobile_url, headers={"Referer": self.url})
+        mobile_url = self.mobile_player.search(res.text)
+        desktop_url = self.desktop_player.search(res.text)
+        return self._get_star_streams(desktop_url.group(1), mobile_url.group(1))
 
 __plugin__ = StarTV

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -418,7 +418,7 @@ class HDSStream(Stream):
         return reader
 
     @classmethod
-    def parse_manifest(cls, session, url, timeout=60, pvswf=None,
+    def parse_manifest(cls, session, url, timeout=60, pvswf=None, is_akamai=False,
                        **request_params):
         """Parses a HDS manifest and returns its substreams.
 
@@ -440,7 +440,7 @@ class HDSStream(Stream):
         request_params.pop("timeout", None)
         request_params.pop("url", None)
 
-        if "akamaihd" in url:
+        if "akamaihd" in url or is_akamai:
             request_params["params"]["hdcore"] = HDCORE_VERSION
 
         res = session.http.get(url, exception=IOError, **request_params)


### PR DESCRIPTION
This PR adds support for live streams on the following sites:
- http://www.a2tv.com.tr
- http://www.ntv.com.tr
- http://www.teve2.com.tr
- http://www.kanald.com.tr
- http://www.cnnturk.com
- http://www.dreamtv.com.tr

and VOD support for:
- http://www.teve2.com.tr
- http://www.kanald.com.tr
