### PR TITLE
packages.flashmedia: fix bug in AMFMessage

### DIFF
--- a/src/streamlink/packages/flashmedia/amf.py
+++ b/src/streamlink/packages/flashmedia/amf.py
@@ -55,7 +55,7 @@ class AMFMessage(Packet):
     def _serialize(self, packet):
         packet += AMF0String(self.target_uri)
         packet += AMF0String(self.response_uri)
-        packet += U32BE(self.size)
+        packet += U32BE(AMF0Value.size(self.value))
         packet += AMF0Value.pack(self.value)
 
     @classmethod


### PR DESCRIPTION
`flashmedia.amf.AMFMessage` sets a field incorrectly when serialising, this PR rectifies that issue.

As this package is no longer maintained by its author, and already has some `streamlink` specific patches, I will continue with small bug fixes for `flashmedia` until a suitable replacement can be found... 