### PR TITLE
utils.l10n: fix bug in iso3166 country lookup

### DIFF
--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -80,6 +80,8 @@ class Language(object):
                             pass
                     if not l:
                         raise KeyError(language)
+                else:
+                    raise KeyError(language)
                 return Language(l.alpha2, l.part3, l.name, l.part2b or l.part2t)
         except (LookupError, KeyError):
             raise LookupError("Invalid language code: {0}".format(language))

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -4,32 +4,37 @@ try:
 except ImportError:
     from mock import patch
 
-
-from streamlink.utils.l10n import Localization, Country, Language
+import streamlink.utils.l10n as l10n
 
 
 class TestLocalization(unittest.TestCase):
+    def setUp(self):
+        l10n.PYCOUNTRY = False
+
+    def test_pycountry(self):
+        self.assertEqual(False, l10n.PYCOUNTRY)
+
     def test_language_code(self):
-        l = Localization("en_US")
+        l = l10n.Localization("en_US")
         self.assertEqual("en_US", l.language_code)
 
     def test_bad_language_code(self):
-        self.assertRaises(LookupError, Localization, "enUS")
+        self.assertRaises(LookupError, l10n.Localization, "enUS")
 
     def test_equivalent(self):
-        l = Localization("en_US")
+        l = l10n.Localization("en_US")
         self.assertTrue(l.equivalent(language="eng"))
         self.assertTrue(l.equivalent(language="en"))
         self.assertTrue(l.equivalent(language="en", country="US"))
         self.assertTrue(l.equivalent(language="en", country="United States"))
 
     def test_equivalent_remap(self):
-        l = Localization("fr_FR")
+        l = l10n.Localization("fr_FR")
         self.assertTrue(l.equivalent(language="fra"))
         self.assertTrue(l.equivalent(language="fre"))
 
     def test_not_equivalent(self):
-        l = Localization("es_ES")
+        l = l10n.Localization("es_ES")
         self.assertFalse(l.equivalent(language="eng"))
         self.assertFalse(l.equivalent(language="en"))
         self.assertFalse(l.equivalent(language="en", country="US"))
@@ -40,48 +45,48 @@ class TestLocalization(unittest.TestCase):
     @patch("locale.getdefaultlocale")
     def test_default(self, getdefaultlocale):
         getdefaultlocale.return_value = (None, None)
-        l = Localization()
+        l = l10n.Localization()
         self.assertEqual("en_US", l.language_code)
         self.assertTrue(l.equivalent(language="en", country="US"))
 
     def test_get_country(self):
         self.assertEqual("US",
-                         Localization.get_country("USA").alpha2)
+                         l10n.Localization.get_country("USA").alpha2)
         self.assertEqual("GB",
-                         Localization.get_country("GB").alpha2)
+                         l10n.Localization.get_country("GB").alpha2)
         self.assertEqual("United States",
-                         Localization.get_country("United States").name)
+                         l10n.Localization.get_country("United States").name)
 
     def test_get_country_miss(self):
-        self.assertRaises(LookupError, Localization.get_country, "XE")
-        self.assertRaises(LookupError, Localization.get_country, "XEX")
-        self.assertRaises(LookupError, Localization.get_country, "Nowhere")
+        self.assertRaises(LookupError, l10n.Localization.get_country, "XE")
+        self.assertRaises(LookupError, l10n.Localization.get_country, "XEX")
+        self.assertRaises(LookupError, l10n.Localization.get_country, "Nowhere")
 
     def test_get_language(self):
         self.assertEqual("eng",
-                         Localization.get_language("en").alpha3)
+                         l10n.Localization.get_language("en").alpha3)
         self.assertEqual("fre",
-                         Localization.get_language("fra").bibliographic)
+                         l10n.Localization.get_language("fra").bibliographic)
         self.assertEqual("fra",
-                         Localization.get_language("fre").alpha3)
+                         l10n.Localization.get_language("fre").alpha3)
         self.assertEqual("gre",
-                         Localization.get_language("gre").bibliographic)
+                         l10n.Localization.get_language("gre").bibliographic)
 
     def test_get_language_miss(self):
-        self.assertRaises(LookupError, Localization.get_language, "00")
-        self.assertRaises(LookupError, Localization.get_language, "000")
-        self.assertRaises(LookupError, Localization.get_language, "0000")
+        self.assertRaises(LookupError, l10n.Localization.get_language, "00")
+        self.assertRaises(LookupError, l10n.Localization.get_language, "000")
+        self.assertRaises(LookupError, l10n.Localization.get_language, "0000")
 
     def test_country_compare(self):
-        a = Country("AA", "AAA", "001", "Test")
-        b = Country("AA", "AAA", "001", "Test")
+        a = l10n.Country("AA", "AAA", "001", "Test")
+        b = l10n.Country("AA", "AAA", "001", "Test")
         self.assertEqual(a, b)
 
     def test_language_compare(self):
-        a = Language("AA", "AAA", "Test")
-        b = Language("AA", None, "Test")
+        a = l10n.Language("AA", "AAA", "Test")
+        b = l10n.Language("AA", None, "Test")
         self.assertEqual(a, b)
 
-        a = Language("BB", "BBB", "Test")
-        b = Language("AA", None, "Test")
+        a = l10n.Language("BB", "BBB", "Test")
+        b = l10n.Language("AA", None, "Test")
         self.assertNotEqual(a, b)

--- a/tests/test_localization_pycountry.py
+++ b/tests/test_localization_pycountry.py
@@ -1,12 +1,15 @@
 from tests.test_localization import TestLocalization
 import streamlink.utils.l10n as l10n
 
-from pycountry import languages, countries
-l10n.countries = countries
-l10n.languages = languages
-l10n.PYCOUNTRY = True
-
 
 class TestLocalizationPyCountry(TestLocalization):
     """Duplicate of all the Localization tests but using PyCountry instead of the iso* modules"""
-    pass
+
+    def setUp(self):
+        from pycountry import languages, countries
+        l10n.countries = countries
+        l10n.languages = languages
+        l10n.PYCOUNTRY = True
+
+    def test_pycountry(self):
+        self.assertEqual(True, l10n.PYCOUNTRY)


### PR DESCRIPTION
The `pycountry` vs. `iso639+iso3166` l10n tests were broken so that the only the `pycountry` tests were being run. This has now been fixed, which uncovered a bug in the `iso3166` country lookup.