### PR TITLE
plugins.pcyourfreetv: add token parameters

### DIFF
--- a/src/streamlink/plugins/pcyourfreetv.py
+++ b/src/streamlink/plugins/pcyourfreetv.py
@@ -6,8 +6,11 @@ from streamlink.stream import HLSStream
 
 
 class PCYourFreeTV(Plugin):
+    LIVE_TV_URL = 'http://pc-yourfreetv.com/index_livetv.php?page_id=1'
+
     _login_url = 'http://pc-yourfreetv.com/home.php'
     _url_re = re.compile(r'http://pc-yourfreetv\.com/index_player\.php\?channel=.+?&page_id=\d+')
+    _token_re = re.compile(r'\b(?P<token_key>auth_[0-9a-f]+)=(?P<token_value>[0-9a-f]+)\b')
     _video_url_re = re.compile(r"jwplayer\('.+?'\)\.setup\({.+?file: \"(?P<video_url>[^\"]+?)\".+?}\);", re.DOTALL)
 
     options = PluginOptions({
@@ -36,15 +39,23 @@ class PCYourFreeTV(Plugin):
         password = self.get_option('password')
 
         if username is None or password is None:
-            self.logger.error("PC-YourFreeTV requires authentication, use --pcyourfreetv-username"
+            self.logger.error("PC-YourFreeTV requires authentication, use --pcyourfreetv-username "
                               "and --pcyourfreetv-password to set your username/password combination")
             return
 
         if self.login(username, password):
             self.logger.info("Successfully logged in as {0}", username)
 
+        # Get a fresh authorization token
+        res = http.get(self.LIVE_TV_URL)
+        match = self._token_re.search(res.text)
+        if match is None:
+            return
+        token_key = match.group('token_key')
+        token_value = match.group('token_value')
+
         # Retrieve URL page and search for stream data
-        res = http.get(self.url)
+        res = http.get(self.url, params={token_key: token_value})
         match = self._video_url_re.search(res.text)
         if match is None:
             return


### PR DESCRIPTION
This PR fixes the pcyourfreetv plugin which doesn't work anymore:
```
streamlink --pcyourfreetv-username "@@@@@" --pcyourfreetv-password "@@@@@" "http://pc-yourfreetv.com/index_player.php?channel=cartoon%20network&page_id=41"
[cli][info] Found matching plugin pcyourfreetv for URL http://pc-yourfreetv.com/index_player.php?channel=cartoon%20network&page_id=41
[plugin.pcyourfreetv][info] Successfully logged in as @@@@@
error: No playable streams found on this URL: http://pc-yourfreetv.com/index_player.php?channel=cartoon%20network&page_id=41
```
Pc-YourFreeTV.com now requires a single token per connection in the URL parameters.
This PR will fetch and add such a token to the passed URL automatically. 