### PR TITLE
plugins.tvrplus: add support for tvrplus.ro live streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -167,6 +167,7 @@ tv8cat              tv8.cat              Yes   No    Streams may be geo-restrict
 tv360               tv360.com.tr         Yes   No
 tvcatchup           - tvcatchup.com      Yes   No    Streams may be geo-restricted to Great Britain.
 tvplayer            tvplayer.com         Yes   No    Streams may be geo-restricted to Great Britain. Premium streams are not supported.
+tvrplus             tvrplus.ro           Yes   No    Streams may be geo-restricted to Romania.
 twitch              twitch.tv            Yes   Yes   Possible to authenticate for access to
                                                      subscription streams.
 ustreamtv           ustream.tv           Yes   Yes   Currently broken.

--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -1,0 +1,29 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+
+
+class TVRPlus(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)tvrplus.ro/live-")
+    hls_file_re = re.compile(r"file: (?P<q>[\"'])(?P<url>http.+?m3u8.*?)(?P=q)")
+
+    stream_schema = validate.Schema(
+        validate.all(
+            validate.transform(hls_file_re.search),
+            validate.any(None, validate.get("url"))
+         ),
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        stream_url = self.stream_schema.validate(http.get(self.url).text)
+        if stream_url:
+            return HLSStream.parse_variant_playlist(self.session, stream_url)
+
+__plugin__ = TVRPlus


### PR DESCRIPTION
As requested by @karlo2105 in #586. The most basic plug-in I could come up with ;)

Example URLs:
- `tvrplus.ro/live-tvr-1`
- `tvrplus.ro/live-tvr-hd`
- `tvrplus.ro/live-tvr-2`
- `tvrplus.ro/live-tvr-3`
- `tvrplus.ro/live-tvr-international` (not geo-locked)
- `tvrplus.ro/live-tvr-moldova`
- `tvrplus.ro/live-tvr-cluj`
- `tvrplus.ro/live-tvr-craiova`
- `tvrplus.ro/live-tvr-iasi`
- `tvrplus.ro/live-tvr-targu-mures`
- `tvrplus.ro/live-tvr-timisoara`