### PR TITLE
Add support for a Bulgarian sports channel

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -108,6 +108,7 @@ ruv                 ruv.is               Yes   Yes   Streams may be geo-restrict
 seemeplay           seemeplay.ru         Yes   Yes
 servustv            servustv.com         ?     ?
 speedrunslive       speedrunslive.com    Yes   --    URL forwarder to Twitch channels.
+sportal             sportal.bg           Yes   No
 sportschau          sportschau.de        Yes   No
 ssh101              ssh101.com           Yes   No
 streamboat          streamboat.tv        Yes   No

--- a/src/streamlink/plugins/sportal.py
+++ b/src/streamlink/plugins/sportal.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import RTMPStream
+from streamlink.plugins.common_jwplayer import _js_to_json
+from streamlink.utils import parse_json
+
+
+class Sportal(Plugin):
+    swf_url = "http://img2.sportal.bg/images/svp/videoplayer.swf"
+    url_re = re.compile(r"https?://(?:www\.)?sportal\.bg/sportal_live_tv.php.*")
+    _playlist_re = re.compile(r"\(\{.*playlist: (\[.*\]),.*?\}\);", re.DOTALL)
+    _playlist_schema = validate.Schema(
+        validate.transform(_playlist_re.search),
+        validate.any(
+            None,
+            validate.all(
+                validate.get(1),
+                validate.transform(_js_to_json),
+                validate.transform(parse_json),
+                [{
+                    "streamer": validate.url(scheme="rtmp"),
+                    "levels": [
+                        {"bitrate": int, "file": validate.text}
+                    ]
+                }],
+                validate.get(0)
+            )
+        )
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+
+        playlist = self._playlist_schema.validate(res.text)
+        if playlist:
+            for level in playlist["levels"]:
+                q = "{0}k".format(level["bitrate"])
+                s = RTMPStream(self.session,
+                               redirect=True,
+                               params={"rtmp": playlist["streamer"],
+                                       "playpath": level["file"],
+                                       "pageUrl": self.url,
+                                       "z": True,
+                                       "swfUrl": self.swf_url})
+                yield q, s
+
+
+__plugin__ = Sportal

--- a/src/streamlink/stream/rtmpdump.py
+++ b/src/streamlink/stream/rtmpdump.py
@@ -99,7 +99,10 @@ class RTMPStream(StreamProcess):
 
             if "rtmp" in self.params:
                 tcurl, playpath = rtmpparse(self.params["rtmp"])
-                rtmp = "{redirect}/{playpath}".format(**locals())
+                if playpath:
+                    rtmp = "{redirect}/{playpath}".format(redirect=redirect, playpath=playpath)
+                else:
+                    rtmp = redirect
                 self.params["rtmp"] = rtmp
 
             if "tcUrl" in self.params:

--- a/src/streamlink/utils.py
+++ b/src/streamlink/utils.py
@@ -114,7 +114,7 @@ def rtmpparse(url):
     netloc = "{hostname}:{port}".format(hostname=parse.hostname,
                                         port=parse.port or 1935)
     split = list(filter(None, parse.path.split("/")))
-
+    playpath = None
     if len(split) > 2:
         app = "/".join(split[:2])
         playpath = "/".join(split[2:])

--- a/tests/test_plugin_sportal.py
+++ b/tests/test_plugin_sportal.py
@@ -1,0 +1,15 @@
+import unittest
+
+from streamlink.plugins.sportal import Sportal
+
+
+class TestPluginSportal(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Sportal.can_handle_url("http://sportal.bg/sportal_live_tv.php?str=15"))
+        self.assertTrue(Sportal.can_handle_url("http://www.sportal.bg/sportal_live_tv.php?"))
+        self.assertTrue(Sportal.can_handle_url("http://www.sportal.bg/sportal_live_tv.php?str=15"))
+
+        # shouldn't match
+        self.assertFalse(Sportal.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(Sportal.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
Adds support for sportal.bg as requested by @roshavagarga.

Pretty much just supports one URL:
- sportal.bg/sportal_live_tv.php?str=15