### PR TITLE
plugins.bnt: fix key request user agent

### DIFF
--- a/src/streamlink/plugin/api/useragents.py
+++ b/src/streamlink/plugin/api/useragents.py
@@ -1,5 +1,7 @@
 ANDROID = ("Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) "
            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36")
+CHROME = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+          "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36")
 CHROME_OS = ("Mozilla/5.0 (X11; CrOS armv7l 4537.56.0) "
              "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.38 Safari/537.36")
 IE_11 = "Mozilla/5.0 (MSIE 10.0; Windows NT 6.1; Trident/5.0)"
@@ -17,6 +19,6 @@ SAFARI_8 = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) "
             "AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12")
 SAFARI_7 = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) "
             "AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A")
-FIREFOX = "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:33.0) Gecko/20120101 Firefox/33.0"
+FIREFOX = "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0"
 FIREFOX_MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10; rv:33.0) Gecko/20100101 Firefox/33.0"
 OPERA = "Opera/9.80 (Windows NT 6.0) Presto/2.12.388 Version/12.14"

--- a/src/streamlink/plugins/bnt.py
+++ b/src/streamlink/plugins/bnt.py
@@ -46,7 +46,7 @@ class BNT(Plugin):
                     return url
 
     def _get_streams(self):
-        http.headers = {"User-Agent": useragents.FIREFOX}
+        http.headers = {"User-Agent": useragents.CHROME}
         res = http.get(self.url)
         iframe_url = self.find_iframe(res)
 
@@ -59,8 +59,9 @@ class BNT(Plugin):
                 return
 
             if stream_url:
-                return HLSStream.parse_variant_playlist(self.session, stream_url, headers={"Referer": iframe_url})
-
+                return HLSStream.parse_variant_playlist(self.session,
+                                                        stream_url,
+                                                        headers={"User-Agent": useragents.CHROME})
 
 
 __plugin__ = BNT


### PR DESCRIPTION
When loading the HLS streams some User Agents were rejected, specifically Firefox. Updating the User Agent string to Chrome resolves the issue. 