### PR TITLE
Fix wrong vlc path for namedpipes

### DIFF
--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -19,6 +19,7 @@ class NamedPipe(object):
     def __init__(self, name):
         self.fifo = None
         self.pipe = None
+        self.name = name
 
         if is_win32:
             self.path = os.path.join("\\\\.\\pipe", name)

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -101,7 +101,7 @@ class PlayerOutput(Output):
 
     def _create_arguments(self):
         if self.namedpipe:
-            filename = self.namedpipe.path
+            filename = "stream://\\\\\\.\\pipe\\" + self.namedpipe.name
         elif self.filename:
             filename = self.filename
         elif self.http:


### PR DESCRIPTION
There seems to have been some changes to the way vlc reads named pipes. On master, currently, using named pipes to view a stream simply does not work. These changes allow named pipes to be created with the correct path, while still allowing vlc to read from them.