### PR TITLE
Play twitch VOD stream from the beginning even if is still being recorded

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -496,7 +496,10 @@ class Twitch(Plugin):
             return {}
 
         try:
-            streams = HLSStream.parse_variant_playlist(self.session, url)
+            # If the stream is a VOD that is still being recorded the stream should start at the
+            # beginning of the recording
+            streams = HLSStream.parse_variant_playlist(self.session, url,
+                                                       force_restart=not stream_type == "live")
         except IOError as err:
             err = str(err)
             if "404 Client Error" in err or "Failed to parse playlist" in err:


### PR DESCRIPTION
This PR fixes #476, an option has been added to `HLSStream` to force the playlist to be played from the start. 

This new option is generally useful for any live stream that has a VOD/DVR feature where you want to start from the beginning of the stream rather than the "live edge". 