### PR TITLE
Revert "stream.hds: ensure the live edge does not go past the latest fragment"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - python -m pytest tests/
-  - coverage run setup.py test
+  - coverage run -m pytest tests/
   # test building the docs
   - if [[ $BUILD_DOCS == 'yes' ]]; then make --directory=docs html; fi
   - if [[ $BUILD_INSTALLER == 'yes' ]]; then ./script/makeinstaller.sh; fi

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -224,7 +224,6 @@ class HDSStreamWorker(SegmentedStreamWorker):
     def fragment_count(self):
         table = self.fragmentruntable.payload.fragment_run_entry_table
         first_fragment, end_fragment = None, None
-        max_end_fragment = 0
 
         for i, fragmentrun in enumerate(table):
             if fragmentrun.discontinuity_indicator is not None:
@@ -240,15 +239,10 @@ class HDSStreamWorker(SegmentedStreamWorker):
             fragment_duration = (fragmentrun.first_fragment_timestamp +
                                  fragmentrun.fragment_duration)
 
-            max_end_fragment = max(fragmentrun.first_fragment, max_end_fragment)
-
             if self.timestamp > fragment_duration:
                 offset = ((self.timestamp - fragment_duration) /
                           fragmentrun.fragment_duration)
                 end_fragment += int(offset)
-
-        # don't go past the last fragment
-        end_fragment = min(max_end_fragment, end_fragment)
 
         if first_fragment is None:
             first_fragment = 1


### PR DESCRIPTION
This reverts commit 80eeba095c5a0a27f4c371c22a292b1d2f7656b4 to fix #817.

The issue is more complex that I realised, I think there might be an issue when calculating the fragment offset to find the current latest - however, I have not worked it out. As 80eeba095c5a0a27f4c371c22a292b1d2f7656b4 appears to break more than it fixes I suggest reverting it for now. 