### PR TITLE
[Facebook] New plugin for 360p HLS streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -95,6 +95,7 @@ earthcam            earthcam.com         Yes   Yes   Only works for the cams hos
 eurocom             eurocom.bg           Yes   No
 euronews            euronews.com         Yes   No
 expressen           expressen.se         Yes   Yes
+facebook            facebook.com         Yes   No    Only 360p HLS streams.
 filmon              filmon.com           Yes   Yes   Only SD quality streams.
 filmon_us           filmon.us            Yes   Yes
 foxtr               fox.com.tr           Yes   No

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -5,7 +5,8 @@ from streamlink.stream import HLSStream
 
 _playlist_url = "https://www.facebook.com/video/playback/playlist.m3u8?v={0}"
 
-_url_re = re.compile(r"http(s)?://(www\.)?facebook.com/[^/]+/videos/(?P<video_id>[\w\-\=]+)")
+_url_re = re.compile(r"http(s)?://(www\.)?facebook\.com/[^/]+/videos/(?P<video_id>\d+)")
+
 
 class Facebook(Plugin):
     @classmethod

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -1,0 +1,23 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.stream import HLSStream
+
+_playlist_url = "https://www.facebook.com/video/playback/playlist.m3u8?v={0}"
+
+_url_re = re.compile(r"http(s)?://(www\.)?facebook.com/[^/]+/videos/(?P<video_id>[\w\-\=]+)")
+
+class Facebook(Plugin):
+    @classmethod
+    def can_handle_url(cls, url):
+        return _url_re.match(url)
+
+    def _get_streams(self):
+        match = _url_re.match(self.url)
+        video = match.group("video_id")
+
+        playlist = _playlist_url.format(video)
+
+        return HLSStream.parse_variant_playlist(self.session, playlist)
+
+__plugin__ = Facebook

--- a/tests/test_plugin_facebook.py
+++ b/tests/test_plugin_facebook.py
@@ -1,0 +1,14 @@
+import unittest
+
+from streamlink.plugins.facebook import Facebook
+
+
+class TestPluginFacebook(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/nos/videos/1725546430794241/"))
+        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/nytfood/videos/1485091228202006/"))
+        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/SporTurkTR/videos/798553173631138/"))
+
+        # shouldn't match
+        self.assertFalse(Facebook.can_handle_url("https://www.facebook.com"))


### PR DESCRIPTION
- Added @ZP [(gist)](https://gist.github.com/zp/c461761565dba764c90548758ee5ae9f) with a patch file / you can see in the [filehistory ](https://github.com/back-to/streamlink/blame/604806374d36f0e539d8fb42cdd9a5475244aa84/src/streamlink/plugins/facebook.py) that @ZP wrote the plugin 
- Added unittests
- Small regex change

since streamlink does not support DASH we can close the Issues

Fixed #226
Fixed #845