### PR TITLE
Specify the subprocess errorlog path

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -58,7 +58,8 @@ class Streamlink(object):
             "stream-segment-threads": 1,
             "stream-segment-timeout": 10.0,
             "stream-timeout": 60.0,
-            "subprocess-errorlog": False
+            "subprocess-errorlog": False,
+            "subprocess-errorlog-path": None
         })
         self.plugins = {}
         self.logger = Logger()
@@ -74,113 +75,116 @@ class Streamlink(object):
 
         **Available options**:
 
-        ======================= =========================================
-        hds-live-edge           (float) Specify the time live HDS
-                                streams will start from the edge of
-                                stream, default: ``10.0``
+        ======================== =========================================
+        hds-live-edge            ( float) Specify the time live HDS
+                                 streams will start from the edge of
+                                 stream, default: ``10.0``
 
-        hds-segment-attempts    (int) How many attempts should be done
-                                to download each HDS segment, default: ``3``
+        hds-segment-attempts     (int) How many attempts should be done
+                                 to download each HDS segment, default: ``3``
 
-        hds-segment-threads     (int) The size of the thread pool used
-                                to download segments, default: ``1``
+        hds-segment-threads      (int) The size of the thread pool used
+                                 to download segments, default: ``1``
 
-        hds-segment-timeout     (float) HDS segment connect and read
-                                timeout, default: ``10.0``
+        hds-segment-timeout      (float) HDS segment connect and read
+                                 timeout, default: ``10.0``
 
-        hds-timeout             (float) Timeout for reading data from
-                                HDS streams, default: ``60.0``
+        hds-timeout              (float) Timeout for reading data from
+                                 HDS streams, default: ``60.0``
 
-        hls-live-edge           (int) How many segments from the end
-                                to start live streams on, default: ``3``
+        hls-live-edge            (int) How many segments from the end
+                                 to start live streams on, default: ``3``
 
-        hls-segment-attempts    (int) How many attempts should be done
-                                to download each HLS segment, default: ``3``
+        hls-segment-attempts     (int) How many attempts should be done
+                                 to download each HLS segment, default: ``3``
 
-        hls-segment-threads     (int) The size of the thread pool used
-                                to download segments, default: ``1``
+        hls-segment-threads      (int) The size of the thread pool used
+                                 to download segments, default: ``1``
 
-        hls-segment-timeout     (float) HLS segment connect and read
-                                timeout, default: ``10.0``
+        hls-segment-timeout      (float) HLS segment connect and read
+                                 timeout, default: ``10.0``
 
-        hls-timeout             (float) Timeout for reading data from
-                                HLS streams, default: ``60.0``
+        hls-timeout              (float) Timeout for reading data from
+                                 HLS streams, default: ``60.0``
 
-        http-proxy              (str) Specify a HTTP proxy to use for
-                                all HTTP requests
+        http-proxy               (str) Specify a HTTP proxy to use for
+                                 all HTTP requests
 
-        https-proxy             (str) Specify a HTTPS proxy to use for
-                                all HTTPS requests
+        https-proxy              (str) Specify a HTTPS proxy to use for
+                                 all HTTPS requests
 
-        http-cookies            (dict or str) A dict or a semi-colon (;)
-                                delimited str of cookies to add to each
-                                HTTP request, e.g. ``foo=bar;baz=qux``
+        http-cookies             (dict or str) A dict or a semi-colon (;)
+                                 delimited str of cookies to add to each
+                                 HTTP request, e.g. ``foo=bar;baz=qux``
 
-        http-headers            (dict or str) A dict or semi-colon (;)
-                                delimited str of headers to add to each
-                                HTTP request, e.g. ``foo=bar;baz=qux``
+        http-headers             (dict or str) A dict or semi-colon (;)
+                                 delimited str of headers to add to each
+                                 HTTP request, e.g. ``foo=bar;baz=qux``
 
-        http-query-params       (dict or str) A dict or a ampersand (&)
-                                delimited string of query parameters to
-                                add to each HTTP request,
-                                e.g. ``foo=bar&baz=qux``
+        http-query-params        (dict or str) A dict or a ampersand (&)
+                                 delimited string of query parameters to
+                                 add to each HTTP request,
+                                 e.g. ``foo=bar&baz=qux``
 
-        http-trust-env          (bool) Trust HTTP settings set in the
-                                environment, such as environment
-                                variables (HTTP_PROXY, etc) and
-                                ~/.netrc authentication
+        http-trust-env           (bool) Trust HTTP settings set in the
+                                 environment, such as environment
+                                 variables (HTTP_PROXY, etc) and
+                                 ~/.netrc authentication
 
-        http-ssl-verify         (bool) Verify SSL certificates,
-                                default: ``True``
+        http-ssl-verify          (bool) Verify SSL certificates,
+                                 default: ``True``
 
-        http-ssl-cert           (str or tuple) SSL certificate to use,
-                                can be either a .pem file (str) or a
-                                .crt/.key pair (tuple)
+        http-ssl-cert            (str or tuple) SSL certificate to use,
+                                 can be either a .pem file (str) or a
+                                 .crt/.key pair (tuple)
 
-        http-timeout            (float) General timeout used by all HTTP
-                                requests except the ones covered by
-                                other options, default: ``20.0``
+        http-timeout             (float) General timeout used by all HTTP
+                                 requests except the ones covered by
+                                 other options, default: ``20.0``
 
-        http-stream-timeout     (float) Timeout for reading data from
-                                HTTP streams, default: ``60.0``
+        http-stream-timeout      (float) Timeout for reading data from
+                                 HTTP streams, default: ``60.0``
 
-        subprocess-errorlog     (bool) Log errors from subprocesses to
-                                a file located in the temp directory
+        subprocess-errorlog      (bool) Log errors from subprocesses to
+                                 a file located in the temp directory
 
-        ringbuffer-size         (int) The size of the internal ring
-                                buffer used by most stream types,
-                                default: ``16777216`` (16MB)
+        subprocess-errorlog-path (str) Log errors from subprocesses to
+                                 a specific file
 
-        rtmp-proxy              (str) Specify a proxy (SOCKS) that RTMP
-                                streams will use
+        ringbuffer-size          (int) The size of the internal ring
+                                 buffer used by most stream types,
+                                 default: ``16777216`` (16MB)
 
-        rtmp-rtmpdump           (str) Specify the location of the
-                                rtmpdump executable used by RTMP streams,
-                                e.g. ``/usr/local/bin/rtmpdump``
+        rtmp-proxy               (str) Specify a proxy (SOCKS) that RTMP
+                                 streams will use
 
-        rtmp-timeout            (float) Timeout for reading data from
-                                RTMP streams, default: ``60.0``
+        rtmp-rtmpdump            (str) Specify the location of the
+                                 rtmpdump executable used by RTMP streams,
+                                 e.g. ``/usr/local/bin/rtmpdump``
 
-        stream-segment-attempts (int) How many attempts should be done
-                                to download each segment, default: ``3``.
-                                General option used by streams not
-                                covered by other options.
+        rtmp-timeout             (float) Timeout for reading data from
+                                 RTMP streams, default: ``60.0``
 
-        stream-segment-threads  (int) The size of the thread pool used
-                                to download segments, default: ``1``.
-                                General option used by streams not
-                                covered by other options.
+        stream-segment-attempts  (int) How many attempts should be done
+                                 to download each segment, default: ``3``.
+                                 General option used by streams not
+                                 covered by other options.
 
-        stream-segment-timeout  (float) Segment connect and read
-                                timeout, default: ``10.0``.
-                                General option used by streams not
-                                covered by other options.
+        stream-segment-threads   (int) The size of the thread pool used
+                                 to download segments, default: ``1``.
+                                 General option used by streams not
+                                 covered by other options.
 
-        stream-timeout          (float) Timeout for reading data from
-                                stream, default: ``60.0``.
-                                General option used by streams not
-                                covered by other options.
-        ======================= =========================================
+        stream-segment-timeout   (float) Segment connect and read
+                                 timeout, default: ``10.0``.
+                                 General option used by streams not
+                                 covered by other options.
+
+        stream-timeout           (float) Timeout for reading data from
+                                 stream, default: ``60.0``.
+                                 General option used by streams not
+                                 covered by other options.
+        ======================== =========================================
 
         """
 
@@ -191,6 +195,8 @@ class Streamlink(object):
             key = "rtmp-proxy"
         elif key == "errorlog":
             key = "subprocess-errorlog"
+        elif key == "errorlog-path":
+            key = "subprocess-errorlog-path"
 
         if key == "http-proxy":
             if not re.match("^http(s)?://", value):

--- a/src/streamlink/stream/streamprocess.py
+++ b/src/streamlink/stream/streamprocess.py
@@ -36,6 +36,7 @@ class StreamProcess(Stream):
 
         self.params = params
         self.errorlog = self.session.options.get("subprocess-errorlog")
+        self.errorlog_path = self.session.options.get("subprocess-errorlog-path")
         self.timeout = timeout
 
     def open(self):
@@ -43,7 +44,9 @@ class StreamProcess(Stream):
         params = self.params.copy()
         params["_bg"] = True
 
-        if self.errorlog:
+        if self.errorlog_path:
+            params["_err"] = open(self.errorlog_path, "w")
+        elif self.errorlog:
             tmpfile = tempfile.NamedTemporaryFile(prefix="streamlink",
                                                   suffix=".err", delete=False)
             params["_err"] = tmpfile

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -750,6 +750,17 @@ transport.add_argument(
     Useful when debugging rtmpdump related issues.
     """
 )
+transport.add_argument(
+    "--subprocess-errorlog-path", "--errorlog-path",
+    type=str,
+    metavar="PATH",
+    help="""
+    Log the subprocess errorlog to a specific file rather than a temporary file.
+    Takes precedence over subprocess-errorlog.
+
+    Useful when debugging rtmpdump related issues.
+    """
+)
 
 
 http = parser.add_argument_group("HTTP options")

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -755,6 +755,7 @@ def setup_options():
         streamlink.set_option("stream-timeout", args.stream_timeout)
 
     streamlink.set_option("subprocess-errorlog", args.subprocess_errorlog)
+    streamlink.set_option("subprocess-errorlog-path", args.subprocess_errorlog_path)
 
     # Deprecated options
     if args.hds_fragment_buffer:

--- a/src/streamlink_cli/utils/stream.py
+++ b/src/streamlink_cli/utils/stream.py
@@ -20,6 +20,8 @@ def stream_to_url(stream):
         for key, value in stream_params.items():
             if isinstance(value, bool):
                 value = str(int(value))
+            if isinstance(value, int):
+                value = str(value)
 
             # librtmp expects some characters to be escaped
             value = value.replace("\\", "\\5c")


### PR DESCRIPTION
As requested in #327 :)

Adds the option `--subprocess-errorlog-path` (`--errorlog-path`) to specify the path of the subprocess error log.

eg.
```
streamlink --errorlog-path rtmpdump.log itv.com/hub/itv best 
```