### PR TITLE
Small tweak to the coverage config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,13 @@
 [run]
-source = streamlink
+source =
+    streamlink
+    streamlink_cli
+
 [report]
 omit =
   */python?.?/*
-    *__init__*
+  *__init__*
+  src/streamlink/packages/*
 
 exclude_lines =
     pragma: no cover


### PR DESCRIPTION
`streamlink_cli` wasn't included before, it is now. 
The vendored packages don't need to be covered... 