### PR TITLE
plugins.stream: fix a default scheme handling for urls

### DIFF
--- a/src/streamlink/plugins/stream.py
+++ b/src/streamlink/plugins/stream.py
@@ -20,6 +20,7 @@ PROTOCOL_MAP = {
     "rtmpte": RTMPStream
 }
 PARAMS_REGEX = r"(\w+)=({.+?}|\[.+?\]|\(.+?\)|'(?:[^'\\]|\\')*'|\"(?:[^\"\\]|\\\")*\"|\S+)"
+SCHEME_REGEX = re.compile(r"^\w+://(.+)")
 
 class StreamURL(Plugin):
     @classmethod
@@ -51,10 +52,10 @@ class StreamURL(Plugin):
 
         split = self.url.split(" ")
         url = split[0]
-        urlnoproto = re.match("^\w+://(.+)", url).group(1)
+        urlnoproto = SCHEME_REGEX.match(url).group(1)
 
         # Prepend http:// if needed.
-        if cls != RTMPStream and not len(urlparse(urlnoproto).scheme):
+        if cls != RTMPStream and not SCHEME_REGEX.match(urlnoproto):
             urlnoproto = "http://{0}".format(urlnoproto)
 
         params = (" ").join(split[1:])


### PR DESCRIPTION
Due to a bug introduced in 707df4f27bf144f4e33dc76ffafbcf2fac2519b8 URLs with scheme (eg. no http) but with a port number would not get http:// appended by default, as urlparse parses anything before the colon as the scheme.