### PR TITLE
plugins.nineanime: add scheme to grabber api url if not present

### DIFF
--- a/src/streamlink/plugins/nineanime.py
+++ b/src/streamlink/plugins/nineanime.py
@@ -1,12 +1,14 @@
 import re
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
+from streamlink.compat import urlparse
 
 
 class NineAnime(Plugin):
-    _episode_info_url = "http://9anime.to/ajax/episode/info"
+    _episode_info_url = "//9anime.to/ajax/episode/info"
 
     _info_schema = validate.Schema({
         "grabber": validate.url(),
@@ -27,13 +29,17 @@ class NineAnime(Plugin):
         }]
     })
 
-    _user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "\
-                  "Chrome/36.0.1944.9 Safari/537.36"
     _url_re = re.compile(r"https?://9anime.to/watch/(?:[^.]+?\.)(\w+)/(\w+)")
 
     @classmethod
     def can_handle_url(cls, url):
         return cls._url_re.match(url) is not None
+
+    def add_scheme(self, url):
+        # update the scheme for the grabber url if required
+        if url.startswith("//"):
+            url = "{0}:{1}".format(urlparse(self.url).scheme, url)
+        return url
 
     def _get_streams(self):
         match = self._url_re.match(self.url)
@@ -41,17 +47,18 @@ class NineAnime(Plugin):
 
         headers = {
             "Referer": self.url,
-            "User-Agent": self._user_agent
+            "User-Agent": useragents.FIREFOX
         }
 
         # Get the info about the Episode, including the Grabber API URL
-        info_res = http.get(self._episode_info_url,
+        info_res = http.get(self.add_scheme(self._episode_info_url),
                             params=dict(update=0, film=film_id, id=episode_id),
                             headers=headers)
         info = http.json(info_res, schema=self._info_schema)
 
         # Get the data about the streams from the Grabber API
-        stream_list_res = http.get(info["grabber"], params=info["params"], headers=headers)
+        grabber_url = self.add_scheme(info["grabber"])
+        stream_list_res = http.get(grabber_url, params=info["params"], headers=headers)
         stream_data = http.json(stream_list_res, schema=self._streams_schema)
 
         for stream in stream_data["data"]:


### PR DESCRIPTION
This PR fixes the issue reported in #447.

The API calls have been updated to use the same URL scheme as the stream URL requested. If the URL requests use http then the API requests also use http, if the stream URL uses https then the API requests use https. 

I suspect 9anime.to is making a transistion to https only. 