### PR TITLE
plugins.raiplay: added plugin to support raiplay.it

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -100,7 +100,8 @@ periscope           periscope.tv         Yes   Yes   Replay/VOD is supported.
 picarto             picarto.tv           Yes   --
 pluzz               pluzz.francetv.fr    Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
 powerapp            powerapp.com.tr      Yes   No
-rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restriced to The Netherlands. Livestreams not supported.
+raiplay             raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
+rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.
 rtve                rtve.es              Yes   No
 ruv                 ruv.is               Yes   Yes   Streams may be geo-restricted to Iceland.
 seemeplay           seemeplay.ru         Yes   Yes

--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+
+
+class RaiPlay(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?raiplay\.it/dirette/(\w+)/?")
+    stream_re = re.compile(r"data-video-url.*?=.*?\"([^\"]+)\"")
+    stream_schema = validate.Schema(
+        validate.all(
+            validate.transform(stream_re.search),
+            validate.any(
+                None,
+                validate.all(validate.get(1), validate.url())
+            )
+        )
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        channel = self.url_re.match(self.url).group(1)
+        self.logger.debug("Found channel: {0}", channel)
+        stream_url = http.get(self.url, schema=self.stream_schema)
+        if stream_url:
+            return HLSStream.parse_variant_playlist(self.session, stream_url)
+
+
+__plugin__ = RaiPlay

--- a/tests/test_plugin_raiplay.py
+++ b/tests/test_plugin_raiplay.py
@@ -1,0 +1,20 @@
+import unittest
+
+from streamlink.plugins.raiplay import RaiPlay
+
+
+class TestPluginRaiPlay(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rai1"))
+        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rai2"))
+        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rai3"))
+        self.assertTrue(RaiPlay.can_handle_url("http://raiplay.it/dirette/rai3"))
+        self.assertTrue(RaiPlay.can_handle_url("https://raiplay.it/dirette/rai3"))
+        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rainews24"))
+        self.assertTrue(RaiPlay.can_handle_url("https://www.raiplay.it/dirette/rainews24"))
+
+        # shouldn't match
+        self.assertFalse(RaiPlay.can_handle_url("http://www.adultswim.com/videos/streams/toonami"))
+        self.assertFalse(RaiPlay.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(RaiPlay.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
As requested in #375.

Example URLs:
- raiplay.it/dirette/rai1
- raiplay.it/dirette/rai3
- raiplay.it/dirette/rainews24
- raiplay.it/dirette/raisport1