### PR TITLE
plugins.zdf_mediathek Added missing headers for http.get

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -210,7 +210,7 @@ wwenetwork          network.wwe.com      Yes   Yes   Requires an account to acce
 younow              younow.com           Yes   --
 youtube             - youtube.com        Yes   Yes   Protected videos are not supported.
                     - youtu.be
-zdf_mediathek       zdf.de               Yes   Yes
+zdf_mediathek       zdf.de               Yes   Yes   Streams may be geo-restricted to Germany.
 zhanqitv            zhanqi.tv            Yes   No
 =================== ==================== ===== ===== ===========================
 

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -100,7 +100,8 @@ class zdf_mediathek(Plugin):
         for quality in format_["qualities"]:
             for track in quality["audio"]["tracks"]:
                 option = self._parse_track(track, parser, name)
-                qualities.update(option)
+                if option:
+                    qualities.update(option)
 
         return qualities
 

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -3,7 +3,6 @@ import re
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HDSStream, HLSStream
-from streamlink.plugin.api.utils import parse_query
 
 API_URL = "https://api.zdf.de"
 
@@ -85,7 +84,7 @@ class zdf_mediathek(Plugin):
             for format_ in priority["formitaeten"]:
                 yield self._extract_from_format(format_)
 
-    def _parse_track(self, track, parser):
+    def _parse_track(self, track, parser, name):
         try:
             return parser(self.session, track["uri"])
         except IOError as err:
@@ -100,25 +99,32 @@ class zdf_mediathek(Plugin):
         name, parser = STREAMING_TYPES[format_["type"]]
         for quality in format_["qualities"]:
             for track in quality["audio"]["tracks"]:
-                option = self._parse_track(track, parser)
+                option = self._parse_track(track, parser, name)
                 qualities.update(option)
 
         return qualities
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
         title = self.url.rsplit('/', 1)[-1]
         if title.endswith(".html"):
             title = title[:-5]
+        if title == "live-tv":
+            self.logger.info("Klicken Sie mit der rechten Maustaste auf dem Player (im Browser) und waehlen Sie 'Beitrags-Url kopieren', um einen gueltigen Link fuer streamlink zu erhalten.")
+            return
+
+        headers = {
+            "Api-Auth": "Bearer d2726b6c8c655e42b68b0db26131b15b22bd1a32",
+            "Referer": self.url
+        }
 
         request_url = "https://api.zdf.de/content/documents/%s.json?profile=player" % title
-        res = http.get(request_url, headers={"Api-Auth": "Bearer d2726b6c8c655e42b68b0db26131b15b22bd1a32"})
+        res = http.get(request_url, headers=headers)
         document = http.json(res, schema=_documents_schema)
 
         stream_request_url = document["mainVideoContent"]["http://zdf.de/rels/target"]["http://zdf.de/rels/streams/ptmd"]
         stream_request_url = API_URL + stream_request_url
 
-        res = http.get(stream_request_url)
+        res = http.get(stream_request_url, headers=headers)
         res = http.json(res, schema=_schema)
 
         streams = {}

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -88,7 +88,7 @@ class zdf_mediathek(Plugin):
         try:
             return parser(self.session, track["uri"])
         except IOError as err:
-            self.logger.error("Failed to extract {0} streams: {1}", name, err)
+            self.logger.debug("Failed to extract {0} streams: {1}", name, err)
 
     def _extract_from_format(self, format_):
         qualities = {}

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -88,7 +88,7 @@ class zdf_mediathek(Plugin):
         try:
             return parser(self.session, track["uri"])
         except IOError as err:
-            self.logger.debug("Failed to extract {0} streams: {1}", name, err)
+            self.logger.error("Failed to extract {0} streams: {1}", name, err)
 
     def _extract_from_format(self, format_):
         qualities = {}


### PR DESCRIPTION
- Removed unused import
- Removed "match" it was not used
- Added missing "name" it was not defined
- Added an **info message** for how to get a **valid link** for the tv channels, if someone uses
`streamlink https://www.zdf.de/live-tv`
- Fixed 403 Client Error (**Added headers for http.get**)

```
[cli][info] Found matching plugin zdf_mediathek for URL https://www.zdf.de/comedy/heute-show/heute-show-vom-24-februar-2017-100.html
error: Unable to open URL: https://api.zdf.de/tmd/2/portal/vod/ptmd/mediathek/170224_sendung_hsh (403 Client Error: Forbidden for url: https://api.zdf.de/tmd/2/portal/vod/ptmd/mediathek/170224_sendung_hsh)
```