### PR TITLE
plugins.playtv: disable HDS streams

### DIFF
--- a/src/streamlink/plugins/playtv.py
+++ b/src/streamlink/plugins/playtv.py
@@ -48,8 +48,8 @@ class PlayTV(Plugin):
         for language in streams:
             for protocol, bitrates in list(streams[language].items()):
                 # - Ignore non-supported protocols (RTSP, DASH)
-                # - Ignore deprecated Flash (RTMPE) streams (PlayTV doesn't provide anymore a Flash player)
-                if protocol in ['rtsp', 'flash', 'dash']:
+                # - Ignore deprecated Flash (RTMPE/HDS) streams (PlayTV doesn't provide anymore a Flash player)
+                if protocol in ['rtsp', 'flash', 'dash', 'hds']:
                     continue
 
                 for bitrate in bitrates['bitrates']:


### PR DESCRIPTION
This PR fixes the playtv plugin which is broken:

```
$ streamlink "http://playtv.fr/television/euronews" best
[cli][info] Found matching plugin playtv for URL http://playtv.fr/television/euronews
error: Unable to open URL: http://edge-02.playmedia-cdn.net/origin02/euronews_800/manifest.f4m?dar=ws&t=18ddf1b11ff0fbb27659a265b39d11263a96f51d89085ca5602bbe1b2cb7f2adcfd6b0980947f7a6f597bd95024faa49ec3f8a021de2b92113556e66a38547ddb2ca26ce9a72b8ddd99243d0efd1dbf46afec9c5fd5df6e9b1f1b9e8d3b988def790ac41bd7cb113cfa08bf6025c15b9d3ec46ec0e87950d (404 Client Error: Not Found for url: https://edge-02.playmedia-cdn.net/origin02/euronews_800/manifest.f4m?dar=ws&t=18ddf1b11ff0fbb27659a265b39d11263a96f51d89085ca5602bbe1b2cb7f2adcfd6b0980947f7a6f597bd95024faa49ec3f8a021de2b92113556e66a38547ddb2ca26ce9a72b8ddd99243d0efd1dbf46afec9c5fd5df6e9b1f1b9e8d3b988def790ac41bd7cb113cfa08bf6025c15b9d3ec46ec0e87950d)
```

It disables HDS streams, returned by the PlayTV API, and no longer available online.

