### PR TITLE
AppVeyor build fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ install:
   # install dev requirements, for testing, etc.
   - "pip install -r dev-requirements.txt"
   - "pip install pycountry" 
-  - "pip install ."
+  - "build.cmd %PYTHON%\\python.exe -m pip install ."
 
 build: off
 


### PR DESCRIPTION
This fixes the build issues we've been having for the last couple of days, since the new version of `pycryptodome` doesn't have wheels for some versions of Python... 