### PR TITLE
Use AVconv if available and FFmpeg is not available

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -60,7 +60,7 @@ class Streamlink(object):
             "stream-timeout": 60.0,
             "subprocess-errorlog": False,
             "subprocess-errorlog-path": None,
-            "ffmpeg-ffmpeg": is_win32 and "ffmpeg.exe" or "ffmpeg",
+            "ffmpeg-ffmpeg": None,
             "ffmpeg-video-transcode": "copy",
             "ffmpeg-audio-transcode": "copy"
         })

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -36,7 +36,7 @@ class MuxedStream(Stream):
 
 
 class FFMPEGMuxer(object):
-    __commands__ = ['ffmpeg', 'avconv']
+    __commands__ = ['ffmpeg', 'ffmpeg.exe', 'avconv', 'avconv.exe']
 
     @staticmethod
     def copy_to_pipe(self, stream, pipe):
@@ -107,7 +107,9 @@ class FFMPEGMuxer(object):
 
     @classmethod
     def command(cls, session):
-        command = [session.options.get("ffmpeg-ffmpeg")]
+        command = []
+        if session.options.get("ffmpeg-ffmpeg"):
+            command.append(session.options.get("ffmpeg-ffmpeg"))
         for cmd in command or cls.__commands__:
             try:
                 pbs.create_command(cmd)


### PR DESCRIPTION
There was a bug that prevented `avconv` from being used if `ffmpeg` was not available. I have fixed the bug and `avconv` can be used instead of `ffmpeg` (for example on Debian). 