### PR TITLE
cli.utils.http_server: avoid "Address already in use" with --player-external-http

### DIFF
--- a/src/streamlink_cli/utils/http_server.py
+++ b/src/streamlink_cli/utils/http_server.py
@@ -23,6 +23,7 @@ class HTTPRequest(BaseHTTPRequestHandler):
 class HTTPServer(object):
     def __init__(self):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self.conn = self.host = self.port = None
         self.bound = False
 
@@ -111,4 +112,5 @@ class HTTPServer(object):
             self.conn.close()
 
         if not client_only:
+            self.socket.shutdown(2)
             self.socket.close()


### PR DESCRIPTION
When using `--player-external-http` if streamlink is closed and restarted a `Address already in use` error can be encountered. This is because the socket is still in the `TIME_WAIT` state (more information can be found here: http://hea-www.harvard.edu/~fine/Tech/addrinuse.html).
The solution is to set the socket option `SO_REUSEADDR` so that the address can be reused before the end of the `TIME_WAIT` state. This does **not** mean that multiple streamlink instance can listen on the same port.

This should fix #595 :)