### PR TITLE
Updated UStreamTV plugin

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -162,8 +162,6 @@ Name                                 Notes
 **Optional**
 --------------------------------------------------------------------------------
 `RTMPDump`_                          Required to play RTMP streams.
-`python-librtmp`_                    Required by the *ustreamtv* plugin to be
-                                     able to use non-mobile streams.
 `ffmpeg`_                            Required to play streams that are made up of separate
                                      audio and video streams, eg. YouTube 1080p+
 ==================================== ===========================================
@@ -176,7 +174,6 @@ Name                                 Notes
 .. _python-singledispatch: http://pypi.python.org/pypi/singledispatch
 .. _RTMPDump: http://rtmpdump.mplayerhq.hu/
 .. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
-.. _python-librtmp: https://github.com/chrippa/python-librtmp
 .. _ffmpeg: https://www.ffmpeg.org/
 .. _iso-639: https://pypi.python.org/pypi/iso-639
 .. _iso3166: https://pypi.python.org/pypi/iso3166

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -186,7 +186,7 @@ tvrby               tvr.by               Yes   No    Streams may be geo-restrict
 tvrplus             tvrplus.ro           Yes   No    Streams may be geo-restricted to Romania.
 twitch              twitch.tv            Yes   Yes   Possible to authenticate for access to
                                                      subscription streams.
-ustreamtv           ustream.tv           Yes   Yes   Currently broken.
+ustreamtv           ustream.tv           Yes   Yes
 vaughnlive          - vaughnlive.tv      Yes   --
                     - breakers.tv
                     - instagib.tv

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -1,627 +1,163 @@
+from __future__ import print_function
+
+import json
 import re
-
-from collections import namedtuple
-from functools import partial
 from random import randint
-from time import sleep
 
-from streamlink.compat import urlparse, urljoin, range
-from streamlink.exceptions import StreamError, PluginError, NoStreamsError
-from streamlink.plugin import Plugin, PluginOptions
-from streamlink.plugin.api import http, validate
-from streamlink.stream import RTMPStream, HLSStream, HTTPStream, Stream
-from streamlink.stream.flvconcat import FLVTagConcat
-from streamlink.stream.segmented import (
-    SegmentedStreamReader, SegmentedStreamWriter, SegmentedStreamWorker
-)
+import itertools
 
-try:
-    import librtmp
-    HAS_LIBRTMP = True
-except ImportError:
-    HAS_LIBRTMP = False
+import time
 
-_url_re = re.compile(r"""
-    http(s)?://(www\.)?ustream.tv
-    (?:
-        (/embed/|/channel/id/)(?P<channel_id>\d+)
-    )?
-    (?:
-        /recorded/(?P<video_id>\d+)
-    )?
-""", re.VERBOSE)
-_channel_id_re = re.compile(r"\"channelId\":(\d+)")
+from streamlink.compat import urljoin
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.stream import HTTPStream
 
-HLS_PLAYLIST_URL = (
-    "http://iphone-streaming.ustream.tv"
-    "/uhls/{0}/streams/live/iphone/playlist.m3u8"
-)
-RECORDED_URL = "http://tcdn.ustream.tv/video/{0}"
-RTMP_URL = "rtmp://r{0}-1-{1}-channel-live.ums.ustream.tv:1935/ustream"
-SWF_URL = "http://static-cdn1.ustream.tv/swf/live/viewer.rsl:505.swf"
 
-_module_info_schema = validate.Schema(
-    list,
-    validate.length(1),
-    validate.get(0),
-    dict
-)
-_amf3_array = validate.Schema(
-    validate.any(
-        validate.all(
-            {int: object},
-            validate.transform(lambda a: list(a.values())),
-        ),
-        list
+class UHSClient(object):
+    WS_URL = "http://r{0}-1-{1}-{2}-{3}.ums.ustream.tv"
+    APP_ID, APP_VERSION = 2, 1
+    api_schama = validate.Schema([{
+        "args": [object],
+        "cmd": validate.text
+    }])
+    connect_schama = validate.Schema([{
+        "args": validate.all([{"host": validate.text, "connectionId": validate.text}], validate.length(1)),
+        "cmd": "tracking"
+    }], validate.length(1), validate.get(0), validate.get("args"), validate.get(0))
+    module_info_schema = validate.Schema(
+        validate.get("args"),
+        [validate.get("stream")],
+        validate.filter(lambda r: r is not None)
     )
-)
-_recorded_schema = validate.Schema({
-    validate.optional("stream"): validate.all(
-        _amf3_array,
-        [{
-            "name": validate.text,
-            "streams": validate.all(
-                _amf3_array,
-                [{
-                    "streamName": validate.text,
-                    "bitrate": float,
-                }],
-            ),
-            validate.optional("url"): validate.text,
-        }]
-    )
-})
-_stream_schema = validate.Schema(
-    validate.any({
-        "name": validate.text,
-        "url": validate.text,
-        "streams": validate.all(
-            _amf3_array,
-            [{
-                "chunkId": validate.any(int, float),
-                "chunkRange": {validate.text: validate.text},
-                "chunkTime": validate.any(int, float),
-                "offset": validate.any(int, float),
-                "offsetInMs": validate.any(int, float),
-                "streamName": validate.text,
-                validate.optional("bitrate"): validate.any(int, float),
-                validate.optional("height"): validate.any(int, float),
-                validate.optional("description"): validate.text,
-                validate.optional("isTranscoded"): bool
-            }],
-        )
-    },
-        {
-        "name": validate.text,
-        "varnishUrl": validate.text
-    })
-)
-_channel_schema = validate.Schema({
-    validate.optional("stream"): validate.any(
-        validate.all(
-            _amf3_array,
-            [_stream_schema],
-        ),
-        "offline"
-    )
-})
 
-Chunk = namedtuple("Chunk", "num url offset")
-
-
-if HAS_LIBRTMP:
-    from io import BytesIO
-    from time import time
-
-    from librtmp.rtmp import RTMPTimeoutError, PACKET_TYPE_INVOKE
-    from streamlink.packages.flashmedia.types import AMF0Value
-
-    def decode_amf(body):
-        def generator():
-            fd = BytesIO(body)
-            while True:
-                try:
-                    yield AMF0Value.read(fd)
-                except IOError:
-                    break
-
-        return list(generator())
-
-    class FlashmediaRTMP(librtmp.RTMP):
-        """RTMP connection using python-flashmedia's AMF decoder.
-
-        TODO: Move to python-librtmp instead.
-        """
-
-        def process_packets(self, transaction_id=None, invoked_method=None,
-                            timeout=None):
-            start = time()
-
-            while self.connected and transaction_id not in self._invoke_results:
-                if timeout and (time() - start) >= timeout:
-                    raise RTMPTimeoutError("Timeout")
-
-                packet = self.read_packet()
-                if packet.type == PACKET_TYPE_INVOKE:
-                    try:
-                        decoded = decode_amf(packet.body)
-                    except IOError:
-                        continue
-
-                    try:
-                        method, transaction_id_, obj = decoded[:3]
-                        args = decoded[3:]
-                    except ValueError:
-                        continue
-
-                    if method == "_result":
-                        if len(args) > 0:
-                            result = args[0]
-                        else:
-                            result = None
-
-                        self._invoke_results[transaction_id_] = result
-                    else:
-                        handler = self._invoke_handlers.get(method)
-                        if handler:
-                            res = handler(*args)
-                            if res is not None:
-                                self.call("_result", res,
-                                          transaction_id=transaction_id_)
-
-                        if method == invoked_method:
-                            self._invoke_args[invoked_method] = args
-                            break
-
-                    if transaction_id_ == 1.0:
-                        self._connect_result = packet
-                    else:
-                        self.handle_packet(packet)
-                else:
-                    self.handle_packet(packet)
-
-            if transaction_id:
-                result = self._invoke_results.pop(transaction_id, None)
-
-                return result
-
-            if invoked_method:
-                args = self._invoke_args.pop(invoked_method, None)
-
-                return args
-
-
-def create_ums_connection(app, media_id, page_url, password,
-                          exception=PluginError):
-    url = RTMP_URL.format(randint(0, 0xffffff), media_id)
-    params = {
-        "application": app,
-        "media": str(media_id),
-        "password": password
-    }
-    conn = FlashmediaRTMP(url,
-                          swfurl=SWF_URL,
-                          pageurl=page_url,
-                          connect_data=params)
-
-    try:
-        conn.connect()
-    except librtmp.RTMPError:
-        raise exception("Failed to connect to RTMP server")
-
-    return conn
-
-
-class UHSStreamWriter(SegmentedStreamWriter):
-    def __init__(self, *args, **kwargs):
-        SegmentedStreamWriter.__init__(self, *args, **kwargs)
-
-        self.concater = FLVTagConcat(flatten_timestamps=True,
-                                     sync_headers=True)
-
-    def fetch(self, chunk, retries=None):
-        if not retries or self.closed:
-            return
-
-        try:
-            params = {}
-            if chunk.offset:
-                params["start"] = chunk.offset
-
-            return http.get(chunk.url,
-                            timeout=self.timeout,
-                            params=params,
-                            exception=StreamError)
-        except StreamError as err:
-            self.logger.error("Failed to open chunk {0}: {1}", chunk.num, err)
-            return self.fetch(chunk, retries - 1)
-
-    def write(self, chunk, res, chunk_size=8192):
-        try:
-            for data in self.concater.iter_chunks(buf=res.content,
-                                                  skip_header=not chunk.offset):
-                self.reader.buffer.write(data)
-
-                if self.closed:
-                    break
-            else:
-                self.logger.debug("Download of chunk {0} complete", chunk.num)
-        except IOError as err:
-            self.logger.error("Failed to read chunk {0}: {1}", chunk.num, err)
-
-
-class UHSStreamWorker(SegmentedStreamWorker):
-    def __init__(self, *args, **kwargs):
-        SegmentedStreamWorker.__init__(self, *args, **kwargs)
-
-        self.chunk_ranges = {}
-        self.chunk_id = None
-        self.chunk_id_max = None
-        self.chunks = []
-        self.filename_format = ""
-        self.module_info_reload_time = 2
-        self.process_module_info()
-
-    def fetch_module_info(self):
-        self.logger.debug("Fetching module info")
-        conn = create_ums_connection("channel",
-                                     self.stream.channel_id,
-                                     self.stream.page_url,
-                                     self.stream.password,
-                                     exception=StreamError)
-
-        try:
-            result = conn.process_packets(invoked_method="moduleInfo",
-                                          timeout=10)
-        except (IOError, librtmp.RTMPError) as err:
-            raise StreamError("Failed to get module info: {0}".format(err))
-        finally:
-            conn.close()
-
-        result = _module_info_schema.validate(result)
-        return _channel_schema.validate(result, "module info")
-
-    def process_module_info(self):
-        if self.closed:
-            return
-
-        try:
-            result = self.fetch_module_info()
-        except PluginError as err:
-            self.logger.error("{0}", err)
-            return
-
-        providers = result.get("stream")
-        if not providers or providers == "offline":
-            self.logger.debug("Stream went offline")
-            self.close()
-            return
-
-        for provider in providers:
-            if provider.get("name") == self.stream.provider:
-                break
-        else:
-            return
-
-        try:
-            stream = provider["streams"][self.stream.stream_index]
-        except IndexError:
-            self.logger.error("Stream index not in result")
-            return
-
-        filename_format = stream["streamName"].replace("%", "%s")
-        filename_format = urljoin(provider["url"], filename_format)
-
-        self.filename_format = filename_format
-        self.update_chunk_info(stream)
-
-    def update_chunk_info(self, result):
-        chunk_range = result["chunkRange"]
-        if not chunk_range:
-            return
-
-        chunk_id = int(result["chunkId"])
-        chunk_offset = int(result["offset"])
-        chunk_range = dict(map(partial(map, int), chunk_range.items()))
-
-        self.chunk_ranges.update(chunk_range)
-        self.chunk_id_min = sorted(chunk_range)[0]
-        self.chunk_id_max = int(result["chunkId"])
-        self.chunks = [Chunk(i, self.format_chunk_url(i),
-                             not self.chunk_id and i == chunk_id and chunk_offset)
-                       for i in range(self.chunk_id_min, self.chunk_id_max + 1)]
-
-        if self.chunk_id is None and self.chunks:
-            self.chunk_id = chunk_id
-
-    def format_chunk_url(self, chunk_id):
-        chunk_hash = ""
-        for chunk_start in sorted(self.chunk_ranges):
-            if chunk_id >= chunk_start:
-                chunk_hash = self.chunk_ranges[chunk_start]
-
-        return self.filename_format % (chunk_id, chunk_hash)
-
-    def valid_chunk(self, chunk):
-        return self.chunk_id and chunk.num >= self.chunk_id
-
-    def iter_segments(self):
-        while not self.closed:
-            for chunk in filter(self.valid_chunk, self.chunks):
-                self.logger.debug("Adding chunk {0} to queue", chunk.num)
-                yield chunk
-
-                # End of stream
-                if self.closed:
-                    return
-
-                self.chunk_id = chunk.num + 1
-
-            if self.wait(self.module_info_reload_time):
-                try:
-                    self.process_module_info()
-                except StreamError as err:
-                    self.logger.warning("Failed to process module info: {0}", err)
-
-
-class UHSStreamReader(SegmentedStreamReader):
-    __worker__ = UHSStreamWorker
-    __writer__ = UHSStreamWriter
-
-    def __init__(self, stream, *args, **kwargs):
-        self.logger = stream.session.logger.new_module("stream.uhs")
-
-        SegmentedStreamReader.__init__(self, stream, *args, **kwargs)
-
-
-class UHSStream(Stream):
-    __shortname__ = "uhs"
-
-    def __init__(self, session, channel_id, page_url, provider,
-                 stream_index, password=""):
-        Stream.__init__(self, session)
-
-        self.channel_id = channel_id
-        self.page_url = page_url
-        self.provider = provider
-        self.stream_index = stream_index
-        self.password = password
-
-    def __repr__(self):
-        return "<UHSStream({0!r}, {1!r}, {2!r}, {3!r}, {4!r})>".format(
-            self.channel_id, self.page_url, self.provider,
-            self.stream_index, self.password
-        )
-
-    def __json__(self):
-        json = Stream.__json__(self)
-        json.update({
-            "channel_id": self.channel_id,
-            "page_url": self.page_url,
-            "provider": self.provider,
-            "stream_index": self.stream_index,
-            "password": self.password
-        })
-        return json
-
-    def open(self):
-        reader = UHSStreamReader(self)
-        reader.open()
-
-        return reader
-
-
-class UStreamTV(Plugin):
-    options = PluginOptions({
-        "password": ""
-    })
+    def __init__(self, session, media_id, application, **options):
+        self.session = session
+        http.headers.update({"User-Agent": useragents.IPHONE_6})
+        self.logger = session.logger.new_module("plugin.ustream.apiclient")
+        self.media_id = media_id
+        self.application = application
+        self.url = options.pop("url", None)
+        self._host = None
+        self.rsid = self.generate_rsid()
+        self.rpin = self.generate_rpin()
+        self._connection_id = None
+        self._app_id = options.pop("app_id", self.APP_ID)
+        self._app_version = options.pop("app_version", self.APP_VERSION)
+        self._cluster = options.pop("cluster", "live")
+
+    def connect(self, **options):
+        options.pop("url", None)
+        result = self.send_command(type="viewer", appId=self._app_id,
+                                   appVersion=self._app_version,
+                                   rsid=self.rsid,
+                                   rpin=self.rpin,
+                                   referrer=self.url or "unknown",
+                                   media=str(self.media_id),
+                                   application=self.application,
+                                   schema=self.connect_schama)
+
+        self._host = "http://{0}".format(result["host"])
+        self._connection_id = result["connectionId"]
+        self.logger.debug("Got new host={0}, and connectionId={1}", self._host, self._connection_id)
+        return True
+
+    def ping(self, schema=None):
+        return self.send_command(connectionId=self._connection_id, schema=schema)
+
+    def generate_rsid(self):
+        return "{0:x}:{1:x}".format(randint(0, 1e10), randint(0, 1e10))
+
+    def generate_rpin(self):
+        return "_rpin.{0:x}".format(randint(0, 1e15))
+
+    def send_command(self, schema=None, **args):
+        res = http.get(self.host, params=args)
+        return http.json(res, schema=schema or self.api_schama)
+
+    @property
+    def host(self):
+        host = self._host or self.WS_URL.format(randint(0, 0xffffff), self.media_id, self.application, self._cluster)
+        return urljoin(host, "/1/ustream")
+
+
+class UStream(Plugin):
+    url_re = re.compile(r"""
+    https?://(www\.)?ustream\.tv
+        (?:
+            (/embed/|/channel/id/)(?P<channel_id>\d+)
+        )?
+        (?:
+            /recorded/(?P<video_id>\d+)
+        )?
+    """, re.VERBOSE)
+    media_id_re = re.compile(r'"ustream:channel_id"\s+content\s*=\s*"(\d+)"')
 
     @classmethod
     def can_handle_url(cls, url):
-        return _url_re.match(url)
+        return cls.url_re.match(url) is not None
 
-    @classmethod
-    def stream_weight(cls, stream):
-        match = re.match(r"mobile_(\w+)", stream)
-        if match:
-            weight, group = Plugin.stream_weight(match.group(1))
-            weight -= 1
-            group = "mobile_ustream"
-        elif stream == "recorded":
-            weight, group = 720, "ustream"
-        else:
-            weight, group = Plugin.stream_weight(stream)
-
-        return weight, group
-
-    def _get_channel_id(self):
-        res = http.get(self.url)
-        match = _channel_id_re.search(res.text)
-        if match:
-            return int(match.group(1))
-
-    def _get_hls_streams(self, channel_id, wait_for_transcode=False):
-        # HLS streams are created on demand, so we may have to wait
-        # for a transcode to be started.
-        attempts = wait_for_transcode and 10 or 1
-        playlist_url = HLS_PLAYLIST_URL.format(channel_id)
-        streams = {}
-        while attempts and not streams:
-            try:
-                streams = HLSStream.parse_variant_playlist(self.session,
-                                                           playlist_url,
-                                                           nameprefix="mobile_")
-            except IOError:
-                # Channel is probably offline
-                break
-
-            attempts -= 1
-            sleep(3)
-
-        return streams
-
-    def _create_rtmp_stream(self, cdn, stream_name):
-        parsed = urlparse(cdn)
-        params = {
-            "rtmp": cdn,
-            "app": parsed.path[1:],
-            "playpath": stream_name,
-            "pageUrl": self.url,
-            "swfUrl": SWF_URL,
-            "live": True
-        }
-
-        return RTMPStream(self.session, params)
-
-    def _get_module_info(self, app, media_id, password="", schema=None):
-        self.logger.debug("Waiting for moduleInfo invoke")
-        conn = create_ums_connection(app, media_id, self.url, password)
-
-        attempts = 3
-        while conn.connected and attempts:
-            try:
-                result = conn.process_packets(invoked_method="moduleInfo",
-                                              timeout=10)
-            except (IOError, librtmp.RTMPError) as err:
-                raise PluginError("Failed to get stream info: {0}".format(err))
-
-            try:
-                result = _module_info_schema.validate(result)
-                break
-            except PluginError:
-                attempts -= 1
-
-        conn.close()
-
-        if schema:
-            result = schema.validate(result)
-
-        return result
-
-    def _get_desktop_streams(self, channel_id):
-        password = self.options.get("password")
-        channel = self._get_module_info("channel", channel_id, password,
-                                        schema=_channel_schema)
-
-        if not isinstance(channel.get("stream"), list):
-            raise NoStreamsError(self.url)
-
-        streams = {}
-        for provider in channel["stream"]:
-            if provider["name"] == u"uhs_akamai":  # not heavily tested, but got a stream working
-                continue
-            provider_url = provider["url"]
-            provider_name = provider["name"]
-            for stream_index, stream_info in enumerate(provider["streams"]):
-                stream = None
-                stream_height = int(stream_info.get("height", 0))
-                stream_name = stream_info.get("description")
-                if not stream_name:
-                    if stream_height > 0:
-                        if not stream_info.get("isTranscoded"):
-                            stream_name = "{0}p+".format(stream_height)
-                        else:
-                            stream_name = "{0}p".format(stream_height)
-                    else:
-                        stream_name = "live"
-
-                if stream_name in streams:
-                    provider_name_clean = provider_name.replace("uhs_", "")
-                    stream_name += "_alt_{0}".format(provider_name_clean)
-
-                if provider_name.startswith("uhs_"):
-                    stream = UHSStream(self.session, channel_id,
-                                       self.url, provider_name,
-                                       stream_index, password)
-                elif provider_url.startswith("rtmp"):
-                    playpath = stream_info["streamName"]
-                    stream = self._create_rtmp_stream(provider_url,
-                                                      playpath)
-
-                if stream:
-                    streams[stream_name] = stream
-
-        return streams
-
-    def _get_live_streams(self, channel_id):
-        has_desktop_streams = False
-        if HAS_LIBRTMP:
-            try:
-                streams = self._get_desktop_streams(channel_id)
-                # TODO: Replace with "yield from" when dropping Python 2.
-                for stream in streams.items():
-                    has_desktop_streams = True
-                    yield stream
-            except PluginError as err:
-                self.logger.error("Unable to fetch desktop streams: {0}", err)
-            except NoStreamsError:
-                pass
-        else:
-            self.logger.warning(
-                "python-librtmp is not installed, but is needed to access "
-                "the desktop streams"
-            )
-
-        try:
-            streams = self._get_hls_streams(channel_id,
-                                            wait_for_transcode=not has_desktop_streams)
-
-            # TODO: Replace with "yield from" when dropping Python 2.
-            for stream in streams.items():
-                yield stream
-        except PluginError as err:
-            self.logger.error("Unable to fetch mobile streams: {0}", err)
-        except NoStreamsError:
-            pass
-
-    def _get_recorded_streams(self, video_id):
-        if HAS_LIBRTMP:
-            recording = self._get_module_info("recorded", video_id,
-                                              schema=_recorded_schema)
-
-            if not isinstance(recording.get("stream"), list):
-                return
-
-            for provider in recording["stream"]:
-                base_url = provider.get("url")
-                for stream_info in provider["streams"]:
-                    bitrate = int(stream_info.get("bitrate", 0))
-                    stream_name = (bitrate > 0 and "{0}k".format(bitrate) or
-                                   "recorded")
-
-                    url = stream_info["streamName"]
-                    if base_url:
-                        url = base_url + url
-
-                    if url.startswith("http"):
-                        yield stream_name, HTTPStream(self.session, url)
-                    elif url.startswith("rtmp"):
-                        params = dict(rtmp=url, pageUrl=self.url)
-                        yield stream_name, RTMPStream(self.session, params)
-
-        else:
-            self.logger.warning(
-                "The proper API could not be used without python-librtmp "
-                "installed. Stream URL is not guaranteed to be valid"
-            )
-
-            url = RECORDED_URL.format(video_id)
-            random_hash = "{0:02x}{1:02x}".format(randint(0, 255),
-                                                  randint(0, 255))
-            params = dict(hash=random_hash)
-            stream = HTTPStream(self.session, url, params=params)
-            yield "recorded", stream
+    def _api_get_streams(self, media_id, application, cluster="live", retries=3):
+        if retries > 0:
+            app_id = 11 if application == "channel" else 2
+            app_ver = 2 if application == "channel" else 3
+            self.api = UHSClient(self.session, media_id, application, url=self.url, cluster=cluster, app_id=app_id, app_version=app_ver)
+            if self.api.connect():
+                for result in self.api.ping():
+                    if result["cmd"] == "moduleInfo":
+                        for stream in UHSClient.module_info_schema.validate(result):
+                            for s in self._parse_module_stream(stream):
+                                yield s
+                    if result["cmd"] == "reject":
+                        for s in self._api_get_streams(media_id,
+                                                       application,
+                                                       cluster=result["args"][0]["cluster"]["name"],
+                                                       retries=retries-1):
+                            yield s
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
+        # establish a mobile non-websockets api connection
+        umatch = self.url_re.match(self.url)
+        application = "channel"
 
-        video_id = match.group("video_id")
-        if video_id:
-            return self._get_recorded_streams(video_id)
-
-        channel_id = match.group("channel_id") or self._get_channel_id()
+        channel_id = umatch.group("channel_id")
+        video_id = umatch.group("video_id")
         if channel_id:
-            return self._get_live_streams(channel_id)
+            application = "channel"
+            media_id = channel_id
+        elif video_id:
+            application = "recorded"
+            media_id = video_id
+        else:
+            media_id = self._find_media_id()
+
+        if media_id:
+            for s in self._api_get_streams(media_id, application):
+                yield s
+        else:
+            self.logger.error("Cannot find a media_id on this page")
+
+    def _find_media_id(self):
+        self.logger.debug("Searching for media ID on the page")
+        res = http.get(self.url, headers={"User-Agent": useragents.CHROME})
+        m = self.media_id_re.search(res.text)
+        return m and m.group(1)
+
+    def _parse_module_stream(self, streams):
+        if isinstance(streams, list):
+            for stream in streams:
+                for s in HLSStream.parse_variant_playlist(self.session, stream["url"]).items():
+                    yield s
+        elif isinstance(streams, dict):
+            for stream in streams.get("streams", []):
+                name = "{0}k".format(stream["bitrate"])
+                for surl in stream["streamName"]:
+                    yield name, HTTPStream(self.session, surl)
+        elif streams == "offline":
+            self.logger.warning("This stream is currently offline")
 
 
-__plugin__ = UStreamTV
+__plugin__ = UStream

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -110,7 +110,7 @@ class UStreamHLSStream(HLSStream):
         return reader
 
 
-class UStream(Plugin):
+class UStreamTV(Plugin):
     url_re = re.compile(r"""
     https?://(www\.)?ustream\.tv
         (?:
@@ -205,4 +205,4 @@ class UStream(Plugin):
         return m and m.group(1)
 
 
-__plugin__ = UStream
+__plugin__ = UStreamTV

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -13,6 +13,10 @@ from streamlink.stream.hls import HLSStreamReader
 
 
 class UHSClient(object):
+    """
+    API Client, reverse engineered by observing the interactions
+    between the web browser and the ustream servers.
+    """
     API_URL = "http://r{0}-1-{1}-{2}-{3}.ums.ustream.tv"
     APP_ID, APP_VERSION = 2, 1
     api_schama = validate.Schema([{
@@ -85,6 +89,9 @@ class UHSClient(object):
 
 class UStreamHLSStream(HLSStream):
     class APIPoller(Thread):
+        """
+        Poll the UStream API so that stream URLs stay valid, otherwise they expire after 30 seconds.
+        """
         def __init__(self, api, interval=10.0):
             Thread.__init__(self)
             self.stopped = Event()


### PR DESCRIPTION
This is a complete re-write of the `UStreamTV` plugin. Only the mobile HLS streams are supported, not the custom fragmented flv/mp4 desktop streams. Some new features have been added though, eg. support for referrer locked embedded streams. There are future plans to support the desktop streams using this new API as well.  

This new plugin uses the new long polling UStream API (rather than the websockets API, to avoid adding a new dependency). The requirement for `python-librtmp` has been removed, and the docs updated to reflect this. 

If this is merged I suggest a new issue be created to track the addition of desktop stream support and the following issues be closed: #57, #58, #110, #129, #719, and #747.