### PR TITLE
stream.hds: omit HDS streams that are protected by DRM

### DIFF
--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -433,6 +433,7 @@ class HDSStream(Stream):
                         from the stream before raising an error.
         :param pvswf: URL of player SWF for Akamai HD player verification.
         """
+        logger = session.logger.new_module("hls.parse_manifest")
 
         if not request_params:
             request_params = {}
@@ -453,6 +454,10 @@ class HDSStream(Stream):
         res = session.http.get(url, exception=IOError, **request_params)
         manifest = session.http.xml(res, "manifest XML", ignore_ns=True,
                                     exception=IOError)
+
+        if manifest.findtext("drmAdditionalHeader"):
+            logger.debug("Omitting HDS stream protected by DRM: {}", url)
+            return {}
 
         parsed = urlparse(url)
         baseurl = manifest.findtext("baseURL")


### PR DESCRIPTION
As discussed in https://github.com/streamlink/streamlink/pull/406#issuecomment-272246813; I have found a better way to deal with the encrypted HDS streams, by simply omitting them when parsing the manifest file.

If the `drmAdditionalHeader` element has some content then it's protected by DRM, so that stream is skipped. 