### PR TITLE
Build with Python 3.6 in the CI environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 matrix:
+matrix:
   include:
   - python: '2.6'
   - python: '2.7'
@@ -8,6 +9,10 @@ matrix:
   - python: '3.4'
   - python: '3.5'
     env: BUILD_DOCS=yes BUILD_INSTALLER=yes STREAMLINK_INSTALLER_DIST_DIR=$TRAVIS_BUILD_DIR/dist/nsis
+  - python: '3.6'
+  - python: '3.7-dev'
+  allow_failures:
+  - python: '3.7-dev'
 
 before_install:
   - pip install --disable-pip-version-check --upgrade pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,12 +5,14 @@ environment:
     - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
+    - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python33-x64"
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python34-x64"
       DISTUTILS_USE_SDK: "1"
     - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
 
 install:
     # If there is a newer build queued for the same PR, cancel this one.


### PR DESCRIPTION
Enable Python 3.6 on Travis and AppVeyor. 

Also enable Python 3.7 dev on Travis, but allow failures until 3.7 is closer to release. 