### PR TITLE
Add a donation page

### DIFF
--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -1,0 +1,30 @@
+Donating
+--------
+
+Thank you for considering a donation to the Streamlink team! Streamlink is an
+organization composed of a geographically diverse group of individuals. As such
+please make your donation directly to the appropriate team member. Note that
+donations are not tax deductible as Streamlink does not operate as a charitable
+organization. Your donation to a team member may be used in any way and does
+not come with expectations of work to be provided or as payment for future
+work. If you would like a specific feature implemented considering creating a
+bounty on `Bountysource <https://www.bountysource.com/teams/streamlink>`_.
+
+---------------
+Streamlink Team
+---------------
+
+`Bastimeyer <https://github.com/bastimeyer>`_
+---------------------------------------------
+
+- `Bitcoin <https://blockchain.info/qr?data=1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8>`_ (`1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8`)
+- `Dogecoin <https://blockchain.info/qr?data=DGkVP7AMUHr2TbVnWy6QyZqSMvCkeEo1ab>`_ (`DGkVP7AMUHr2TbVnWy6QyZqSMvCkeEo1ab`)
+- `Flattr <https://flattr.com/thing/3956088>`_
+- `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`_
+
+`Gravyboat <https://github.com/gravyboat`_
+------------------------------------------
+
+- `Bitcoin <https://blockchain.info/qr?data=1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`_ (`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`)
+- `Flattr <https://flattr.com/profile/gravyboat>`_
+- `Gratipay <https://gratipay.com/~gravyboat/>`_

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -23,7 +23,7 @@ Streamlink Team
 - `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`__
 
 `Beardypig <https://github.com/beardypig>`_
----------------------------------------------
+-------------------------------------------
 
 - `Bitcoin <https://blockchain.info/qr?data=1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh>`__ (`1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh`)
 

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -22,8 +22,8 @@ Streamlink Team
 - `Flattr <https://flattr.com/thing/3956088>`_
 - `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`_
 
-`Gravyboat <https://github.com/gravyboat`_
-------------------------------------------
+`Gravyboat <https://github.com/gravyboat>`_
+-------------------------------------------
 
 - `Bitcoin <https://blockchain.info/qr?data=1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`_ (`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`)
 - `Flattr <https://flattr.com/profile/gravyboat>`_

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -22,6 +22,11 @@ Streamlink Team
 - `Flattr <https://flattr.com/thing/3956088>`__
 - `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`__
 
+`Beardypig <https://github.com/beardypig>`_
+---------------------------------------------
+
+- `Bitcoin <https://blockchain.info/qr?data=1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh>`__ (`1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh`)
+
 `Gravyboat <https://github.com/gravyboat>`_
 -------------------------------------------
 

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -17,14 +17,14 @@ Streamlink Team
 `Bastimeyer <https://github.com/bastimeyer>`_
 ---------------------------------------------
 
-- `Bitcoin <https://blockchain.info/qr?data=1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8>`_ (`1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8`)
-- `Dogecoin <https://blockchain.info/qr?data=DGkVP7AMUHr2TbVnWy6QyZqSMvCkeEo1ab>`_ (`DGkVP7AMUHr2TbVnWy6QyZqSMvCkeEo1ab`)
-- `Flattr <https://flattr.com/thing/3956088>`_
-- `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`_
+- `Bitcoin <https://blockchain.info/qr?data=1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8>`__ (`1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8`)
+- `Dogecoin <https://blockchain.info/qr?data=DGkVP7AMUHr2TbVnWy6QyZqSMvCkeEo1ab>`__ (`DGkVP7AMUHr2TbVnWy6QyZqSMvCkeEo1ab`)
+- `Flattr <https://flattr.com/thing/3956088>`__
+- `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`__
 
 `Gravyboat <https://github.com/gravyboat>`_
 -------------------------------------------
 
-- `Bitcoin <https://blockchain.info/qr?data=1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`_ (`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`)
-- `Flattr <https://flattr.com/profile/gravyboat>`_
-- `Gratipay <https://gratipay.com/~gravyboat/>`_
+- `Bitcoin <https://blockchain.info/qr?data=1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`__ (`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`)
+- `Flattr <https://flattr.com/profile/gravyboat>`__
+- `Gratipay <https://gratipay.com/~gravyboat/>`__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,3 +65,4 @@ See their respective sections for more information on how to use them.
     api_guide
     api
     changelog
+    donate


### PR DESCRIPTION
This is an initial draft for what a possible donation page would look like. This fixes #347. I believe that this PR addresses https://github.com/streamlink/streamlink/issues/347#issuecomment-270068127 as it prominently features bountysource in addition to direct donation methods. At this time I've only added myself and @bastimeyer as the donation details were easy to find.

Edit: It would probably good to add a donation page link to the releases as well.