### PR TITLE
plugins.trtspor: added support for trtspor.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -118,6 +118,7 @@ tga                 - star.plu.cn        Yes   No
                     - star.tga.plu.cn
 tigerdile           tigerdile.com        Yes   --
 trt                 trt.net.tr           Yes   No    Some streams may be geo-restricted to Turkey.
+trtspor             trtspor.com          Yes   No    Some streams are geo-restricted to Turkey.
 turkuvaz            - atv.com.tr         Yes   No
                     - a2tv.com.tr
                     - ahaber.com.tr

--- a/src/streamlink/plugins/trtspor.py
+++ b/src/streamlink/plugins/trtspor.py
@@ -1,0 +1,39 @@
+from __future__ import print_function
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import AkamaiHDStream
+from streamlink.stream import HDSStream
+from streamlink.stream import HLSStream
+
+
+class TRTSpor(Plugin):
+    """
+    Support for trtsport.com a Turkish Sports Broadcaster
+    """
+    url_re = re.compile(r"https?://(?:www.)?trtspor.com/canli-yayin-izle/.+/?")
+    f4mm_re = re.compile(r'''(?P<q>["'])(?P<url>http[^"']+?.f4m)(?P=q),''')
+    m3u8_re = re.compile(r'''(?P<q>["'])(?P<url>http[^"']+?.m3u8)(?P=q),''')
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        url_m = self.m3u8_re.search(res.text)
+        hls_url = url_m and url_m.group("url")
+        if hls_url:
+            for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
+                yield s
+
+        f4m_m = self.f4mm_re.search(res.text)
+        f4m_url = f4m_m and f4m_m.group("url")
+        if f4m_url:
+            for n, s in HDSStream.parse_manifest(self.session, f4m_url).items():
+                yield n, s
+
+
+__plugin__ = TRTSpor


### PR DESCRIPTION
Adds support for http://www.trtspor.com.

Supports TV and radio streams, the TV streams are geo-locked to Turkey, so tricky to test without being in Turkey or without a Turkish proxy. 

Example URLs:
- http://www.trtspor.com/canli-yayin-izle/trtspor-159/ (geo-locked to Turkey)
- http://www.trtspor.com/canli-yayin-izle/trtspor-160/