### PR TITLE
plugins: all regex string should be raw

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -16,7 +16,7 @@ CHANNEL_RESULT_ERROR = 0
 CHANNEL_RESULT_OK = 1
 
 
-_url_re = re.compile("http(s)?://(\w+\.)?afreeca(tv)?.com/(?P<username>\w+)(/\d+)?")
+_url_re = re.compile(r"http(s)?://(\w+\.)?afreeca(tv)?.com/(?P<username>\w+)(/\d+)?")
 
 _channel_schema = validate.Schema(
     {

--- a/src/streamlink/plugins/afreecatv.py
+++ b/src/streamlink/plugins/afreecatv.py
@@ -10,10 +10,10 @@ VIEW_LIVE_API_URL = "http://api.afreeca.tv/live/view_live.php"
 VIEW_LIVE_API_URL_TW = "http://api.afreecatv.com.tw/live/view_live.php"
 VIEW_LIVE_API_URL_JP = "http://api.afreecatv.jp/live/view_live.php"
 
-_url_re = re.compile("http(s)?://(\w+\.)?(afreecatv.com.tw|afreeca.tv|afreecatv.jp)/(?P<channel>[\w\-_]+)")
-_url_re_tw = re.compile("http(s)?://(\w+\.)?(afreecatv.com.tw)/(?P<channel>[\w\-_]+)")
-_url_re_jp = re.compile("http(s)?://(\w+\.)?(afreecatv.jp)/(?P<channel>[\w\-_]+)")
-_flashvars_re = re.compile('<param name="flashvars" value="([^"]+)" />')
+_url_re = re.compile(r"http(s)?://(\w+\.)?(afreecatv.com.tw|afreeca.tv|afreecatv.jp)/(?P<channel>[\w\-_]+)")
+_url_re_tw = re.compile(r"http(s)?://(\w+\.)?(afreecatv.com.tw)/(?P<channel>[\w\-_]+)")
+_url_re_jp = re.compile(r"http(s)?://(\w+\.)?(afreecatv.jp)/(?P<channel>[\w\-_]+)")
+_flashvars_re = re.compile(r'<param name="flashvars" value="([^"]+)" />')
 
 _flashvars_schema = validate.Schema(
     validate.transform(_flashvars_re.findall),

--- a/src/streamlink/plugins/aftonbladet.py
+++ b/src/streamlink/plugins/aftonbladet.py
@@ -15,10 +15,10 @@ STREAM_FORMATS = ("m3u8", "f4m")
 VIDEO_INFO_URL = "http://aftonbladet-play-static-ext.cdn.drvideo.aptoma.no/actions/video"
 METADATA_URL = "http://aftonbladet-play-metadata.cdn.drvideo.aptoma.no/video/{0}.json"
 
-_embed_re = re.compile("<iframe src=\"(http://tv.aftonbladet.se[^\"]+)\"")
-_aptoma_id_re = re.compile("<div id=\"drvideo\".+data-aptomaId=\"([^\"]+)\"")
-_live_re = re.compile("data-isLive=\"true\"")
-_url_re = re.compile("http(s)?://(\w+.)?.aftonbladet.se")
+_embed_re = re.compile(r"<iframe src=\"(http://tv.aftonbladet.se[^\"]+)\"")
+_aptoma_id_re = re.compile(r"<div id=\"drvideo\".+data-aptomaId=\"([^\"]+)\"")
+_live_re = re.compile(r"data-isLive=\"true\"")
+_url_re = re.compile(r"http(s)?://(\w+.)?.aftonbladet.se")
 
 _video_schema = validate.Schema(
     {

--- a/src/streamlink/plugins/alieztv.py
+++ b/src/streamlink/plugins/alieztv.py
@@ -7,7 +7,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HTTPStream, RTMPStream
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?aliez.tv
     (?:
         /live/[^/]+
@@ -16,8 +16,8 @@ _url_re = re.compile("""
         /video/\d+/[^/]+
     )?
 """, re.VERBOSE)
-_file_re = re.compile("\"?file\"?:\s+['\"]([^'\"]+)['\"]")
-_swf_url_re = re.compile("swfobject.embedSWF\(\"([^\"]+)\",")
+_file_re = re.compile(r"\"?file\"?:\s+['\"]([^'\"]+)['\"]")
+_swf_url_re = re.compile(r"swfobject.embedSWF\(\"([^\"]+)\",")
 
 _schema = validate.Schema(
     validate.union({

--- a/src/streamlink/plugins/antenna.py
+++ b/src/streamlink/plugins/antenna.py
@@ -5,10 +5,10 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HDSStream
 
-_url_re = re.compile("(http(s)?://(\w+\.)?antenna.gr)/webtv/watch\?cid=.+")
-_playlist_re = re.compile("playlist:\s*\"(/templates/data/jplayer\?cid=[^\"]+)")
-_manifest_re = re.compile("jwplayer:source\s+file=\"([^\"]+)\"")
-_swf_re = re.compile("<jwplayer:provider>(http[^<]+)</jwplayer:provider>")
+_url_re = re.compile(r"(http(s)?://(\w+\.)?antenna.gr)/webtv/watch\?cid=.+")
+_playlist_re = re.compile(r"playlist:\s*\"(/templates/data/jplayer\?cid=[^\"]+)")
+_manifest_re = re.compile(r"jwplayer:source\s+file=\"([^\"]+)\"")
+_swf_re = re.compile(r"<jwplayer:provider>(http[^<]+)</jwplayer:provider>")
 
 class Antenna(Plugin):
     @classmethod

--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -18,7 +18,7 @@ STREAMING_TYPES = {
     )
 }
 
-_url_re = re.compile("http(s)?://live.daserste.de/(?P<channel>[^/?]+)?")
+_url_re = re.compile(r"http(s)?://live.daserste.de/(?P<channel>[^/?]+)?")
 
 _livestream_schema = validate.Schema(
     validate.xml_findall("video/*"),

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -15,8 +15,8 @@ QUALITY_MAP = {
     0: "144p"
 }
 
-_url_re = re.compile("http(s)?://(\w+\.)?ardmediathek.de/tv")
-_media_id_re = re.compile("/play/config/(\d+)")
+_url_re = re.compile(r"http(s)?://(\w+\.)?ardmediathek.de/tv")
+_media_id_re = re.compile(r"/play/config/(\d+)")
 _media_schema = validate.Schema({
     "_mediaArray": [{
         "_mediaStreamArray": [{

--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -11,8 +11,8 @@ from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
 SWF_URL = "http://www.arte.tv/player/v2/jwplayer6/mediaplayer.6.6.swf"
 
-_url_re = re.compile("http(s)?://(\w+\.)?arte.tv/")
-_json_re = re.compile("arte_vp_(?:live-)?url=(['\"])(.+?)\\1")
+_url_re = re.compile(r"http(s)?://(\w+\.)?arte.tv/")
+_json_re = re.compile(r'arte_vp_(?:live-)?url=([\'"])(.+?)\1')
 
 _schema = validate.Schema(
     validate.transform(_json_re.search),

--- a/src/streamlink/plugins/azubutv.py
+++ b/src/streamlink/plugins/azubutv.py
@@ -21,7 +21,7 @@ HTTP_HEADERS = {
 
 }
 
-_url_re = re.compile("http(s)?://(\w+\.)?azubu.tv/(?P<domain>\w+)")
+_url_re = re.compile(r"http(s)?://(\w+\.)?azubu.tv/(?P<domain>\w+)")
 
 PARAMS_REGEX = r"(\w+)=({.+?}|\[.+?\]|\(.+?\)|'(?:[^'\\]|\\')*'|\"(?:[^\"\\]|\\\")*\"|\S+)"
 stream_video_url = "http://api.azubu.tv/public/channel/{}/player"

--- a/src/streamlink/plugins/bambuser.py
+++ b/src/streamlink/plugins/bambuser.py
@@ -11,7 +11,7 @@ API_CONTEXT = "b_broadcastpage"
 API_KEY = "005f64509e19a868399060af746a00aa"
 API_URL_VIDEO = "http://player-c.api.bambuser.com/getVideo.json"
 
-_url_re = re.compile("http(s)?://(\w+.)?bambuser.com/v/(?P<video_id>\d+)")
+_url_re = re.compile(r"http(s)?://(\w+.)?bambuser.com/v/(?P<video_id>\d+)")
 _video_schema = validate.Schema({
     validate.optional("error"): validate.text,
     validate.optional("result"): {

--- a/src/streamlink/plugins/beam.py
+++ b/src/streamlink/plugins/beam.py
@@ -4,7 +4,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import RTMPStream
 
-_url_re = re.compile("http(s)?://(\w+.)?beam.pro/(?P<channel>[^/]+)")
+_url_re = re.compile(r"http(s)?://(\w+.)?beam.pro/(?P<channel>[^/]+)")
 
 CHANNEL_INFO = "https://beam.pro/api/v1/channels/{0}"
 CHANNEL_MANIFEST = "https://beam.pro/api/v1/channels/{0}/manifest.smil"

--- a/src/streamlink/plugins/beattv.py
+++ b/src/streamlink/plugins/beattv.py
@@ -42,7 +42,7 @@ QUALITY_MAP = {
     "web_hd": 12
 }
 
-_url_re = re.compile("http(s)?://(\w+\.)?be-at.tv/")
+_url_re = re.compile(r"http(s)?://(\w+\.)?be-at.tv/")
 _schema = validate.Schema(
     validate.any(
         None,

--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -14,12 +14,12 @@ STREAM_WEIGHTS = {
     "source": 1080
 }
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://live.bilibili.com
     /(?P<channel>[^/]+)
 """, re.VERBOSE)
 
-_room_re = re.compile('var ROOMID = (\\d+)')
+_room_re = re.compile(r'var ROOMID = (\d+)')
 
 class Bilibili(Plugin):
     @classmethod

--- a/src/streamlink/plugins/bliptv.py
+++ b/src/streamlink/plugins/bliptv.py
@@ -4,9 +4,9 @@ from streamlink.plugin import Plugin, PluginError
 from streamlink.plugin.api import http
 from streamlink.stream import HTTPStream
 
-_url_re = re.compile("(http(s)?://)?blip.tv/.*-(?P<videoid>\d+)")
+_url_re = re.compile(r"(http(s)?://)?blip.tv/.*-(?P<videoid>\d+)")
 VIDEO_GET_URL = 'http://player.blip.tv/file/get/{0}'
-SINGLE_VIDEO_URL = re.compile('.*\.((mp4)|(mov)|(m4v)|(flv))')
+SINGLE_VIDEO_URL = re.compile(r'.*\.((mp4)|(mov)|(m4v)|(flv))')
 
 QUALITY_WEIGHTS = {
     "ultra": 1080,
@@ -15,7 +15,7 @@ QUALITY_WEIGHTS = {
     "low": 240,
 }
 
-QUALITY_WEIGHTS_ULTRA = re.compile('ultra+_(?P<level>\d+)')
+QUALITY_WEIGHTS_ULTRA = re.compile(r'ultra+_(?P<level>\d+)')
 
 
 def get_quality_dict(quality_list):

--- a/src/streamlink/plugins/chaturbate.py
+++ b/src/streamlink/plugins/chaturbate.py
@@ -4,8 +4,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HLSStream
 
-_url_re = re.compile("http(s)?://(\w+.)?chaturbate.com/[^/?&]+")
-_playlist_url_re = re.compile("html \+= \"src='(?P<url>[^']+)'\";")
+_url_re = re.compile(r"http(s)?://(\w+.)?chaturbate.com/[^/?&]+")
+_playlist_url_re = re.compile(r"html \+= \"src='(?P<url>[^']+)'\";")
 _schema = validate.Schema(
     validate.transform(_playlist_url_re.search),
     validate.any(

--- a/src/streamlink/plugins/common_jwplayer.py
+++ b/src/streamlink/plugins/common_jwplayer.py
@@ -7,8 +7,8 @@ from streamlink.plugin.api.utils import parse_json
 
 __all__ = ["parse_playlist"]
 
-_playlist_re = re.compile("\(?\{.*playlist: (\[.*\]),.*?\}\)?;", re.DOTALL)
-_js_to_json = partial(re.compile("(\w+):\s").sub, r'"\1":')
+_playlist_re = re.compile(r"\(?\{.*playlist: (\[.*\]),.*?\}\)?;", re.DOTALL)
+_js_to_json = partial(re.compile(r"(\w+):\s").sub, r'"\1":')
 
 _playlist_schema = validate.Schema(
     validate.transform(_playlist_re.search),

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -41,7 +41,7 @@ def parse_timestamp(ts):
     )
 
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?crunchyroll\.
     (?:
         com|de|es|fr|co.jp

--- a/src/streamlink/plugins/cybergame.py
+++ b/src/streamlink/plugins/cybergame.py
@@ -8,7 +8,7 @@ from streamlink.stream import RTMPStream
 LIVE_STREAM_URL = "rtmp://stream1.cybergame.tv:2936/live/"
 PLAYLIST_URL = "http://api.cybergame.tv/p/playlist.smil"
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?cybergame.tv
     (?:
         /videos/(?P<video_id>\d+)

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -24,12 +24,12 @@ QUALITY_MAP = {
 }
 STREAM_INFO_URL = "http://www.dailymotion.com/sequence/full/{0}"
 
-_rtmp_re = re.compile("""
+_rtmp_re = re.compile(r"""
     (?P<host>rtmp://[^/]+)
     /(?P<app>[^/]+)
     /(?P<playpath>.+)
 """, re.VERBOSE)
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?
     dailymotion.com
     (/embed)?/(video|live)

--- a/src/streamlink/plugins/disney_de.py
+++ b/src/streamlink/plugins/disney_de.py
@@ -13,11 +13,11 @@ from streamlink.plugin.api import http
 from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?disney(channel)?.de/")
+_url_re = re.compile(r"http(s)?://(\w+\.)?disney(channel)?.de/")
 
 # stream urls are in `Grill.burger`->stack->data->externals->data
-_stream_hls_re = re.compile("\"hlsStreamUrl\":\s*(\"[^\"]+\")")
-_stream_data_re = re.compile("\"dataUrl\":\s*(\"[^\"]+\")")
+_stream_hls_re = re.compile(r"\"hlsStreamUrl\":\s*(\"[^\"]+\")")
+_stream_data_re = re.compile(r"\"dataUrl\":\s*(\"[^\"]+\")")
 
 
 class DisneyDE(Plugin):

--- a/src/streamlink/plugins/dmcloud.py
+++ b/src/streamlink/plugins/dmcloud.py
@@ -6,9 +6,9 @@ from streamlink.plugin.api import http, validate
 from streamlink.stream import RTMPStream, HTTPStream, HLSStream
 from streamlink.utils import parse_json, rtmpparse, swfdecompress
 
-_url_re = re.compile("http(s)?://api.dmcloud.net/player/embed/[^/]+/[^/]+")
-_rtmp_re = re.compile(b"customURL[^h]+(https://.*?)\\\\")
-_info_re = re.compile("var info = (.*);")
+_url_re = re.compile(r"http(s)?://api.dmcloud.net/player/embed/[^/]+/[^/]+")
+_rtmp_re = re.compile(br'customURL[^h]+(https://.*?)\\')
+_info_re = re.compile(r"var info = (.*);")
 _schema = validate.Schema(
     {
         "mode": validate.text,

--- a/src/streamlink/plugins/dmcloud_embed.py
+++ b/src/streamlink/plugins/dmcloud_embed.py
@@ -8,10 +8,10 @@ HEADERS = {
                    "Gecko/20100101 Firefox/25.0")
 }
 URLS = [
-    re.compile("http(s)?://(\w+\.)?action24.gr")
+    re.compile(r"http(s)?://(\w+\.)?action24.gr")
 ]
 
-_embed_re = re.compile("http(s)?://api.dmcloud.net/player/embed/[\w\?=&\/;\-]+")
+_embed_re = re.compile(r"http(s)?://api.dmcloud.net/player/embed/[\w\?=&\/;\-]+")
 
 
 class DMCloudEmbed(Plugin):

--- a/src/streamlink/plugins/dommune.py
+++ b/src/streamlink/plugins/dommune.py
@@ -7,7 +7,7 @@ from streamlink.plugin.api import http, validate
 
 DATA_URL = "http://www.dommune.com/freedommunezero2012/live/data/data.json"
 
-_url_re = re.compile("http(s)?://(\w+\.)?dommune.com")
+_url_re = re.compile(r"http(s)?://(\w+\.)?dommune.com")
 _data_schema = validate.Schema({
     "channel": validate.text,
     "channel2": validate.text

--- a/src/streamlink/plugins/douyutv.py
+++ b/src/streamlink/plugins/douyutv.py
@@ -21,7 +21,7 @@ STREAM_WEIGHTS = {
     "source": 1080
 }
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(www\.)?douyu.com
     /(?P<channel>[^/]+)
 """, re.VERBOSE)

--- a/src/streamlink/plugins/euronews.py
+++ b/src/streamlink/plugins/euronews.py
@@ -7,7 +7,7 @@ from streamlink.stream import HLSStream, HTTPStream
 
 
 class Euronews(Plugin):
-    _url_re = re.compile("http(?:s)?://(\w+)\.?euronews.com/(live|.*)")
+    _url_re = re.compile(r"http(?:s)?://(\w+)\.?euronews.com/(live|.*)")
     _re_vod = re.compile(r'<meta\s+property="og:video"\s+content="(http.*?)"\s*/>')
     _live_api_url = "http://fr.euronews.com/api/watchlive.json"
     _live_schema = validate.Schema({

--- a/src/streamlink/plugins/expressen.py
+++ b/src/streamlink/plugins/expressen.py
@@ -7,8 +7,8 @@ from streamlink.stream import HDSStream, HLSStream, RTMPStream
 
 STREAMS_INFO_URL = "http://www.expressen.se/Handlers/WebTvHandler.ashx?id={0}";
 
-_url_re = re.compile("http(s)?://(?:\w+.)?\.expressen\.se")
-_meta_xmlurl_id_re = re.compile('<meta.+xmlUrl=http%3a%2f%2fwww.expressen.se%2fHandlers%2fWebTvHandler.ashx%3fid%3d([0-9]*)" />')
+_url_re = re.compile(r"http(s)?://(?:\w+.)?\.expressen\.se")
+_meta_xmlurl_id_re = re.compile(r'<meta.+xmlUrl=http%3a%2f%2fwww.expressen.se%2fHandlers%2fWebTvHandler.ashx%3fid%3d([0-9]*)" />')
 
 
 class Expressen(Plugin):

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -20,9 +20,9 @@ QUALITY_WEIGHTS = {
 }
 STREAM_TYPES = ("hls", "rtmp")
 
-_url_re = re.compile("http(s)?://(\w+\.)?filmon.com/(channel|tv|vod)/")
-_channel_id_re = re.compile("/channels/(\d+)/extra_big_logo.png")
-_vod_id_re = re.compile("movie_id=(\d+)")
+_url_re = re.compile(r"http(s)?://(\w+\.)?filmon.com/(channel|tv|vod)/")
+_channel_id_re = re.compile(r"/channels/(\d+)/extra_big_logo.png")
+_vod_id_re = re.compile(r"movie_id=(\d+)")
 
 _channel_schema = validate.Schema({
     "streams": [{

--- a/src/streamlink/plugins/filmon_us.py
+++ b/src/streamlink/plugins/filmon_us.py
@@ -9,12 +9,12 @@ from streamlink.stream import RTMPStream, HTTPStream
 SWF_LIVE_URL = "https://www.filmon.com/tv/modules/FilmOnTV/files/flashapp/filmon/FilmonPlayer.swf"
 SWF_VIDEO_URL = "http://www.filmon.us/application/themes/base/flash/MediaPlayer.swf"
 
-_url_re = re.compile("http(s)?://(\w+\.)?filmon.us")
+_url_re = re.compile(r"http(s)?://(\w+\.)?filmon.us")
 _live_export_re = re.compile(
     "<iframe src=\"(https://www.filmon.com/channel/export[^\"]+)\""
 )
-_live_json_re = re.compile("var startupChannel = (.+);")
-_replay_json_re = re.compile("var standByVideo = encodeURIComponent\('(.+)'\);")
+_live_json_re = re.compile(r"var startupChannel = (.+);")
+_replay_json_re = re.compile(r"var standByVideo = encodeURIComponent\('(.+)'\);")
 _history_re = re.compile(
     "helpers.common.flash.flashplayerinstall\({url:'([^']+)',"
 )

--- a/src/streamlink/plugins/furstream.py
+++ b/src/streamlink/plugins/furstream.py
@@ -4,8 +4,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import RTMPStream
 
-_url_re = re.compile("^http(s)?://(\w+\.)?furstre\.am/stream/.+")
-_stream_url_re = re.compile("<source src=\"([^\"]+)\"")
+_url_re = re.compile(r"^http(s)?://(\w+\.)?furstre\.am/stream/.+")
+_stream_url_re = re.compile(r"<source src=\"([^\"]+)\"")
 _schema = validate.Schema(
     validate.transform(_stream_url_re.search),
     validate.any(

--- a/src/streamlink/plugins/gaminglive.py
+++ b/src/streamlink/plugins/gaminglive.py
@@ -18,11 +18,11 @@ QUALITY_WEIGHTS = {
     "low": 1
 }
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?gaminglive\.tv
     /(?P<type>channels|videos)/(?P<name>[^/]+)
 """, re.VERBOSE)
-_quality_re = re.compile("[^/]+-(?P<quality>[^/]+)")
+_quality_re = re.compile(r"[^/]+-(?P<quality>[^/]+)")
 
 _channel_schema = validate.Schema(
     {

--- a/src/streamlink/plugins/gomexp.py
+++ b/src/streamlink/plugins/gomexp.py
@@ -13,7 +13,7 @@ API_BASE = "http://gox.gomexp.com/cgi-bin"
 API_URL_APP = API_BASE + "/app_api.cgi"
 API_URL_LIVE = API_BASE + "/gox_live.cgi"
 
-_url_re = re.compile("http(s)?://(www\.)?gomexp.com")
+_url_re = re.compile(r"http(s)?://(www\.)?gomexp.com")
 
 _entries_schema = validate.Schema(
     validate.xml_findall("./ENTRY/*/[@reftype='live'][@href]"),

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -12,7 +12,7 @@ QUALITIES = {
     "240p": "_240"
 }
 
-_url_re = re.compile("https://(?:www\.)?goodgame.ru/channel/(?P<user>\w+)")
+_url_re = re.compile(r"https://(?:www\.)?goodgame.ru/channel/(?P<user>\w+)")
 _stream_re = re.compile(r'var src = "([^"]+)";')
 _ddos_re = re.compile(r'document.cookie="(__DDOS_[^;]+)')
 

--- a/src/streamlink/plugins/hitbox.py
+++ b/src/streamlink/plugins/hitbox.py
@@ -15,8 +15,8 @@ SWF_BASE = "http://edge.vie.hitbox.tv/static/player/flowplayer/"
 SWF_URL = SWF_BASE + "flowplayer.commercial-3.2.16.swf"
 VOD_BASE_URL = "http://www.hitbox.tv/"
 
-_quality_re = re.compile("(\d+p)$")
-_url_re = re.compile("""
+_quality_re = re.compile(r"(\d+p)$")
+_url_re = re.compile(r"""
     http(s)?://(www\.)?hitbox.tv
     /(?P<channel>[^/]+)
     (?:

--- a/src/streamlink/plugins/letontv.py
+++ b/src/streamlink/plugins/letontv.py
@@ -7,7 +7,7 @@ from streamlink.stream import RTMPStream
 PLAYER_URL = "http://leton.tv/player.php"
 SWF_URL = "http://files.leton.tv/jwplayer.flash.swf"
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http?://(\w+.)?leton.tv
     (?:
         /player\.php\?.*streampage=
@@ -17,8 +17,8 @@ _url_re = re.compile("""
     )?
     (?P<streampage>[^/?&]+)
 """, re.VERBOSE)
-_js_var_re = re.compile("var (?P<var>\w+)\s?=\s?'?(?P<value>[^;']+)'?;")
-_rtmp_re = re.compile("/(?P<app>[^/]+)/(?P<playpath>.+)")
+_js_var_re = re.compile(r"var (?P<var>\w+)\s?=\s?'?(?P<value>[^;']+)'?;")
+_rtmp_re = re.compile(r"/(?P<app>[^/]+)/(?P<playpath>.+)")
 
 
 def _parse_server_ip(values):

--- a/src/streamlink/plugins/livestation.py
+++ b/src/streamlink/plugins/livestation.py
@@ -7,9 +7,9 @@ from streamlink.stream import HLSStream
 LOGIN_PAGE_URL = "http://www.livestation.com/en/users/new"
 LOGIN_POST_URL = "http://www.livestation.com/en/sessions.json"
 
-_csrf_token_re = re.compile("<meta content=\"([^\"]+)\" name=\"csrf-token\"")
-_hls_playlist_re = re.compile("<meta content=\"([^\"]+.m3u8)\" property=\"og:video\" />")
-_url_re = re.compile("http(s)?://(\w+\.)?livestation.com")
+_csrf_token_re = re.compile(r"<meta content=\"([^\"]+)\" name=\"csrf-token\"")
+_hls_playlist_re = re.compile(r"<meta content=\"([^\"]+.m3u8)\" property=\"og:video\" />")
+_url_re = re.compile(r"http(s)?://(\w+\.)?livestation.com")
 
 _csrf_token_schema = validate.Schema(
     validate.transform(_csrf_token_re.search),

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -6,7 +6,7 @@ from streamlink.plugin.api import http, validate
 from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import AkamaiHDStream, HLSStream
 
-_url_re = re.compile("http(s)?://(www\.)?livestream.com/")
+_url_re = re.compile(r"http(s)?://(www\.)?livestream.com/")
 _stream_config_schema = validate.Schema({
     "event": {
         "stream_info": validate.any({

--- a/src/streamlink/plugins/media_ccc_de.py
+++ b/src/streamlink/plugins/media_ccc_de.py
@@ -29,12 +29,12 @@ API_URL_MEDIA           = "https://api.media.ccc.de"
 API_URL_STREAMING_MEDIA = "https://streaming.media.ccc.de/streams/v1.json"
 
 # http(s)://media.ccc.de/path/to/talk.html
-_url_media_re           = re.compile("(?P<scheme>http|https)"
+_url_media_re           = re.compile(r"(?P<scheme>http|https)"
                                      ":\/\/"
                                      "(?P<server>media\.ccc\.de)"
                                      "\/")
 # https://streaming.media.ccc.de/room/
-_url_streaming_media_re = re.compile("(?P<scheme>http|https)"
+_url_streaming_media_re = re.compile(r"(?P<scheme>http|https)"
                                      ":\/\/"
                                      "(?P<server>streaming\.media\.ccc\.de)"
                                      "\/"

--- a/src/streamlink/plugins/mips.py
+++ b/src/streamlink/plugins/mips.py
@@ -9,9 +9,9 @@ BALANCER_URL = "http://www.mips.tv:1935/loadbalancer"
 PLAYER_URL = "http://mips.tv/embedplayer/{0}/1/500/400"
 SWF_URL = "http://mips.tv/content/scripts/eplayer.swf"
 
-_url_re = re.compile("http(s)?://(\w+.)?mips.tv/(?P<channel>[^/&?]+)")
-_flashvars_re = re.compile("'FlashVars', '([^']+)'")
-_rtmp_re = re.compile("redirect=(.+)")
+_url_re = re.compile(r"http(s)?://(\w+.)?mips.tv/(?P<channel>[^/&?]+)")
+_flashvars_re = re.compile(r"'FlashVars', '([^']+)'")
+_rtmp_re = re.compile(r"redirect=(.+)")
 
 _schema = validate.Schema(
     validate.transform(_flashvars_re.search),

--- a/src/streamlink/plugins/mlgtv.py
+++ b/src/streamlink/plugins/mlgtv.py
@@ -14,7 +14,7 @@ STREAM_TYPES = {
 
 _stream_id_re = re.compile(r"<meta content='.+/([\w_-]+).+' property='og:video'>")
 _player_config_re = re.compile(r"var playerConfig = (.+);")
-_url_re = re.compile("http(s)?://(\w+\.)?(majorleaguegaming\.com|mlg\.tv)")
+_url_re = re.compile(r"http(s)?://(\w+\.)?(majorleaguegaming\.com|mlg\.tv)")
 
 _player_config_schema = validate.Schema(
     {

--- a/src/streamlink/plugins/nhkworld.py
+++ b/src/streamlink/plugins/nhkworld.py
@@ -8,7 +8,7 @@ from streamlink.stream import HLSStream
 
 API_URL = "http://{}.nhk.or.jp/nhkworld/app/tv/hlslive_web.xml"
 
-_url_re = re.compile("http(?:s)?://(?:(\w+)\.)?nhk.or.jp/nhkworld")
+_url_re = re.compile(r"http(?:s)?://(?:(\w+)\.)?nhk.or.jp/nhkworld")
 _schema = validate.Schema(
         validate.xml_findtext("./main_url/wstrm")
 )

--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -14,12 +14,12 @@ from streamlink.plugin.api import http
 from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HTTPStream, HLSStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?nos.nl/")
-_js_re = re.compile('\((.*)\)')
-_data_stream_re = re.compile('data-stream="(.*?)"', re.DOTALL | re.IGNORECASE)
-_source_re = re.compile("<source(?P<source>[^>]+)>", re.IGNORECASE)
-_source_src_re = re.compile("src=\"(?P<src>[^\"]+)\"", re.IGNORECASE)
-_source_type_re = re.compile("type=\"(?P<type>[^\"]+)\"", re.IGNORECASE)
+_url_re = re.compile(r"http(s)?://(\w+\.)?nos.nl/")
+_js_re = re.compile(r'\((.*)\)')
+_data_stream_re = re.compile(r'data-stream="(.*?)"', re.DOTALL | re.IGNORECASE)
+_source_re = re.compile(r"<source(?P<source>[^>]+)>", re.IGNORECASE)
+_source_src_re = re.compile(r"src=\"(?P<src>[^\"]+)\"", re.IGNORECASE)
+_source_type_re = re.compile(r"type=\"(?P<type>[^\"]+)\"", re.IGNORECASE)
 
 
 class NOS(Plugin):

--- a/src/streamlink/plugins/npo.py
+++ b/src/streamlink/plugins/npo.py
@@ -13,7 +13,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
 from streamlink.stream import HTTPStream, HLSStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?npo.nl/")
+_url_re = re.compile(r"http(s)?://(\w+\.)?npo.nl/")
 HTTP_HEADERS = {
     "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1944.9 Safari/537.36"
 }
@@ -26,7 +26,7 @@ class NPO(Plugin):
     def get_token(self):
         url = 'http://ida.omroep.nl/npoplayer/i.js?s={}'.format(quote(self.url))
         token = http.get(url, headers=HTTP_HEADERS).text
-        token = re.compile('token.*?"(.*?)"', re.DOTALL + re.IGNORECASE).search(token).group(1)
+        token = re.compile(r'token.*?"(.*?)"', re.DOTALL + re.IGNORECASE).search(token).group(1)
 
         # Great the have a ['en','ok','t'].reverse() decurity option in npoplayer.js
         secured = list(token)
@@ -53,9 +53,9 @@ class NPO(Plugin):
 
     def _get_meta(self):
         html = http.get('http://www.npo.nl/live/{}'.format(self.npo_id), headers=HTTP_HEADERS).text
-        program_id = re.compile('data-prid="(.*?)"', re.DOTALL + re.IGNORECASE).search(html).group(1)
+        program_id = re.compile(r'data-prid="(.*?)"', re.DOTALL + re.IGNORECASE).search(html).group(1)
         meta = http.get('http://e.omroep.nl/metadata/{}'.format(program_id), headers=HTTP_HEADERS).text
-        meta = re.compile('({.*})', re.DOTALL + re.IGNORECASE).search(meta).group(1)
+        meta = re.compile(r'({.*})', re.DOTALL + re.IGNORECASE).search(meta).group(1)
         return json.loads(meta)
 
     def _get_vod_streams(self):
@@ -77,7 +77,7 @@ class NPO(Plugin):
         url = 'http://ida.omroep.nl/aapi/?type=jsonp&stream={}&token={}'.format(stream, self.get_token())
         streamdata = http.get(url, headers=HTTP_HEADERS).json()
         deeplink = http.get(streamdata['stream'], headers=HTTP_HEADERS).text
-        deeplink = re.compile('"(.*?)"', re.DOTALL + re.IGNORECASE).search(deeplink).group(1)
+        deeplink = re.compile(r'"(.*?)"', re.DOTALL + re.IGNORECASE).search(deeplink).group(1)
         playlist_url = deeplink.replace("\\/", "/")
         return HLSStream.parse_variant_playlist(self.session, playlist_url)
 

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -11,9 +11,9 @@ COOKIE_PARAMS = (
     "preferred-player-live=hlslink"
 )
 
-_id_re = re.compile("/(?:program|direkte|serie/[^/]+)/([^/]+)")
-_url_re = re.compile("https?://(tv|radio).nrk.no/")
-_api_baseurl_re = re.compile('apiBaseUrl:\s*"(?P<baseurl>[^"]+)"')
+_id_re = re.compile(r"/(?:program|direkte|serie/[^/]+)/([^/]+)")
+_url_re = re.compile(r"https?://(tv|radio).nrk.no/")
+_api_baseurl_re = re.compile(r'apiBaseUrl:\s*"(?P<baseurl>[^"]+)"')
 
 _schema = validate.Schema(
     validate.transform(_api_baseurl_re.search),

--- a/src/streamlink/plugins/oldlivestream.py
+++ b/src/streamlink/plugins/oldlivestream.py
@@ -5,7 +5,7 @@ from streamlink.stream import HLSStream
 
 PLAYLIST_URL = "http://x{0}x.api.channel.livestream.com/3.0/playlist.m3u8"
 
-_url_re = re.compile("http(s)?://original.livestream.com/(?P<channel>[^&?/]+)")
+_url_re = re.compile(r"http(s)?://original.livestream.com/(?P<channel>[^&?/]+)")
 
 
 class OldLivestream(Plugin):

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -4,8 +4,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HLSStream
 
-_url_re = re.compile("http(s)?://(www\.)?openrec.tv/(live|movie)/[^/?&]+")
-_playlist_url_re = re.compile("data-file=\"(?P<url>[^\"]+)\"")
+_url_re = re.compile(r"http(s)?://(www\.)?openrec.tv/(live|movie)/[^/?&]+")
+_playlist_url_re = re.compile(r"data-file=\"(?P<url>[^\"]+)\"")
 _schema = validate.Schema(
     validate.transform(_playlist_url_re.search),
     validate.any(

--- a/src/streamlink/plugins/pandatv.py
+++ b/src/streamlink/plugins/pandatv.py
@@ -12,7 +12,7 @@ HD_URL_PATTERN = "http://pl{0}.live.panda.tv/live_panda/{1}_mid.flv"
 # I don't know ordinary-definition url pattern, sorry for ignore it.
 OD_URL_PATTERN = "http://pl{0}.live.panda.tv/live_panda/{1}_mid.flv"
 
-_url_re = re.compile("http(s)?://(\w+.)?panda.tv/(?P<channel>[^/&?]+)")
+_url_re = re.compile(r"http(s)?://(\w+.)?panda.tv/(?P<channel>[^/&?]+)")
 
 _room_schema = validate.Schema(
         {

--- a/src/streamlink/plugins/piczel.py
+++ b/src/streamlink/plugins/piczel.py
@@ -8,7 +8,7 @@ STREAMS_URL = "https://piczel.tv:3000/streams/{0}?&page=1&sfw=false&live_only=tr
 HLS_URL = "https://5810b93fdf674.streamlock.net:1936/live/{0}/playlist.m3u8"
 RTMP_URL = "rtmp://piczel.tv:1935/live/{0}"
 
-_url_re = re.compile("https://piczel.tv/watch/(\w+)")
+_url_re = re.compile(r"https://piczel.tv/watch/(\w+)")
 
 _streams_schema = validate.Schema(
 	{

--- a/src/streamlink/plugins/rtlxl.py
+++ b/src/streamlink/plugins/rtlxl.py
@@ -4,7 +4,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HDSStream, HLSStream, RTMPStream
 
-_url_re = re.compile("""http(?:s)?://(?:\w+\.)?rtlxl.nl/#!/(?:.*)/(?P<uuid>.*?)\Z""", re.IGNORECASE)
+_url_re = re.compile(r"""http(?:s)?://(?:\w+\.)?rtlxl.nl/#!/(?:.*)/(?P<uuid>.*?)\Z""", re.IGNORECASE)
 
 class rtlxl(Plugin):
     @classmethod
@@ -16,7 +16,7 @@ class rtlxl(Plugin):
         uuid = match.group("uuid")
         html = http.get('http://www.rtl.nl/system/s4m/vfd/version=2/uuid={}/d=pc/fmt=adaptive/'.format(uuid)).text
 
-        playlist_url = "http://manifest.us.rtl.nl" + re.compile('videopath":"(?P<playlist_url>.*?)",', re.IGNORECASE).search(html).group("playlist_url")
+        playlist_url = "http://manifest.us.rtl.nl" + re.compile(r'videopath":"(?P<playlist_url>.*?)",', re.IGNORECASE).search(html).group("playlist_url")
         return HLSStream.parse_variant_playlist(self.session, playlist_url)
 
 __plugin__ = rtlxl

--- a/src/streamlink/plugins/seemeplay.py
+++ b/src/streamlink/plugins/seemeplay.py
@@ -5,8 +5,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HLSStream, HTTPStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?seemeplay.ru/")
-_player_re = re.compile("""
+_url_re = re.compile(r"http(s)?://(\w+\.)?seemeplay.ru/")
+_player_re = re.compile(r"""
     SMP.(channel|video).player.init\({
     \s+file:\s+"([^"]+)"
 """, re.VERBOSE)

--- a/src/streamlink/plugins/speedrunslive.py
+++ b/src/streamlink/plugins/speedrunslive.py
@@ -4,7 +4,7 @@ from streamlink.plugin import Plugin
 
 TWITCH_URL_FORMAT = "http://www.twitch.tv/{0}"
 
-_url_re = re.compile("http://(?:www\.)?speedrunslive.com/#!/(?P<user>\w+)")
+_url_re = re.compile(r"http://(?:www\.)?speedrunslive.com/#!/(?P<user>\w+)")
 
 
 class SpeedRunsLive(Plugin):

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -5,8 +5,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
 from streamlink.stream import HDSStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?sportschau.de/")
-_player_js = re.compile("https?://deviceids-medp.wdr.de/ondemand/.*\.js")
+_url_re = re.compile(r"http(s)?://(\w+\.)?sportschau.de/")
+_player_js = re.compile(r"https?://deviceids-medp.wdr.de/ondemand/.*\.js")
 
 class sportschau(Plugin):
     @classmethod

--- a/src/streamlink/plugins/ssh101.py
+++ b/src/streamlink/plugins/ssh101.py
@@ -5,9 +5,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HLSStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?ssh101\.com/")
+_url_re = re.compile(r"http(s)?://(\w+\.)?ssh101\.com/")
 
-_live_re = re.compile("""
+_live_re = re.compile(r"""
 \s*jwplayer\(\"player\"\)\.setup\({.*?
 \s*primary:\s+"([^"]+)".*?
 \s*file:\s+"([^"]+)"

--- a/src/streamlink/plugins/streamboat.py
+++ b/src/streamlink/plugins/streamboat.py
@@ -4,7 +4,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
 from streamlink.stream import HLSStream
 
-_RE_URL = re.compile('^https?://streamboat.tv/.+')
+_RE_URL = re.compile(r'^https?://streamboat.tv/.+')
 _RE_CDN = re.compile(r'"cdn_host"\s*:\s*"([^"]+)"')
 _RE_PLAYLIST = re.compile(r'"playlist_url"\s*:\s*"([^"]+)"')
 

--- a/src/streamlink/plugins/streamingvideoprovider.py
+++ b/src/streamlink/plugins/streamingvideoprovider.py
@@ -12,7 +12,7 @@ API_URL = "http://player.webvideocore.net/index.php"
 _url_re = re.compile(
     "http(s)?://(\w+\.)?streamingvideoprovider.co.uk/(?P<channel>[^/&?]+)"
 )
-_hls_re = re.compile("'(http://.+\.m3u8)'")
+_hls_re = re.compile(r"'(http://.+\.m3u8)'")
 
 _rtmp_schema = validate.Schema(
     validate.xml_findtext("./info/url"),

--- a/src/streamlink/plugins/streamlive.py
+++ b/src/streamlink/plugins/streamlive.py
@@ -7,8 +7,8 @@ from streamlink.stream import HLSStream, RTMPStream
 
 CHANNEL_URL = "http://www.mobileonline.tv/channel.php"
 
-_url_re = re.compile("http(s)?://(\w+\.)?(ilive.to|streamlive.to)/.*/(?P<channel>\d+)")
-_link_re = re.compile("<a href=(\S+) target=\"_blank\"")
+_url_re = re.compile(r"http(s)?://(\w+\.)?(ilive.to|streamlive.to)/.*/(?P<channel>\d+)")
+_link_re = re.compile(r"<a href=(\S+) target=\"_blank\"")
 _schema = validate.Schema(
     validate.transform(_link_re.findall),
 )

--- a/src/streamlink/plugins/streamupcom.py
+++ b/src/streamlink/plugins/streamupcom.py
@@ -5,8 +5,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import RTMPStream, HLSStream
 
-_url_re = re.compile("http(s)?://(\w+\.)?streamup.com/(?P<channel>[^/?]+)")
-_hls_manifest_re = re.compile('HlsManifestUrl:\\s*"//"\\s*\\+\\s*response\\s*\\+\\s*"(.+)"')
+_url_re = re.compile(r'http(s)?://(\w+\.)?streamup.com/(?P<channel>[^/?]+)')
+_hls_manifest_re = re.compile(r'HlsManifestUrl:\s*"//"\s*\+\s*response\s*\+\s*"(.+)"')
 
 class StreamupCom(Plugin):
     @classmethod

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -6,7 +6,7 @@ from streamlink.stream import HLSStream, HDSStream
 
 API_URL = "http://www.svt.se/videoplayer-api/video/{0}"
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://
     (www\.)?
     (?:

--- a/src/streamlink/plugins/tga.py
+++ b/src/streamlink/plugins/tga.py
@@ -11,8 +11,8 @@ CHANNEL_INFO_URL = "http://api.plu.cn/tga/streams/%s"
 QQ_STREAM_INFO_URL = "http://info.zb.qq.com/?cnlid=%d&cmd=2&stream=%d&system=1&sdtfrom=113"
 PLU_STREAM_INFO_URL = "http://star.api.plu.cn/live/GetLiveUrl?roomId=%d"
 
-_quality_re = re.compile("\d+x(\d+)$")
-_url_re = re.compile("http://star\.longzhu\.(?:tv|com)/(m\/)?(?P<domain>[a-z0-9]+)")
+_quality_re = re.compile(r"\d+x(\d+)$")
+_url_re = re.compile(r"http://star\.longzhu\.(?:tv|com)/(m\/)?(?P<domain>[a-z0-9]+)")
 
 _channel_schema = validate.Schema(
     {

--- a/src/streamlink/plugins/tigerdile.py
+++ b/src/streamlink/plugins/tigerdile.py
@@ -8,7 +8,7 @@ PAGE_URL = "https://www.tigerdile.com/stream/"
 ROOT_URL = "rtmp://stream.tigerdile.com/live/{}"
 STREAM_TYPES=["rtmp"]
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     https?://(?:www|sfw)\.tigerdile\.com
     \/stream\/(.*)\/""", re.VERBOSE)
 

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -10,7 +10,7 @@ from streamlink.stream import HDSStream, RTMPStream
 ASSET_URL = "http://prima.tv4play.se/api/web/asset/{0}/play"
 SWF_URL = "http://www.tv4play.se/flash/tv4video.swf"
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(www\.)?
     (?:
         tv4play.se/program/[^\?/]+|

--- a/src/streamlink/plugins/tvcatchup.py
+++ b/src/streamlink/plugins/tvcatchup.py
@@ -5,7 +5,7 @@ from streamlink.plugin.api import http
 from streamlink.stream import HLSStream
 
 USER_AGENT = "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
-_url_re = re.compile("http://(?:www\.)?tvcatchup.com/watch/\w+")
+_url_re = re.compile(r"http://(?:www\.)?tvcatchup.com/watch/\w+")
 _stream_re = re.compile(r'''(?P<q>["'])(?P<stream_url>https?://.*m3u8\?.*clientKey=.*?)(?P=q)''')
 
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -54,7 +54,7 @@ _url_re = re.compile(r"""
         (?P<clip_name>[\w]+)
     )?
 """, re.VERBOSE)
-_time_re = re.compile("""
+_time_re = re.compile(r"""
     (?:
         (?P<hours>\d+)h
     )?

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     HAS_LIBRTMP = False
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(www\.)?ustream.tv
     (?:
         (/embed/|/channel/id/)(?P<channel_id>\d+)
@@ -30,7 +30,7 @@ _url_re = re.compile("""
         /recorded/(?P<video_id>\d+)
     )?
 """, re.VERBOSE)
-_channel_id_re = re.compile("\"channelId\":(\d+)")
+_channel_id_re = re.compile(r"\"channelId\":(\d+)")
 
 HLS_PLAYLIST_URL = (
     "http://iphone-streaming.ustream.tv"

--- a/src/streamlink/plugins/vaughnlive.py
+++ b/src/streamlink/plugins/vaughnlive.py
@@ -14,14 +14,14 @@ DOMAIN_MAP = {
     "vaughnlive": "live",
 }
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?
     (?P<domain>vaughnlive|breakers|instagib|vapers).tv
     (/embed/video)?
     /(?P<channel>[^/&?]+)
 """, re.VERBOSE)
 
-_swf_player_re = re.compile('swfobject.embedSWF\("(/\d+/swf/[0-9A-Za-z]+\.swf)"')
+_swf_player_re = re.compile(r'swfobject.embedSWF\("(/\d+/swf/[0-9A-Za-z]+\.swf)"')
 
 _schema = validate.Schema(
     validate.transform(lambda s: s.split(";")),

--- a/src/streamlink/plugins/veetle.py
+++ b/src/streamlink/plugins/veetle.py
@@ -7,7 +7,7 @@ from streamlink.stream import FLVPlaylist, HTTPStream
 
 API_URL = "http://veetle.com/index.php/stream/ajaxStreamLocation/{0}/flash"
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?veetle.com
     (:?
         /.*(v|view)/

--- a/src/streamlink/plugins/vgtv.py
+++ b/src/streamlink/plugins/vgtv.py
@@ -27,8 +27,8 @@ STREAM_FORMATS = ("mp4")
 
 INFO_URL = "http://www.vgtv.no/data/actions/videostatus/"
 
-_url_re = re.compile("https?://(www\.)?(vgtv|vg).no")
-_content_id_re = re.compile("(?:data-videoid=\"|videostatus/\?id=)(\d+)")
+_url_re = re.compile(r"https?://(www\.)?(vgtv|vg).no")
+_content_id_re = re.compile(r"(?:data-videoid=\"|videostatus/\?id=)(\d+)")
 _url_id_re = re.compile((
     "https?://(?:www\.)?vgtv.no/"
     "(?:(?:#!/)?video/|(?:#!|\?)id=)(\d+)"

--- a/src/streamlink/plugins/viagame.py
+++ b/src/streamlink/plugins/viagame.py
@@ -11,8 +11,8 @@ STREAM_API_URL = "http://playapi.mtgx.tv/v3/videos/stream/{0}"
 _embed_url_re = re.compile(
     '<meta itemprop="embedURL" content="http://www.viagame.com/embed/video/([^"]+)"'
 )
-_store_data_re = re.compile("window.fluxData\s*=\s*JSON.parse\(\"(.+)\"\);")
-_url_re = re.compile("http(s)?://(www\.)?viagame.com/channels/.+")
+_store_data_re = re.compile(r"window.fluxData\s*=\s*JSON.parse\(\"(.+)\"\);")
+_url_re = re.compile(r"http(s)?://(www\.)?viagame.com/channels/.+")
 
 _store_schema = validate.Schema(
     {

--- a/src/streamlink/plugins/viasat.py
+++ b/src/streamlink/plugins/viasat.py
@@ -10,10 +10,10 @@ from streamlink.utils import rtmpparse
 
 STREAM_API_URL = "http://playapi.mtgx.tv/v3/videos/stream/{0}"
 
-_swf_url_re = re.compile("data-flashplayer-url=\"([^\"]+)\"")
-_player_data_re = re.compile("window.fluxData\s*=\s*JSON.parse\(\"(.+)\"\);")
+_swf_url_re = re.compile(r"data-flashplayer-url=\"([^\"]+)\"")
+_player_data_re = re.compile(r"window.fluxData\s*=\s*JSON.parse\(\"(.+)\"\);")
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(www\.)?
     (?:
         tv(3|6|8|10)play |

--- a/src/streamlink/plugins/viasat_embed.py
+++ b/src/streamlink/plugins/viasat_embed.py
@@ -4,8 +4,8 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
 
 
-_url_re = re.compile("http(s)?://(www\.)?tv(3|6|8|10)\.se")
-_embed_re = re.compile('<iframe class="iframe-player" src="([^"]+)">')
+_url_re = re.compile(r"http(s)?://(www\.)?tv(3|6|8|10)\.se")
+_embed_re = re.compile(r'<iframe class="iframe-player" src="([^"]+)">')
 
 
 class ViasatEmbed(Plugin):

--- a/src/streamlink/plugins/wattv.py
+++ b/src/streamlink/plugins/wattv.py
@@ -9,8 +9,8 @@ from streamlink.stream import HDSStream
 # (tv/wat/player/media/Media.as)
 TOKEN_SECRET = '9b673b13fa4682ed14c3cfa5af5310274b514c4133e9b3a81e6e3aba009l2564'
 
-_url_re = re.compile("http(s)?://(\w+\.)?wat.tv/")
-_video_id_re = re.compile("href=\"http://m.wat.tv/video/([^\"]+)", re.IGNORECASE)
+_url_re = re.compile(r"http(s)?://(\w+\.)?wat.tv/")
+_video_id_re = re.compile(r"href=\"http://m.wat.tv/video/([^\"]+)", re.IGNORECASE)
 
 
 class WAT(Plugin):

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -9,7 +9,7 @@ from streamlink.utils import parse_json
 
 
 class WebTV(Plugin):
-    _url_re = re.compile("http(?:s)?://(\w+)\.web.tv/?")
+    _url_re = re.compile(r"http(?:s)?://(\w+)\.web.tv/?")
     _sources_re = re.compile(r'"sources": (\[.*?\]),', re.DOTALL)
     _sources_schema = validate.Schema([
         {

--- a/src/streamlink/plugins/weeb.py
+++ b/src/streamlink/plugins/weeb.py
@@ -27,7 +27,7 @@ BLOCKED_MSG_FORMAT = (
 BLOCK_TYPE_VIEWING_LIMIT = 1
 BLOCK_TYPE_NO_SLOTS = 11
 
-_url_re = re.compile("http(s)?://(\w+\.)?weeb.tv/(channel|online)/(?P<channel>[^/&?]+)")
+_url_re = re.compile(r"http(s)?://(\w+\.)?weeb.tv/(channel|online)/(?P<channel>[^/&?]+)")
 _schema = validate.Schema(
     dict,
     validate.map(lambda k, v: (PARAMS_KEY_MAP.get(k, k), v)),

--- a/src/streamlink/plugins/younow.py
+++ b/src/streamlink/plugins/younow.py
@@ -9,7 +9,7 @@ from streamlink.stream import RTMPStream
 jsonapi= "https://api.younow.com/php/api/broadcast/info/curId=0/user="
 
 # http://younow.com/channel/
-_url_re = re.compile("http(s)?://(\w+.)?younow.com/(?P<channel>[^/&?]+)")
+_url_re = re.compile(r"http(s)?://(\w+.)?younow.com/(?P<channel>[^/&?]+)")
 
 def getStreamURL(channel):
     url = jsonapi + channel

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -90,9 +90,9 @@ _search_schema = validate.Schema(
     validate.get("items")
 )
 
-_channelid_re = re.compile('meta itemprop="channelId" content="([^"]+)"')
-_livechannelid_re = re.compile('meta property="og:video:url" content="([^"]+)')
-_url_re = re.compile("""
+_channelid_re = re.compile(r'meta itemprop="channelId" content="([^"]+)"')
+_livechannelid_re = re.compile(r'meta property="og:video:url" content="([^"]+)')
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?youtube.com
     (?:
         (?:

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -24,7 +24,7 @@ STREAMING_TYPES = {
     )
 }
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(\w+\.)?zdf.de/
 """, re.VERBOSE | re.IGNORECASE)
 


### PR DESCRIPTION
Support for non-standard escape characters has been deprecated in Python 3.6 so all the regex string that contained regex style escape sequences (eg. `\w`) have to be raw strings. 