### PR TITLE
Fix deprecation warnings in Python 3.6

### DIFF
--- a/src/streamlink/plugins/beattv.py
+++ b/src/streamlink/plugins/beattv.py
@@ -286,7 +286,7 @@ class BeatTV(Plugin):
 
     def _get_stream_info(self, url):
         res = http.get(url, headers=HEADERS)
-        match = re.search("embed.swf\?p=(\d+)", res.text)
+        match = re.search(r"embed.swf\?p=(\d+)", res.text)
         if not match:
             return
         program = match.group(1)

--- a/src/streamlink/plugins/bongacams.py
+++ b/src/streamlink/plugins/bongacams.py
@@ -23,8 +23,8 @@ CONST_HEADERS = {}
 CONST_HEADERS['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) '
 CONST_HEADERS['User-Agent'] += 'Chrome/54.0.2840.99 Safari/537.36 OPR/41.0.2353.69'
 
-url_re = re.compile("(http(s)?://)?(\w{2}.)?(bongacams.com)/([\w\d_-]+)")
-swf_re = re.compile("/swf/\w+/\w+.swf\?cache=\d+")
+url_re = re.compile(r"(http(s)?://)?(\w{2}.)?(bongacams.com)/([\w\d_-]+)")
+swf_re = re.compile(r"/swf/\w+/\w+.swf\?cache=\d+")
 
 amf_msg_schema = validate.Schema({
     "status": "success",
@@ -136,13 +136,10 @@ class bongacams(Plugin):
             "pageUrl": stream_page_url,
             "playpath": "%s?uid=%s" % (''.join(('stream_', stream_page_path)),
                                        self._get_stream_uid(stream_source_info['userData']['username'])),
-            # Multiple args with same name not supported.
-            # Details: https://github.com/streamlink/streamlink/issues/321
-            "conn": "S:{username} --conn=S:{access_key} --conn=B:0 --conn=S:{data_key}".format(
-                username=stream_source_info['userData']['username'],
-                access_key=stream_source_info['localData']['NC_AccessKey'],
-                data_key=stream_source_info['localData']['dataKey']
-            )
+            "conn": ["S:{0}".format(stream_source_info['userData']['username']),
+                     "S:{0}".format(stream_source_info['localData']['NC_AccessKey']),
+                     "B:0",
+                     "S:{0}".format(stream_source_info['localData']['dataKey'])]
         }
 
         self.logger.debug("Stream params:\n{}", stream_params)

--- a/src/streamlink/plugins/filmon_us.py
+++ b/src/streamlink/plugins/filmon_us.py
@@ -16,10 +16,10 @@ _live_export_re = re.compile(
 _live_json_re = re.compile(r"var startupChannel = (.+);")
 _replay_json_re = re.compile(r"var standByVideo = encodeURIComponent\('(.+)'\);")
 _history_re = re.compile(
-    "helpers.common.flash.flashplayerinstall\({url:'([^']+)',"
+    r"helpers.common.flash.flashplayerinstall\(\{url:'([^']+)',"
 )
 _video_flashvars_re = re.compile(
-    "<embed width=\"486\" height=\"326\" flashvars=\"([^\"]+)\""
+    r"<embed width=\"486\" height=\"326\" flashvars=\"([^\"]+)\""
 )
 
 _live_schema = validate.Schema({

--- a/src/streamlink/plugins/huajiao.py
+++ b/src/streamlink/plugins/huajiao.py
@@ -15,7 +15,7 @@ USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTM
 HUAJIAO_URL = "http://www.huajiao.com/l/{}"
 LAPI_URL = "http://g2.live.360.cn/liveplay?stype=flv&channel={}&bid=huajiao&sn={}&sid={}&_rate=xd&ts={}&r={}&_ostype=flash&_delay=0&_sign=null&_ver=13"
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
         http(s)?://(www\.)?huajiao.com
         /l/(?P<channel>[^/]+)
 """, re.VERBOSE)

--- a/src/streamlink/plugins/media_ccc_de.py
+++ b/src/streamlink/plugins/media_ccc_de.py
@@ -30,16 +30,16 @@ API_URL_STREAMING_MEDIA = "https://streaming.media.ccc.de/streams/v1.json"
 
 # http(s)://media.ccc.de/path/to/talk.html
 _url_media_re = re.compile(r"(?P<scheme>http|https)"
-                           ":\/\/"
+                           "://"
                            "(?P<server>media\.ccc\.de)"
-                           "\/")
+                           "/")
 # https://streaming.media.ccc.de/room/
 _url_streaming_media_re = re.compile(r"(?P<scheme>http|https)"
-                                     ":\/\/"
+                                     "://"
                                      "(?P<server>streaming\.media\.ccc\.de)"
-                                     "\/"
+                                     "/"
                                      "(?P<room>.*)"
-                                     "\/")
+                                     "/")
 
 
 def get_event_id(url):

--- a/src/streamlink/plugins/streamingvideoprovider.py
+++ b/src/streamlink/plugins/streamingvideoprovider.py
@@ -10,7 +10,7 @@ SWF_URL = "http://play.streamingvideoprovider.com/player2.swf"
 API_URL = "http://player.webvideocore.net/index.php"
 
 _url_re = re.compile(
-    "http(s)?://(\w+\.)?streamingvideoprovider.co.uk/(?P<channel>[^/&?]+)"
+    r"http(s)?://(\w+\.)?streamingvideoprovider.co.uk/(?P<channel>[^/&?]+)"
 )
 _hls_re = re.compile(r"'(http://.+\.m3u8)'")
 

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -422,7 +422,7 @@ class UStreamTV(Plugin):
 
     @classmethod
     def stream_weight(cls, stream):
-        match = re.match("mobile_(\w+)", stream)
+        match = re.match(r"mobile_(\w+)", stream)
         if match:
             weight, group = Plugin.stream_weight(match.group(1))
             weight -= 1

--- a/src/streamlink/plugins/vgtv.py
+++ b/src/streamlink/plugins/vgtv.py
@@ -30,8 +30,8 @@ INFO_URL = "http://www.vgtv.no/data/actions/videostatus/"
 _url_re = re.compile(r"https?://(www\.)?(vgtv|vg).no")
 _content_id_re = re.compile(r"(?:data-videoid=\"|videostatus/\?id=)(\d+)")
 _url_id_re = re.compile((
-    "https?://(?:www\.)?vgtv.no/"
-    "(?:(?:#!/)?video/|(?:#!|\?)id=)(\d+)"
+    r"https?://(?:www\.)?vgtv.no/"
+    r"(?:(?:#!/)?video/|(?:#!|\?)id=)(\d+)"
 ))
 
 _video_schema = validate.Schema({

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -140,8 +140,8 @@ class YouTube(Plugin):
 
     @classmethod
     def stream_weight(cls, stream):
-        match_3d = re.match("(\w+)_3d", stream)
-        match_hfr = re.match("(\d+p)(\d+)", stream)
+        match_3d = re.match(r"(\w+)_3d", stream)
+        match_hfr = re.match(r"(\d+p)(\d+)", stream)
         if match_3d:
             weight, group = Plugin.stream_weight(match_3d.group(1))
             weight -= 1

--- a/src/streamlink/plugins/zhanqi.py
+++ b/src/streamlink/plugins/zhanqi.py
@@ -17,7 +17,7 @@ STREAM_WEIGHTS = {
     "live": 1080
 }
 
-_url_re = re.compile("""
+_url_re = re.compile(r"""
     http(s)?://(www\.)?zhanqi.tv
     /(?P<channel>[^/]+)
 """, re.VERBOSE)


### PR DESCRIPTION
Regular expressions should be raw strings (`r""`) when they contain regex escape sequences (eg. `\w`). 