### PR TITLE
Don't reject future pycryptodome versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ else:
     deps.append("requests>=1.0,!=2.12.0,!=2.12.1,<3.0")
 
 # this version of pycryptodome is known to work and has a Windows wheel for py2.7, py3.3-3.5
-deps.append("pycryptodome==3.4.3")
+deps.append("pycryptodome>=3.4.3")
 
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.


### PR DESCRIPTION
I'm not sure about the exact details of the effect, but I think specifying a single version might create an issue in the future, if one wants to update cryptodome and streamlink hasn't been updated yet.

I'm fairly confident there isn't a problem with future cryptodome versions yet, as 3.4.3 is the latest! :-)