### PR TITLE
streamlink_cli.utils.progress: write new line at finish

### DIFF
--- a/src/streamlink_cli/utils/progress.py
+++ b/src/streamlink_cli/utils/progress.py
@@ -121,3 +121,5 @@ def progress(iterator, prefix):
                 speed=format_filesize(speed)
             )
             print_inplace(status)
+    sys.stderr.write("\n")
+    sys.stderr.flush()


### PR DESCRIPTION
without it:
```
[download][test.flv] Written 129.2 MB (5s @ 7.5 MB/s)
cli][info] Stream ended
```

with it:
```
[download][test.flv] Written 129.2 MB (5s @ 7.5 MB/s)
[cli][info] Stream ended
```