### PR TITLE
plugins.bigo : More robust regex for url matching, added unittest

### DIFF
--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -47,7 +47,7 @@ class BigoStream(Stream):
 
 
 class Bigo(Plugin):
-    _url_re = re.compile(r"https?://(live.bigo.tv/\d+|bigoweb.co/show/\d+)")
+    _url_re = re.compile(r"https?://(?:www\.)?(live.bigo.tv/\d+|bigoweb.co/show/\d+)")
     _flashvars_re = flashvars = re.compile(
         r'''^\s*(?<!<!--)<param.*value="tmp=(\d+)&channel=(\d+)&srv=(\d+\.\d+\.\d+\.\d+)&port=(\d+)"''',
         re.M)

--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -47,7 +47,7 @@ class BigoStream(Stream):
 
 
 class Bigo(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?(live.bigo.tv/\d+|bigoweb.co/show/\d+)")
+    _url_re = re.compile(r"https?://(?:www\.)?(bigo\.tv/\d+|bigoweb\.co/show/\d+)")
     _flashvars_re = flashvars = re.compile(
         r'''^\s*(?<!<!--)<param.*value="tmp=(\d+)&channel=(\d+)&srv=(\d+\.\d+\.\d+\.\d+)&port=(\d+)"''',
         re.M)

--- a/tests/test_plugin_bigo.py
+++ b/tests/test_plugin_bigo.py
@@ -1,0 +1,31 @@
+import unittest
+
+from streamlink.plugins.bigo import Bigo
+
+
+class TestPluginBongacams(unittest.TestCase):
+    def test_can_handle_url(self):
+        # Correct urls
+        self.assertTrue(Bigo.can_handle_url("http://www.bigoweb.co/show/00000000"))
+        self.assertTrue(Bigo.can_handle_url("https://www.bigoweb.co/show/00000000"))
+        self.assertTrue(Bigo.can_handle_url("http://bigoweb.co/show/00000000"))
+        self.assertTrue(Bigo.can_handle_url("https://bigoweb.co/show/00000000"))
+        self.assertTrue(Bigo.can_handle_url("http://bigo.tv/00000000"))
+        self.assertTrue(Bigo.can_handle_url("https://bigo.tv/00000000"))
+        self.assertTrue(Bigo.can_handle_url("https://www.bigo.tv/00000000"))
+        self.assertTrue(Bigo.can_handle_url("http://www.bigo.tv/00000000"))
+
+        # Old URLs don't work anymore
+        self.assertFalse(Bigo.can_handle_url("http://live.bigo.tv/00000000"))
+        self.assertFalse(Bigo.can_handle_url("https://live.bigo.tv/00000000"))
+
+        # Wrong URL structure
+        self.assertFalse(Bigo.can_handle_url("ftp://www.bigo.tv/00000000"))
+        self.assertFalse(Bigo.can_handle_url("https://www.bigo.tv/show/00000000"))
+        self.assertFalse(Bigo.can_handle_url("http://www.bigo.tv/show/00000000"))
+        self.assertFalse(Bigo.can_handle_url("http://bigo.tv/show/00000000"))
+        self.assertFalse(Bigo.can_handle_url("https://bigo.tv/show/00000000"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #722. Removed the old wrong url, made match more accurate by escaping url-dots. Added unittest.