### PR TITLE
Crunchyroll plugin fails on string.format in Python 2.6

### DIFF
--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -9,7 +9,7 @@ from streamlink.stream import HLSStream
 
 API_URL = "https://api.crunchyroll.com/{0}.0.json"
 API_DEFAULT_LOCALE = "en_US"
-API_USER_AGENT = "Mozilla/5.0 (iPhone; iPhone OS 8.3.0; {})"
+API_USER_AGENT = "Mozilla/5.0 (iPhone; iPhone OS 8.3.0; {0})"
 API_HEADERS = {
     "Host": "api.crunchyroll.com",
     "Accept-Encoding": "gzip, deflate",


### PR DESCRIPTION
See Issue #538 

This is a rather trivial pull request, it literally adds a single character to a format string to allow it to function on Python 2.6