### PR TITLE
stream.hls: option to select a specific, non-standard audio channel

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -289,6 +289,7 @@ class HLSStream(HTTPStream):
         # Backwards compatibility with "namekey" and "nameprefix" params.
         name_key = request_params.pop("namekey", name_key)
         name_prefix = request_params.pop("nameprefix", name_prefix)
+        audio_select = session_.options.get("hls-audio-select")
 
         res = session_.http.get(url, exception=IOError, **request_params)
 
@@ -321,8 +322,10 @@ class HLSStream(HTTPStream):
                     default_audio = media
 
                 # select the first audio stream that matches the users explict language selection
-                if (not preferred_audio or media.default) and locale.explicit and locale.equivalent(
-                        language=media.language):
+                if ((media.language == audio_select or media.name == audio_select) or
+                    ((not preferred_audio or media.default) and
+                        locale.explicit and
+                        locale.equivalent(language=media.language))):
                     preferred_audio = media
 
             # final fallback on the first audio stream listed

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -653,6 +653,15 @@ transport.add_argument(
     Default is 60.0.
     """)
 transport.add_argument(
+    "--hls-audio-select",
+    type=str,
+    metavar="CODE",
+    help="""
+    Selects a specific audio source, by language code, when multiple audio sources are available.
+
+    Note: This is only useful in special circumstances where the regular locale option fails.
+    """)
+transport.add_argument(
     "--http-stream-timeout",
     type=num(float, min=0),
     metavar="TIMEOUT",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -718,6 +718,9 @@ def setup_options():
     if args.hls_timeout:
         streamlink.set_option("hls-timeout", args.hls_timeout)
 
+    if args.hls_audio_select:
+        streamlink.set_option("hls-audio-select", args.hls_audio_select)
+
     if args.hds_live_edge:
         streamlink.set_option("hds-live-edge", args.hds_live_edge)
 


### PR DESCRIPTION
Some HLS streams have multiple audio sources that do not use the iso standard language codes, or use codes that are reserved for internal use,for example 'qaa' or 'qad'. These have to be interpreted on a case-by-case basis so there is no generic solution to picking the "right" one.

This adds a new option `--hls-audio-select` which overrides the audio stream and selects the one with the specific language code supplied. eg. `--hls-audio-select=qaa`.

Should fix #681 too :)