### PR TITLE
plugins.ovvatv: add support for ovva.tv live streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -112,6 +112,7 @@ nrk                 - tv.nrk.no          Yes   Yes   Streams may be geo-restrict
 oldlivestream       original.liv... [3]_ Yes   No    Only mobile streams are supported.
 openrectv           openrec.tv           Yes   Yes
 orf_tvthek          tvthek.orf.at        Yes   Yes
+ovvatv              ovva.tv              Yes   No
 pandatv             panda.tv             Yes   ?
 periscope           periscope.tv         Yes   Yes   Replay/VOD is supported.
 picarto             picarto.tv           Yes   --

--- a/src/streamlink/plugins/ovvatv.py
+++ b/src/streamlink/plugins/ovvatv.py
@@ -1,0 +1,63 @@
+from __future__ import print_function
+import re
+import string
+from base64 import b64decode
+from pprint import pprint
+
+from streamlink import PluginError
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.compat import urlparse
+from streamlink.utils import parse_json
+
+
+class ovvaTV(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?ovva.tv/(?:ua/)?tvguide/.*?/online")
+    iframe_re = re.compile(r"iframe .*?src=\"((?:https?:)?//(?:\w+\.)?ovva.tv/[^\"]+)\"", re.DOTALL)
+    data_re = re.compile(r"ovva\(\'(.*?)\'\);")
+    ovva_data_schema = validate.Schema({
+        "url": validate.url()
+    }, validate.get("url"))
+    ovva_redirect_schema = validate.Schema(validate.all(
+        validate.transform(lambda x: x.split("=")),
+        ['302', validate.url()],
+        validate.get(1)
+    ))
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def find_iframe(self, res):
+        for url in self.iframe_re.findall(res.text):
+            if url.startswith("//"):
+                p = urlparse(self.url)
+                return "{0}:{1}".format(p.scheme, url)
+            else:
+                return url
+
+    def _get_streams(self):
+        http.headers = {"User-Agent": useragents.ANDROID}
+        res = http.get(self.url)
+        iframe_url = self.find_iframe(res)
+
+        if iframe_url:
+            self.logger.debug("Found iframe: {0}", iframe_url)
+            res = http.get(iframe_url, headers={"Referer": self.url})
+            data = self.data_re.search(res.text)
+            if data:
+                try:
+                    ovva_url = parse_json(b64decode(data.group(1)), schema=self.ovva_data_schema)
+                    stream_url = http.get(ovva_url, schema=self.ovva_redirect_schema)
+                except PluginError as e:
+                    self.logger.error("Could not find stream URL: {0}", e)
+                else:
+                    return HLSStream.parse_variant_playlist(self.session, stream_url)
+            else:
+                self.logger.error("Could not find player data.")
+
+
+__plugin__ = ovvaTV


### PR DESCRIPTION
As requested in #592 by @karlo2105: 

Add support for the Ukrainian live TV streams on ovva.tv.
The streams are provided via HLS and do not appear to be geo-locked.

Supported URLs:
- ovva.tv/tvguide/1plus1/online
- ovva.tv/ua/tvguide/1plus1/online
- ovva.tv/tvguide/1plus1in/online
- ovva.tv/ua/tvguide/1plus1in/online
- ovva.tv/tvguide/2plus2/online
- ovva.tv/ua/tvguide/2plus2/online
- ovva.tv/tvguide/tet/online
- ovva.tv/ua/tvguide/tet/online
- ovva.tv/tvguide/tsnsurdo/online
- ovva.tv/ua/tvguide/tsnsurdo/online
- ovva.tv/tvguide/unian/online
- ovva.tv/ua/tvguide/unian/online