### PR TITLE
Read negative segment duration as 0

### DIFF
--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -122,6 +122,7 @@ class M3U8Parser(object):
         match = re.match("(?P<duration>\d+(\.\d+)?)(,(?P<title>.+))?", value)
         if match:
             return float(match.group("duration")), match.group("title")
+        return (0, None)
 
     def parse_hex(self, value):
         value = value[2:]


### PR DESCRIPTION
If an invalid duration for a segment is encountered eg. `#EXTINF:-0.016,` it is ignored and read as `0` duration, the duration is not that important for our use. The baviour for most players seems to be to ingore the invalid duration and round it to 0, and I don't think it's too bad for us to do the same.

This occurs in some Twitch VOD streams, possibly due to very long duration (the example in #471 is 12 hours long), although I was unable to recreate the issue with any other very long stream (twitch.tv/dotapit/v/116506478 18h works fine). 