### PR TITLE
Support for videos on Google Docs/Drive

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -96,6 +96,7 @@ furstream           furstre.am           Yes   No
 garena              garena.live          Yes   --
 gomexp              gomexp.com           Yes   No
 goodgame            goodgame.ru          Yes   No    Only HLS streams are available.
+googledocs          docs.google.com      --    Yes
 gulli               replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France.
 hitbox              hitbox.tv            Yes   Yes
 huajiao             huajiao.com          Yes   No    

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -96,7 +96,8 @@ furstream           furstre.am           Yes   No
 garena              garena.live          Yes   --
 gomexp              gomexp.com           Yes   No
 goodgame            goodgame.ru          Yes   No    Only HLS streams are available.
-googledocs          docs.google.com      --    Yes
+googledrive         - docs.google.com    --    Yes
+                    - drive.google.com
 gulli               replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France.
 hitbox              hitbox.tv            Yes   Yes
 huajiao             huajiao.com          Yes   No    

--- a/src/streamlink/plugins/googledocs.py
+++ b/src/streamlink/plugins/googledocs.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import re
 
 from streamlink.compat import parse_qsl
@@ -9,7 +7,7 @@ from streamlink.stream import HTTPStream
 
 
 class GoogleDocs(Plugin):
-    url_re = re.compile(r"https://docs.google.com/file/d/(.+?)/preview")
+    url_re = re.compile(r"https://docs.google.com/file/d/([^/]+)/?")
     api_url = "https://docs.google.com/get_video_info"
 
     @classmethod
@@ -18,13 +16,17 @@ class GoogleDocs(Plugin):
 
     def _get_streams(self):
         docid = self.url_re.match(self.url).group(1)
+        self.logger.debug("Google Docs ID: {0}", docid)
         res = http.get(self.api_url, params=dict(docid=docid))
         data = dict(parse_qsl(res.text))
-        fmts = dict([s.split('/')[:2] for s in data["fmt_list"].split(",")])
-        streams = [s.split('|') for s in data["fmt_stream_map"].split(",")]
-        for qcode, url in streams:
-            _, h = fmts[qcode].split("x")
-            yield "{0}p".format(h), HTTPStream(self.session, url)
 
+        if data["status"] == "ok":
+            fmts = dict([s.split('/')[:2] for s in data["fmt_list"].split(",")])
+            streams = [s.split('|') for s in data["fmt_stream_map"].split(",")]
+            for qcode, url in streams:
+                _, h = fmts[qcode].split("x")
+                yield "{0}p".format(h), HTTPStream(self.session, url)
+        else:
+            self.logger.error("{0} (ID: {1})", data["reason"], docid)
 
 __plugin__ = GoogleDocs

--- a/src/streamlink/plugins/googledocs.py
+++ b/src/streamlink/plugins/googledocs.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+
+import re
+
+from streamlink.compat import parse_qsl
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.stream import HTTPStream
+
+
+class GoogleDocs(Plugin):
+    url_re = re.compile(r"https://docs.google.com/file/d/(.+?)/preview")
+    api_url = "https://docs.google.com/get_video_info"
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        docid = self.url_re.match(self.url).group(1)
+        res = http.get(self.api_url, params=dict(docid=docid))
+        data = dict(parse_qsl(res.text))
+        fmts = dict([s.split('/')[:2] for s in data["fmt_list"].split(",")])
+        streams = [s.split('|') for s in data["fmt_stream_map"].split(",")]
+        for qcode, url in streams:
+            _, h = fmts[qcode].split("x")
+            yield "{0}p".format(h), HTTPStream(self.session, url)
+
+
+__plugin__ = GoogleDocs

--- a/src/streamlink/plugins/googledrive.py
+++ b/src/streamlink/plugins/googledrive.py
@@ -7,7 +7,7 @@ from streamlink.stream import HTTPStream
 
 
 class GoogleDocs(Plugin):
-    url_re = re.compile(r"https://docs.google.com/file/d/([^/]+)/?")
+    url_re = re.compile(r"https?://(?:drive|docs).google.com/file/d/([^/]+)/?")
     api_url = "https://docs.google.com/get_video_info"
 
     @classmethod


### PR DESCRIPTION
A plugin to support playing videos stored on Google Drive or Google Docs. Only videos that don't require authentication are supported.

(Super) Random Examples:
- drive.google.com/file/d/0B_0CLdJvAxuAM2hFWTJYOXhXVzQ/edit
- drive.google.com/file/d/0B2TQCD_DizLdOHQ5eVhjWk5EVTA/view