### PR TITLE
plugins.canalplus: disable HDS streams for live videos

### DIFF
--- a/src/streamlink/plugins/canalplus.py
+++ b/src/streamlink/plugins/canalplus.py
@@ -23,6 +23,7 @@ class CanalPlus(Plugin):
     _video_id_re = re.compile(r'\bdata-video="(?P<video_id>[0-9]+)"')
     _mp4_bitrate_re = re.compile(r'.*_(?P<bitrate>[0-9]+k)\.mp4')
     _api_schema = validate.Schema({
+        'TYPE': validate.text,
         'MEDIA': validate.Schema({
             'VIDEOS': validate.Schema({
                 validate.text: validate.any(
@@ -73,7 +74,8 @@ class CanalPlus(Plugin):
             parsed.append(video_url)
 
             try:
-                if '.f4m' in video_url:
+                # HDS streams don't seem to work for live videos
+                if '.f4m' in video_url and videos['TYPE'] != 'CHAINE LIVE':
                     for stream in HDSStream.parse_manifest(self.session,
                                                            video_url,
                                                            params={'hdcore': self.HDCORE_VERSION},


### PR DESCRIPTION
This PR fixes the canalplus plugin which doesn't work anymore with live streams (VOD streams are OK):
```
$ streamlink http://www.canalplus.fr/pid3580-live-tv-clair.html
[cli][info] Found matching plugin canalplus for URL http://www.canalplus.fr/pid3580-live-tv-clair.html
error: Unable to open URL: http://hds_live_cpc_aka-lh.akamaihd.net/z/cpc_hds@182615/manifest.f4m (400 Client Error: Bad Request for url: http://hds_live_cpc_aka-lh.akamaihd.net/z/cpc_hds@182615/manifest.f4m?hdcore=3.1.0&g=HILLKWGDTICA)

$ streamlink http://www.c8.fr/pid5323-c8-live.html
[cli][info] Found matching plugin canalplus for URL http://www.c8.fr/pid5323-c8-live.html
error: Unable to open URL: http://hds_live_d8_aka-lh.akamaihd.net/z/d8_hds@182613/manifest.f4m (400 Client Error: Bad Request for url: http://hds_live_d8_aka-lh.akamaihd.net/z/d8_hds@182613/manifest.f4m?hdcore=3.1.0&g=BHEACWOXDILQ)

$ streamlink http://www.cstar.fr/pid5322-cstar-live.html
[cli][info] Found matching plugin canalplus for URL http://www.cstar.fr/pid5322-cstar-live.html
error: Unable to open URL: http://hds_live_d17_aka-lh.akamaihd.net/z/d17_hds@182614/manifest.f4m (400 Client Error: Bad Request for url: http://hds_live_d17_aka-lh.akamaihd.net/z/d17_hds@182614/manifest.f4m?hdcore=3.1.0&g=ZBUPHQCUXAWZ)
```

It disables HDS streams, only for live channels.