### PR TITLE
Deploy nightly builds to Bintray instead of S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ addons:
     packages:
     - nsis
 
+before_deploy:
+  - ./script/bintrayconfig.sh
+
 deploy:
   - provider: releases
     api_key: "${RELEASES_API_KEY}"
@@ -54,15 +57,19 @@ deploy:
     on:
       tags: true
       condition: $BUILD_INSTALLER = yes
-  - provider: s3
+  - provider: bintray
+    file: build/bintray-nightly.json
+    user: "${BINTRAY_USER}"
+    key: "${BINTRAY_KEY}"
     skip_cleanup: true
-    local_dir: $STREAMLINK_INSTALLER_DIST_DIR
-    bucket: streamlink-builds
-    upload-dir: nightly/windows
     on:
       branch: master
-      condition: $BUILD_INSTALLER = yes
-    secret_access_key:
-      secure: 3abBcpXNxhWDJyznMA/wDmQ+lUSaJVwi62aXHjFxA7Zrz/CidbHmXkNedViWTOivMyVcM4Ypej4JD1V74Uo78GN09TICRbSc9fTF08O8Hu+hKiAcVWepfmuV54nyoQHY5mcxBPwgUZwnTwSYLzKXCqDEmQXrUrM313m4f2cbDSQgo6VPoCqE+U7JTVaUI6asutsErvK7vfw9EqGSumndRNjQdD0triubs5kh6WPv5STpKrkUNWX95fjBbkuf5hy+DIQN22hLpHYwqV3DoTnhWzbPy8/OnCKoUjEAspLehkjr86brwuls1UfR1uC2uG53O2Rb3CCYkZSVC7GKdEw0SnbLNVfbhy500a8AiPbWC0AV75PidXNEe+1zye4n/xKdx0KA8aRXr7v/89x7KibHNpwf6rdpx7axYhlsWcFcyfoOTZJ3thhu7ib9QYJZ7gkRVGWbawZU6I370I5sMJLIwmzBXgZ2y8jFk7LUNbb2GUS3LKcw5gRYOqo+ZEHFdiLpPYXFHUslTkpaMNoPCNUR7Tsa2JPfJ29yEDMsdDs2lJbP+Km8hAnpkyJfpfPcVUcl8Ootd1cTe8iPdD1nqt3KvIy4sCjkCxvQFnmGOTWFqXY/UDD+Yqo3IVOG1aLPR3UxhzHtPX6M5FxtNB22kv8hrbN/QxhBEo/SfNhGIGZJNdI=
-    access_key_id:
-      secure: sjjc1tM756TvFbD8+0VCs/MOLFRhY+VZv/lq7pvNldtbGdv21lcJguvgg0gUwUZ7SihceyL1YagfUlDU2vWS1N5Si04z0VUcHO4lbj9nUJ4CXy27pMNFuk92HmblxYQ4bJw/xVqzsrT9Zeh4tIrbV+F3lYXtg7FDqjpm5bqrUJ5ULyWbhax31s2k8JRVnG2fxVmJiU+j4zwgzCqeZJXQkvXsfdzSe88mLyIrl7Otfjlp1rySocxStQ8qlmkvRAmsYmsKriUq+VgtX21HFAIJqHQp4WbL15eh0aFFzbmORf7OMIKmsmkyeYYeM6xp+Jm9m7ZcWHZ+7siplVM/9ksmumN3+CGp6pogduZ5zFH4BtRQa9o8N2SWnPiPvMrpoyLbHbQhg/uhcMJkYI1yrzj/s9MEH7DVnDEMmgc/UKsyTC2PRwZcgqYYPHxqRVWXzvBWDUe1wtxdNyaXWWKdD/1E7u8XF2+zPTPaUNAYAF1rSi5GNF38uRNMC+QSuEm8wZ/32KXFN4m+RW3NtpT9YHI8MCo4ofVxpRUMcEUwPDF/jV5zW7Krz7LEeL5/zcHMcNay/Ls8e3eApQShAcLAx1jZo+EjznVGXtlRbH9ABXmPO5AcxUH5+20tMiMoj0q6hJen03X8Jx+OMmcDNDufDgPikSym3KVC3Lvj65lG4G9pAyY=
+      condition: $BUILD_INSTALLER = yes && $TRAVIS_EVENT_TYPE == cron
+  - provider: bintray
+    file: build/bintray-latest.json
+    user: "${BINTRAY_USER}"
+    key: "${BINTRAY_KEY}"
+    skip_cleanup: true
+    on:
+      branch: master
+      condition: $BUILD_INSTALLER = yes && $TRAVIS_EVENT_TYPE == cron

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -239,7 +239,7 @@ Windows binaries
 
 You can download the latest stable Windows installer from the `GitHub Releases Page <https://github.com/streamlink/streamlink/releases/latest>`__.
 
-Alternatively, you can download the latest `nightly Windows installer <https://streamlink-builds.s3.amazonaws.com/nightly/windows/streamlink-latest.exe>`__.
+Alternatively, you can download the latest `nightly Windows installer <https://dl.bintray.com/streamlink/streamlink-nightly/streamlink-latest.exe>`__.
 
 This is a installer which contains:
 

--- a/script/bintrayconfig.sh
+++ b/script/bintrayconfig.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Script to generate bintray config for nightly builds
+#
+
+build_dir="$(pwd)/build"
+nsis_dir="${build_dir}/nsis"
+# get the dist directory from an environment variable, but default to the build/nsis directory
+dist_dir="${STREAMLINK_INSTALLER_DIST_DIR:-$nsis_dir}"
+
+# TODO: extract this common version detection code in to a separate function
+STREAMLINK_VERSION_PLAIN=$(python setup.py --version)
+# For travis nightly builds generate a version number with commit hash
+if [ -n "${TRAVIS_BRANCH}" ] && [ -z "${TRAVIS_TAG}" ]; then
+    STREAMLINK_VI_VERSION="${STREAMLINK_VERSION_PLAIN}.${TRAVIS_BUILD_NUMBER}"
+    STREAMLINK_INSTALLER="streamlink-${STREAMLINK_VERSION_PLAIN}-${TRAVIS_BUILD_NUMBER}-${TRAVIS_COMMIT:0:7}"
+    STREAMLINK_VERSION="${STREAMLINK_VERSION_PLAIN}+${TRAVIS_COMMIT:0:7}"
+else
+    STREAMLINK_VI_VERSION="${STREAMLINK_VERSION_PLAIN}.${TRAVIS_BUILD_NUMBER:-0}"
+    STREAMLINK_VERSION="${STREAMLINK_VERSION_PLAIN}"
+    STREAMLINK_INSTALLER="streamlink-${STREAMLINK_VERSION}"
+fi
+
+cat > "${build_dir}/bintray-latest.json" <<EOF
+{
+  "package": {
+    "subject": "streamlink",
+    "repo": "streamlink-nightly",
+    "name": "streamlink"
+  },
+
+  "version": {
+    "name": "latest",
+    "released": "$(date +'%Y-%m-%d')",
+    "desc": "Latest version of the installer (${STREAMLINK_VERSION})"
+  },
+
+  "files": [
+    {
+      "includePattern": "${dist_dir}/${STREAMLINK_INSTALLER}.exe",
+      "uploadPattern": "streamlink-latest.exe",
+      "matrixParams": {
+        "override": 1,
+        "publish": 1
+      }
+    }
+  ],
+
+  "publish": true
+}
+EOF
+
+echo "Wrote Bintray config to: ${build_dir}/bintray-latest.json"
+
+cat > "${build_dir}/bintray-nightly.json" <<EOF
+{
+  "package": {
+    "subject": "streamlink",
+    "repo": "streamlink-nightly",
+    "name": "streamlink"
+  },
+
+  "version": {
+    "name": "$(date +'%Y.%m.%d')",
+    "released": "$(date +'%Y-%m-%d')",
+    "desc": "Streamlink Nightly based on ${STREAMLINK_VERSION}"
+  },
+
+  "files": [
+    {
+      "includePattern": "${dist_dir}/${STREAMLINK_INSTALLER}.exe",
+      "uploadPattern": "streamlink-${STREAMLINK_VERSION_PLAIN}-$(date +'%Y%m%d').exe",
+      "matrixParams": {
+        "override": 1,
+        "publish": 1
+      }
+    }
+  ],
+
+  "publish": true
+}
+EOF
+
+echo "Wrote Bintray config to: ${build_dir}/bintray-nightly.json"

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -208,10 +208,5 @@ cp -r "win32/rtmpdump" "${nsis_dir}/"
 
 pynsist build/streamlink.cfg
 
-# Make a copy of this build for the "latest" nightly
-if [ -n "${TRAVIS_BRANCH}" ] && [ -z "${TRAVIS_TAG}" ]; then
-    cp "${dist_dir}/${STREAMLINK_INSTALLER}.exe" "${dist_dir}/streamlink-latest.exe"
-fi
-
 echo "Success!" 1>&2
 echo "The installer should be in ${dist_dir}." 1>&2


### PR DESCRIPTION
This PR removes the S3 deploy tasks in Travis and replaces them with Bintray deploy tasks. 

The Bintray deploy will only be performed when Travis is running a cronjob (which needs to be setup to run daily). I have already setup the `BINTRAY_USER` and `BINTRAY_KEY` variables for the travis build. 

I have created a redirect page for the existing S3-hosted installer, it will look like this: https://streamlink-builds.s3.amazonaws.com/nightly/windows/streamlink-latest2.exe

(@gravyboat, I still need to add you to the Bintray organisation)

Fixes #877 