### PR TITLE
stream.hls: format string name input for parse_variant_playlist

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -271,7 +271,7 @@ class HLSStream(HTTPStream):
     @classmethod
     def parse_variant_playlist(cls, session_, url, name_key="name",
                                name_prefix="", check_streams=False,
-                               force_restart=False,
+                               force_restart=False, name_fmt=None,
                                **request_params):
         """Attempts to parse a variant playlist and return its streams.
 
@@ -279,8 +279,10 @@ class HLSStream(HTTPStream):
         :param name_key: Prefer to use this key as stream name, valid keys are:
                          name, pixels, bitrate.
         :param name_prefix: Add this prefix to the stream names.
+        :param check_streams: Only allow streams that are accessible.
         :param force_restart: Start at the first segment even for a live stream
-        :param check_streams: Only allow streams that are accesible.
+        :param name_fmt: A format string for the name, allowed format keys are
+                         name, pixels, bitrate.
         """
         logger = session_.logger.new_module("hls.parse_variant_playlist")
         locale = session_.localization
@@ -338,8 +340,11 @@ class HLSStream(HTTPStream):
                 else:
                     names["bitrate"] = "{0}k".format(bw / 1000.0)
 
-            stream_name = (names.get(name_key) or names.get("name") or
-                           names.get("pixels") or names.get("bitrate"))
+            if name_fmt:
+                stream_name = name_fmt.format(**names)
+            else:
+                stream_name = (names.get(name_key) or names.get("name") or
+                               names.get("pixels") or names.get("bitrate"))
 
             if not stream_name:
                 continue

--- a/tests/test_plugin_stream.py
+++ b/tests/test_plugin_stream.py
@@ -2,6 +2,7 @@ import unittest
 
 from streamlink import Streamlink
 from streamlink.plugins.stream import StreamURL
+from streamlink.plugin.plugin import stream_weight
 from streamlink.stream import *
 
 
@@ -106,6 +107,32 @@ class TestPluginStream(unittest.TestCase):
             dict(conn=['B:1', 'S:authMe', 'O:1', 'NN:code:1.23', 'NS:flag:ok', 'O:0']),
             StreamURL._parse_params(""""conn=['B:1', 'S:authMe', 'O:1', 'NN:code:1.23', 'NS:flag:ok', 'O:0']""")
         )
+
+    def test_stream_weight(self):
+        self.assertEqual(
+            (720, "pixels"),
+            stream_weight("720p"))
+        self.assertEqual(
+            (721, "pixels"),
+            stream_weight("720p+"))
+        self.assertEqual(
+            (780, "pixels"),
+            stream_weight("720p60"))
+
+        self.assertTrue(
+            stream_weight("720p+") > stream_weight("720p"))
+        self.assertTrue(
+            stream_weight("720p") == stream_weight("720p"))
+        self.assertTrue(
+            stream_weight("720p_3000k") > stream_weight("720p_2500k"))
+        self.assertTrue(
+            stream_weight("720p60_3000k") > stream_weight("720p_3000k"))
+        self.assertTrue(
+            stream_weight("720p_3000k") < stream_weight("720p+_3000k"))
+
+        self.assertTrue(
+            stream_weight("3000k") > stream_weight("2500k"))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This allows developers to use a format string to name the streams, which allows more descriptive names. eg. {pixels}_{bitrate} can be used to produce 720p_3500k, 720p_4500k, which is useful if the streams are available in multiple resolutions at the same bitrate.

This feature can also be used when using the builtin stream plugins, eg.
```shell
streamlink "hlsvariant://test.se/master.m3u8 name_fmt=\"{pixels}_{bitrate}\""
```

The limitation being that the name string has to be enclosed by `"` quotes.

This should go someway to fixing issues like #540.