### PR TITLE
plugins.schoolism: add support for schoolism.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -115,6 +115,7 @@ raiplay             raiplay.it           Yes   No    Most streams are geo-restri
 rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.
 rtve                rtve.es              Yes   No
 ruv                 ruv.is               Yes   Yes   Streams may be geo-restricted to Iceland.
+schoolism           schoolism.com        --    Yes   Requires a login and a subscription.
 seemeplay           seemeplay.ru         Yes   Yes
 servustv            servustv.com         ?     ?
 speedrunslive       speedrunslive.com    Yes   --    URL forwarder to Twitch channels.

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -1,0 +1,103 @@
+from __future__ import print_function
+
+import re
+from functools import partial
+
+from streamlink.plugin import Plugin, PluginOptions
+from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
+
+
+class Schoolism(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?schoolism\.com/watchLesson.php")
+    login_url = "https://www.schoolism.com/index.php"
+    key_time_url = "https://www.schoolism.com/video-html/key-time.php"
+    playlist_re = re.compile(r"var allVideos=(\[\{.*\}]);", re.DOTALL)
+    js_to_json = partial(re.compile(r'(?!<")(\w+):(?!/)').sub, r'"\1":')
+    playlist_schema = validate.Schema(
+        validate.transform(playlist_re.search),
+        validate.any(
+            None,
+            validate.all(
+                validate.get(1),
+                validate.transform(js_to_json),
+                validate.transform(lambda x: x.replace(",}", "}")),  # remove invalid ,
+                validate.transform(parse_json),
+                [{
+                    "sources": validate.all([{
+                        "playlistTitle": validate.text,
+                        "title": validate.text,
+                        "src": validate.text,
+                        "type": validate.text,
+                    }],
+                        # only include HLS streams
+                        validate.filter(lambda s: s["type"] == "application/x-mpegurl")
+                    )
+                }]
+            )
+        )
+    )
+
+    options = PluginOptions({
+        "email": None,
+        "password": None,
+        "part": 1
+    })
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def login(self, email, password):
+        """
+        Login to the schoolism account and return the users account
+        :param email: (str) email for account
+        :param password: (str) password for account
+        :return: (str) users email
+        """
+        if self.options.get("email") and self.options.get("password"):
+            res = http.post(self.login_url, data={"email": email,
+                                                  "password": password,
+                                                  "redirect": None,
+                                                  "submit": "Login"})
+
+            if res.cookies.get("password") and res.cookies.get("email"):
+                return res.cookies.get("email")
+            else:
+                self.logger.error("Failed to login to Schoolism, incorrect email/password combination")
+        else:
+            self.logger.error("An email and password are required to access Schoolism streams")
+
+    def _get_streams(self):
+        user = self.login(self.options.get("email"), self.options.get("password"))
+        if user:
+            self.logger.debug("Logged in to Schoolism as {0}", user)
+            res = http.get(self.url, headers={"User-Agent": useragents.SAFARI_8})
+            lesson_playlist = self.playlist_schema.validate(res.text)
+
+            part = self.options.get("part")
+
+            self.logger.info("Attempting to play lesson Part {0}", part)
+            found = False
+
+            # make request to key-time api, to get key specific headers
+            res = http.get(self.key_time_url, headers={"User-Agent": useragents.SAFARI_8})
+
+            for i, video in enumerate(lesson_playlist, 1):
+                if video["sources"] and i == part:
+                    found = True
+                    for source in video["sources"]:
+                        for s in HLSStream.parse_variant_playlist(self.session,
+                                                                  source["src"],
+                                                                  headers={"User-Agent": useragents.SAFARI_8,
+                                                                           "Referer": self.url}).items():
+                            yield s
+
+            if not found:
+                self.logger.error("Could not find lesson Part {0}", part)
+
+
+__plugin__ = Schoolism

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1040,7 +1040,31 @@ plugin.add_argument(
     A BTV account password to use with --btv-username.
     """
 )
+plugin.add_argument(
+    "--schoolism-email",
+    metavar="EMAIL",
+    help="""
+    The email associated with your Schoolism account, required to access any Schoolism stream.
+    """
+)
+plugin.add_argument(
+    "--schoolism-password",
+    metavar="PASSWORD",
+    help="""
+    A Schoolism account password to use with --schoolism-email.
+    """
+)
+plugin.add_argument(
+    "--schoolism-part",
+    type=int,
+    default=1,
+    metavar="PART",
+    help="""
+    Play part number PART of the lesson
 
+    Defaults is 1
+    """
+)
 
 # Deprecated options
 stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -833,6 +833,18 @@ def setup_plugin_options():
     if btv_password:
         streamlink.set_plugin_option("btv", "password", btv_password)
 
+    if args.schoolism_email:
+        streamlink.set_plugin_option("schoolism", "email", args.schoolism_email)
+    if args.schoolism_email and not args.schoolism_password:
+        schoolism_password = console.askpass("Enter Schoolism password: ")
+    else:
+        schoolism_password = args.schoolism_password
+    if schoolism_password:
+        streamlink.set_plugin_option("schoolism", "password", schoolism_password)
+
+    if args.schoolism_part:
+        streamlink.set_plugin_option("schoolism", "part", args.schoolism_part)
+
     # Deprecated options
     if args.jtv_legacy_names:
         console.logger.warning("The option --jtv/twitch-legacy-names is "


### PR DESCRIPTION
Requires 3 new command line options have to support the site
--schoolism-email: providing the users email address
--schoolism-password: providing the users password
--schoolism-part: specifying which part of a lesson to play