### PR TITLE
plugins.seetv: add support for seetv.tv live streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -126,6 +126,7 @@ rtvs                rtvs.sk              Yes   No    Streams may be geo-restrict
 ruv                 ruv.is               Yes   Yes   Streams may be geo-restricted to Iceland.
 schoolism           schoolism.com        --    Yes   Requires a login and a subscription.
 seemeplay           seemeplay.ru         Yes   Yes
+seetv               seetv.tv             Yes   No    Streams that are embedded from other sites will not work.
 servustv            servustv.com         ?     ?
 speedrunslive       speedrunslive.com    Yes   --    URL forwarder to Twitch channels.
 sportal             sportal.bg           Yes   No

--- a/src/streamlink/plugins/seetv.py
+++ b/src/streamlink/plugins/seetv.py
@@ -1,0 +1,78 @@
+import re
+
+import time
+
+from streamlink import PluginError
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.compat import urlparse, parse_qsl
+
+
+class SeeTV(Plugin):
+    _url_re = re.compile(r"""(http://seetv.tv/vse-tv-online/.*?)(#|$)""")
+    _api_url = "http://seetv.tv/get/player/{0}"
+    _main_source_re = re.compile(r'stream-active-main" rel="(\d+)"')
+    api_schema = validate.Schema(validate.any(
+        {
+            "status": False,
+            "text": validate.text
+        },
+        {
+            "status": True,
+            "file": validate.any(
+                validate.all(validate.url(), validate.transform(lambda x: x.replace("%3F", "?"))),
+                validate.all(validate.text, validate.startswith("<"))
+            ),
+            "height": validate.text,
+        }
+    ))
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    @property
+    def referer(self):
+        return self._url_re.match(self.url).group(1)
+
+    def _get_tv_link(self):
+        res = http.get(self.url)
+        link_m = self._main_source_re.search(res.text)
+        return link_m and link_m.group(1)
+
+    def _get_streams(self):
+        http.headers.update({"User-Agent": useragents.CHROME,
+                             "Referer": self.referer})
+        fragment = dict(parse_qsl(urlparse(self.url).fragment))
+        link = fragment.get("link")
+        if not link:
+            link = self._get_tv_link()
+
+        if not link:
+            self.logger.error("Missing link fragment: stream unavailable")
+            return
+
+        player_url = self._api_url.format(link)
+        self.logger.debug("Requesting player API: {0} (referer={1})", player_url, self.referer)
+        res = http.get(player_url,
+                       params={"_": int(time.time() * 1000)},
+                       headers={"X-Requested-With": "XMLHttpRequest"})
+
+        try:
+            data = http.json(res, schema=self.api_schema)
+        except PluginError as e:
+            print(e)
+            self.logger.error("Cannot play this stream type")
+        else:
+            if data["status"]:
+                if data["file"].startswith("<"):
+                    self.logger.error("Cannot play embedded streams")
+                else:
+                    return HLSStream.parse_variant_playlist(self.session, data["file"])
+            else:
+                self.logger.error(data["text"])
+
+__plugin__ = SeeTV

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -96,7 +96,7 @@ class M3U8Parser(object):
         match = re.match("#(?P<tag>[\w-]+)(:(?P<value>.+))?", line)
 
         if match:
-            return match.group("tag"), match.group("value").strip()
+            return match.group("tag"), (match.group("value") or "").strip()
 
         return None, None
 


### PR DESCRIPTION
Only the streams that are provided directly from seetv.tv will work, embedded (`<iframe />` or `<object />`) streams are not supported.

Example URLs:
- seetv.tv/vse-tv-online/stb-ch-ua
- seetv.tv/vse-tv-online/tv-inter-ua