### PR TITLE
plugins.tvnbg: add support for live streams on tvn.bg

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -206,6 +206,8 @@ tv8                 tv8.com.tr           Yes   No
 tv8cat              tv8.cat              Yes   No    Streams may be geo-restricted to Spain/Catalunya.
 tv360               tv360.com.tr         Yes   No
 tvcatchup           tvcatchup.com        Yes   No    Streams may be geo-restricted to Great Britain.
+tvnbg               - tvn.bg             Yes   -
+                    - live.tvn.bg
 tvplayer            tvplayer.com         Yes   No    Streams may be geo-restricted to Great Britain. Premium streams are not supported.
 tvrby               tvr.by               Yes   No    Streams may be geo-restricted to Belarus.
 tvrplus             tvrplus.ro           Yes   No    Streams may be geo-restricted to Romania.

--- a/src/streamlink/plugins/tvnbg.py
+++ b/src/streamlink/plugins/tvnbg.py
@@ -1,0 +1,38 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.compat import urljoin
+from streamlink.stream import HLSStream
+
+
+class TVNBG(Plugin):
+    url_re = re.compile(r"https?://(?:live\.)?tvn\.bg/(?:live)?")
+    iframe_re = re.compile(r'<iframe.*?src="([^"]+)".*?></iframe>')
+    src_re = re.compile(r'<source.*?src="([^"]+)".*?/>')
+
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        base_url = self.url
+        res = http.get(self.url)
+
+        # Search for the iframe in the page
+        iframe_m = self.iframe_re.search(res.text)
+        if iframe_m:
+            # If the iframe is found, load the embedded page
+            base_url = iframe_m.group(1)
+            res = http.get(iframe_m.group(1))
+
+        # Search the page (original or embedded) for the stream URL
+        src_m = self.src_re.search(res.text)
+        if src_m:
+            stream_url = urljoin(base_url, src_m.group(1))
+            # There is no variant playlist, only a plain HLS Stream
+            yield "live", HLSStream(self.session, stream_url)
+
+
+__plugin__ = TVNBG


### PR DESCRIPTION
Fixes #818. 

Simple plugin, supports:
 - live.tvn.bg
 - tvn.bg/live/
