### PR TITLE
plugins.euronews: update for live API change

### DIFF
--- a/tests/test_plugin_euronews.py
+++ b/tests/test_plugin_euronews.py
@@ -1,0 +1,27 @@
+import unittest
+
+from streamlink.plugins.euronews import Euronews
+
+
+class TestPluginEuronews(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Euronews.can_handle_url("http://www.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://fr.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://de.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://it.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://es.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://pt.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://ru.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://ua.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://tr.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://gr.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://hu.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://fa.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://arabic.euronews.com/live"))
+        self.assertTrue(Euronews.can_handle_url("http://www.euronews.com/2017/05/10/peugeot-expects-more-opel-losses-this-year"))
+        self.assertTrue(Euronews.can_handle_url("http://fr.euronews.com/2017/05/10/l-ag-de-psa-approuve-le-rachat-d-opel"))
+
+        # shouldn't match
+        self.assertFalse(Euronews.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(Euronews.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
The euronews plugin is broken for live streams, due to API changes (VOD streams are still OK).
```
$ streamlink "http://fr.euronews.com/live"
[cli][info] Found matching plugin euronews for URL http://fr.euronews.com/live
error: Unable to validate JSON: Unable to validate key 'primary': Type of 'http://euronews-fr-p7-cdn.hexaglobe.net/1c52769160a4c3fc93b932305f4e37dc/59136712/euronews/euronews-euronews-website-web-responsive-2/ewnsabrfrpri_fre.smil/playlist.m3u8' should be 'dict' but is 'str'
```
This PR fixes the plugin to use the new API scheme for live streams. Unit tests are also added.