### PR TITLE
plugins.animelab: added support for AnimeLab.com VOD

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -17,6 +17,7 @@ afreeca             afreecatv.com        Yes   No
 afreecatv           afreeca.tv           Yes   No
 aftonbladet         aftonbladet.se       Yes   Yes
 alieztv             aliez.tv             Yes   Yes
+animelab            animelab.com         --    Yes   Requires a login. Streams may be geo-restricted to Australia and New Zealand.
 antenna             antenna.gr           --    Yes
 app17               17app.co             Yes   --
 ard_live            live.daserste.de     Yes   --    Streams may be geo-restricted to Germany.

--- a/src/streamlink/plugins/animelab.py
+++ b/src/streamlink/plugins/animelab.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+import re
+from pprint import pprint
+
+from streamlink.plugin import Plugin, PluginOptions
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import HTTPStream
+from streamlink.utils import parse_json
+
+
+class AnimeLab(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?animelab\.com/player/")
+    login_url = "https://www.animelab.com/login"
+    video_collection_re = re.compile(r"VideoCollection\((\[.*?\])\);")
+    playlist_position_re = re.compile(r"playlistPosition\s*=\s*(\d+);")
+    video_collection_schema = validate.Schema(
+        validate.union({
+            "position": validate.all(
+                validate.transform(playlist_position_re.search),
+                validate.any(
+                    None,
+                    validate.all(validate.get(1), validate.transform(int))
+                )
+            ),
+            "playlist": validate.all(
+                validate.transform(video_collection_re.search),
+                validate.any(
+                    None,
+                    validate.all(
+                        validate.get(1),
+                        validate.transform(parse_json)
+                    )
+                )
+            )
+        })
+    )
+    options = PluginOptions({
+        "email": None,
+        "password": None
+    })
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def login(self, email, password):
+        self.logger.debug("Attempting to log in as {0}", email)
+        res = http.post(self.login_url,
+                        data=dict(email=email, password=password),
+                        allow_redirects=False,
+                        raise_for_status=False)
+        loc = res.headers.get("Location", "")
+        if "geoblocked" in loc.lower():
+            self.logger.error("AnimeLab is not available in your territory")
+        elif res.status_code >= 400:
+            self.logger.error("Failed to login to AnimeLab, check your email/password combination")
+        else:
+            return True
+
+        return False
+
+    def _get_streams(self):
+        email, password = self.get_option("email"), self.get_option("password")
+        if not email or not password:
+            self.logger.error("AnimeLab requires authentication, use --animelab-email "
+                              "and --animelab-password to set your email/password combination")
+            return
+
+        if self.login(email, password):
+            self.logger.info("Successfully logged in as {0}", email)
+            video_collection = http.get(self.url, schema=self.video_collection_schema)
+            if video_collection["playlist"] is None or video_collection["position"] is None:
+                return
+
+            data = video_collection["playlist"][video_collection["position"]]
+
+            self.logger.debug("Found {0} version {1} hard-subs",
+                              data["language"]["name"],
+                              "with" if data["hardSubbed"] else "without")
+
+            for video in data["videoInstances"]:
+                if video["httpUrl"]:
+                    q = video["videoQuality"]["description"]
+                    s = HTTPStream(self.session, video["httpUrl"])
+                    yield q, s
+
+
+
+__plugin__ = AnimeLab

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1163,6 +1163,20 @@ plugin.add_argument(
     A WWE Network account password to use with --wwenetwork-email.
     """
 )
+plugin.add_argument(
+    "--animelab-email",
+    metavar="EMAIL",
+    help="""
+    The email address used to register with animelab.com.
+    """
+)
+plugin.add_argument(
+    "--animelab-password",
+    metavar="PASSWORD",
+    help="""
+    A TVPlayer account password to use with --animelab-email.
+    """
+)
 
 # Deprecated options
 stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -893,6 +893,17 @@ def setup_plugin_options():
     if wwenetwork_password:
         streamlink.set_plugin_option("wwenetwork", "password", wwenetwork_password)
 
+    if args.animelab_email:
+        streamlink.set_plugin_option("animelab", "email", args.animelab_email)
+
+    if args.animelab_email and not args.animelab_password:
+        animelab_password = console.askpass("Enter AnimeLab password: ")
+    else:
+        animelab_password = args.animelab_password
+
+    if animelab_password:
+        streamlink.set_plugin_option("animelab", "password", animelab_password)
+
     # Deprecated options
     if args.jtv_legacy_names:
         console.logger.warning("The option --jtv/twitch-legacy-names is "


### PR DESCRIPTION
As requested in #645 by @starchivore.

Two new options were added to support this plugin:
  - `--animelab-email`: the email address to login to AnimeLab
  - `--animelab-password`: the password for your AnimeLab account

The content is only available with a login.

While the website says that it's restricted to Australia and New Zealand, I was able to access using a UK proxy. I was not able to access using a US or German proxy. 