### PR TITLE
plugins.daisuki: fix for truncated subtitles

### DIFF
--- a/src/streamlink/plugins/daisuki.py
+++ b/src/streamlink/plugins/daisuki.py
@@ -18,7 +18,6 @@ from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
 from streamlink.stream.ffmpegmux import MuxedStream, FFMPEGMuxer
 from streamlink.stream.file import FileStream
-from streamlink.utils.l10n import Language
 
 HDCORE_VERSION = "3.2.0"
 
@@ -87,9 +86,7 @@ _xml_to_srt_schema = validate.Schema(
                             ),
                             "text": validate.all(
                                 validate.get(1),
-                                validate.getattr("text"),
-                                validate.transform(lambda s: s.strip()),
-                                validate.transform(lambda s: s.replace("<br />", "\n"))
+                                validate.transform(lambda x: '\n'.join([s.strip() for s in x.itertext()]))
                             )
                         }),
                         validate.transform(


### PR DESCRIPTION
Only the first text portion was being used when converting the XML subtitles to SRT, this meant that only the first line was included.

This fixes the issue mention in #609. Tested in `VLC2.2.4`, `VLC3.0.0beta` and `mpv`.