### PR TITLE
Add a general locale setting which can be used by plugins

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -156,6 +156,8 @@ Name                                 Notes
 `python-requests`_                   At least version **1.0**.
 `python-singledispatch`_             Only needed on Python versions older than **3.4**.
 `pycryptodome`_                      Required to play some encrypted streams
+`iso-639`_                           Used for localization settings, provides language information
+`iso3166`_                           Used for localization settings, provides country information
 
 **Optional**
 --------------------------------------------------------------------------------
@@ -176,6 +178,8 @@ Name                                 Notes
 .. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
 .. _python-librtmp: https://github.com/chrippa/python-librtmp
 .. _ffmpeg: https://www.ffmpeg.org/
+.. _iso-639: https://pypi.python.org/pypi/iso-639
+.. _iso3166: https://pypi.python.org/pypi/iso3166
 
 
 Installing without root permissions

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -42,6 +42,8 @@ format=bundled
 packages=requests
          streamlink
          streamlink_cli
+         iso639
+         iso3166
 pypi_wheels=pycryptodome==3.4.3
 
 files=../win32/LICENSE.txt > \$INSTDIR

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ if version_info[0] == 2:
     deps.append("backports.shutil_which")
     deps.append("backports.shutil_get_terminal_size")
 
+# for localization
+deps.append("iso-639")
+deps.append("iso3166")
+
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.
 if environ.get("NO_DEPS"):

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -205,7 +205,7 @@ class Crunchyroll(Plugin):
         "username": None,
         "password": None,
         "purge_credentials": None,
-        "locale": API_DEFAULT_LOCALE
+        "locale": None
     })
 
     @classmethod
@@ -284,12 +284,13 @@ class Crunchyroll(Plugin):
 
         current_time = datetime.datetime.utcnow()
         device_id = self._get_device_id()
-        locale = self.options.get("locale")
+        # use the crunchyroll locale as an override, for backwards compatibility
+        locale = self.get_option("locale") or self.session.localization.language_code
         api = CrunchyrollAPI(
             self.cache.get("session_id"), self.cache.get("auth"), locale
         )
 
-        self.logger.debug("Creating session")
+        self.logger.debug("Creating session with locale: {0}", locale)
         try:
             api.session_id = api.start_session(device_id, schema=_session_schema)
         except CrunchyrollAPIError as err:

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -1,10 +1,12 @@
 import imp
+import locale
 import pkgutil
 import re
 import sys
 import traceback
 
 import requests
+from streamlink.utils.l10n import Localization
 
 from . import plugins, __version__
 from .compat import urlparse, is_win32
@@ -64,7 +66,8 @@ class Streamlink(object):
             "subprocess-errorlog-path": None,
             "ffmpeg-ffmpeg": None,
             "ffmpeg-video-transcode": "copy",
-            "ffmpeg-audio-transcode": "copy"
+            "ffmpeg-audio-transcode": "copy",
+            "locale": None
         })
         self.plugins = {}
         self.logger = Logger()
@@ -207,6 +210,10 @@ class Streamlink(object):
                                  stream, default: ``60.0``.
                                  General option used by streams not
                                  covered by other options.
+
+        locale                   (str) Locale setting, in the RFC 1766 format
+                                 eg. en_US or es_ES
+                                 default: ``system locale``.
         ======================== =========================================
 
         """
@@ -460,6 +467,10 @@ class Streamlink(object):
     @property
     def version(self):
         return __version__
+
+    @property
+    def localization(self):
+        return Localization(self.get_option("locale"))
 
 
 __all__ = ["Streamlink"]

--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -1,0 +1,67 @@
+import locale
+from iso639 import languages
+from iso3166 import countries
+
+DEFAULT_LANGUAGE_CODE = "en_US"
+
+
+class Localization(object):
+    language_code_remap = {
+        "fre": "fra"
+    }
+
+    def __init__(self, language_code=None):
+        self._language_code = None
+        self.country = None
+        self.language = None
+        self.explicit = bool(language_code)
+        self.language_code = language_code
+
+    @property
+    def language_code(self):
+        return self._language_code
+
+    @language_code.setter
+    def language_code(self, language_code):
+        if language_code is None:
+            language_code, _ = locale.getdefaultlocale()
+            if language_code is None or language_code == "C":
+                # cannot be determined
+                language_code = DEFAULT_LANGUAGE_CODE
+
+        parts = language_code.split("_", 1)
+
+        if len(parts) != 2 or len(parts[0]) != 2 or len(parts[1]) != 2:
+            raise ValueError("Invalid language code: {0}".format(language_code))
+
+        self._language_code = language_code
+        self.language = self.get_language(parts[0])
+        self.country = self.get_country(parts[1])
+
+    def equivalent(self, language=None, country=None):
+        equivalent = True
+        equivalent = equivalent and (not language or self.language == self.get_language(language))
+        equivalent = equivalent and (not country or self.country == self.get_country(country))
+
+        return equivalent
+
+    @classmethod
+    def get_country(cls, country):
+        try:
+            return countries.get(country)
+        except KeyError:
+            raise ValueError("Invalid country code: {0}".format(country))
+
+    @classmethod
+    def get_language(cls, language):
+        # some language codes need to be remapped. why? because standards were designed to be broken.
+        _language = cls.language_code_remap.get(language, language)
+        try:
+            if len(_language) == 2:
+                return languages.get(alpha2=_language)
+            elif len(_language) == 3:
+                return languages.get(part3=_language)
+            else:
+                raise ValueError("Invalid language code: {0}".format(language))
+        except KeyError:
+            raise ValueError("Invalid language code: {0}".format(language))

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -274,6 +274,20 @@ general.add_argument(
     Runs a version check and exits.
     """
 )
+general.add_argument(
+    "--locale",
+    type=str,
+    metavar="LOCALE",
+    help="""
+    The preferred locale setting, for selecting the preferred
+    subtitle and audio language.
+
+    The locale is formatted as [language_code]_[country_code],
+     eg. eg. en_US or es_ES
+
+    Default is system locale.
+    """
+)
 
 player = parser.add_argument_group("Player options")
 player.add_argument(
@@ -1010,17 +1024,6 @@ plugin.add_argument(
     """
 )
 plugin.add_argument(
-    "--crunchyroll-locale",
-    metavar="LOCALE",
-    help="""
-    Indicate which locale to use for Crunchyroll subtitles.
-
-    The locale is formatted as [language_code]_[country_code].
-
-    Default is en_US.
-    """
-)
-plugin.add_argument(
     "--livestation-email",
     metavar="EMAIL",
     help="""
@@ -1112,6 +1115,11 @@ http.add_argument(
 http.add_argument(
     "--http-query-params",
     metavar="PARAMS",
+    help=argparse.SUPPRESS
+)
+plugin.add_argument(
+    "--crunchyroll-locale",
+    metavar="LOCALE",
     help=argparse.SUPPRESS
 )
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -771,6 +771,8 @@ def setup_options():
 
     streamlink.set_option("subprocess-errorlog", args.subprocess_errorlog)
     streamlink.set_option("subprocess-errorlog-path", args.subprocess_errorlog_path)
+    streamlink.set_option("locale", args.locale)
+
 
     # Deprecated options
     if args.hds_fragment_buffer:

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -1,0 +1,71 @@
+import unittest
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from streamlink.utils.l10n import Localization
+
+
+class TestLocalization(unittest.TestCase):
+    def test_language_code(self):
+        l = Localization("en_US")
+        self.assertEqual("en_US", l.language_code)
+
+    def test_bad_language_code(self):
+        self.assertRaises(ValueError, Localization, "enUS")
+
+    def test_equivalent(self):
+        l = Localization("en_US")
+        self.assertTrue(l.equivalent(language="eng"))
+        self.assertTrue(l.equivalent(language="en"))
+        self.assertTrue(l.equivalent(language="en", country="US"))
+        self.assertTrue(l.equivalent(language="en", country="United States"))
+
+    def test_equivalent_remap(self):
+        l = Localization("fr_FR")
+        self.assertTrue(l.equivalent(language="fra"))
+        self.assertTrue(l.equivalent(language="fre"))
+
+    def test_not_equivalent(self):
+        l = Localization("es_ES")
+        self.assertFalse(l.equivalent(language="eng"))
+        self.assertFalse(l.equivalent(language="en"))
+        self.assertFalse(l.equivalent(language="en", country="US"))
+        self.assertFalse(l.equivalent(language="en", country="United States"))
+        self.assertFalse(l.equivalent(language="en", country="ES"))
+        self.assertFalse(l.equivalent(language="en", country="Spain"))
+
+    @patch("locale.getdefaultlocale")
+    def test_default(self, getdefaultlocale):
+        getdefaultlocale.return_value = (None, None)
+        l = Localization()
+        self.assertEqual("en_US", l.language_code)
+        self.assertTrue(l.equivalent(language="en", country="US"))
+
+    def test_get_country(self):
+        self.assertEqual("US",
+                         Localization.get_country("USA").alpha2)
+        self.assertEqual("GB",
+                         Localization.get_country("GB").alpha2)
+        self.assertEqual("United States",
+                         Localization.get_country("United States").name)
+
+    def test_get_country_miss(self):
+        self.assertRaises(ValueError, Localization.get_country, "XE")
+        self.assertRaises(ValueError, Localization.get_country, "XEX")
+        self.assertRaises(ValueError, Localization.get_country, "Nowhere")
+
+    def test_get_language(self):
+        self.assertEqual("eng",
+                         Localization.get_language("en").part3)
+        self.assertEqual("fra",
+                         Localization.get_language("fra").part3)
+        self.assertEqual("fra",
+                         Localization.get_language("fre").part3,
+                         msg="fre should be remapped to fra")
+
+    def test_get_language_miss(self):
+        self.assertRaises(ValueError, Localization.get_language, "00")
+        self.assertRaises(ValueError, Localization.get_language, "000")
+        self.assertRaises(ValueError, Localization.get_language, "0000")


### PR DESCRIPTION
The `crunchyroll-locale` option was useful, but too specific to crunchyroll. There is a general usefulness for users to be able to control their desired locale settings. For example, in streams with multiple audio languages the correct language could be selected based on the locale setting. (I am working on this for HLS Streams). 

I have added a `Localization` class that provides some useful methods for compare languages using different length codes (eg. 'en' vs. 'eng') and for determining the default locale settings. 

The Crunchyroll plugin has been updated to use the new locale setting and will benefit from automatically switching to the users locale, much like it would on the web version of crunchyroll. 

Two dependencies were added `iso-639` and `iso3166`, which provide information and lookup for countries and languages. 