### PR TITLE
Add support for replay.gulli.fr

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -80,6 +80,7 @@ furstream           furstre.am           Yes   No
 gaminglive          gaminglive.tv        Yes   Yes
 gomexp              gomexp.com           Yes   No
 goodgame            goodgame.ru          Yes   No    Only HLS streams are available.
+gulli               replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France, Belgium and Switzerland.
 hitbox              hitbox.tv            Yes   Yes
 huajiao             huajiao.com          Yes   No    
 ine                 ine.com              ---   Yes

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -80,7 +80,7 @@ furstream           furstre.am           Yes   No
 gaminglive          gaminglive.tv        Yes   Yes
 gomexp              gomexp.com           Yes   No
 goodgame            goodgame.ru          Yes   No    Only HLS streams are available.
-gulli               replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France, Belgium and Switzerland.
+gulli               replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France.
 hitbox              hitbox.tv            Yes   Yes
 huajiao             huajiao.com          Yes   No    
 ine                 ine.com              ---   Yes

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -1,6 +1,5 @@
 import re
 
-from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HLSStream, HTTPStream
@@ -76,8 +75,9 @@ class Gulli(Plugin):
                     else:
                         bitrate = 'vod'
                     yield bitrate, HTTPStream(self.session, video_url)
-            except PluginError:
-                self.logger.error('Failed to access stream, may be due to geo-restriction')
+            except IOError as err:
+                if '403 Client Error' in str(err):
+                    self.logger.error('Failed to access stream, may be due to geo-restriction')
                 raise
 
 

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -1,0 +1,84 @@
+import re
+
+from streamlink.exceptions import PluginError
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http, validate
+from streamlink.stream import HLSStream, HTTPStream
+from streamlink.utils import parse_json
+
+
+class Gulli(Plugin):
+    LIVE_PLAYER_URL = 'http://replay.gulli.fr/jwplayer/embedstreamtv'
+    VOD_PLAYER_URL = 'http://replay.gulli.fr/jwplayer/embed/{0}'
+
+    _url_re = re.compile(r'http://replay\.gulli\.fr/(?:Direct|.+/(?P<video_id>VOD[0-9]+))')
+    _playlist_re = re.compile(r'sources: (\[.+?\])', re.DOTALL)
+    _vod_video_index_re = re.compile(r'jwplayer\(idplayer\).playlistItem\((?P<video_index>[0-9]+)\)')
+    _mp4_bitrate_re = re.compile(r'.*_(?P<bitrate>[0-9]+)\.mp4')
+
+    _video_schema = validate.Schema(
+        validate.all(
+            validate.transform(lambda x: re.sub(r'"?file"?:\s*[\'"](.+?)[\'"]', r'"file": "\1"', x, flags=re.DOTALL)),
+            validate.transform(parse_json),
+            [
+                validate.Schema({
+                    'file': validate.url()
+                })
+            ]
+        )
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return Gulli._url_re.match(url)
+
+    def _get_streams(self):
+        match = self._url_re.match(self.url)
+        video_id = match.group('video_id')
+        if video_id is not None:
+            # VOD
+            live = False
+            player_url = self.VOD_PLAYER_URL.format(video_id)
+        else:
+            # Live
+            live = True
+            player_url = self.LIVE_PLAYER_URL
+
+        res = http.get(player_url)
+        playlist = re.findall(self._playlist_re, res.text)
+        index = 0
+        if not live:
+            # Get the index for the video on the playlist
+            match = self._vod_video_index_re.search(res.text)
+            if match is None:
+                return
+            index = int(match.group('video_index'))
+
+        if not playlist:
+            return
+        videos = self._video_schema.validate(playlist[index])
+
+        for video in videos:
+            video_url = video['file']
+
+            # Ignore non-supported MSS streams
+            if 'isml/Manifest' in video_url:
+                continue
+
+            try:
+                if '.m3u8' in video_url:
+                    for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
+                        yield stream
+                elif '.mp4' in video_url:
+                    match = self._mp4_bitrate_re.match(video_url)
+                    if match is not None:
+                        bitrate = '%sk' % match.group('bitrate')
+                    else:
+                        bitrate = 'vod'
+                    yield bitrate, HTTPStream(self.session, video_url)
+            except PluginError:
+                self.logger.error('Failed to access stream, may be due to geo-restriction')
+                raise
+
+
+__plugin__ = Gulli

--- a/tests/test_plugin_gulli.py
+++ b/tests/test_plugin_gulli.py
@@ -1,0 +1,20 @@
+import unittest
+
+from streamlink.plugins.gulli import Gulli
+
+
+class TestPluginGulli(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/Direct"))
+        self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/dessins-animes/My-Little-Pony-les-amies-c-est-magique/VOD68328764799000"))
+        self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/emissions/In-Ze-Boite2/VOD68639028668000"))
+        self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/series/Power-Rangers-Dino-Super-Charge/VOD68612908435000"))
+
+        # shouldn't match
+        self.assertFalse(Gulli.can_handle_url("http://replay.gulli.fr/"))
+        self.assertFalse(Gulli.can_handle_url("http://replay.gulli.fr/dessins-animes"))
+        self.assertFalse(Gulli.can_handle_url("http://replay.gulli.fr/emissions"))
+        self.assertFalse(Gulli.can_handle_url("http://replay.gulli.fr/series"))
+        self.assertFalse(Gulli.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(Gulli.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
This plugin add support for the French TV channel Gulli (for children). It supports both VOD and live streams. Streams are geo-restricted to France, Belgium and Switzerland.

The live stream is available at http://replay.gulli.fr/Direct
