### PR TITLE
plugins.nbc: support vod from nbc.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -120,6 +120,7 @@ mips                mips.tv              Yes   --    Requires rtmpdump with K-S-
 mitele              mitele.es            Yes   No    Streams may be geo-restricted to Spain.
 mlgtv               mlg.tv               Yes   --
 nbc                 nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
+nbcsports           nbcsports.com        No    Yes   Streams maybe be geo-restricted to USA. Authentication is not supported.
 nhkworld            nhk.or.jp/nhkworld   Yes   No
 nineanime           9anime.to            --    Yes
 nos                 nos.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -119,6 +119,7 @@ mediaklikk          mediaklikk.hu        Yes   No    Streams may be geo-restrict
 mips                mips.tv              Yes   --    Requires rtmpdump with K-S-V patches.
 mitele              mitele.es            Yes   No    Streams may be geo-restricted to Spain.
 mlgtv               mlg.tv               Yes   --
+nbc                 nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
 nhkworld            nhk.or.jp/nhkworld   Yes   No
 nineanime           9anime.to            --    Yes
 nos                 nos.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.
@@ -173,6 +174,7 @@ tf1                 - tf1.fr             Yes   No    Streams may be geo-restrict
 tga                 - star.plu.cn        Yes   No
                     - star.tga.plu.cn
                     - star.longzhu.com
+theplatform         player.thepl... [7]_ No    Yes
 tigerdile           tigerdile.com        Yes   --
 trt                 trt.net.tr           Yes   No    Some streams may be geo-restricted to Turkey.
 trtspor             trtspor.com          Yes   No    Some streams are geo-restricted to Turkey.
@@ -233,3 +235,4 @@ zhanqitv            zhanqi.tv            Yes   No
 .. [4] streaming.media.ccc.de
 .. [5] mediathek.daserste.de
 .. [6] players.brightcove.net
+.. [7] player.theplatform.com

--- a/src/streamlink/plugins/nbc.py
+++ b/src/streamlink/plugins/nbc.py
@@ -1,0 +1,27 @@
+import re
+
+from streamlink import streams
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.utils import update_scheme
+
+
+class NBC(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?nbc\.com")
+    embed_url_re = re.compile(r'''(?P<q>["'])embedURL(?P=q)\s*:\s*(?P<q2>["'])(?P<url>.*?)(?P=q2)''')
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        m = self.embed_url_re.search(res.text)
+        platform_url = m and m.group("url")
+
+        if platform_url:
+            # hand off to ThePlatform plugin
+            return streams(update_scheme(self.url, platform_url))
+
+
+__plugin__ = NBC

--- a/src/streamlink/plugins/nbcsports.py
+++ b/src/streamlink/plugins/nbcsports.py
@@ -6,9 +6,9 @@ from streamlink.plugins.theplatform import ThePlatform
 from streamlink.utils import update_scheme
 
 
-class NBC(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?nbc\.com")
-    embed_url_re = re.compile(r'''(?P<q>["'])embedURL(?P=q)\s*:\s*(?P<q2>["'])(?P<url>.*?)(?P=q2)''')
+class NBCSports(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?nbcsports\.com")
+    embed_url_re = re.compile(r'''id\s*=\s*"vod-player"\s+src\s*=\s*"(?P<url>.*?)"''')
 
     @classmethod
     def can_handle_url(cls, url):
@@ -23,8 +23,8 @@ class NBC(Plugin):
             url = update_scheme(self.url, platform_url)
             # hand off to ThePlatform plugin
             p = ThePlatform(url)
-            p.bind(self.session, "plugin.nbc")
+            p.bind(self.session, "plugin.nbcsports")
             return p.streams()
 
 
-__plugin__ = NBC
+__plugin__ = NBCSports

--- a/src/streamlink/plugins/theplatform.py
+++ b/src/streamlink/plugins/theplatform.py
@@ -1,0 +1,39 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.stream import HLSStream
+
+
+class ThePlatform(Plugin):
+    """
+    Plugin to support streaming videos hosted by thePlatform
+    """
+    url_re = re.compile(r"https?://player.theplatform.com/p/")
+    release_re = re.compile(r'''tp:releaseUrl\s*=\s*"(.*?)"''')
+    video_src_re = re.compile(r'''video.*?src="(.*?)"''')
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        m = self.release_re.search(res.text)
+        release_url = m and m.group(1)
+        if release_url:
+            api_url = release_url+"&formats=m3u,mpeg4"
+            res = http.get(api_url, allow_redirects=False, raise_for_status=False)
+            if res.status_code == 302:
+                stream_url = res.headers.get("Location")
+                return HLSStream.parse_variant_playlist(self.session, stream_url, headers={
+                    "Referer": self.url
+                })
+            else:
+                error = http.json(res)
+                self.logger.error("{0}: {1}",
+                                  error.get("title", "Error"),
+                                  error.get("description", "An unknown error occurred"))
+
+
+__plugin__ = ThePlatform


### PR DESCRIPTION
Added a plugin to support NBC, NBCSports and thePlatform (which hosts the NBC videos). 
Only un-authenticated streams are supported, supporting cable logins would be a lot of maintenance. 

NBCSports was requested in #325.

Examples:

- nbc.com/the-tonight-show/video/vin-diesel-is-afraid-of-roller-coasters/3495809
- nbc.com/the-voice/video/the-battles-part-4/3489385
- nbcsports.com/video/league/nba