### PR TITLE
tests: speed up the cmdline tests

### DIFF
--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -97,8 +97,7 @@ class PlayerOutput(Output):
     @property
     def running(self):
         sleep(0.5)
-        self.player.poll()
-        return self.player.returncode is None
+        return self.player.poll() is None
 
     def _create_arguments(self):
         if self.namedpipe:

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -32,8 +32,14 @@ class TestCommandLineInvocation(unittest.TestCase):
     @patch('sys.argv')
     def _test_args(self, args, commandline, mock_argv, mock_popen, mock_setup_streamlink, passthrough=False):
         mock_argv.__getitem__.side_effect = lambda x: args[x]
-        mock_popen().returncode = None
-        mock_popen().poll.return_value = None
+
+        def side_effect(results):
+            def fn(*args):
+                result = results.pop(0)
+                return result
+            return fn
+
+        mock_popen().poll.side_effect = side_effect([None, 0])
 
         streamlink_cli.main.main()
         mock_setup_streamlink.assert_called_with()


### PR DESCRIPTION
When #453 was merged it added some possible delay in killing the player process, this delay was also experienced in the tests. By mocking the expected return values of `poll()`, the delay can be avoided and the runtime of the tests reduced from around 60 seconds to 6 seconds.