### PR TITLE
build: update the bintray release notes for nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      condition: $BUILD_INSTALLER = yes
+      condition: $BUILD_INSTALLER == yes
   - provider: bintray
     file: build/bintray-nightly.json
     user: "${BINTRAY_USER}"
@@ -64,7 +64,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: $BUILD_INSTALLER = yes && $TRAVIS_EVENT_TYPE == cron
+      condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron
   - provider: bintray
     file: build/bintray-latest.json
     user: "${BINTRAY_USER}"
@@ -72,4 +72,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: $BUILD_INSTALLER = yes && $TRAVIS_EVENT_TYPE == cron
+      condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron
+
+after_deploy:
+  - if [[ "$BUILD_INSTALLER" == 'yes' && "$TRAVIS_EVENT_TYPE" == 'cron' ]]; then ./script/bintrayupdate.sh; fi

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -237,11 +237,13 @@ Windows binaries
     Windows XP is not supported.
     Windows Vista requires at least SP2 to be installed. 
 
-You can download the latest stable Windows installer from the `GitHub Releases Page <https://github.com/streamlink/streamlink/releases/latest>`__.
+A Windows installer of the latest **stable release** can be found on the `GitHub releases page <https://github.com/streamlink/streamlink/releases/latest>`__.
 
-Alternatively, you can download the latest `nightly Windows installer <https://dl.bintray.com/streamlink/streamlink-nightly/streamlink-latest.exe>`__.
+Alternatively, a Windows installer of the `latest development build <https://dl.bintray.com/streamlink/streamlink-nightly/streamlink-latest.exe>`__ for testing purposes is available,
+with a summary of the changes in the `release notes <https://bintray.com/streamlink/streamlink-nightly/streamlink/latest#release>`__. This development build is updated once per day,
+and a list of `previous builds <https://dl.bintray.com/streamlink/streamlink-nightly/>`__ is provided.
 
-This is a installer which contains:
+This is an installer which contains:
 
 - A compiled version of Streamlink that does not require an existing Python
   installation

--- a/script/bintrayconfig.sh
+++ b/script/bintrayconfig.sh
@@ -82,3 +82,12 @@ cat > "${build_dir}/bintray-nightly.json" <<EOF
 EOF
 
 echo "Wrote Bintray config to: ${build_dir}/bintray-nightly.json"
+
+# update repo to full clone and get the tags
+git fetch --unshallow
+git fetch --tags
+latest_tag=$(git describe --tags --abbrev=0)
+tag_changes_json=$(git log ${latest_tag}..HEAD --no-merges --pretty=format:" * [\`%h\`](https://github.com/streamlink/streamlink/commit/%H) %s" | sed ':a;N;$!ba;s/\n/\\n/g' | sed 's/"/\\"/g')
+echo "{\"bintray\": {\"content\": \"**This build includes the following changes since [v${latest_tag}](https://github.com/streamlink/streamlink/releases/tag/${latest_tag})**\n\n${tag_changes_json}\"}}" > "${build_dir}/bintray-changelog.json"
+
+echo "Wrote changelog to ${build_dir}/bintray-changelog.json"

--- a/script/bintrayupdate.sh
+++ b/script/bintrayupdate.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Update the Bintray release
+
+build_dir="$(pwd)/build"
+current_api_url="https://api.bintray.com/packages/streamlink/streamlink-nightly/streamlink/versions/$(date +'%Y.%m.%d')/release_notes"
+latest_api_url="https://api.bintray.com/packages/streamlink/streamlink-nightly/streamlink/versions/latest/release_notes"
+curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -H "Content-Type: application/json" -d @"${build_dir}/bintray-changelog.json" ${current_api_url}
+curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -H "Content-Type: application/json" -d @"${build_dir}/bintray-changelog.json" ${latest_api_url}


### PR DESCRIPTION
I have added a script to update the release notes for the Bintray nightly. It produces a log similar to the one below:

> 
> **This build includes the following changes since [v0.5.0](https://github.com/streamlink/streamlink/releases/tag/0.5.0)**
> 
> 
>  * [`b11ae2a7`](https://github.com/streamlink/streamlink/commit/b11ae2a7784a179b7cc31dbd90880c3fe151c139) build: update the bintray release notes for nightlies
>  * [`5d6fff0b`](https://github.com/streamlink/streamlink/commit/5d6fff0b5935322a5f3f9211b8424ee8473848b3) utils.crypto: fix openssl_decrypt for py27
>  * [`fa2a6a89`](https://github.com/streamlink/streamlink/commit/fa2a6a897ad05d4d4a2ddd0ca855c90ebc918bad) plugins.streann: support for ott.streann.com
>  * [`0648c388`](https://github.com/streamlink/streamlink/commit/0648c388fcfd8c4ce2e68100b37fb3845480a3cb) Deploy nightly builds to Bintray instead of S3
>  * [`6405af16`](https://github.com/streamlink/streamlink/commit/6405af1689f7026891c3cb2ab67d07b2510b93b4) Update for new new page layout
>  * [`603aabb7`](https://github.com/streamlink/streamlink/commit/603aabb7ba0cf41f9c347316543132b705fbe533) plugins.apac: add ustream apac wrapper
>  * [`435890bc`](https://github.com/streamlink/streamlink/commit/435890bc44da055395ff6fa8e66e5742b796c4f2) plugins.tvnbg: add support for live streams on tvn.bg
>  * [`23108b9c`](https://github.com/streamlink/streamlink/commit/23108b9c4cdb06d086671b62ec88de6f12fd7294) plugins.tvplayer: allow https stream URLs
>  * [`d741a8c2`](https://github.com/streamlink/streamlink/commit/d741a8c2f3f2374f7b0ea12a727d858fc90385c8) Add support for ElTreceTV (VOD & Live) (#816)
>  * [`8e4edc8e`](https://github.com/streamlink/streamlink/commit/8e4edc8e8a0bde8d14bac564bd0df06a2aa3abba) Fix method decorator
>  * [`7c581ce6`](https://github.com/streamlink/streamlink/commit/7c581ce67ddbc3672799be8f8d084a60baabfc7c) Send Referer and UserAgent headers
>  * [`225b6802`](https://github.com/streamlink/streamlink/commit/225b680228ab774bc88a354c57e0149a0bcc62c8) Update for new page layout
>  * [`9ab54e9f`](https://github.com/streamlink/streamlink/commit/9ab54e9fd47796e01904ff9cbc4b4e7114c7c2ec) plugin.tvplayer: update tests to match new plugin
>  * [`741d6b27`](https://github.com/streamlink/streamlink/commit/741d6b27f85dab67cd818a40f8ffe2978500738a) plugin.tvplayer: update to support new site layout
>  * [`7e9ec465`](https://github.com/streamlink/streamlink/commit/7e9ec46517fe76b2b7cc95838d2d411c184600c2) [ArteTV] new regex, removed rtmp and better result for available streams
>  * [`eac8bce5`](https://github.com/streamlink/streamlink/commit/eac8bce540db0efaeb3e2c195a58874efe9e28b9) [Facebook] Added unittests
>  * [`4a64c9e9`](https://github.com/streamlink/streamlink/commit/4a64c9e902cd3d7ab278573c41fbb70540a5aa11) New plugin for Facebook 360p streams https://gist.github.com/zp/c461761565dba764c90548758ee5ae9f

I have updated the wording on the installer page a bit too. 