### PR TITLE
travis: use pytest to run the tests for coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 
 script:
   - python -m pytest tests/
-  - coverage run setup.py test
+  - coverage run -m pytest tests/
   # test building the docs
   - if [[ $BUILD_DOCS == 'yes' ]]; then make --directory=docs html; fi
   - if [[ $BUILD_INSTALLER == 'yes' ]]; then ./script/makeinstaller.sh; fi


### PR DESCRIPTION
Use the `pytest` runner for coverage (the same as regular tests). It should fix the travis build errors for python3.6 🤞 