### PR TITLE
Will exit with exit code 1 if stream cannot be opened.

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -314,9 +314,9 @@ def read_stream(stream, output, prebuffer, chunk_size=8192):
                 break
     except IOError as err:
         console.exit("Error when reading from stream: {0}, exiting", err)
-
-    stream.close()
-    console.logger.info("Stream ended")
+    finally:
+        stream.close()
+        console.logger.info("Stream ended")
 
 
 def handle_stream(plugin, streams, stream_name):

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -249,6 +249,7 @@ def output_stream(stream):
         try:
             stream_fd, prebuffer = open_stream(stream)
             success_open = True
+            break
         except StreamError as err:
             console.logger.error("Try {0}/{1}: Could not open stream {2} ({3})", i+1, args.retry_open, stream, err)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -244,14 +244,16 @@ def output_stream(stream):
     """Open stream, create output and finally write the stream to output."""
     global output
 
+    success_open = False
     for i in range(args.retry_open):
         try:
             stream_fd, prebuffer = open_stream(stream)
-            break
+            success_open = True
         except StreamError as err:
-            console.exit("Could not open stream {0} ({1})", stream, err)
-    else:
-        return
+            console.log.error("Try {0}/{1}: Could not open stream {2} ({3})", i, args.retry_open, stream, err)
+
+    if not success_open:
+        console.exit("Could not open stream {0}, tried {1} times, exiting", stream, args.retry_open)
 
     output = create_output()
 
@@ -307,11 +309,11 @@ def read_stream(stream, output, prebuffer, chunk_size=8192):
                 elif is_http and err.errno in ACCEPTABLE_ERRNO:
                     console.logger.info("HTTP connection closed")
                 else:
-                    console.logger.error("Error when writing to output: {0}", err)
+                    console.exit("Error when writing to output: {0}, exiting", err)
 
                 break
     except IOError as err:
-        console.logger.error("Error when reading from stream: {0}", err)
+        console.exit("Error when reading from stream: {0}, exiting", err)
 
     stream.close()
     console.logger.info("Stream ended")

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -250,7 +250,7 @@ def output_stream(stream):
             stream_fd, prebuffer = open_stream(stream)
             success_open = True
         except StreamError as err:
-            console.log.error("Try {0}/{1}: Could not open stream {2} ({3})", i, args.retry_open, stream, err)
+            console.log.error("Try {0}/{1}: Could not open stream {2} ({3})", i+1, args.retry_open, stream, err)
 
     if not success_open:
         console.exit("Could not open stream {0}, tried {1} times, exiting", stream, args.retry_open)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -249,7 +249,7 @@ def output_stream(stream):
             stream_fd, prebuffer = open_stream(stream)
             break
         except StreamError as err:
-            console.logger.error("{0}", err)
+            console.exit("Could not open stream {0} ({1})", stream, err)
     else:
         return
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -250,7 +250,7 @@ def output_stream(stream):
             stream_fd, prebuffer = open_stream(stream)
             success_open = True
         except StreamError as err:
-            console.log.error("Try {0}/{1}: Could not open stream {2} ({3})", i+1, args.retry_open, stream, err)
+            console.logger.error("Try {0}/{1}: Could not open stream {2} ({3})", i+1, args.retry_open, stream, err)
 
     if not success_open:
         console.exit("Could not open stream {0}, tried {1} times, exiting", stream, args.retry_open)


### PR DESCRIPTION
Fixes #781 as reported by @strudelkuchen. 

There is a couple other cases where possible a console.exit is better than to just log and exit with success. Namely [L310](https://github.com/Germandrummer92/streamlink/blob/48fb299c556c80a1dd6ac7727abb6f97b4355f9a/src/streamlink_cli/main.py#L310) and/or [L314](https://github.com/Germandrummer92/streamlink/blob/48fb299c556c80a1dd6ac7727abb6f97b4355f9a/src/streamlink_cli/main.py#L314). not sure though if those cases can occur with a "normal" close of the stream (e.g. the streamer stops it) in which case they should stay like they are, or if it's indicative of any error and it should exit with exit code 1.