### PR TITLE
cli: wait for process to exit, not exit with non-0 error code

### DIFF
--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -165,7 +165,7 @@ class PlayerOutput(Output):
                 self.player.terminate()
                 if not is_win32:
                     t, timeout = 0.0, self.PLAYER_TERMINATE_TIMEOUT
-                    while not self.player.poll() and t < timeout:
+                    while self.player.poll() is None and t < timeout:
                         sleep(0.5)
                         t += 0.5
 


### PR DESCRIPTION
As pointed out by @LoneFox78. The loop should wait for the process to exit regardless of the error code, rather than waiting for a non-0 error code. Currently it waits for a truthy response, which means it will wait even if the process ended with exit code 0. 

A gross error on my part this one ... 