### PR TITLE
--can-handle-url-no-redirect parameter added

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -343,7 +343,7 @@ class Streamlink(object):
 
         raise NoPluginError
 
-    def resolve_url_nohead(self, url):
+    def resolve_url_no_redirect(self, url):
         """Attempts to find a plugin that can use this URL.
 
         The default protocol (http) will be prefixed to the URL if
@@ -424,3 +424,4 @@ class Streamlink(object):
         return __version__
 
 __all__ = ["Streamlink"]
+

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -343,6 +343,29 @@ class Streamlink(object):
 
         raise NoPluginError
 
+    def resolve_url_nohead(self, url):
+        """Attempts to find a plugin that can use this URL.
+
+        The default protocol (http) will be prefixed to the URL if
+        not specified.
+
+        Raises :exc:`NoPluginError` on failure.
+
+        :param url: a URL to match against loaded plugins
+
+        """
+        parsed = urlparse(url)
+
+        if len(parsed.scheme) == 0:
+            url = "http://" + url
+
+        for name, plugin in self.plugins.items():
+            if plugin.can_handle_url(url):
+                obj = plugin(url)
+                return obj
+
+        raise NoPluginError
+
     def streams(self, url, **params):
         """Attempts to find a plugin and extract streams from the *url*.
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -213,6 +213,13 @@ general.add_argument(
     """
 )
 general.add_argument(
+    "--can-handle-url-nohead",
+    metavar="URL",
+    help="""
+    Same as --can-handle-url but without HTTP operations involved.
+    """
+)
+general.add_argument(
     "--config",
     action="append",
     metavar="FILENAME",

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -213,10 +213,10 @@ general.add_argument(
     """
 )
 general.add_argument(
-    "--can-handle-url-nohead",
+    "--can-handle-url-no-redirect",
     metavar="URL",
     help="""
-    Same as --can-handle-url but without HTTP operations involved.
+    Same as --can-handle-url but without following redirects when looking up the URL.
     """
 )
 general.add_argument(
@@ -1038,3 +1038,4 @@ http.add_argument(
 )
 
 __all__ = ["parser"]
+

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -892,6 +892,13 @@ def main():
             sys.exit(1)
         else:
             sys.exit(0)
+    elif args.can_handle_url_nohead:
+        try:
+            streamlink.resolve_url_nohead(args.can_handle_url_nohead)
+        except NoPluginError:
+            sys.exit(1)
+        else:
+            sys.exit(0)
     elif args.url:
         try:
             setup_options()

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -892,9 +892,9 @@ def main():
             sys.exit(1)
         else:
             sys.exit(0)
-    elif args.can_handle_url_nohead:
+    elif args.can_handle_url_no_redirect:
         try:
-            streamlink.resolve_url_nohead(args.can_handle_url_nohead)
+            streamlink.resolve_url_no_redirect(args.can_handle_url_no_redirect)
         except NoPluginError:
             sys.exit(1)
         else:
@@ -929,3 +929,4 @@ def main():
             "read the manual at https://streamlink.github.io"
         ).format(usage=usage)
         console.msg(msg)
+

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -34,6 +34,12 @@ class TestSession(unittest.TestCase):
         self.assertTrue(isinstance(channel, Plugin))
         self.assertTrue(isinstance(channel, plugins["testplugin"]))
 
+    def test_resolve_url_no_redirect(self):
+        plugins = self.session.get_plugins()
+        channel = self.session.resolve_url_no_redirect("http://test.se/channel")
+        self.assertTrue(isinstance(channel, Plugin))
+        self.assertTrue(isinstance(channel, plugins["testplugin"]))
+
     def test_options(self):
         self.session.set_option("test_option", "option")
         self.assertEqual(self.session.get_option("test_option"), "option")


### PR DESCRIPTION
Do the same as --can-handle-url but without HTTP operations involved as issued in https://github.com/streamlink/streamlink/issues/331