### PR TITLE
cli: add --url option that can be used in config files to set a URL

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -467,6 +467,15 @@ output.add_argument(
 
 stream = parser.add_argument_group("Stream options")
 stream.add_argument(
+    "--url",
+    dest="url_param",
+    metavar="URL",
+    help="""
+    Alternative parameter to specify a URL to attempt to
+    extract streams from.
+    """
+)
+stream.add_argument(
     "--default-stream",
     type=comma_list,
     metavar="STREAM",

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -166,6 +166,7 @@ positional.add_argument(
     A URL to attempt to extract streams from.
 
     If it's a HTTP URL then "http://" can be omitted.
+    The URL can also be specified using the --url option.
     """
 )
 positional.add_argument(
@@ -471,8 +472,11 @@ stream.add_argument(
     dest="url_param",
     metavar="URL",
     help="""
-    Alternative parameter to specify a URL to attempt to
-    extract streams from.
+    A URL to attempt to extract streams from.
+
+    If it's a HTTP URL then "http://" can be omitted.
+
+    This is an alternative to setting the URL using a positional argument.
     """
 )
 stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -577,6 +577,9 @@ def setup_args(config_files=[]):
     if args.stream:
         args.stream = [stream.lower() for stream in args.stream]
 
+    if not args.url and args.url_param:
+        args.url = args.url_param
+
 
 def setup_config_args():
     config_files = []


### PR DESCRIPTION
Fixes #777 by allowing a URL to be set in a config file that can be loaded on demand using the @ syntax.