### PR TITLE
plugin.gardenersworld: support for VOD on gardenersworld.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -96,6 +96,7 @@ foxtr               fox.com.tr           Yes   No
 funimationnow       - funimation.com     --    Yes
                     - funimationnow.uk
 furstream           furstre.am           Yes   No
+gardenersworld      gardenersworld.com   --    Yes
 garena              garena.live          Yes   --
 gomexp              gomexp.com           Yes   No
 goodgame            goodgame.ru          Yes   No    Only HLS streams are available.

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -1,15 +1,46 @@
+import random
 import re
+from binascii import hexlify
+from io import BytesIO
 
 from streamlink import PluginError
+from streamlink.packages.flashmedia import AMFMessage, AMFPacket
+from streamlink.packages.flashmedia.types import AMF3ObjectBase
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate, useragents
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
-from streamlink.utils import urlparse, parse_qsl
+from streamlink.compat import urlparse, parse_qsl, urlencode
+
+
+@AMF3ObjectBase.register("com.brightcove.experience.ViewerExperienceRequest")
+class ViewerExperienceRequest(AMF3ObjectBase):
+    def __init__(self, experienceId, URL, playerKey, deliveryType, TTLToken, contentOverrides):
+        self.experienceId = experienceId
+        self.URL = URL
+        self.playerKey = playerKey
+        self.deliveryType = deliveryType
+        self.TTLToken = TTLToken
+        self.contentOverrides = contentOverrides
+
+
+@AMF3ObjectBase.register("com.brightcove.experience.ContentOverride")
+class ContentOverride(AMF3ObjectBase):
+    def __init__(self, featuredRefId, contentRefIds, contentId, target="videoPlayer", contentIds=None,
+                 contentType=0, featuredId=float('nan'), contentRefId=None):
+        self.featuredRefId = featuredRefId
+        self.contentRefIds = contentRefIds
+        self.contentId = contentId
+        self.target = target
+        self.contentIds = contentIds
+        self.contentType = contentType
+        self.featuredId = featuredId
+        self.contentRefId = contentRefId
 
 
 class BrightcovePlayer(object):
     player_page = "http://players.brightcove.net/{account_id}/{player_id}/index.html"
     api_url = "https://edge.api.brightcove.com/playback/v1/"
+    amf_broker = "http://c.brightcove.com/services/messagebroker/amf"
 
     policy_key_re = re.compile(r'''policyKey\s*:\s*(?P<q>['"])(?P<key>.*?)(?P=q)''')
 
@@ -27,6 +58,7 @@ class BrightcovePlayer(object):
     def __init__(self, session, account_id, player_id="default_default"):
         self.session = session
         self.logger = session.logger.new_module("plugins.brightcove")
+        self.logger.debug("Creating player for account {0} (player_id={1})", account_id, player_id)
         self.account_id = account_id
         self.player_id = player_id
 
@@ -59,6 +91,7 @@ class BrightcovePlayer(object):
         return policy_key
 
     def get_streams(self, video_id):
+        self.logger.debug("Finding streams for video: {0}", video_id)
         policy_key = self.policy_key(video_id)
         self.logger.debug("Found policy key: {0}", policy_key)
         data = self.video_info(video_id, policy_key)
@@ -95,15 +128,46 @@ class BrightcovePlayer(object):
         bp = cls(session, account_id=account_id, player_id=player_id)
         return bp.get_streams(video_id)
 
+    @classmethod
+    def from_player_key(cls, session, player_id, player_key, video_id, url=None):
+        amf_message = AMFMessage("com.brightcove.experience.ExperienceRuntimeFacade.getDataForExperience",
+                                 "/1",
+                                 [
+                                     ''.join(["{0:02x}".format(random.randint(0, 255)) for _ in range(20)]),  # random id
+                                     ViewerExperienceRequest(experienceId=int(player_id),
+                                                             URL=url or "",
+                                                             playerKey=player_key,
+                                                             deliveryType=float('nan'),
+                                                             TTLToken="",
+                                                             contentOverrides=[ContentOverride(
+                                                                 featuredRefId=None,
+                                                                 contentRefIds=None,
+                                                                 contentId=int(video_id)
+                                                             )])
+                                 ])
+        amf_packet = AMFPacket(version=3)
+        amf_packet.messages.append(amf_message)
+
+        res = http.post(cls.amf_broker,
+                        headers={"Content-Type": "application/x-amf"},
+                        data=amf_packet.serialize(),
+                        params=dict(playerKey=player_key),
+                        raise_for_status=False)
+        data = AMFPacket.deserialize(BytesIO(res.content))
+        result = data.messages[0].value
+        bp = cls(session=session, account_id=int(result.publisherId))
+        return bp.get_streams(video_id)
+
 
 class Brightcove(Plugin):
-    url_re = re.compile(r"https?://players.brightcove.net/.*?/.*?/index.html")
+    url_re = re.compile(r"https?://players.brightcove.net/.*?/index.html")
 
     @classmethod
     def can_handle_url(cls, url):
-        cls.url_re.match(url) is not None
+        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
-        return BrightcovePlayer.from_url(self.url)
+        return BrightcovePlayer.from_url(self.session, self.url)
+
 
 __plugin__ = Brightcove

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -1,0 +1,35 @@
+from __future__ import print_function
+
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugins.brightcove import BrightcovePlayer
+
+
+class GardenersWorld(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?gardenersworld\.com/")
+    object_re = re.compile('''<object.*?id="brightcove-pod-object".*?>(.*?)</object>''', re.DOTALL)
+    param_re = re.compile('''<param.*?name="(.*?)".*?value="(.*?)".*?/>''')
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        page = http.get(self.url)
+        object_m = self.object_re.search(page.text)
+        if object_m:
+            object_t = object_m.group(1)
+            params = {}
+            for param_m in self.param_re.finditer(object_t):
+                params[param_m.group(1)] = param_m.group(2)
+
+            return BrightcovePlayer.from_player_key(self.session,
+                                                    params.get("playerID"),
+                                                    params.get("playerKey"),
+                                                    params.get("videoID"),
+                                                    url=self.url)
+
+
+__plugin__ = GardenersWorld


### PR DESCRIPTION
Includes some improvements to the Brightcove player.

Examples:
- gardenersworld.com/how-to/grow-plants/two-ways-of-sowing-hardy-annuals-in-a-border/
- gardenersworld.com/how-to/grow-plants/how-to-plant-a-hydrangea/