### PR TITLE
Add support for Play TV

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -109,6 +109,7 @@ orf_tvthek          tvthek.orf.at        Yes   Yes
 pandatv             panda.tv             Yes   ?
 periscope           periscope.tv         Yes   Yes   Replay/VOD is supported.
 picarto             picarto.tv           Yes   --
+playtv              playtv.fr            Yes   --    Streams may be geo-restricted to France.
 pluzz               pluzz.francetv.fr    Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
 powerapp            powerapp.com.tr      Yes   No
 raiplay             raiplay.it           Yes   No    Most streams are geo-restricted to Italy.

--- a/src/streamlink/plugins/playtv.py
+++ b/src/streamlink/plugins/playtv.py
@@ -1,0 +1,71 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http, validate
+from streamlink.stream import HDSStream, HLSStream
+
+
+class PlayTV(Plugin):
+    FORMATS_URL = 'http://playtv.fr/player/initialize/{0}/'
+    API_URL = 'http://playtv.fr/player/play/{0}/?format={1}&language={2}&bitrate={3}'
+
+    _url_re = re.compile(r'http://playtv\.fr/television/(?P<channel>[^/]+)/?')
+
+    _formats_schema = validate.Schema({
+        'streams': validate.any(
+            [],
+            {
+                validate.text: validate.Schema({
+                    validate.text: {
+                        'bitrates': validate.all([
+                            validate.Schema({
+                                'value': int
+                            })
+                        ])
+                    }
+                })
+            }
+        )
+    })
+    _api_schema = validate.Schema({
+        'url': validate.url()
+    })
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return PlayTV._url_re.match(url)
+
+    def _get_streams(self):
+        match = self._url_re.match(self.url)
+        channel = match.group('channel')
+
+        res = http.get(self.FORMATS_URL.format(channel))
+        streams = http.json(res, schema=self._formats_schema)['streams']
+        if streams == []:
+            self.logger.error('Channel may be geo-restricted, not directly provided by PlayTV or not freely available')
+            return
+
+        for language in streams:
+            for protocol, bitrates in list(streams[language].items()):
+                # - Ignore non-supported protocols (RTSP, DASH)
+                # - Ignore deprecated Flash (RTMPE) streams (PlayTV doesn't provide anymore a Flash player)
+                if protocol in ['rtsp', 'flash', 'dash']:
+                    continue
+
+                for bitrate in bitrates['bitrates']:
+                    if bitrate['value'] == 0:
+                        continue
+                    api_url = self.API_URL.format(channel, protocol, language, bitrate['value'])
+                    res = http.get(api_url)
+                    video_url = http.json(res, schema=self._api_schema)['url']
+                    bs = '{0}k'.format(bitrate['value'])
+
+                    if protocol == 'hls':
+                        for _, stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
+                            yield bs, stream
+                    elif protocol == 'hds':
+                        for _, stream in HDSStream.parse_manifest(self.session, video_url).items():
+                            yield bs, stream
+
+
+__plugin__ = PlayTV

--- a/tests/test_plugin_playtv.py
+++ b/tests/test_plugin_playtv.py
@@ -1,0 +1,18 @@
+import unittest
+
+from streamlink.plugins.playtv import PlayTV
+
+
+class TestPluginPlayTV(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/arte"))
+        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/arte/"))
+        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/tv5-monde"))
+        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/france-24-english/"))
+
+        # shouldn't match
+        self.assertFalse(PlayTV.can_handle_url("http://playtv.fr/television/"))
+        self.assertFalse(PlayTV.can_handle_url("http://playtv.fr/replay-tv/"))
+        self.assertFalse(PlayTV.can_handle_url("http://tvcatchup.com/"))
+        self.assertFalse(PlayTV.can_handle_url("http://youtube.com/"))


### PR DESCRIPTION
This plugin adds support for the French TV streaming platform [Play TV](http://playtv.fr/).
Some channels may be geo-restricted.