### PR TITLE
[ArteTV] new regex, removed rtmp and better result for available streams

### DIFF
--- a/tests/test_plugin_artetv.py
+++ b/tests/test_plugin_artetv.py
@@ -6,6 +6,16 @@ from streamlink.plugins.artetv import ArteTV
 class TestPluginArteTV(unittest.TestCase):
     def test_can_handle_url(self):
         # should match
+        # new url
+        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/fr/direct/"))
+        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/de/live/"))
+        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/de/videos/074633-001-A/gesprach-mit-raoul-peck"))
+        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/en/videos/071437-010-A/sunday-soldiers"))
+        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/fr/videos/074633-001-A/entretien-avec-raoul-peck"))
+        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/pl/videos/069873-000-A/supermama-i-businesswoman"))
+
+        # should match
+        # old url - some of them get redirected and some are 404
         self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/fr/direct"))
         self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/de/live"))
         self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/fr/024031-000-A/le-testament-du-docteur-mabuse"))
@@ -17,5 +27,6 @@ class TestPluginArteTV(unittest.TestCase):
         # shouldn't match
         self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/guide/fr/plus7/"))
         self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/guide/de/plus7/"))
-        self.assertFalse(ArteTV.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(ArteTV.can_handle_url("http://www.youtube.com/"))
+        # shouldn't match - playlists without video ids in url
+        self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/en/videos/RC-014457/the-power-of-forests/"))
+        self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/en/videos/RC-013118/street-art/"))


### PR DESCRIPTION
- New regex to match **new urls**
- New regex to match **old urls** (some of the old urls still work, some are 404)
- New regex to match **ignore playlists without video ids**
- **Removed rtmp** streams, I don't think they support rtmp anymore
- **Better result for streams**, it will now only show the streams with the same language as the url.

Before (all available languages, only two languages here, but there are streams with five)
```
[cli][info] Found matching plugin artetv for URL http://www.arte.tv/guide/de/074633-001-A/das-testament-des-dr-mabuse
Available streams:
406p_http_alt, 720p_alt, 406p_http, 360p_http_alt, 216p_http, 720p_http,
720p_http_alt, 216p_alt, 360p_http, 61k_alt, 360p_alt, 406p_alt, 216p_http_alt,
61k (worst), 216p, 360p, 406p, 720p (best)
```
After (only language from url, here **de**)
```
[cli][info] Found matching plugin artetv for URL http://www.arte.tv/guide/de/074633-001-A/das-testament-des-dr-mabuse
Available streams:
406p_http, 216p_http, 720p_http, 360p_http,
61k (worst), 216p, 360p, 406p, 720p (best)
```