### PR TITLE
streamlinkrc : Version check disabled by default

### DIFF
--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -66,3 +66,6 @@ ffmpeg-ffmpeg=ffmpeg.exe
 
 # Number of threads to use when streaming HDS streams
 #hds-segment-threads=1
+
+# Disable version check
+no-version-check


### PR DESCRIPTION
I added line to disable version checking by default. This should stop streamlink ping on launch. 
[https://github.com/streamlink/streamlink/issues/590](url)