### PR TITLE
plugins.liveme: added support for liveme.com streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -73,6 +73,7 @@ hitbox              hitbox.tv            Yes   Yes
 itvplayer           itv.com/itvplayer    Yes   Yes   Streams may be geo-restricted to Great Britain.
 letontv             leton.tv             Yes   --
 livecoding          livecoding.tv        Yes   --
+liveme              liveme.com           Yes   --
 livestation         livestation.com      Yes   --
 livestream          new.livestream.com   Yes   --
 media_ccc_de        - media.ccc.de       Yes   Yes   Only mp4 and HLS are supported.

--- a/src/streamlink/plugins/liveme.py
+++ b/src/streamlink/plugins/liveme.py
@@ -1,0 +1,50 @@
+from __future__ import print_function
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.compat import urlparse, parse_qsl
+from streamlink.stream import HLSStream
+from streamlink.stream import HTTPStream
+
+
+class LiveMe(Plugin):
+    url_re = re.compile(r"https?://(www.)?liveme.com/media/play/(.*)")
+    api_url = "http://live.ksmobile.net/live/queryinfo?userid=1&videoid={id}"
+    api_schema = validate.Schema(validate.all({
+        "status": "200",
+        "data": {
+            "video_info": {
+                "videosource": validate.any('', validate.url()),
+                "hlsvideosource": validate.any('', validate.url()),
+            }
+        }
+    }, validate.get("data")))
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _make_stream(self, url):
+        if url and url.endswith("flv"):
+            return HTTPStream(self.session, url)
+        elif url and url.endswith("m3u8"):
+            return HLSStream(self.session, url)
+
+    def _get_streams(self):
+        url_params = dict(parse_qsl(urlparse(self.url).query))
+        video_id = url_params.get("videoid")
+
+        if video_id:
+            self.logger.debug("Found Video ID: {}", video_id)
+            res = http.get(self.api_url.format(id=video_id))
+            data = http.json(res, schema=self.api_schema)
+            hls = self._make_stream(data["video_info"]["hlsvideosource"])
+            video = self._make_stream(data["video_info"]["videosource"])
+            if hls:
+                yield "live", hls
+            if video:
+                yield "live", video
+
+__plugin__ = LiveMe

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -13,11 +13,9 @@ SWF_URL = "http://www.tv4play.se/flash/tv4video.swf"
 _url_re = re.compile("""
     http(s)?://(www\.)?
     (?:
-        tv4play.se/program/[^\?/]+
-    )?
-    (?:
+        tv4play.se/program/[^\?/]+|
         fotbollskanalen.se/video
-    )?
+    )
     .+(video_id|videoid)=(?P<video_id>\d+)
 """, re.VERBOSE)
 


### PR DESCRIPTION
This PR adds liveme.com stream support, as requested in #291. 

Could do with some testing, for VOD in particular.

It supports URLS like:
http://www.liveme.com/media/play/?videoid=23456789098765&extra_stuff=xxxx