### PR TITLE
plugins.goodgame: support for http URLs

### DIFF
--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -12,14 +12,14 @@ QUALITIES = {
     "240p": "_240"
 }
 
-_url_re = re.compile(r"https://(?:www\.)?goodgame.ru/channel/(?P<user>\w+)")
+_url_re = re.compile(r"https?://(?:www\.)?goodgame.ru/channel/(?P<user>\w+)")
 _stream_re = re.compile(r'var src = "([^"]+)";')
 _ddos_re = re.compile(r'document.cookie="(__DDOS_[^;]+)')
 
 
 class GoodGame(Plugin):
     @classmethod
-    def can_handle_url(self, url):
+    def can_handle_url(cls, url):
         return _url_re.match(url)
 
     def _check_stream(self, url):


### PR DESCRIPTION
As reported in #670, by @loboque. 

goodgame.ru has re-enabled http support and no longer has only https URLs. 