### PR TITLE
Upgrade Twitch plugin to use API v3

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -198,8 +198,11 @@ class TwitchAPI(object):
         else:
             url = "https://{0}.twitch.tv{1}".format(self.subdomain, path)
 
+        headers = { 'Accept': 'application/vnd.twitchtv.v3+json',
+                    'Client-ID': TWITCH_CLIENT_ID }
+
         # The certificate used by Twitch cannot be verified on some OpenSSL versions.
-        res = http.get(url, params=params, verify=False, headers={'Client-ID': TWITCH_CLIENT_ID})
+        res = http.get(url, params=params, verify=False, headers=headers)
 
         if format == "json":
             return http.json(res, schema=schema)

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -220,7 +220,7 @@ class TwitchAPI(object):
         return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), **params)
 
     def channel_info(self, channel, **params):
-        return self.call("/api/channels/{0}".format(channel), **params)
+        return self.call("/kraken/channels/{0}".format(channel), **params)
 
     def channel_subscription(self, channel, **params):
         return self.call("/api/channels/{0}/subscription".format(channel), **params)
@@ -235,7 +235,7 @@ class TwitchAPI(object):
         return self.call("/kraken/user", **params)
 
     def videos(self, video_id, **params):
-        return self.call("/api/videos/{0}".format(video_id), **params)
+        return self.call("/kraken/videos/{0}".format(video_id), **params)
 
     def viewer_info(self, **params):
         return self.call("/api/viewer/info", **params)


### PR DESCRIPTION
Current Twitch API documentation[1] recommends for every API request to specify the API version by setting the Accept HTTP header to the appropriate value. This patch:

* sets the value to v3 (older versions of the API are going to be removed).
* uses the base URL`https://api.twitch.tv/kraken` to access (public) API resources

  [1]: https://github.com/justintv/Twitch-API

See #20 for details