### PR TITLE
plugins.showroom: Mimic browser request headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - python -m pytest tests/
-  - coverage run setup.py test
+  - coverage run -m pytest tests/
   # test building the docs
   - if [[ $BUILD_DOCS == 'yes' ]]; then make --directory=docs html; fi
   - if [[ $BUILD_INSTALLER == 'yes' ]]; then ./script/makeinstaller.sh; fi

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -74,7 +74,7 @@ _info_pages = set((
 
 
 class Showroom(Plugin):
-    @staticmethod
+    @classmethod
     def can_handle_url(cls, url):
         match = _url_re.match(url)
         if not match or match.group("room_title") in _info_pages:

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -2,7 +2,7 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import http, validate
+from streamlink.plugin.api import http, validate, useragents
 from streamlink.stream import RTMPStream
 
 _url_re = re.compile(r'''^https?://
@@ -75,11 +75,6 @@ _info_pages = set((
 
 class Showroom(Plugin):
     @staticmethod
-    def _get_stream_info(room_id):
-        res = http.get(_api_data_url.format(room_id=room_id))
-        return http.json(res, schema=_api_data_schema)
-
-    @classmethod
     def can_handle_url(cls, url):
         match = _url_re.match(url)
         if not match or match.group("room_title") in _info_pages:
@@ -95,6 +90,10 @@ class Showroom(Plugin):
 
     def __init__(self, url):
         Plugin.__init__(self, url)
+        self._headers = {
+            'Referer': self.url,
+            'User-Agent': useragents.FIREFOX
+        }
         self._room_id = None
         self._info = None
         self._title = None
@@ -112,6 +111,10 @@ class Showroom(Plugin):
             self._room_id = self._get_room_id()
         return self._room_id
 
+    def _get_stream_info(self, room_id):
+        res = http.get(_api_data_url.format(room_id=room_id), headers=self._headers)
+        return http.json(res, schema=_api_data_schema)
+
     def _get_room_id(self):
         """
         Locates unique identifier ("room_id") for the room.
@@ -123,7 +126,7 @@ class Showroom(Plugin):
         if match_dict['room_id'] is not None:
             return match_dict['room_id']
         else:
-            res = http.get(self.url)
+            res = http.get(self.url, headers=self._headers)
             match = _room_id_re.search(res.text)
             if not match:
                 title = self.url.rsplit('/', 1)[-1]

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -224,7 +224,6 @@ class HDSStreamWorker(SegmentedStreamWorker):
     def fragment_count(self):
         table = self.fragmentruntable.payload.fragment_run_entry_table
         first_fragment, end_fragment = None, None
-        max_end_fragment = 0
 
         for i, fragmentrun in enumerate(table):
             if fragmentrun.discontinuity_indicator is not None:
@@ -240,15 +239,10 @@ class HDSStreamWorker(SegmentedStreamWorker):
             fragment_duration = (fragmentrun.first_fragment_timestamp +
                                  fragmentrun.fragment_duration)
 
-            max_end_fragment = max(fragmentrun.first_fragment, max_end_fragment)
-
             if self.timestamp > fragment_duration:
                 offset = ((self.timestamp - fragment_duration) /
                           fragmentrun.fragment_duration)
                 end_fragment += int(offset)
-
-        # don't go past the last fragment
-        end_fragment = min(max_end_fragment, end_fragment)
 
         if first_fragment is None:
             first_fragment = 1


### PR DESCRIPTION
Recently, presumably to fight a wave of view/follow bots, Showroom has started blocking unknown User-Agents from their webpages and api. This PR sends the necessary information so streamlink doesn't get caught in the block.