### PR TITLE
cli: add wildcard to --stream-types option

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -1,6 +1,5 @@
 import operator
 import re
-
 from functools import partial
 
 from ..cache import Cache
@@ -83,7 +82,10 @@ def stream_type_priority(stream_types, stream):
     try:
         prio = stream_types.index(stream_type)
     except ValueError:
-        prio = 99
+        try:
+            prio = stream_types.index("*")
+        except ValueError:
+            prio = 99
 
     return prio
 
@@ -258,7 +260,8 @@ class Plugin(object):
         for name, stream in sorted_streams:
             stream_type = type(stream).shortname()
 
-            if stream_type not in stream_types:
+            # Use * as wildcard to match other stream types
+            if "*" not in stream_types and stream_type not in stream_types:
                 continue
 
             # drop _alt from any stream names

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1,6 +1,5 @@
 import argparse
 import re
-
 from string import printable
 from textwrap import dedent
 
@@ -8,7 +7,6 @@ from .constants import (
     LIVESTREAMER_VERSION, STREAM_PASSTHROUGH, DEFAULT_PLAYER_ARGUMENTS
 )
 from .utils import find_default_player
-
 
 _filesize_re = re.compile("""
     (?P<size>\d+(\.\d+)?)
@@ -502,9 +500,11 @@ stream.add_argument(
     A comma-delimited list of stream types to allow.
 
     The order will be used to separate streams when there are multiple
-    streams with the same name but different stream types.
+    streams with the same name but different stream types. Any stream type
+    not listed will be omitted from the available streams list.  A ``*``
+    can be used as a wildcard to match any other type of stream, eg. muxed-stream.
 
-    Default is "rtmp,hls,hds,http,akamaihd".
+    Default is "rtmp,hls,hds,http,akamaihd,*".
     """
 )
 stream.add_argument(

--- a/tests/test_streamlink_api.py
+++ b/tests/test_streamlink_api.py
@@ -31,3 +31,21 @@ class TestStreamlinkAPI(unittest.TestCase):
     @patch('streamlink.api.Streamlink', side_effect=get_session)
     def test_no_streams(self, session):
         self.assertEqual({}, streams("test.se/empty"))
+
+    @patch('streamlink.api.Streamlink', side_effect=get_session)
+    def test_stream_type_filter(self, session):
+        stream_types = ["rtmp", "hls"]
+        available_streams = streams("test.se", stream_types=stream_types)
+        self.assertTrue("rtmp" in available_streams)
+        self.assertTrue("hls" in available_streams)
+        self.assertTrue("test" not in available_streams)
+        self.assertTrue("http" not in available_streams)
+
+    @patch('streamlink.api.Streamlink', side_effect=get_session)
+    def test_stream_type_wildcard(self, session):
+        stream_types = ["rtmp", "hls", "*"]
+        available_streams = streams("test.se", stream_types=stream_types)
+        self.assertTrue("rtmp" in available_streams)
+        self.assertTrue("hls" in available_streams)
+        self.assertTrue("test" in available_streams)
+        self.assertTrue("http" in available_streams)


### PR DESCRIPTION
When changing the stream priority using `--stream-types` any stream types that are not explicitly included are ignored. For example if a user wants HTTP streams to be preferred and then HLS streams, with the other stream types in any order they might expect that `--stream-types "http,hls"` would be sufficient. However, any stream type not included in this list will be omitted. The default behavior for the `--stream-types` option means that other types are included.

This commit introduces a wildcard character (`*`), where any stream type not listed can be matched. For example, to order the streams with `HTTP`, then `HLS`, then others, the user could specify the `--stream-types` option as `"http,hls,*"`.
The documentation has been clarified to highlight the fact that other stream types not listed will be omitted and that a wildcard character can be used to match the other stream types. The addition of the wildcard does not change the existing behaviour of `--stream-types`.