### PR TITLE
Links on crunchy's rss no longer contain the show name in the url

### DIFF
--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -46,7 +46,7 @@ _url_re = re.compile(r"""
     (?:
         com|de|es|fr|co.jp
     )
-    /[^/&?]+
+    (?:/[^/&?]+)?
     /[^/&?]+-(?P<media_id>\d+)
 """, re.VERBOSE)
 

--- a/tests/test_plugin_crunchyroll.py
+++ b/tests/test_plugin_crunchyroll.py
@@ -1,0 +1,17 @@
+import unittest
+
+from streamlink.plugins.crunchyroll import Crunchyroll
+
+
+class TestPluginCrunchyroll(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/idol-incidents/episode-1-why-become-a-dietwoman-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/idol-incidents/media-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/media-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.fr/media-728233"))
+
+        # shouldn't match
+        self.assertFalse(Crunchyroll.can_handle_url("http://www.crunchyroll.com/gintama"))
+        self.assertFalse(Crunchyroll.can_handle_url("http://www.crunchyroll.es/gintama"))
+        self.assertFalse(Crunchyroll.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
I don't know since when, but rss links on crunchy no longer contain the show name slug on the url, so the current regex fails to match against those links.
I didn't remove the group since some people get the link directly from the page, which still use the previous format.