### PR TITLE
session: add an option to disable Diffie Hellman key exchange

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -4,6 +4,8 @@ import re
 import sys
 import traceback
 
+import requests
+
 from . import plugins, __version__
 from .compat import urlparse, is_win32
 from .exceptions import NoPluginError, PluginError
@@ -246,6 +248,15 @@ class Streamlink(object):
             self.http.trust_env = value
         elif key == "http-ssl-verify":
             self.http.verify = value
+        elif key == "http-disable-dh":
+            if value:
+                requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS += ':!DH'
+                try:
+                    requests.packages.urllib3.contrib.pyopenssl.DEFAULT_SSL_CIPHER_LIST = \
+                        requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS.encode("ascii")
+                except AttributeError:
+                    # no ssl to disable the cipher on
+                    pass
         elif key == "http-ssl-cert":
             self.http.cert = value
         elif key == "http-timeout":

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -883,6 +883,15 @@ http.add_argument(
     """
 )
 http.add_argument(
+    "--http-disable-dh",
+    action="store_true",
+    help="""
+    Disable Diffie Hellman key exchange
+
+    Usually a bad idea, only use this if you know what you're doing.
+    """
+)
+http.add_argument(
     "--http-ssl-cert",
     metavar="FILENAME",
     help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -655,6 +655,9 @@ def setup_http_session():
     if args.http_no_ssl_verify:
         streamlink.set_option("http-ssl-verify", False)
 
+    if args.http_disable_dh:
+        streamlink.set_option("http-disable-dh", True)
+
     if args.http_ssl_cert:
         streamlink.set_option("http-ssl-cert", args.http_ssl_cert)
 


### PR DESCRIPTION
This is useful if an old server has a DH key that is too short for modern implementations of ssl.

(As far as I understand it): 
Due to the logjam attack (CVE-2015-4000) DH primes that are too short will be rejected by ssl. If the stream you are trying to load uses a weak DH key, this option allows you to disable Diffie Hellman as a possible key exchange method and use an alternative. This may or may not be a good idea, and should be used with caution. 