### PR TITLE
plugins.vidio: fix for regex, if the url is the english version

### DIFF
--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -16,7 +16,7 @@ def html_unescape(s):
     return parser.unescape(s)
 
 
-_url_re = re.compile(r"https?://(?:www\.)?vidio\.com/(?P<type>live|watch)/(?P<id>\d+)-(?P<name>[^/?#&]+)")
+_url_re = re.compile(r"https?://(?:www\.)?vidio\.com/(?:en/)?(?P<type>live|watch)/(?P<id>\d+)-(?P<name>[^/?#&]+)")
 _clipdata_re = re.compile(r"""data-json-clips\s*=\s*(['"])(.*?)\1""")
 
 _schema = validate.Schema(


### PR DESCRIPTION
As reported by @karlo2105 in #662 :)

The URLs will have the language code `en` when viewing the English version of the website.