### PR TITLE
Support for local files

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -37,6 +37,18 @@ This command will tell Streamlink to attempt to extract streams from the URL
 specified, and if it's successful, print out a list of available streams to choose
 from.
 
+In some cases  (`Supported streaming protocols`_)  local files are supported
+using the ``file://`` protocol, for example a local HLS playlist can be played.
+Relative file paths and absolute paths are supported. All path separators are ``/``,
+even on Windows.
+
+.. code-block:: console
+
+    $ streamlink hlsvariant://file://C:/hls/playlist.m3u8
+    [cli][info] Found matching plugin stream for URL hlsvariant://file://C:/hls/playlist.m3u8
+    Available streams: 180p (worst), 272p, 408p, 554p, 818p, 1744p (best)
+
+
 To select a stream and start playback, we simply add the stream name as a second
 argument to the :command:`streamlink` command:
 
@@ -289,12 +301,12 @@ Name                           Prefix
 ============================== =================================================
 Adobe HTTP Dynamic Streaming   hds://
 Akamai HD Adaptive Streaming   akamaihd://
-Apple HTTP Live Streaming      hls:// hlsvariant://
+Apple HTTP Live Streaming      hls:// hlsvariant:// [1]_
 Real Time Messaging Protocol   rtmp:// rtmpe:// rtmps:// rtmpt:// rtmpte://
-Progressive HTTP, HTTPS, etc   httpstream://
+Progressive HTTP, HTTPS, etc   httpstream:// [1]_
 ============================== =================================================
 
-
+.. [1] supports local files using the file:// protocol
 .. _cli-options:
 
 Command-line usage

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -14,6 +14,8 @@ Copyright 2015 Red Hat, Inc.
    limitations under the License.
 """
 from io import BytesIO
+
+import sys
 from requests.adapters import BaseAdapter
 from requests.compat import urlparse, unquote, urljoin
 from requests import Response, codes
@@ -41,7 +43,7 @@ class FileAdapter(BaseAdapter):
         url_parts = urlparse(request.url)
 
         # Reject URLs with a hostname component
-        if url_parts.netloc and not url_parts.netloc in ("localhost", ".", ".."):
+        if url_parts.netloc and not url_parts.netloc in ("localhost", ".", "..", "-"):
             raise ValueError("file: URLs with hostname components are not permitted")
 
         # If the path is relative update it to be absolute
@@ -56,50 +58,56 @@ class FileAdapter(BaseAdapter):
         # Use urllib's unquote to translate percent escapes into whatever
         # they actually need to be
         try:
-            # Split the path on / (the URL directory separator) and decode any
-            # % escapes in the parts
-            path_parts = [unquote(p) for p in url_parts.path.split('/')]
+            # If the netloc is - then read from stdin
+            if url_parts.netloc == "-":
+                resp.raw = sys.stdin
+                # make a fake response URL, the current directory
+                resp.url = "file://" + os.path.abspath(".").replace(os.sep, "/") + "/"
+            else:
+                # Split the path on / (the URL directory separator) and decode any
+                # % escapes in the parts
+                path_parts = [unquote(p) for p in url_parts.path.split('/')]
 
-            # Strip out the leading empty parts created from the leading /'s
-            while path_parts and not path_parts[0]:
-                path_parts.pop(0)
-
-            # If os.sep is in any of the parts, someone fed us some shenanigans.
-            # Treat is like a missing file.
-            if any(os.sep in p for p in path_parts):
-                raise IOError(errno.ENOENT, os.strerror(errno.ENOENT))
-
-            # Look for a drive component. If one is present, store it separately
-            # so that a directory separator can correctly be added to the real
-            # path, and remove any empty path parts between the drive and the path.
-            # Assume that a part ending with : or | (legacy) is a drive.
-            if path_parts and (path_parts[0].endswith('|') or
-                               path_parts[0].endswith(':')):
-                path_drive = path_parts.pop(0)
-                if path_drive.endswith('|'):
-                    path_drive = path_drive[:-1] + ':'
-
+                # Strip out the leading empty parts created from the leading /'s
                 while path_parts and not path_parts[0]:
                     path_parts.pop(0)
-            else:
-                path_drive = ''
 
-            # Try to put the path back together
-            # Join the drive back in, and stick os.sep in front of the path to
-            # make it absolute.
-            path = path_drive + os.sep + os.path.join(*path_parts)
+                # If os.sep is in any of the parts, someone fed us some shenanigans.
+                # Treat is like a missing file.
+                if any(os.sep in p for p in path_parts):
+                    raise IOError(errno.ENOENT, os.strerror(errno.ENOENT))
 
-            # Check if the drive assumptions above were correct. If path_drive
-            # is set, and os.path.splitdrive does not return a drive, it wasn't
-            # reall a drive. Put the path together again treating path_drive
-            # as a normal path component.
-            if path_drive and not os.path.splitdrive(path):
-                path = os.sep + os.path.join(path_drive, *path_parts)
+                # Look for a drive component. If one is present, store it separately
+                # so that a directory separator can correctly be added to the real
+                # path, and remove any empty path parts between the drive and the path.
+                # Assume that a part ending with : or | (legacy) is a drive.
+                if path_parts and (path_parts[0].endswith('|') or
+                                   path_parts[0].endswith(':')):
+                    path_drive = path_parts.pop(0)
+                    if path_drive.endswith('|'):
+                        path_drive = path_drive[:-1] + ':'
 
-            # Use io.open since we need to add a release_conn method, and
-            # methods can't be added to file objects in python 2.
-            resp.raw = io.open(path, "rb")
-            resp.raw.release_conn = resp.raw.close
+                    while path_parts and not path_parts[0]:
+                        path_parts.pop(0)
+                else:
+                    path_drive = ''
+
+                # Try to put the path back together
+                # Join the drive back in, and stick os.sep in front of the path to
+                # make it absolute.
+                path = path_drive + os.sep + os.path.join(*path_parts)
+
+                # Check if the drive assumptions above were correct. If path_drive
+                # is set, and os.path.splitdrive does not return a drive, it wasn't
+                # reall a drive. Put the path together again treating path_drive
+                # as a normal path component.
+                if path_drive and not os.path.splitdrive(path):
+                    path = os.sep + os.path.join(path_drive, *path_parts)
+
+                # Use io.open since we need to add a release_conn method, and
+                # methods can't be added to file objects in python 2.
+                resp.raw = io.open(path, "rb")
+                resp.raw.release_conn = resp.raw.close
         except IOError as e:
             if e.errno == errno.EACCES:
                 resp.status_code = codes.forbidden

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -17,7 +17,7 @@ from io import BytesIO
 
 import sys
 from requests.adapters import BaseAdapter
-from requests.compat import urlparse, unquote, urljoin, is_py3
+from requests.compat import urlparse, unquote, urljoin
 from requests import Response, codes
 import errno
 import os
@@ -25,6 +25,8 @@ import os.path
 import stat
 import locale
 import io
+
+from streamlink.compat import is_win32, is_py3
 
 
 class FileAdapter(BaseAdapter):
@@ -49,6 +51,9 @@ class FileAdapter(BaseAdapter):
         # If the path is relative update it to be absolute
         if url_parts.netloc in (".", ".."):
             pwd = os.path.abspath(url_parts.netloc).replace(os.sep, "/") + "/"
+            if is_win32:
+                # prefix the path with a / in Windows
+                pwd = "/" + pwd
             url_parts = url_parts._replace(path=urljoin(pwd, url_parts.path.lstrip("/")))
 
         resp = Response()

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -17,7 +17,7 @@ from io import BytesIO
 
 import sys
 from requests.adapters import BaseAdapter
-from requests.compat import urlparse, unquote, urljoin
+from requests.compat import urlparse, unquote, urljoin, is_py3
 from requests import Response, codes
 import errno
 import os
@@ -60,7 +60,10 @@ class FileAdapter(BaseAdapter):
         try:
             # If the netloc is - then read from stdin
             if url_parts.netloc == "-":
-                resp.raw = sys.stdin
+                if is_py3:
+                    resp.raw = sys.stdin.buffer
+                else:
+                    resp.raw = sys.stdin
                 # make a fake response URL, the current directory
                 resp.url = "file://" + os.path.abspath(".").replace(os.sep, "/") + "/"
             else:

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -1,0 +1,125 @@
+"""
+Copyright 2015 Red Hat, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+from io import BytesIO
+from requests.adapters import BaseAdapter
+from requests.compat import urlparse, unquote
+from requests import Response, codes
+import errno
+import os
+import stat
+import locale
+import io
+
+
+class FileAdapter(BaseAdapter):
+    def send(self, request, **kwargs):
+        """ Wraps a file, described in request, in a Response object.
+
+            :param request: The PreparedRequest` being "sent".
+            :returns: a Response object containing the file
+        """
+
+        # Check that the method makes sense. Only support GET
+        if request.method not in ("GET", "HEAD"):
+            raise ValueError("Invalid request method %s" % request.method)
+
+        # Parse the URL
+        url_parts = urlparse(request.url)
+
+        # Reject URLs with a hostname component
+        if url_parts.netloc and url_parts.netloc != "localhost":
+            raise ValueError("file: URLs with hostname components are not permitted")
+
+        resp = Response()
+        resp.url = request.url
+
+        # Open the file, translate certain errors into HTTP responses
+        # Use urllib's unquote to translate percent escapes into whatever
+        # they actually need to be
+        try:
+            # Split the path on / (the URL directory separator) and decode any
+            # % escapes in the parts
+            path_parts = [unquote(p) for p in url_parts.path.split('/')]
+
+            # Strip out the leading empty parts created from the leading /'s
+            while path_parts and not path_parts[0]:
+                path_parts.pop(0)
+
+            # If os.sep is in any of the parts, someone fed us some shenanigans.
+            # Treat is like a missing file.
+            if any(os.sep in p for p in path_parts):
+                raise IOError(errno.ENOENT, os.strerror(errno.ENOENT))
+
+            # Look for a drive component. If one is present, store it separately
+            # so that a directory separator can correctly be added to the real
+            # path, and remove any empty path parts between the drive and the path.
+            # Assume that a part ending with : or | (legacy) is a drive.
+            if path_parts and (path_parts[0].endswith('|') or
+                               path_parts[0].endswith(':')):
+                path_drive = path_parts.pop(0)
+                if path_drive.endswith('|'):
+                    path_drive = path_drive[:-1] + ':'
+
+                while path_parts and not path_parts[0]:
+                    path_parts.pop(0)
+            else:
+                path_drive = ''
+
+            # Try to put the path back together
+            # Join the drive back in, and stick os.sep in front of the path to
+            # make it absolute.
+            path = path_drive + os.sep + os.path.join(*path_parts)
+
+            # Check if the drive assumptions above were correct. If path_drive
+            # is set, and os.path.splitdrive does not return a drive, it wasn't
+            # reall a drive. Put the path together again treating path_drive
+            # as a normal path component.
+            if path_drive and not os.path.splitdrive(path):
+                path = os.sep + os.path.join(path_drive, *path_parts)
+
+            # Use io.open since we need to add a release_conn method, and
+            # methods can't be added to file objects in python 2.
+            resp.raw = io.open(path, "rb")
+            resp.raw.release_conn = resp.raw.close
+        except IOError as e:
+            if e.errno == errno.EACCES:
+                resp.status_code = codes.forbidden
+            elif e.errno == errno.ENOENT:
+                resp.status_code = codes.not_found
+            else:
+                resp.status_code = codes.bad_request
+
+            # Wrap the error message in a file-like object
+            # The error message will be localized, try to convert the string
+            # representation of the exception into a byte stream
+            resp_str = str(e).encode(locale.getpreferredencoding(False))
+            resp.raw = BytesIO(resp_str)
+            resp.headers['Content-Length'] = len(resp_str)
+
+            # Add release_conn to the BytesIO object
+            resp.raw.release_conn = resp.raw.close
+        else:
+            resp.status_code = codes.ok
+
+            # If it's a regular file, set the Content-Length
+            resp_stat = os.fstat(resp.raw.fileno())
+            if stat.S_ISREG(resp_stat.st_mode):
+                resp.headers['Content-Length'] = resp_stat.st_size
+
+        return resp
+
+    def close(self):
+        pass

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -44,6 +44,10 @@ class FileAdapter(BaseAdapter):
         # Parse the URL
         url_parts = urlparse(request.url)
 
+        # Make the Windows URLs slightly nicer
+        if is_win32 and url_parts.netloc.endswith(":"):
+            url_parts = url_parts._replace(path="/" + url_parts.netloc + url_parts.path, netloc='')
+
         # Reject URLs with a hostname component
         if url_parts.netloc and not url_parts.netloc in ("localhost", ".", "..", "-"):
             raise ValueError("file: URLs with hostname components are not permitted")

--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -1,6 +1,7 @@
 from requests import Session, __build__ as requests_version
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
+from streamlink.packages.requests_file import FileAdapter
 
 try:
     from requests.packages.urllib3.util import Timeout
@@ -65,6 +66,8 @@ class HTTPSession(Session):
         if TIMEOUT_ADAPTER_NEEDED:
             self.mount("http://", HTTPAdapterWithReadTimeout())
             self.mount("https://", HTTPAdapterWithReadTimeout())
+
+        self.mount('file://', FileAdapter())
 
     @classmethod
     def determine_json_encoding(cls, sample):

--- a/src/streamlink/plugins/stream.py
+++ b/src/streamlink/plugins/stream.py
@@ -54,7 +54,7 @@ class StreamURL(Plugin):
         urlnoproto = re.match("^\w+://(.+)", url).group(1)
 
         # Prepend http:// if needed.
-        if cls != RTMPStream and not re.match("^http(s)?://", urlnoproto):
+        if cls != RTMPStream and not len(urlparse(urlnoproto).scheme):
             urlnoproto = "http://{0}".format(urlnoproto)
 
         params = (" ").join(split[1:])

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -4,10 +4,7 @@ from binascii import unhexlify
 from collections import namedtuple
 from itertools import starmap
 
-try:
-    from urlparse import urljoin
-except ImportError:
-    from urllib.parse import urljoin
+from streamlink.compat import urljoin, urlparse
 
 __all__ = ["load", "M3U8Parser"]
 
@@ -258,7 +255,7 @@ class M3U8Parser(object):
         return self.m3u8
 
     def uri(self, uri):
-        if uri and uri.startswith("http"):
+        if uri and urlparse(uri).scheme:
             return uri
         elif self.base_uri and uri:
             return urljoin(self.base_uri, uri)


### PR DESCRIPTION
As requested in #253 and chrippa/livestreamer#1514. 

Support for local files via the `file://` protocol.

`hls`, `hlsvariant` and `httpstream` are supported. Files can be loaded from relative or absolute paths, or even read from `stdin`.

eg.
```sh
streamlink hlsvariant://file://./playlist.m3u8 best
cat playlist.m3u8 | streamlink hlsvariant://file://- best
# httpstream works, but is mostly pointless :)
streamlink httpstream://file://./hadoken.mp4
cat hadoken.mp4 | streamlink httpstream://file://- best
```
