### PR TITLE
plugin.npo: rewrite of plugin to use the new API

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -111,7 +111,9 @@ mlgtv               mlg.tv               Yes   --
 nhkworld            nhk.or.jp/nhkworld   Yes   No
 nineanime           9anime.to            --    Yes
 nos                 nos.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.
-npo                 npo.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.
+npo                 - npo.nl             Yes   Yes   Streams may be geo-restricted to Netherlands.
+                    - zapp.nl
+                    - zappelin.nl
 nrk                 - tv.nrk.no          Yes   Yes   Streams may be geo-restricted to Norway.
                     - radio.nrk.no
 oldlivestream       original.liv... [3]_ Yes   No    Only mobile streams are supported.

--- a/src/streamlink/plugins/npo.py
+++ b/src/streamlink/plugins/npo.py
@@ -6,90 +6,80 @@ Supports:
 """
 
 import re
-import json
 
-from streamlink.compat import quote
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
-from streamlink.stream import HTTPStream, HLSStream
-
-_url_re = re.compile(r"http(s)?://(\w+\.)?npo.nl/")
-HTTP_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1944.9 Safari/537.36"
-}
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
 
 
 class NPO(Plugin):
+    api_url = "http://ida.omroep.nl/app.php/{endpoint}"
+    url_re = re.compile(r"http(s)?://(\w+\.)?npo.nl/")
+    prid_re = re.compile(r'data-prid="(\w+)"')
+
+    auth_schema = validate.Schema({"token": validate.text}, validate.get("token"))
+    streams_schema = validate.Schema({
+        "items": [
+            [{
+                "label": validate.text,
+                "contentType": validate.text,
+                "url": validate.url(),
+                "format": validate.text
+            }]
+        ]
+    }, validate.get("items"), validate.get(0))
+    stream_info_schema = validate.Schema(validate.any(
+        validate.url(),
+        validate.all({"errorcode": 0, "url": validate.url()},
+                     validate.get("url"))
+    ))
+
     @classmethod
     def can_handle_url(cls, url):
-        return _url_re.match(url)
+        return cls.url_re.match(url) is not None
 
-    def get_token(self):
-        url = 'http://ida.omroep.nl/npoplayer/i.js?s={0}'.format(quote(self.url))
-        token = http.get(url, headers=HTTP_HEADERS).text
-        token = re.compile(r'token.*?"(.*?)"', re.DOTALL + re.IGNORECASE).search(token).group(1)
+    def __init__(self, url):
+        super(NPO, self).__init__(url)
+        self._token = None
+        http.headers.update({"User-Agent": useragents.CHROME})
 
-        # Great the have a ['en','ok','t'].reverse() decurity option in npoplayer.js
-        secured = list(token)
-        token = list(token)
+    def api_call(self, endpoint, schema=None, params=None):
+        url = self.api_url.format(endpoint=endpoint)
+        res = http.get(url, params=params)
+        return http.json(res, schema=schema)
 
-        first = -1
-        second = -1
-        for i, c in enumerate(token):
-            if c.isdigit() and 4 < i < len(token):
-                if first == -1:
-                    first = i
-                else:
-                    second = i
-                    break
-
-        if first == -1:
-            first = 12
-        if second == -1:
-            second = 13
-
-        secured[first] = token[second]
-        secured[second] = token[first]
-        return ''.join(secured)
-
-    def _get_meta(self):
-        html = http.get('http://www.npo.nl/live/{0}'.format(self.npo_id), headers=HTTP_HEADERS).text
-        program_id = re.compile(r'data-prid="(.*?)"', re.DOTALL + re.IGNORECASE).search(html).group(1)
-        meta = http.get('http://e.omroep.nl/metadata/{0}'.format(program_id), headers=HTTP_HEADERS).text
-        meta = re.compile(r'({.*})', re.DOTALL + re.IGNORECASE).search(meta).group(1)
-        return json.loads(meta)
-
-    def _get_vod_streams(self):
-        url = 'http://ida.omroep.nl/odi/?prid={0}&puboptions=adaptive,h264_bb,h264_sb,h264_std&adaptive=no&part=1&token={1}'\
-            .format(quote(self.npo_id), quote(self.get_token()))
-        res = http.get(url, headers=HTTP_HEADERS)
-
-        data = res.json()
-
-        streams = {}
-        stream = http.get(data['streams'][0].replace('jsonp', 'json'), headers=HTTP_HEADERS).json()
-        streams['best'] = streams['high'] = HTTPStream(self.session, stream['url'])
-        return streams
-
-    def _get_live_streams(self):
-        meta = self._get_meta()
-        stream = [x for x in meta['streams'] if x['type'] == 'hls'][0]['url']
-
-        url = 'http://ida.omroep.nl/aapi/?type=jsonp&stream={0}&token={1}'.format(stream, self.get_token())
-        streamdata = http.get(url, headers=HTTP_HEADERS).json()
-        deeplink = http.get(streamdata['stream'], headers=HTTP_HEADERS).text
-        deeplink = re.compile(r'"(.*?)"', re.DOTALL + re.IGNORECASE).search(deeplink).group(1)
-        playlist_url = deeplink.replace("\\/", "/")
-        return HLSStream.parse_variant_playlist(self.session, playlist_url)
+    @property
+    def token(self):
+        if not self._token:
+            self._token = self.api_call("auth", schema=self.auth_schema)
+        return self._token
 
     def _get_streams(self):
-        urlparts = self.url.split('/')
-        self.npo_id = urlparts[-1]
+        res = http.get(self.url)
+        # Locate the asset id for the content on the page
+        prid_m = self.prid_re.search(res.text)
 
-        if (urlparts[-2] == 'live'):
-            return self._get_live_streams()
-        else:
-            return self._get_vod_streams()
+        if prid_m:
+            asset_id = prid_m.group(1)
+
+            streams = self.api_call(asset_id,
+                                    params=dict(adaptive="yes",
+                                                token=self.token),
+                                    schema=self.streams_schema)
+
+            for stream in streams:
+                if stream["format"] == "hls":
+                    # using type=json removes the javascript function wrapper
+                    info_url = stream["url"].replace("type=jsonp", "type=json")
+
+                    # find the actual stream URL
+                    stream_url = http.json(http.get(info_url),
+                                           schema=self.stream_info_schema)
+
+                    for s in HLSStream.parse_variant_playlist(self.session, stream_url).items():
+                        yield s
 
 
 __plugin__ = NPO

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1177,6 +1177,13 @@ plugin.add_argument(
     A TVPlayer account password to use with --animelab-email.
     """
 )
+plugin.add_argument(
+    "--npo-subtitles",
+    action="store_true",
+    help="""
+    Include subtitles for the deaf or hard of hearing, if available
+    """
+)
 
 # Deprecated options
 stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -904,6 +904,9 @@ def setup_plugin_options():
     if animelab_password:
         streamlink.set_plugin_option("animelab", "password", animelab_password)
 
+    if args.npo_subtitles:
+        streamlink.set_plugin_option("npo", "subtitles", args.npo_subtitles)
+
     # Deprecated options
     if args.jtv_legacy_names:
         console.logger.warning("The option --jtv/twitch-legacy-names is "


### PR DESCRIPTION
As reported in #638 the NPO.nl plugin has stopped working. 

This is a mostly total rewrite of the existing plugin to use the updated API. 

Subtitles can be enabled on the stream (if available) by using the `--npo-subtitles` option.