### PR TITLE
stream.hds: warn about streams being protected by DRM

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -484,7 +484,7 @@ def handle_url():
         console.exit(u"{0}", err)
 
     if not streams:
-        console.exit("No streams found on this URL: {0}", args.url)
+        console.exit("No playable streams found on this URL: {0}", args.url)
 
     if args.best_stream_default:
         args.default_stream = ["best"]


### PR DESCRIPTION
Make the fact that some streams are protected by DRM more obvious to the user. This is useful if the user specifies a `hds://` URL that has DRMed streams and wonders why no streams are returned.
If child streams are protected by DRM the warning message is only printed once, but a debug message will be printed for each stream. The message is deliberately vague in stating whether or not any stream are available as this message is generated by the HDS manifest parsing method and in a plugin other streams may be available.
