### PR TITLE
plugins.pluzz: add support for ludo.fr and zouzous.fr

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -116,6 +116,7 @@ picarto             picarto.tv           Yes   --
 playtv              playtv.fr            Yes   --    Streams may be geo-restricted to France.
 pluzz               pluzz.francetv.fr    Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
                     ludo.fr
+                    zouzous.fr
 powerapp            powerapp.com.tr      Yes   No
 raiplay             raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
 rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -115,6 +115,7 @@ periscope           periscope.tv         Yes   Yes   Replay/VOD is supported.
 picarto             picarto.tv           Yes   --
 playtv              playtv.fr            Yes   --    Streams may be geo-restricted to France.
 pluzz               pluzz.francetv.fr    Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
+                    ludo.fr
 powerapp            powerapp.com.tr      Yes   No
 raiplay             raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
 rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -101,6 +101,7 @@ class Pluzz(Plugin):
         geolocked = False
         drm = False
         expired = False
+
         for video in videos['videos']:
             video_url = video['url']
 
@@ -156,7 +157,9 @@ class Pluzz(Plugin):
                 if match is not None:
                     bitrate = match.group('bitrate')
                 else:
-                    bitrate = video['format']
+                    # Fallback bitrate (seems all France Televisions MP4 videos
+                    # seem have such bitrate)
+                    bitrate = '1500k'
                 yield bitrate, HTTPStream(self.session, video_url)
 
         if offline:

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -13,9 +13,9 @@ class Pluzz(Plugin):
     API_URL = 'http://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion={0}&catalogue={1}'
     TOKEN_URL = 'http://hdfauthftv-a.akamaihd.net/esi/TA?url={0}'
 
-    _url_re = re.compile(r'http://(pluzz\.francetv\.fr/(videos/.+\.html|[\w-]+)|www\.ludo\.fr/heros/[\w-]+)')
+    _url_re = re.compile(r'http://(pluzz\.francetv\.fr/(videos/.+\.html|[\w-]+)|www\.(ludo|zouzous)\.fr/heros/[\w-]+)')
     _pluzz_video_id_re = re.compile(r'id="current_video" href="http://.+?\.(?:francetv|francetelevisions)\.fr/(?:video/|\?id-video=)(?P<video_id>.+?)"')
-    _ludo_video_id_re = re.compile(r'playlist: \[{.*?,"identity":"(?P<video_id>.+?)@Ludo"')
+    _other_video_id_re = re.compile(r'playlist: \[{.*?,"identity":"(?P<video_id>.+?)@(?P<catalogue>Ludo|Zouzous)"')
     _player_re = re.compile(r'src="(?P<player>//staticftv-a\.akamaihd\.net/player/jquery\.player.+?-[0-9a-f]+?\.js)"></script>')
     _swf_re = re.compile(r'getUrl\("(?P<swf>/bower_components/player_flash/dist/FranceTVNVPVFlashPlayer\.akamai.+?\.swf)"\)')
     _hds_pv_data_re = re.compile(r"~data=.+?!")
@@ -73,14 +73,15 @@ class Pluzz(Plugin):
         res = http.get(self.url)
         if 'pluzz.francetv.fr' in self.url:
             video_re = self._pluzz_video_id_re
-            catalogue = 'Pluzz'
-        elif 'www.ludo.fr' in self.url:
-            video_re = self._ludo_video_id_re
-            catalogue = 'Ludo'
+        else:
+            video_re = self._other_video_id_re
         match = video_re.search(res.text)
         if match is None:
             return
+        catalogue = 'Pluzz'
         video_id = match.group('video_id')
+        if 'catalogue' in match.groupdict():
+            catalogue = match.group('catalogue')
 
         # Retrieve SWF player URL
         match = self._player_re.search(res.text)

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -150,7 +150,8 @@ class Pluzz(Plugin):
             elif '.m3u8' in video_url:
                 for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
                     yield stream
-            elif '.mp4' in video_url:
+            # HBB TV streams are not provided anymore by France Televisions
+            elif '.mp4' in video_url and '/hbbtv/' not in video_url:
                 match = self._mp4_bitrate_re.match(video_url)
                 if match is not None:
                     bitrate = match.group('bitrate')

--- a/tests/test_plugin_pluzz.py
+++ b/tests/test_plugin_pluzz.py
@@ -15,8 +15,12 @@ class TestPluginPluzz(unittest.TestCase):
         self.assertTrue(Pluzz.can_handle_url("http://pluzz.francetv.fr/franceinfo"))
         self.assertTrue(Pluzz.can_handle_url("http://pluzz.francetv.fr/videos/jt20h.html"))
         self.assertTrue(Pluzz.can_handle_url("http://pluzz.francetv.fr/videos/jt_1213_franche_comte.html"))
+        self.assertTrue(Pluzz.can_handle_url("http://www.ludo.fr/heros/the-batman"))
+        self.assertTrue(Pluzz.can_handle_url("http://www.ludo.fr/heros/il-etait-une-fois-la-vie"))
 
         # shouldn't match
         self.assertFalse(Pluzz.can_handle_url("http://pluzz.francetv.fr/"))
+        self.assertFalse(Pluzz.can_handle_url("http://www.ludo.fr/"))
+        self.assertFalse(Pluzz.can_handle_url("http://www.ludo.fr/jeux"))
         self.assertFalse(Pluzz.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.youtube.com/"))

--- a/tests/test_plugin_pluzz.py
+++ b/tests/test_plugin_pluzz.py
@@ -17,10 +17,13 @@ class TestPluginPluzz(unittest.TestCase):
         self.assertTrue(Pluzz.can_handle_url("http://pluzz.francetv.fr/videos/jt_1213_franche_comte.html"))
         self.assertTrue(Pluzz.can_handle_url("http://www.ludo.fr/heros/the-batman"))
         self.assertTrue(Pluzz.can_handle_url("http://www.ludo.fr/heros/il-etait-une-fois-la-vie"))
+        self.assertTrue(Pluzz.can_handle_url("http://www.zouzous.fr/heros/oui-oui"))
+        self.assertTrue(Pluzz.can_handle_url("http://www.zouzous.fr/heros/marsupilami-1"))
 
         # shouldn't match
         self.assertFalse(Pluzz.can_handle_url("http://pluzz.francetv.fr/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.ludo.fr/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.ludo.fr/jeux"))
+        self.assertFalse(Pluzz.can_handle_url("http://www.zouzous.fr/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
This PR improves the pluzz plugin to add support for the following VOD platforms for youth, provided by France Télévisions:

* ludo.fr (as requested in https://github.com/streamlink/streamlink/issues/534)
* zouzous.fr

As for the streams on pluzz.francetv.fr, videos on these two websites are georestricted to France, Andorra and Monaco.
