### PR TITLE
Option to set crunchyroll session ID

### DIFF
--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -205,7 +205,8 @@ class Crunchyroll(Plugin):
         "username": None,
         "password": None,
         "purge_credentials": None,
-        "locale": None
+        "locale": None,
+        "session_id": None,
     })
 
     @classmethod
@@ -281,13 +282,14 @@ class Crunchyroll(Plugin):
         if self.options.get("purge_credentials"):
             self.cache.set("session_id", None, 0)
             self.cache.set("auth", None, 0)
+            self.cache.set("session_id", None, 0)
 
         current_time = datetime.datetime.utcnow()
         device_id = self._get_device_id()
         # use the crunchyroll locale as an override, for backwards compatibility
         locale = self.get_option("locale") or self.session.localization.language_code
         api = CrunchyrollAPI(
-            self.cache.get("session_id"), self.cache.get("auth"), locale
+            self.options.get("session_id") or self.cache.get("session_id"), self.cache.get("auth"), locale
         )
 
         self.logger.debug("Creating session with locale: {0}", locale)

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1024,6 +1024,14 @@ plugin.add_argument(
     """
 )
 plugin.add_argument(
+    "--crunchyroll-session-id",
+    metavar="SESSION_ID",
+    help="""
+    Set a specific session ID for crunchyroll, can be used to bypass
+    region restrictions
+    """
+)
+plugin.add_argument(
     "--livestation-email",
     metavar="EMAIL",
     help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -814,6 +814,9 @@ def setup_plugin_options():
     if args.crunchyroll_purge_credentials:
         streamlink.set_plugin_option("crunchyroll", "purge_credentials",
                                      args.crunchyroll_purge_credentials)
+    if args.crunchyroll_session_id:
+        streamlink.set_plugin_option("crunchyroll", "session_id",
+                                     args.crunchyroll_session_id)
 
     if args.crunchyroll_locale:
         streamlink.set_plugin_option("crunchyroll", "locale",


### PR DESCRIPTION
Adds the option `--crunchyroll-session-id` which allows the user to specify a specific API session ID, useful for bypassing the region restrictions. Fixes #505 