### PR TITLE
plugins.earthcam add support for earthcam.com streams | Fixed #342

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -70,6 +70,7 @@ dplay               - dplay.se           --    Yes   Streams may be geo-restrict
                     - dplay.no
                     - dplay.dk
 drdk                dr.dk                Yes   Yes   Streams may be geo-restricted to Denmark.
+earthcam            earthcam.com         Yes   Yes   Only works for the cams hosted on EarthCam.
 eurocom             eurocom.bg           Yes   No
 euronews            euronews.com         Yes   No
 expressen           expressen.se         Yes   Yes

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -1,0 +1,69 @@
+from __future__ import print_function
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.compat import urlparse
+from streamlink.stream import RTMPStream
+from streamlink.utils import parse_json
+
+
+class EarthCam(Plugin):
+    url_re = re.compile(r"https?://(?:www.)?earthcam.com/.*")
+    swf_url = "http://static.earthcam.com/swf/streaming/stream_viewer_v3.swf"
+    json_base_re = re.compile(r"""var[ ]+json_base[^=]+=.*?(\{.*?});""", re.DOTALL)
+    cam_name_re = re.compile(r"""var[ ]+currentName[^=]+=[ \t]+(?P<quote>["'])(?P<name>\w+)(?P=quote);""", re.DOTALL)
+    cam_data_schema = validate.Schema(
+        validate.transform(json_base_re.search),
+        validate.any(
+            None,
+            validate.all(
+                validate.get(1),
+                validate.transform(lambda d: d.replace("\\/", "/")),
+                validate.transform(parse_json),
+            )
+        )
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        m = self.cam_name_re.search(res.text)
+        cam_name = m and m.group("name")
+        json_base = self.cam_data_schema.validate(res.text)
+
+        cam_data = json_base["cam"][cam_name]
+
+        self.logger.debug("Found cam for {} - {}", cam_data["group"], cam_data["title"])
+
+        is_live = cam_data["liveon"] == "true"
+        rtmp_domain = cam_data["streamingdomain" if is_live else "archivedomain"]
+        if rtmp_domain:
+            if is_live:
+                playpath = cam_data.get("livestreamingpath")
+            else:
+                playpath = cam_data.get("archivepath")
+
+            if not playpath:
+                self.logger.error("This cam stream appears to be in offline or "
+                                  "snapshot mode and not live stream can be played.")
+                return
+
+            rtmp_url = rtmp_domain + playpath
+
+            self.logger.debug("RTMP URL: {0}", rtmp_url)
+
+            params = {"rtmp": rtmp_url,
+                      "playpath": playpath,
+                      "pageUrl": self.url,
+                      "swfUrl": self.swf_url}
+            if is_live:
+                params["live"] = True
+            yield "live", RTMPStream(self.session, params)
+
+
+__plugin__ = EarthCam

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -1,16 +1,17 @@
 from __future__ import print_function
+
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
 from streamlink.plugin.api import validate
-from streamlink.compat import urlparse
-from streamlink.stream import RTMPStream
+from streamlink.stream import HLSStream, RTMPStream
 from streamlink.utils import parse_json
 
 
 class EarthCam(Plugin):
     url_re = re.compile(r"https?://(?:www.)?earthcam.com/.*")
+    playpath_re = re.compile(r"(?P<folder>/.*/)(?P<file>.*?\.flv)")
     swf_url = "http://static.earthcam.com/swf/streaming/stream_viewer_v3.swf"
     json_base_re = re.compile(r"""var[ ]+json_base[^=]+=.*?(\{.*?});""", re.DOTALL)
     cam_name_re = re.compile(r"""var[ ]+currentName[^=]+=[ \t]+(?P<quote>["'])(?P<name>\w+)(?P=quote);""", re.DOTALL)
@@ -38,32 +39,62 @@ class EarthCam(Plugin):
 
         cam_data = json_base["cam"][cam_name]
 
-        self.logger.debug("Found cam for {} - {}", cam_data["group"], cam_data["title"])
+        self.logger.debug("Found cam for {0} - {1}", cam_data["group"], cam_data["title"])
 
-        is_live = cam_data["liveon"] == "true"
-        rtmp_domain = cam_data["streamingdomain" if is_live else "archivedomain"]
-        if rtmp_domain:
-            if is_live:
-                playpath = cam_data.get("livestreamingpath")
-            else:
-                playpath = cam_data.get("archivepath")
+        is_live = (cam_data["liveon"] == "true" and cam_data["defaulttab"] == "live")
 
-            if not playpath:
-                self.logger.error("This cam stream appears to be in offline or "
-                                  "snapshot mode and not live stream can be played.")
-                return
+        # HLS data
+        hls_domain = cam_data["html5_streamingdomain"]
+        hls_playpath = cam_data["html5_streampath"]
 
-            rtmp_url = rtmp_domain + playpath
+        # RTMP data
+        rtmp_playpath = ""
+        if is_live:
+            n = "live"
+            rtmp_domain = cam_data["streamingdomain"]
+            rtmp_path = cam_data["livestreamingpath"]
+            rtmp_live = cam_data["liveon"]
 
-            self.logger.debug("RTMP URL: {0}", rtmp_url)
+            if rtmp_path:
+                match = self.playpath_re.search(rtmp_path)
+                rtmp_playpath = match.group("file")
+                rtmp_url = rtmp_domain + match.group("folder")
+        else:
+            n = "vod"
+            rtmp_domain = cam_data["archivedomain"]
+            rtmp_path = cam_data["archivepath"]
+            rtmp_live = cam_data["archiveon"]
 
-            params = {"rtmp": rtmp_url,
-                      "playpath": playpath,
-                      "pageUrl": self.url,
-                      "swfUrl": self.swf_url}
-            if is_live:
-                params["live"] = True
-            yield "live", RTMPStream(self.session, params)
+            if rtmp_path:
+                rtmp_playpath = rtmp_path
+                rtmp_url = rtmp_domain
 
+        # RTMP stream
+        if rtmp_playpath:
+            self.logger.debug("RTMP URL: {0}{1}", rtmp_url, rtmp_playpath)
+
+            params = {
+                "rtmp": rtmp_url,
+                "playpath": rtmp_playpath,
+                "pageUrl": self.url,
+                "swfUrl": self.swf_url,
+                "live": rtmp_live
+            }
+
+            yield n, RTMPStream(self.session, params)
+
+        # HLS stream
+        if hls_playpath and is_live:
+            hls_url = hls_domain + hls_playpath
+
+            self.logger.debug("HLS URL: {0}", hls_url)
+
+            for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
+                yield s
+
+        if not (rtmp_playpath or hls_playpath):
+            self.logger.error("This cam stream appears to be in offline or "
+                              "snapshot mode and not live stream can be played.")
+            return
 
 __plugin__ = EarthCam


### PR DESCRIPTION
_used the commit from beardypig as a base script and changed some stuff there_
_tested this new script on 0.3.2, even if this is 150+ commits behind master_

## [earthcam] Added HLS, Fixed live RTMP and changes some stuff


- __Added HLS__ streams
- Added a better "live" stream check
- __Fixed RTMP__ streams for live streams.

```
BEFORE:
    "rtmp_domain": "rtmp://video3.earthcam.com",
    "rtmp_path": "/fecnetwork/hdtimes10.flv",
AFTER:
    "rtmp_domain": "rtmp://video3.earthcam.com/fecnetwork/",
    "rtmp_path": "hdtimes10.flv",
```

### Known Issues

- Some old links like `http://www.earthcam.com/newyears/ts2012/` won't work.
- snapshot mode won't work
- works only for cams that are hosted on EarthCam


## DEBUG DATA
Here is some debug data,
you can see here why the code changes are so ugly.

They have sometimes dead streams but it gets tagged as live etc.


__RTMP / HLS - Live Stream__

```
[plugin.earthcam][debug] Found cam for Times Square Cams - Times Square 4K
is_live: True
http://www.earthcam.com/usa/newyork/timessquare/?cam=tsrobo1
{
    "defaulttab": "live",
"": "",
    "liveon": "true",
    "archiveon": "true",
"": "",
    "streamingdomain": "rtmp://video3.earthcam.com",
    "livestreamingpath": "/fecnetwork/hdtimes10.flv",
"": "",
    "html5_streamingdomain": "http://video3.earthcam.com",
    "html5_streampath": "/fecnetwork/hdtimes10.flv/playlist.m3u8",
"": "",
    "archivedomain": "http://archives.earthcam.com",
    "archivepath": "/archives3/ny/ny/studio/24hrtimelapse.mp4",
}
[plugin.earthcam][debug] RTMP URL: rtmp://video3.earthcam.com/fecnetwork/hdtimes10.flv
[plugin.earthcam][debug] HLS URL: http://video3.earthcam.com/fecnetwork/hdtimes10.flv/playlist.m3u8

```

__RTMP - Archive Stream__
- with dead rtmp / hls livestream link

```
[plugin.earthcam][debug] Found cam for Fish Bowl II - Fish Bowl II
is_live: False
http://www.earthcam.com/events/fishbowl/2016/?cam=fishbowl_2015
{
    "defaulttab": "archives",
"": "",
    "liveon": "true",
    "archiveon": "true",
"": "",
    "streamingdomain": "rtmp://video1.earthcam.com",
    "livestreamingpath": "/fishbowl/fishbowl_720p",
"": "",
    "html5_streamingdomain": "http://video3.earthcam.com",
    "html5_streampath": "/fishbowl/fishbowl_720p/playlist.m3u8",
"": "",
    "archivedomain": "rtmp://video2archives.earthcam.com/archives",
    "archivepath": "/events/fishbowl/Fishbowl2015.flv",
}
```

__RTMP - Archive Stream__
- with html5 livestream link

```
[plugin.earthcam][debug] Found cam for 5th Ave @ 48th St. - 5th Avenue Cam
is_live: False
http://www.earthcam.com/events/puertoricanparade/2016/?cam=prp_2016_nyc5th_str
{
    "defaulttab": "live",
"": "",
    "liveon": "false",
    "archiveon": "true",
"": "",
    "streamingdomain": "rtmp://video3.earthcam.com",
    "livestreamingpath": "/fecnetwork/fridays_5th.flv",
"": "",
    "html5_streamingdomain": "http://video3.earthcam.com",
    "html5_streampath": "/fecnetwork/fridays_5th.flv/playlist.m3u8",
"": "",
    "archivedomain": "rtmp://video2archives.earthcam.com/archives",
    "archivepath": "/events/prday/2016/5th_ave.flv",
}
```

__Offline__
- with defaulttab=live and liveon=true
- no paths

```
[plugin.earthcam][debug] Found cam for Times Square Cams - Times Square Bowtie
is_live: True
http://www.earthcam.com/usa/newyork/timessquare/?cam=gped
{
    "defaulttab": "live",
"": "",
    "liveon": "true",
    "archiveon": "false",
"": "",
    "streamingdomain": "rtmp://video3.earthcam.com",
    "livestreamingpath": "",
"": "",
    "html5_streamingdomain": "http://video3.earthcam.com",
    "html5_streampath": "",
"": "",
    "archivedomain": "http://archives.earthcam.com",
    "archivepath": "",
}
[plugin.earthcam][error] This cam stream appears to be in offline or snapshot mode and not live stream can be played.
```

Fixed #342 