### PR TITLE
New Periscope URL #748

### DIFF
--- a/src/streamlink/plugins/periscope.py
+++ b/src/streamlink/plugins/periscope.py
@@ -10,7 +10,7 @@ STREAM_INFO_URL = "https://api.periscope.tv/api/v2/getAccessPublic"
 STATUS_GONE = 410
 STATUS_UNAVAILABLE = (STATUS_GONE,)
 
-_url_re = re.compile(r"http(s)?://(www\.)?periscope.tv/[^/]+/(?P<broadcast_id>[\w\-\=]+)")
+_url_re = re.compile(r"http(s)?://(www\.)?(periscope|pscp)\.tv/[^/]+/(?P<broadcast_id>[\w\-\=]+)")
 _stream_schema = validate.Schema(
     validate.any(
         None,


### PR DESCRIPTION
Old periscope URL still works / is accessible. Using new one temporarily (?) during legal action in turkey. API URL (STREAM_INFO_URL) not interchangeable yet.