### PR TITLE
plugins.brightcove: support for HLS stream URLs with query strings + RTMPE stream URLs

### DIFF
--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -73,7 +73,7 @@ class BrightcovePlayer(object):
                 q = "live"
 
             if ((source.get("type") == "application/x-mpegURL" and source.get("src")) or
-                    (source.get("src") and source.get("src").endswith(".m3u8"))):
+                    (source.get("src") and ".m3u8" in source.get("src"))):
                 for s in HLSStream.parse_variant_playlist(self.session, source.get("src")).items():
                     yield s
             elif source.get("app_name"):

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -18,7 +18,10 @@ class BrightcovePlayer(object):
             validate.optional("height"): validate.any(int, None),
             validate.optional("avg_bitrate"): validate.any(int, None),
             validate.optional("src"): validate.url(),
-            validate.optional("app_name"): validate.url(scheme="rtmp"),
+            validate.optional("app_name"): validate.any(
+                validate.url(scheme="rtmp"),
+                validate.url(scheme="rtmpe")
+            ),
             validate.optional("stream_name"): validate.text,
             validate.optional("type"): validate.text
         }]


### PR DESCRIPTION
This PR provides small improvements for the BrightcovePlayer class, required for a plugin I'm currently writing to support bfmtv.com.

* support for HLS playlist URLs with query strings.

  For example, with the account ID 5067014665001 and the player ID 5080870408001, the API returns the following data:

```json
{
[...]
    "account_id": "5067014665001",
    "sources": [
        {
            "avg_bitrate": null,
            "width": null,
            "src": "https://rmcsporthdslive-lh.akamaihd.net/i/DVMR_BFMSPORT@182576/master.m3u8?__nn__=5078103454001&hdnea=st=1492124400~exp=1492128000~acl=/i/*~hmac=83b8f65edb5480d9cd997c203f0e1809353d0d9e2f166252775c7f31fc9545cc",
            "size": 0,
            "height": null,
            "duration": -1,
            "container": "M2TS",
            "codec": "H264",
            "asset_id": "5080888428001"
        },
        {
            "avg_bitrate": null,
            "width": null,
            "src": "http://rmcsporthdslive-lh.akamaihd.net/z/DVMR_BFMSPORT@182576/manifest.f4m?__nn__=5078103454001&hdnea=st=1492124400~exp=1492128000~acl=/z/*~hmac=52b50e23396bf819e557cc6fab1e49e0944f78ebfe79c95e89769e34617aa900",
            "size": 0,
            "height": null,
            "duration": -1,
            "container": "MP4",
            "codec": "H264",
            "asset_id": "5080888429001"
        }
    ],
    "name": "LIVE BFM Sport",
[...]
    "id": "5080870408001",
[...]
}
```

* support for RTMPE streams.

  For example, with the account ID 1969646226001 and the player ID 5393084243001, the API returns the following data:

```json
{
[...]
    "account_id": "1969646226001",
    "sources": [
        {
            "avg_bitrate": 512000,
            "width": 480,
            "duration": 2904095,
            "size": 187337224,
            "stream_name": "mp4:23/1969646226001/201704/3218/1969646226001_5393113723001_5393084243001.mp4",
            "codec": "H264",
            "asset_id": "5393113723001",
            "container": "MP4",
            "height": 270,
            "app_name": "rtmpe://cp101677.edgefcs.net/ondemand"
        },
        {
            "avg_bitrate": 994000,
            "width": 640,
            "duration": 2904095,
            "size": 362560618,
            "stream_name": "mp4:23/1969646226001/201704/3218/1969646226001_5393114353001_5393084243001.mp4",
            "codec": "H264",
            "asset_id": "5393114353001",
            "container": "MP4",
            "height": 360,
            "app_name": "rtmpe://cp101677.edgefcs.net/ondemand"
        },
[...]
    ],
    "name": "LA CITE DISPARUE DE POMPEI",
[...]
    "id": "5393084243001",
[...]
}
```