### PR TITLE
Add support for Bloomberg

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -36,6 +36,7 @@ bfmtv               bfmtv.com            Yes   Yes
 bigo                - live.bigo.tv       Yes   --
                     - bigoweb.co
 bilibili            live.bilibili.com    Yes   ?
+bloomberg           bloomberg.com        Yes   Yes
 bongacams           bongacams.com        Yes   No    Only RTMP streams are available.
 brightcove          players.brig... [6]_ Yes   Yes
 btv                 btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -1,0 +1,143 @@
+from functools import partial
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http, validate
+from streamlink.stream import HDSStream, HLSStream, HTTPStream
+from streamlink.utils import parse_json, update_scheme
+
+
+class Bloomberg(Plugin):
+    VOD_API_URL = 'https://www.bloomberg.com/api/embed?id={0}'
+    PLAYER_URL = 'https://cdn.gotraffic.net/projector/latest/bplayer.js'
+    CHANNEL_MAP = {
+        'europe': 'EU',
+        'us': 'US',
+        'asia': 'ASIA',
+        'stream': 'EVENT',
+        'emea': 'EMEA_EVENT',
+        'asia_stream': 'ASIA_EVENT'
+    }
+
+    _url_re = re.compile(r'''
+        https?://www\.bloomberg\.com/(
+            news/videos/[^/]+/[^/]+ |
+            live/(?P<channel>stream|emea|asia_stream|europe|us|asia)/?
+        )
+''', re.VERBOSE)
+    _live_player_re = re.compile(r'APP_BUNDLE:"(?P<live_player_url>.+?/app.js)"')
+    _js_to_json_re = partial(re.compile(r'(\w+):(["\']|\d?\.?\d+,|true|false|\[|{)').sub, r'"\1":\2')
+    _video_id_re = re.compile(r'data-bmmr-id=\\"(?P<video_id>.+?)\\"')
+    _mp4_bitrate_re = re.compile(r'.*_(?P<bitrate>[0-9]+)\.mp4')
+
+    _live_streams_schema = validate.Schema(
+        validate.transform(_js_to_json_re),
+        validate.transform(lambda x: x.replace(':.', ':0.')),
+        validate.transform(parse_json),
+        validate.Schema(
+            {
+                'cdns': validate.all(
+                    [
+                        validate.Schema(
+                            {
+                                'streams': validate.all([
+                                    validate.Schema(
+                                        {'url': validate.transform(lambda x: re.sub(r'(https?:/)([^/])', r'\1/\2', x))},
+                                        validate.get('url'),
+                                        validate.url()
+                                    )
+                                ]),
+                            },
+                            validate.get('streams')
+                        )
+                    ],
+                    validate.transform(lambda x: [i for y in x for i in y])
+                )
+            },
+            validate.get('cdns')
+        )
+    )
+
+    _vod_api_schema = validate.Schema(
+        {
+            'secureStreams': validate.all([
+                validate.Schema(
+                    {'url': validate.url()},
+                    validate.get('url')
+                )
+            ]),
+            'streams': validate.all([
+                validate.Schema(
+                    {'url': validate.url()},
+                    validate.get('url')
+                )
+            ]),
+            'contentLoc': validate.url(),
+        },
+        validate.transform(lambda x: list(set(x['secureStreams'] + x['streams'] + [x['contentLoc']])))
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return Bloomberg._url_re.match(url)
+
+    def _get_live_streams(self):
+        # Get channel id
+        match = self._url_re.match(self.url)
+        channel = match.group('channel')
+
+        # Retrieve live player URL
+        res = http.get(self.PLAYER_URL)
+        match = self._live_player_re.search(res.text)
+        if match is None:
+            return []
+        live_player_url = update_scheme(self.url, match.group('live_player_url'))
+
+        # Extract streams from the live player page
+        res = http.get(live_player_url)
+        stream_datas = re.findall(r'{0}(?:_MINI)?:({{.+?}}]}}]}})'.format(self.CHANNEL_MAP[channel]), res.text)
+        streams = []
+        for s in stream_datas:
+            for u in self._live_streams_schema.validate(s):
+                if u not in streams:
+                    streams.append(u)
+
+        return streams
+
+    def _get_vod_streams(self):
+        # Retrieve URL page and search for video ID
+        res = http.get(self.url)
+        match = self._video_id_re.search(res.text)
+        if match is None:
+            return []
+        video_id = match.group('video_id')
+
+        res = http.get(self.VOD_API_URL.format(video_id))
+        streams = http.json(res, schema=self._vod_api_schema)
+        return streams
+
+    def _get_streams(self):
+        if '/live/' in self.url:
+            # Live
+            streams = self._get_live_streams()
+        else:
+            # VOD
+            streams = self._get_vod_streams()
+
+        for video_url in streams:
+            if '.f4m' in video_url:
+                for stream in HDSStream.parse_manifest(self.session, video_url).items():
+                    yield stream
+            elif '.m3u8' in video_url:
+                for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
+                    yield stream
+            if '.mp4' in video_url:
+                match = self._mp4_bitrate_re.match(video_url)
+                if match is not None:
+                    bitrate = match.group('bitrate') + 'k'
+                else:
+                    bitrate = 'vod'
+                yield bitrate, HTTPStream(self.session, video_url)
+
+
+__plugin__ = Bloomberg

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -11,18 +11,19 @@ class Bloomberg(Plugin):
     VOD_API_URL = 'https://www.bloomberg.com/api/embed?id={0}'
     PLAYER_URL = 'https://cdn.gotraffic.net/projector/latest/bplayer.js'
     CHANNEL_MAP = {
-        'europe': 'EU',
-        'us': 'US',
-        'asia': 'ASIA',
-        'stream': 'EVENT',
-        'emea': 'EMEA_EVENT',
-        'asia_stream': 'ASIA_EVENT'
+        'audio': 'BBG_RADIO',
+        'live/europe': 'EU',
+        'live/us': 'US',
+        'live/asia': 'ASIA',
+        'live/stream': 'EVENT',
+        'live/emea': 'EMEA_EVENT',
+        'live/asia_stream': 'ASIA_EVENT'
     }
 
     _url_re = re.compile(r'''
         https?://www\.bloomberg\.com/(
             news/videos/[^/]+/[^/]+ |
-            live/(?P<channel>stream|emea|asia_stream|europe|us|asia)/?
+            (?P<channel>live/(?:stream|emea|asia_stream|europe|us|asia)|audio)/?
         )
 ''', re.VERBOSE)
     _live_player_re = re.compile(r'APP_BUNDLE:"(?P<live_player_url>.+?/app.js)"')
@@ -117,12 +118,12 @@ class Bloomberg(Plugin):
         return streams
 
     def _get_streams(self):
-        if '/live/' in self.url:
-            # Live
-            streams = self._get_live_streams()
-        else:
+        if '/news/videos/' in self.url:
             # VOD
             streams = self._get_vod_streams()
+        else:
+            # Live
+            streams = self._get_live_streams()
 
         for video_url in streams:
             if '.f4m' in video_url:

--- a/tests/test_plugin_bloomberg.py
+++ b/tests/test_plugin_bloomberg.py
@@ -1,0 +1,22 @@
+import unittest
+
+from streamlink.plugins.bloomberg import Bloomberg
+
+
+class TestPluginBloomberg(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/live/us"))
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/live/europe"))
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/live/asia"))
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/live/stream"))
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/live/emea"))
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/live/asia_stream"))
+        self.assertTrue(Bloomberg.can_handle_url("https://www.bloomberg.com/news/videos/2017-04-17/wozniak-science-fiction-finally-becoming-reality-video"))
+        self.assertTrue(Bloomberg.can_handle_url("http://www.bloomberg.com/news/videos/2017-04-17/russia-s-stake-in-a-u-s-north-korea-conflict-video"))
+
+        # shouldn't match
+        self.assertFalse(Bloomberg.can_handle_url("https://www.bloomberg.com/live/"))
+        self.assertFalse(Bloomberg.can_handle_url("https://www.bloomberg.com/politics/articles/2017-04-17/french-race-up-for-grabs-days-before-voters-cast-first-ballots"))
+        self.assertFalse(Bloomberg.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(Bloomberg.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
This PR provides support for Bloomberg TV, as requested in https://github.com/streamlink/streamlink/issues/776. It supports:

* live TV/radio streams:
  * https://www.bloomberg.com/live/europe
  * https://www.bloomberg.com/live/us
  * https://www.bloomberg.com/live/asia
  * https://www.bloomberg.com/live/stream
  * https://www.bloomberg.com/live/emea
  * https://www.bloomberg.com/live/asia_stream
  * https://www.bloomberg.com/audio (radio)
* VOD (https://www.bloomberg.com/news/videos/*/*), for example:
  * https://www.bloomberg.com/news/videos/2017-04-18/is-may-s-call-for-an-early-election-a-risky-move-video
  * https://www.bloomberg.com/news/videos/2017-04-18/full-show-bloomberg-daybreak-americas-04-17-video

Streams don't seem to be georestricted.