### PR TITLE
Adultswin VOD fix for live show replays

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -12,7 +12,7 @@ is limited.
 =================== ==================== ===== ===== ===========================
 Name                URL(s)               Live  VOD   Notes
 =================== ==================== ===== ===== ===========================
-adultswim           adultswim.com        Yes   No    Streams may be geo-restricted, VOD streams are encrypted
+adultswim           adultswim.com        Yes   Yes   Streams may be geo-restricted, some VOD streams are protected by DRM.
 afreeca             afreecatv.com        Yes   No
 afreecatv           afreeca.tv           Yes   No
 aftonbladet         aftonbladet.se       Yes   Yes

--- a/src/streamlink/plugin/api/mapper.py
+++ b/src/streamlink/plugin/api/mapper.py
@@ -41,9 +41,12 @@ class StreamMapper(object):
                 yield value
             else:
                 try:
-                    # TODO: Replace with "yield from" when dropping Python 2.
-                    for __ in value:
-                        yield __
+                    if isinstance(value, dict):
+                        for __ in value.items():
+                            yield __
+                    else:
+                        for __ in value:
+                            yield __
                 except TypeError:
                     # Non-iterable returned
                     continue

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -257,6 +257,10 @@ class Plugin(object):
             if stream_type not in stream_types:
                 continue
 
+            # drop _alt from any stream names
+            if name.endswith("_alt"):
+                name = name[:-len("_alt")]
+
             existing = streams.get(name)
             if existing:
                 existing_stream_type = type(existing).shortname()

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -322,7 +322,6 @@ class HDSStreamWorker(SegmentedStreamWorker):
 
                 fragment_duration = int(self.fragment_duration(fragment) * 1000)
                 fragment_url = self.fragment_url(self.current_segment, fragment)
-                self.logger.debug(fragment_url)
                 fragment = Fragment(self.current_segment, fragment,
                                     fragment_duration, fragment_url)
 

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -322,6 +322,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
 
                 fragment_duration = int(self.fragment_duration(fragment) * 1000)
                 fragment_url = self.fragment_url(self.current_segment, fragment)
+                self.logger.debug(fragment_url)
                 fragment = Fragment(self.current_segment, fragment,
                                     fragment_duration, fragment_url)
 

--- a/tests/test_plugin_adultswim.py
+++ b/tests/test_plugin_adultswim.py
@@ -1,6 +1,10 @@
-import unittest
+import sys
 
 from streamlink.plugins.adultswim import AdultSwim
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestPluginAdultSwim(unittest.TestCase):
@@ -10,7 +14,33 @@ class TestPluginAdultSwim(unittest.TestCase):
         self.assertTrue(AdultSwim.can_handle_url("http://www.adultswim.com/videos/streams/"))
         self.assertTrue(AdultSwim.can_handle_url("http://www.adultswim.com/videos/streams/last-stream-on-the-left"))
         self.assertTrue(AdultSwim.can_handle_url("http://www.adultswim.com/videos/specials/the-adult-swim-golf-classic-extended/"))
+        self.assertTrue(AdultSwim.can_handle_url("http://www.adultswim.com/videos/streams/toonami-pre-flight/friday-december-30th-2016"))
 
         # shouldn't match
         self.assertFalse(AdultSwim.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(AdultSwim.can_handle_url("http://www.youtube.com/"))
+
+    def _test_regex(self, url, expected):
+        m = AdultSwim.url_re.match(url)
+        self.assertIsNotNone(m)
+        self.assertListEqual(expected, list(m.groups()))
+
+    def test_regex_live_stream(self):
+        self._test_regex("http://www.adultswim.com/videos/streams/toonami",
+                         ["streams", "toonami", None])
+
+    def test_regex_live_stream_default(self):
+        self._test_regex("http://www.adultswim.com/videos/streams/",
+                         ["streams", None, None])
+
+    def test_regex_special_vod(self):
+        self._test_regex("http://www.adultswim.com/videos/specials/the-adult-swim-golf-classic-extended/",
+                         [None, "specials", "the-adult-swim-golf-classic-extended"])
+
+    def test_regex_live_replay(self):
+        self._test_regex("http://www.adultswim.com/videos/streams/toonami-pre-flight/friday-december-30th-2016",
+                         ["streams", "toonami-pre-flight", "friday-december-30th-2016"])
+
+    def test_regex_show_vod(self):
+        self._test_regex("http://www.adultswim.com/videos/aqua-teen-hunger-force/vampirus/",
+                         [None, "aqua-teen-hunger-force", "vampirus"])


### PR DESCRIPTION
Fixes the issues with the previous PR https://github.com/streamlink/streamlink/pull/406#issuecomment-272434885 along with #417 which removes the DRM streams. 

Tested URLs:
- adultswim.com/videos/aqua-teen-hunger-force/vampirus
- adultswim.com/videos/streams/toonami-pre-flight/friday-january-6th-2017 (some DRMed streams)
- adultswim.com/videos/streams/toonami
- adultswim.com/videos/specials/the-adult-swim-golf-classic-extended