### PR TITLE
Ensure retries with HLS Streams

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -53,6 +53,7 @@ class Streamlink(object):
             "hls-segment-threads": 1,
             "hls-segment-timeout": 10.0,
             "hls-timeout": 60.0,
+            "hls-playlist-reload-attempts": 3,
             "http-stream-timeout": 60.0,
             "ringbuffer-size": 1024 * 1024 * 16,  # 16 MB
             "rtmp-timeout": 60.0,

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -1,38 +1,21 @@
 import struct
 from collections import defaultdict, namedtuple
 
-<<<<<<< Updated upstream
-import requests
-
-=======
 from Crypto.Cipher import AES
 
 from streamlink.stream import hls_playlist
->>>>>>> Stashed changes
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, MuxedStream
-from streamlink.utils.l10n import Localization
-
-try:
-    from Crypto.Cipher import AES
-    import struct
-
-
-    def num_to_iv(n):
-        return struct.pack(">8xq", n)
-
-
-    CAN_DECRYPT = True
-except ImportError:
-    CAN_DECRYPT = False
-
-from . import hls_playlist
-from .http import HTTPStream
-from .segmented import (SegmentedStreamReader,
-                        SegmentedStreamWriter,
-                        SegmentedStreamWorker)
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.segmented import (SegmentedStreamReader,
+                                         SegmentedStreamWriter,
+                                         SegmentedStreamWorker)
 from ..exceptions import StreamError
 
 Sequence = namedtuple("Sequence", "num segment")
+
+
+def num_to_iv(n):
+    return struct.pack(">8xq", n)
 
 
 class HLSStreamWriter(SegmentedStreamWriter):
@@ -92,49 +75,37 @@ class HLSStreamWriter(SegmentedStreamWriter):
         try:
             request_params = self.create_request_params(sequence)
             return self.session.http.get(sequence.segment.uri,
-                                         stream=True,
                                          timeout=self.timeout,
                                          exception=StreamError,
                                          retries=self.retries,
                                          **request_params)
         except StreamError as err:
             self.logger.error("Failed to open segment {0}: {1}", sequence.num, err)
-            return self.fetch(sequence, retries - 1)
-
-    def write(self, sequence, res, chunk_size=8192, retries=None):
-        retries = retries or self.retries
-        if retries == 0:
-            self.logger.error("Failed to open segment {0}", sequence.num)
             return
-        try:
-            if sequence.segment.key and sequence.segment.key.method != "NONE":
-                try:
-                    decryptor = self.create_decryptor(sequence.segment.key,
-                                                      sequence.num)
-                except StreamError as err:
-                    self.logger.error("Failed to create decryptor: {0}", err)
-                    self.close()
-                    return
 
-                for chunk in res.iter_content(chunk_size):
-                    # If the input data is not a multiple of 16, cut off any garbage
-                    garbage_len = len(chunk) % 16
-                    if garbage_len:
-                        self.logger.debug("Cutting off {0} bytes of garbage "
-                                          "before decrypting", garbage_len)
-                        decrypted_chunk = decryptor.decrypt(chunk[:-garbage_len])
-                    else:
-                        decrypted_chunk = decryptor.decrypt(chunk)
-                    self.reader.buffer.write(decrypted_chunk)
-            else:
-                for chunk in res.iter_content(chunk_size):
-                    self.reader.buffer.write(chunk)
-        except (StreamError, requests.exceptions.RequestException) as err:
-            self.logger.error("Failed to open segment {0}: {1}", sequence.num, err)
-            return self.write(sequence,
-                              self.fetch(sequence, retries=self.retries),
-                              chunk_size=chunk_size,
-                              retries=retries - 1)
+    def write(self, sequence, res, chunk_size=8192):
+        if sequence.segment.key and sequence.segment.key.method != "NONE":
+            try:
+                decryptor = self.create_decryptor(sequence.segment.key,
+                                                  sequence.num)
+            except StreamError as err:
+                self.logger.error("Failed to create decryptor: {0}", err)
+                self.close()
+                return
+
+            for chunk in res.iter_content(chunk_size):
+                # If the input data is not a multiple of 16, cut off any garbage
+                garbage_len = len(chunk) % 16
+                if garbage_len:
+                    self.logger.debug("Cutting off {0} bytes of garbage "
+                                      "before decrypting", garbage_len)
+                    decrypted_chunk = decryptor.decrypt(chunk[:-garbage_len])
+                else:
+                    decrypted_chunk = decryptor.decrypt(chunk)
+                self.reader.buffer.write(decrypted_chunk)
+        else:
+            for chunk in res.iter_content(chunk_size):
+                self.reader.buffer.write(chunk)
 
         self.logger.debug("Download of segment {0} complete", sequence.num)
 
@@ -163,7 +134,6 @@ class HLSStreamWorker(SegmentedStreamWorker):
                                     exception=StreamError,
                                     retries=self.playlist_reload_retries,
                                     **self.reader.request_params)
-
         try:
             playlist = hls_playlist.load(res.text, res.url)
         except ValueError as err:
@@ -188,9 +158,6 @@ class HLSStreamWorker(SegmentedStreamWorker):
 
         if first_sequence.segment.key and first_sequence.segment.key.method != "NONE":
             self.logger.debug("Segments in this playlist are encrypted")
-
-            if not CAN_DECRYPT:
-                raise StreamError("Need pyCrypto or pycryptodome installed to decrypt this stream")
 
         self.playlist_changed = ([s.num for s in self.playlist_sequences] !=
                                  [s.num for s in sequences])

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -601,6 +601,17 @@ transport.add_argument(
     """
 )
 transport.add_argument(
+    "--hls-playlist-reload-attempts",
+    type=num(int, min=0),
+    metavar="ATTEMPTS",
+    help="""
+    How many attempts should be done to reload the HLS playlist
+    before giving up.
+
+    Default is 3.
+    """
+)
+transport.add_argument(
     "--hls-segment-threads",
     type=num(int, max=10),
     metavar="THREADS",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -707,6 +707,9 @@ def setup_options():
     if args.hls_segment_attempts:
         streamlink.set_option("hls-segment-attempts", args.hls_segment_attempts)
 
+    if args.hls_playlist_reload_attempts:
+        streamlink.set_option("hls-playlist-reload-attempts", args.hls_playlist_reload_attempts)
+
     if args.hls_segment_threads:
         streamlink.set_option("hls-segment-threads", args.hls_segment_threads)
 


### PR DESCRIPTION
This should fix both #446 and #463. 

I fixed the retries on the HLS segments as well as adding retries (via a general HTTPSession mechanism) to the `playlist_reload` and `create_decryptor` methods. A new `--hls-reload-playlist-attempts` option has been added to control the retries for the playlist. 

I reverted most of the changes made for #166/#260 as it has caused some unforeseen issues. Mainly due to the exception handling of `HTTPSession.request` and `iter_content` being quite different. (The exception handling in livestreamer/streamlink is generally a mess.)

We'll have to reopen #166 until we have a more suitable solution.