### PR TITLE
plugins.wwenetwork: use the resolution and bitrate in the stream name

### DIFF
--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -146,7 +146,7 @@ class WWENetwork(Plugin):
                 if info.get("session_key"):
                     self.session_key = info.get("session_key")
                 for url in info["urls"]:
-                    for s in HLSStream.parse_variant_playlist(self.session, url).items():
+                    for s in HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items():
                         yield s
             else:
                 raise PluginError("Could not load streams: {message} ({code})".format(**info["status"]))


### PR DESCRIPTION
Additional for #636, to expose the bit rate. 