### PR TITLE
cli.utils.http_server: ignore errors with socket.shutdown

### DIFF
--- a/src/streamlink_cli/utils/http_server.py
+++ b/src/streamlink_cli/utils/http_server.py
@@ -112,5 +112,8 @@ class HTTPServer(object):
             self.conn.close()
 
         if not client_only:
-            self.socket.shutdown(2)
+            try:
+                self.socket.shutdown(2)
+            except OSError:
+                pass
             self.socket.close()


### PR DESCRIPTION
The socket may already be closed on the other end, so ignore any errors that occur when trying to shutdown the server socket.

This should fix #604 reported by @thinkpad4.