### PR TITLE
Move streamlink_cli.utils.named_pipe in to streamlink.utils

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -8,7 +8,7 @@ import sys
 from streamlink.packages import pbs
 from streamlink.packages.pbs import CommandNotFound
 from streamlink.stream import Stream
-from streamlink_cli.utils import NamedPipe
+from streamlink.utils import NamedPipe
 try:
     from subprocess import DEVNULL
     devnull = lambda: DEVNULL

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -7,8 +7,9 @@ try:
 except ImportError:  # pragma: no cover
     import xml.etree.ElementTree as ET
 
-from .compat import urljoin, urlparse, parse_qsl, is_py2
-from .exceptions import PluginError
+from streamlink.compat import urljoin, urlparse, parse_qsl, is_py2
+from streamlink.exceptions import PluginError
+from streamlink.utils.named_pipe import NamedPipe
 
 
 def swfdecompress(data):
@@ -221,4 +222,4 @@ def swfverify(url):  # pragma: no cover
 
 __all__ = ["urlopen", "urlget", "urlresolve", "swfdecompress", "swfverify",
            "verifyjson", "absolute_url", "parse_qsd", "parse_json", "res_json",
-           "parse_xml", "res_xml", "rtmpparse", "prepend_www"]
+           "parse_xml", "res_xml", "rtmpparse", "prepend_www", "NamedPipe"]

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -1,0 +1,73 @@
+import os
+import tempfile
+
+from ..compat import is_win32, is_py3
+
+
+if is_win32:
+    from ctypes import windll, cast, c_ulong, c_void_p, byref
+
+    PIPE_ACCESS_OUTBOUND = 0x00000002
+    PIPE_TYPE_BYTE = 0x00000000
+    PIPE_READMODE_BYTE = 0x00000000
+    PIPE_WAIT = 0x00000000
+    PIPE_UNLIMITED_INSTANCES = 255
+    INVALID_HANDLE_VALUE = -1
+
+
+class NamedPipe(object):
+    def __init__(self, name):
+        self.fifo = None
+        self.pipe = None
+
+        if is_win32:
+            self.path = os.path.join("\\\\.\\pipe", name)
+            self.pipe = self._create_named_pipe(self.path)
+        else:
+            self.path = os.path.join(tempfile.gettempdir(), name)
+            self._create_fifo(self.path)
+
+    def _create_fifo(self, name):
+        os.mkfifo(name, 0o660)
+
+    def _create_named_pipe(self, path):
+        bufsize = 8192
+
+        if is_py3:
+            create_named_pipe = windll.kernel32.CreateNamedPipeW
+        else:
+            create_named_pipe = windll.kernel32.CreateNamedPipeA
+
+        pipe = create_named_pipe(path, PIPE_ACCESS_OUTBOUND,
+                                 PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+                                 PIPE_UNLIMITED_INSTANCES,
+                                 bufsize, bufsize,
+                                 0, None)
+
+        if pipe == INVALID_HANDLE_VALUE:
+            error_code = windll.kernel32.GetLastError()
+            raise IOError("Error code 0x{0:08X}".format(error_code))
+
+        return pipe
+
+    def open(self, mode):
+        if not self.pipe:
+            self.fifo = open(self.path, mode)
+
+    def write(self, data):
+        if self.pipe:
+            windll.kernel32.ConnectNamedPipe(self.pipe, None)
+            written = c_ulong(0)
+            windll.kernel32.WriteFile(self.pipe, cast(data, c_void_p),
+                                      len(data), byref(written),
+                                      None)
+            return written
+        else:
+            return self.fifo.write(data)
+
+    def close(self):
+        if self.pipe:
+            windll.kernel32.DisconnectNamedPipe(self.pipe)
+        else:
+            self.fifo.close()
+            os.unlink(self.path)

--- a/src/streamlink_cli/utils/__init__.py
+++ b/src/streamlink_cli/utils/__init__.py
@@ -3,7 +3,7 @@ import json
 from contextlib import contextmanager
 
 from .http_server import HTTPServer
-from .named_pipe import NamedPipe
+from streamlink.utils.named_pipe import NamedPipe
 from .progress import progress
 from .player import find_default_player
 from .stream import stream_to_url

--- a/src/streamlink_cli/utils/named_pipe.py
+++ b/src/streamlink_cli/utils/named_pipe.py
@@ -1,73 +1,12 @@
-import os
-import tempfile
-
-from ..compat import is_win32, is_py3
-
+# These imports, while unused, are here to provide API compatibility for this module
+from streamlink.utils.named_pipe import NamedPipe
+from ..compat import is_win32
 
 if is_win32:
-    from ctypes import windll, cast, c_ulong, c_void_p, byref
-
-    PIPE_ACCESS_OUTBOUND = 0x00000002
-    PIPE_TYPE_BYTE = 0x00000000
-    PIPE_READMODE_BYTE = 0x00000000
-    PIPE_WAIT = 0x00000000
-    PIPE_UNLIMITED_INSTANCES = 255
-    INVALID_HANDLE_VALUE = -1
-
-
-class NamedPipe(object):
-    def __init__(self, name):
-        self.fifo = None
-        self.pipe = None
-
-        if is_win32:
-            self.path = os.path.join("\\\\.\\pipe", name)
-            self.pipe = self._create_named_pipe(self.path)
-        else:
-            self.path = os.path.join(tempfile.gettempdir(), name)
-            self._create_fifo(self.path)
-
-    def _create_fifo(self, name):
-        os.mkfifo(name, 0o660)
-
-    def _create_named_pipe(self, path):
-        bufsize = 8192
-
-        if is_py3:
-            create_named_pipe = windll.kernel32.CreateNamedPipeW
-        else:
-            create_named_pipe = windll.kernel32.CreateNamedPipeA
-
-        pipe = create_named_pipe(path, PIPE_ACCESS_OUTBOUND,
-                                 PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
-                                 PIPE_UNLIMITED_INSTANCES,
-                                 bufsize, bufsize,
-                                 0, None)
-
-        if pipe == INVALID_HANDLE_VALUE:
-            error_code = windll.kernel32.GetLastError()
-            raise IOError("Error code 0x{0:08X}".format(error_code))
-
-        return pipe
-
-    def open(self, mode):
-        if not self.pipe:
-            self.fifo = open(self.path, mode)
-
-    def write(self, data):
-        if self.pipe:
-            windll.kernel32.ConnectNamedPipe(self.pipe, None)
-            written = c_ulong(0)
-            windll.kernel32.WriteFile(self.pipe, cast(data, c_void_p),
-                                      len(data), byref(written),
-                                      None)
-            return written
-        else:
-            return self.fifo.write(data)
-
-    def close(self):
-        if self.pipe:
-            windll.kernel32.DisconnectNamedPipe(self.pipe)
-        else:
-            self.fifo.close()
-            os.unlink(self.path)
+    from streamlink.utils.named_pipe import (
+        PIPE_ACCESS_OUTBOUND,
+        PIPE_TYPE_BYTE,
+        PIPE_READMODE_BYTE,
+        PIPE_WAIT,
+        PIPE_UNLIMITED_INSTANCES,
+        INVALID_HANDLE_VALUE)


### PR DESCRIPTION
Refactor of `streamlink_cli.utils.named_pipe` so that the `streamlink` module can remain independent from the `streamlink_cli` module, ie. `streamlink` has no dependency on `streamlink_cli`, only the other way around.

The `streamlink_cli.utils` API is not affected by this change.