### PR TITLE
plugins.bbciplayer: add support for BBC iPlayer live and VOD

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -27,6 +27,7 @@ artetv              arte.tv              Yes   Yes
 atresplayer         atresplayer.com      Yes   No    Streams are geo-restricted to Spain.
 azubutv             azubu.tv             Yes   No
 bambuser            bambuser.com         Yes   Yes
+bbciplayer          bbc.co.uk/iplayer    Yes   Yes   Streams may be geo-restricted to the United Kingdom.
 beam                beam.pro             Yes   No
 beattv              be-at.tv             Yes   Yes   Playlist not implemented yet.
 bigo                - live.bigo.tv       Yes   --

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -1,0 +1,86 @@
+from __future__ import print_function
+
+import base64
+import re
+from functools import partial
+from hashlib import sha1
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
+from streamlink.stream import HDSStream
+from streamlink.utils import parse_xml, parse_json
+
+
+class BBCiPlayer(Plugin):
+    url_re = re.compile(r"""https?://(?:www\.)?bbc.co.uk/iplayer/
+        (
+            episode/(?P<episode_id>\w+)|
+            live/(?P<channel_name>\w+)
+        )
+    """, re.VERBOSE)
+    vpid_re = re.compile(r'"vpid"\s*:\s*"(\w+)"')
+    tvip_re = re.compile(r'event_master_brand=(\w+?)&')
+    swf_url = "http://emp.bbci.co.uk/emp/SMPf/1.18.3/StandardMediaPlayerChromelessFlash.swf"
+    hash = base64.b64decode(b"N2RmZjc2NzFkMGM2OTdmZWRiMWQ5MDVkOWExMjE3MTk5MzhiOTJiZg==")
+    api_url = ("http://open.live.bbc.co.uk/mediaselector/5/select/"
+               "version/2.0/mediaset/pc/vpid/{vpid}/atk/{vpid_hash}/asn/1/")
+    mediaselector_schema = validate.Schema(
+        validate.transform(partial(parse_xml, ignore_ns=True)),
+        validate.xml_findall(".//media[@kind='video']//connection[@transferFormat='hds']"),
+        [validate.all(validate.getattr("attrib"), validate.get("href"))],
+        validate.transform(lambda x: list(set(x)))  # unique
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    @classmethod
+    def _hash_vpid(cls, vpid):
+        return sha1(cls.hash + str(vpid).encode("utf8")).hexdigest()
+
+    def find_vpid(self, url):
+        self.logger.debug("Looking for vpid on {0}", url)
+        res = http.get(url)
+        m = self.vpid_re.search(res.text)
+        return m and m.group(1)
+
+    def find_tvip(self, url):
+        self.logger.debug("Looking for tvip on {0}", url)
+        res = http.get(url)
+        m = self.tvip_re.search(res.text)
+        return m and m.group(1)
+
+    def mediaselector(self, vpid):
+        url = self.api_url.format(vpid=vpid, vpid_hash=self._hash_vpid(vpid))
+        stream_urls = http.get(url, schema=self.mediaselector_schema)
+        return stream_urls
+
+    def _get_streams(self):
+        m = self.url_re.match(self.url)
+        episode_id = m.group("episode_id")
+        channel_name = m.group("channel_name")
+
+        if episode_id:
+            self.logger.debug("Loading streams for episode: {0}", episode_id)
+            vpid = self.find_vpid(self.url)
+            if vpid:
+                self.logger.debug("Found VPID: {0}", vpid)
+                s = self.mediaselector(vpid)
+                for url in s:
+                    for s in HDSStream.parse_manifest(self.session, url).items():
+                        yield s
+            else:
+                self.logger.error("Could not find VPID for episode {0}", episode_id)
+        elif channel_name:
+            self.logger.debug("Loading stream for live channel: {0}", channel_name)
+            tvip = self.find_tvip(self.url)
+            if tvip:
+                self.logger.debug("Found TVIP: {0}", tvip)
+                s = self.mediaselector(tvip)
+                for url in s:
+                    for s in HDSStream.parse_manifest(self.session, url).items():
+                        yield s
+
+__plugin__ = BBCiPlayer

--- a/tests/test_plugin_bbciplayer.py
+++ b/tests/test_plugin_bbciplayer.py
@@ -1,0 +1,21 @@
+import unittest
+
+from streamlink.plugins.bbciplayer import BBCiPlayer
+
+
+class TestPluginBBCiPlayer(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(BBCiPlayer.can_handle_url("http://www.bbc.co.uk/iplayer/episode/b00ymh67/madagascar-1-island-of-marvels"))
+        self.assertTrue(BBCiPlayer.can_handle_url("http://www.bbc.co.uk/iplayer/live/bbcone"))
+
+        # shouldn't match
+        self.assertFalse(BBCiPlayer.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(BBCiPlayer.can_handle_url("http://www.sportal.bg/sportal_live_tv.php?str=15"))
+        self.assertFalse(BBCiPlayer.can_handle_url("http://www.bbc.co.uk/iplayer/"))
+
+    def test_vpid_hash(self):
+        self.assertEqual(
+            "71c345435589c6ddeea70d6f252e2a52281ecbf3",
+            BBCiPlayer._hash_vpid("1234567890")
+        )


### PR DESCRIPTION
Support for live and VOD iPlayer streams.

Supported URLs include:
- bbc.co.uk/iplayer/live/bbcone
- bbc.co.uk/iplayer/live/bbctwo
- bbc.co.uk/iplayer/live/bbcone
- bbc.co.uk/iplayer/episode/b00ymh67/madagascar-1-island-of-marvels