### PR TITLE
stream.hls: Retry HTTP requests to get the key for HLS streams

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -39,6 +39,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
         if self.key_uri != key.uri:
             res = self.session.http.get(key.uri, exception=StreamError,
+                                        retries=self.retries,
                                         **self.reader.request_params)
             self.key_data = res.content
             self.key_uri = key.uri


### PR DESCRIPTION
If the HTTP request for the key for an HLS stream fails then the
stream will end. This is a problem for streams where the key is updated
periodically. If the key request fails it will be retried a few times
(same retry count as hls-segment-attempts). This should fix #547.