### PR TITLE
plugins.aljazeeraen: support for live and vod streams from aljazeera.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -17,6 +17,7 @@ afreeca             afreecatv.com        Yes   No
 afreecatv           afreeca.tv           Yes   No
 aftonbladet         aftonbladet.se       Yes   Yes
 alieztv             aliez.tv             Yes   Yes
+aljazeeraen         aljazeera.com        Yes   Yes   English version of the site.
 animelab            animelab.com         --    Yes   Requires a login. Streams may be geo-restricted to Australia and New Zealand.
 antenna             antenna.gr           --    Yes
 app17               17app.co             Yes   --

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -35,6 +35,7 @@ bigo                - live.bigo.tv       Yes   --
                     - bigoweb.co
 bilibili            live.bilibili.com    Yes   ?
 bongacams           bongacams.com        Yes   No    Only RTMP streams are available.
+brightcove          players.brig... [6]_ Yes   Yes
 btv                 btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
 camsoda             camsoda.com          Yes   No
 canalplus           - canalplus.fr       Yes   Yes   Streams may be geo-restricted to France.
@@ -227,3 +228,4 @@ zhanqitv            zhanqi.tv            Yes   No
 .. [3] original.livestream.com
 .. [4] streaming.media.ccc.de
 .. [5] mediathek.daserste.de
+.. [6] players.brightcove.net

--- a/src/streamlink/plugins/aljazeeraen.py
+++ b/src/streamlink/plugins/aljazeeraen.py
@@ -1,0 +1,40 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugins.brightcove import BrightcovePlayer
+from streamlink.stream import RTMPStream
+
+
+class AlJazeeraEnglish(Plugin):
+    url_re = re.compile(r"https?://(?:\w+\.)?aljazeera\.com")
+    account_id = 665003303001
+    render_re = re.compile(r'''RenderPagesVideo\((?P<q>['"])(?P<id>\d+)(?P=q)''')  # VOD
+    video_id_re = re.compile(r'''videoId=(?P<id>\d+)["']''')  # Live
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+
+        # check two different styles to include the video id in the page
+        video_id_m = self.render_re.search(res.text) or self.video_id_re.search(res.text)
+        video_id = video_id_m and video_id_m.group("id")
+
+        if not video_id:
+            self.logger.error("Could not find a video ID on this page")
+            return
+
+        # Use BrightcovePlayer class to get the streams
+        self.logger.debug("Found video ID: {0}", video_id)
+        bp = BrightcovePlayer(self.session, self.account_id)
+
+        for q, s in bp.get_streams(video_id):
+            # RTMP Streams are listed, but they do not appear to work
+            if not isinstance(s, RTMPStream):
+                yield q, s
+
+
+__plugin__ = AlJazeeraEnglish

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -1,0 +1,87 @@
+import re
+
+from streamlink import PluginError
+from streamlink.plugin.api import http, validate
+from streamlink.plugin.api import useragents
+from streamlink.stream import HLSStream
+from streamlink.stream import HTTPStream
+from streamlink.stream import RTMPStream
+
+
+class BrightcovePlayer(object):
+    player_page = "http://players.brightcove.net/{account_id}/{player_id}/index.html"
+    api_url = "https://edge.api.brightcove.com/playback/v1/"
+
+    policy_key_re = re.compile(r'''policyKey\s*:\s*(?P<q>['"])(?P<key>.*?)(?P=q)''')
+
+    schema = validate.Schema({
+        "sources": [{
+            validate.optional("height"): validate.any(int, None),
+            validate.optional("avg_bitrate"): validate.any(int, None),
+            validate.optional("src"): validate.url(),
+            validate.optional("app_name"): validate.url(scheme="rtmp"),
+            validate.optional("stream_name"): validate.text,
+            validate.optional("type"): validate.text
+        }]
+    })
+
+    def __init__(self, session, account_id, player_id="default_default"):
+        self.session = session
+        self.logger = session.logger.new_module("plugins.brightcove")
+        self.account_id = account_id
+        self.player_id = player_id
+
+    def player_url(self, video_id):
+        return self.player_page.format(account_id=self.account_id,
+                                       player_id=self.player_id,
+                                       params=dict(videoId=video_id))
+
+    def video_info(self, video_id, policy_key):
+        url = "{base}accounts/{account_id}/videos/{video_id}".format(base=self.api_url,
+                                                                     account_id=self.account_id,
+                                                                     video_id=video_id)
+        res = http.get(url,
+                       headers={
+                           "User-Agent": useragents.CHROME,
+                           "Referer": self.player_url(video_id),
+                           "Accept": "application/json;pk={0}".format(policy_key)
+                       })
+        return http.json(res, schema=self.schema)
+
+    def policy_key(self, video_id):
+        # Get the embedded player page
+        res = http.get(self.player_url(video_id))
+
+        policy_key_m = self.policy_key_re.search(res.text)
+        policy_key = policy_key_m and policy_key_m.group("key")
+        if not policy_key:
+            raise PluginError("Could not find Brightcove policy key")
+
+        return policy_key
+
+    def get_streams(self, video_id):
+        policy_key = self.policy_key(video_id)
+        self.logger.debug("Found policy key: {0}", policy_key)
+        data = self.video_info(video_id, policy_key)
+
+        for source in data.get("sources"):
+            # determine quality name
+            if source.get("height"):
+                q = "{0}p".format(source.get("height"))
+            elif source.get("avg_bitrate"):
+                q = "{0}k".format(source.get("avg_bitrate") // 1000)
+            else:
+                q = "live"
+
+            if ((source.get("type") == "application/x-mpegURL" and source.get("src")) or
+                    (source.get("src") and source.get("src").endswith(".m3u8"))):
+                for s in HLSStream.parse_variant_playlist(self.session, source.get("src")).items():
+                    yield s
+            elif source.get("app_name"):
+                s = RTMPStream(self.session,
+                               {"rtmp": source.get("app_name"),
+                                "playpath": source.get("stream_name")})
+                yield q, s
+            elif source.get("src") and source.get("src").endswith(".mp4"):
+                yield q, HTTPStream(self.session, source.get("src"))
+


### PR DESCRIPTION
Only the English variant of the website is support (aljazeera.com).
Live streams and VOD are both supported.

A support class `BrightcovePlayer` was added to simplify the process of playing streams hosted by Brightcove.

Example URLs:
- aljazeera.com/programmes/witness/
- aljazeera.com/live/
- aljazeera.com/programmes/the-big-picture/2017/02/big-picture-people-america-170216063801575.html

I plan to update the `tv8cat` plugin to use the new `BrightcovePlayer` class when/if it is merged.