### PR TITLE
Fix bug in customized Windows install

### DIFF
--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -50,13 +50,13 @@
 # RTMP streams are downloaded using rtmpdump. Full path or relative path
 # to the rtmpdump exe should be specified here.
 #rtmpdump=C:\Program Files (x86)\Streamlink\rtmpdump\rtmpdump.exe
-rtmpdump=
+rtmpdump=rtmpdump.exe
 
 # FFMPEG is used to mux separate video and audio streams in to a single
-# stream so that they can be played. The pull or relative path to ffmpeg
+# stream so that they can be played. The full or relative path to ffmpeg
 # or avconv should be specified here.
 #ffmpeg-ffmpeg=C:\Program Files (x86)\Streamlink\ffmpeg\ffmpeg.exe
-ffmpeg-ffmpeg=
+ffmpeg-ffmpeg=ffmpeg.exe
 
 # Log level, default is info
 #loglevel=debug


### PR DESCRIPTION
As discussed in #481, the config file previously needed to be updated if the user chose not to install ffmpeg. With this patch, if `rtmpdump.exe` or `ffmpeg.exe` are in the `%PATH%` they will be located automatically, if they are not found then the default behaviour still occurs (which is to omit streams that require `ffmpeg` or `rtmpdump`). 

Should preempt a few issues. 