### PR TITLE
cli: disable automatic version checking by default

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -131,6 +131,14 @@ def keyvalue(value):
     return match.group("key", "value")
 
 
+def boolean(value):
+    truths = ["yes", "1", "true", "on"]
+    falses = ["no", "0", "false", "off"]
+    if value.lower() not in truths+falses:
+        raise argparse.ArgumentTypeError("{0} was not one of {{{1}}}".format(value, ', '.join(truths+falses)))
+
+    return value.lower() in truths
+
 parser = ArgumentParser(
     fromfile_prefix_chars="@",
     formatter_class=HelpFormatter,
@@ -262,9 +270,9 @@ general.add_argument(
 )
 general.add_argument(
     "--auto-version-check",
-    type=str,
-    choices=["yes", "no"],
-    default="no",
+    type=boolean,
+    metavar="{yes,true,1,on,no,false,0,off}",
+    default=False,
     help="""
     Enable or disable the automatic check for a new version of Streamlink.
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -261,10 +261,14 @@ general.add_argument(
     """
 )
 general.add_argument(
-    "--no-version-check",
-    action="store_true",
+    "--auto-version-check",
+    type=str,
+    choices=["yes", "no"],
+    default="no",
     help="""
-    Do not check for new Streamlink releases.
+    Enable or disable the automatic check for a new version of Streamlink.
+
+    Default is no
     """
 )
 general.add_argument(
@@ -1170,6 +1174,11 @@ http.add_argument(
 plugin.add_argument(
     "--crunchyroll-locale",
     metavar="LOCALE",
+    help=argparse.SUPPRESS
+)
+general.add_argument(
+    "--no-version-check",
+    action="store_true",
     help=argparse.SUPPRESS
 )
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -928,7 +928,7 @@ def main():
     setup_http_session()
     check_root()
 
-    if args.version_check or args.auto_version_check == "yes":
+    if args.version_check or (not args.no_version_check and args.auto_version_check):
         with ignored(Exception):
             check_version(force=args.version_check)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -928,7 +928,7 @@ def main():
     setup_http_session()
     check_root()
 
-    if args.version_check or not args.no_version_check:
+    if args.version_check or args.auto_version_check == "yes":
         with ignored(Exception):
             check_version(force=args.version_check)
 


### PR DESCRIPTION
Adds a new option `--auto-version-check=(yes|no)` and suppresses the existing option `--no-version-check`. `--auto-version-check` defaults to `no`, and can re-enabled by setting `--auto-version-check=yes`.

See discussion in #590.