### PR TITLE
plugins.tf1: added plugin to support tf1.fr and lci.fr

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -117,6 +117,8 @@ streamupcom         streamup.com         Yes   --
 svtplay             - svtplay.se         Yes   Yes   Streams may be geo-restricted to Sweden.
                     - svtflow.se
                     - oppetarkiv.se
+tf1                 - tf1.fr             Yes   No    Streams may be geo-restricted to France.
+                    - lci.fr
 tga                 - star.plu.cn        Yes   No
                     - star.tga.plu.cn
 tigerdile           tigerdile.com        Yes   --

--- a/src/streamlink/plugin/api/useragents.py
+++ b/src/streamlink/plugin/api/useragents.py
@@ -1,0 +1,22 @@
+ANDROID = ("Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) "
+           "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36")
+CHROME_OS = ("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) "
+             "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36")
+IE_11 = "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
+IE_6 = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; WOW64; Trident/4.0; SLCC1)"
+IE_7 = "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; WOW64; Trident/4.0; SLCC1)"
+IE_8 = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; WOW64; Trident/4.0; SLCC1)"
+IE_9 = "Mozilla/5.0 (MSIE 9.0; Windows NT 6.1; Trident/5.0)"
+IPHONE_6 = ("Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) "
+            "AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25")
+IPAD = ("Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) "
+        "AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25")
+WINDOWS_PHONE_8 = ("Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; "
+                   "Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)")
+SAFARI_8 = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) "
+            "AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12")
+SAFARI_7 = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) "
+            "AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A")
+FIREFOX = "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:33.0) Gecko/20120101 Firefox/33.0"
+FIREFOX_MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0"
+OPERA = "Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14"

--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -1,0 +1,60 @@
+from __future__ import print_function
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http, useragents
+from streamlink.stream import HDSStream
+from streamlink.stream import HLSStream
+
+
+class TF1(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/(\w+)/direct|(lci).fr/direct)/?")
+    embed_url = "http://www.wat.tv/embedframe/live{0}"
+    embed_re = re.compile(r"urlLive.*?:.*?\"(http.*?)\"", re.MULTILINE)
+    api_url = "http://www.wat.tv/get/androidlive{0}/591997"
+    swf_url = "http://www.wat.tv/images/v70/PlayerWat.swf?rev=04.00.861"
+    hds_channel_remap = {"tf1": "connect"}
+    hls_channel_remap = {"lci": "LCI", "tf1": "V4"}
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_hds_streams(self, channel):
+        channel = self.hds_channel_remap.get(channel, channel)
+        manifest_url = http.get(self.api_url.format(channel),
+                                params={"getURL": 1}).text
+
+        for s in HDSStream.parse_manifest(self.session,
+                                          manifest_url,
+                                          pvswf=self.swf_url).items():
+            yield s
+
+    def _get_hls_streams(self, channel):
+        channel = self.hls_channel_remap.get(channel, channel)
+        embed_url = self.embed_url.format(channel)
+        self.logger.debug("Found embed URL: {0}", embed_url)
+        # page needs to have a mobile user agent
+        embed_page = http.get(embed_url, headers={"User-Agent": useragents.ANDROID})
+
+        m = self.embed_re.search(embed_page.text)
+        if m:
+            hls_stream_url = m.group(1)
+
+            for s in HLSStream.parse_variant_playlist(self.session, hls_stream_url).items():
+                yield s
+
+    def _get_streams(self):
+        m = self.url_re.match(self.url)
+        if m:
+            channel = m.group(1) or m.group(2)
+            self.logger.debug("Found channel {0}", channel)
+            for s in self._get_hds_streams(channel):
+                yield s
+
+            for s in self._get_hls_streams(channel):
+                yield s
+
+
+
+__plugin__ = TF1

--- a/tests/test_plugin_tf1.py
+++ b/tests/test_plugin_tf1.py
@@ -1,0 +1,18 @@
+import unittest
+
+from streamlink.plugins.tf1 import TF1
+
+
+class TestPluginTF1(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(TF1.can_handle_url("http://tf1.fr/tf1/direct/"))
+        self.assertTrue(TF1.can_handle_url("http://lci.fr/direct"))
+        self.assertTrue(TF1.can_handle_url("http://www.lci.fr/direct"))
+        self.assertTrue(TF1.can_handle_url("http://tf1.fr/tmc/direct"))
+
+        # shouldn't match
+        self.assertFalse(TF1.can_handle_url("http://tf1.fr/direct"))
+        self.assertFalse(TF1.can_handle_url("http://www.tf1.fr/direct"))
+        self.assertFalse(TF1.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(TF1.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
As requested in #376. 

Example URLs:
- tf1.fr/ft1/direct
- tf1.fr/nt1/direct
- tf1.fr/tmc/direct
- tf1.fr/lci/direct
- lci.fr/direct