### PR TITLE
Add a github issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,36 @@
+*Thanks for reporting an issue!*
+*Please read the contribution guidelines first!*
+
+*Feel free to use the following template. Be as detailed as possible.*
+*Don't forget to remove this text before submitting.*
+
+----
+
+### Checklist
+
+- [x] This is a bug report.
+- [ ] This is a plugin request.
+- [ ] This is a feature request.
+- [ ] I used the search function to find already opened/closed issues or pull requests.
+
+### Description
+
+...
+
+### Expected / Actual behavior
+
+...
+
+### Reproduction steps / Stream URLs to test
+
+1. ...
+2. ...
+3. ...
+
+### Environment details (operating system, python version, etc.)
+
+...
+
+### Comments, logs, screenshots, etc.
+
+...


### PR DESCRIPTION
I'm not sure if an issue template is really necessary here or if this specific template fits the project, but I thought that we could at least have a discussion about it.

👎
- It might be overwhelming or intimidating for casual users or bug reporters
- Not all information is always necessary

👍
- People *usually* read the template before submitting, resulting in clearer reports
- Reduces the number of duplicates
- Environment details will *most likely* be included without asking first (reduces number of responses)
- Posts are formatted correctly *most of the time*

My suggested template can ofc be changed if it's too much or if sth is missing... 😜 