### PR TITLE
plugins.bbciplayer: add login support

### DIFF
--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -20,7 +20,7 @@ class BBCiPlayer(Plugin):
             live/(?P<channel_name>\w+)
         )
     """, re.VERBOSE)
-    vpid_re = re.compile(r'"vpid"\s*:\s*"(\w+)"')
+    vpid_re = re.compile(r'"ident_id"\s*:\s*"(\w+)"')
     tvip_re = re.compile(r'event_master_brand=(\w+?)&')
     swf_url = "http://emp.bbci.co.uk/emp/SMPf/1.18.3/StandardMediaPlayerChromelessFlash.swf"
     hash = base64.b64decode(b"N2RmZjc2NzFkMGM2OTdmZWRiMWQ5MDVkOWExMjE3MTk5MzhiOTJiZg==")

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -5,7 +5,7 @@ import re
 from functools import partial
 from hashlib import sha1
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginOptions
 from streamlink.plugin.api import http
 from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream
@@ -22,12 +22,26 @@ class BBCiPlayer(Plugin):
     """, re.VERBOSE)
     vpid_re = re.compile(r'"ident_id"\s*:\s*"(\w+)"')
     tvip_re = re.compile(r'event_master_brand=(\w+?)&')
+    account_locals_re = re.compile(r'window.bbcAccount.locals\s*=\s*(\{.*?});')
     swf_url = "http://emp.bbci.co.uk/emp/SMPf/1.18.3/StandardMediaPlayerChromelessFlash.swf"
     hash = base64.b64decode(b"N2RmZjc2NzFkMGM2OTdmZWRiMWQ5MDVkOWExMjE3MTk5MzhiOTJiZg==")
     api_url = ("http://open.live.bbc.co.uk/mediaselector/5/select/"
                "version/2.0/mediaset/{platform}/vpid/{vpid}/atk/{vpid_hash}/asn/1/")
     platforms = ("pc", "iptv-all")
+    config_url = "http://www.bbc.co.uk/idcta/config"
+    auth_url = "https://account.bbc.com/signin"
 
+    config_schema = validate.Schema(
+        validate.transform(parse_json),
+        {
+            "signin_url": validate.url(),
+            "identity": {
+                "cookieAgeDays": int,
+                "accessTokenCookieName": validate.text,
+                "idSignedInCookieName": validate.text
+            }
+         }
+    )
     mediaselector_schema = validate.Schema(
         validate.transform(partial(parse_xml, ignore_ns=True)),
         validate.union({
@@ -39,6 +53,10 @@ class BBCiPlayer(Plugin):
             validate.transform(lambda x: list(set(x)))  # unique
         )}
     )
+    options = PluginOptions({
+        "password": None,
+        "username": None
+    })
 
     @classmethod
     def can_handle_url(cls, url):
@@ -48,9 +66,10 @@ class BBCiPlayer(Plugin):
     def _hash_vpid(cls, vpid):
         return sha1(cls.hash + str(vpid).encode("utf8")).hexdigest()
 
-    def find_vpid(self, url):
+    def find_vpid(self, url, res=None):
         self.logger.debug("Looking for vpid on {0}", url)
-        res = http.get(url)
+        # Use pre-fetched page if available
+        res = res or http.get(url)
         m = self.vpid_re.search(res.text)
         return m and m.group(1)
 
@@ -71,14 +90,46 @@ class BBCiPlayer(Plugin):
                 for s in HDSStream.parse_manifest(self.session, surl).items():
                     yield s
 
+    def login(self, ptrt_url, context="tvandiplayer"):
+        # get the site config, to find the signin url
+        config = http.get(self.config_url, params=dict(ptrt=ptrt_url), schema=self.config_schema)
+
+        res = http.get(config["signin_url"],
+                       params=dict(userOrigin=context, context=context),
+                       headers={"Referer": self.url})
+        m = self.account_locals_re.search(res.text)
+        if m:
+            auth_data = parse_json(m.group(1))
+            res = http.post(self.auth_url,
+                            params=dict(context=auth_data["userOrigin"],
+                                        ptrt=auth_data["ptrt"]["value"],
+                                        userOrigin=auth_data["userOrigin"],
+                                        nonce=auth_data["nonce"]),
+                            data=dict(jsEnabled="false", attempts=0, username=self.get_option("username"),
+                                      password=self.get_option("password")))
+            # redirects to ptrt_url on successful login
+            if res.url == ptrt_url:
+                return res
+        else:
+            self.logger.error("Could not authenticate, could not find the authentication nonce")
+
     def _get_streams(self):
+        self.logger.info("A TV License is required to watch BBC iPlayer streams, see the BBC website for more "
+                         "information: https://www.bbc.co.uk/iplayer/help/tvlicence")
+        page_res = None
+        if self.get_option("username"):
+            page_res = self.login(self.url)
+            if not page_res:
+                self.logger.error("Could not authenticate, check your username and password")
+                return
+
         m = self.url_re.match(self.url)
         episode_id = m.group("episode_id")
         channel_name = m.group("channel_name")
 
         if episode_id:
             self.logger.debug("Loading streams for episode: {0}", episode_id)
-            vpid = self.find_vpid(self.url)
+            vpid = self.find_vpid(self.url, res=page_res)
             if vpid:
                 self.logger.debug("Found VPID: {0}", vpid)
                 for s in self.mediaselector(vpid):
@@ -92,6 +143,5 @@ class BBCiPlayer(Plugin):
                 self.logger.debug("Found TVIP: {0}", tvip)
                 for s in self.mediaselector(tvip):
                     yield s
-
 
 __plugin__ = BBCiPlayer

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1231,6 +1231,20 @@ plugin.add_argument(
     A pc-yourfreetv.com account password to use with --pcyourfreetv-username.
     """
 )
+plugin.add_argument(
+    "--bbciplayer-username",
+    metavar="USERNAME",
+    help="""
+    The username used to register with bbc.co.uk.
+    """
+)
+plugin.add_argument(
+    "--bbciplayer-password",
+    metavar="PASSWORD",
+    help="""
+    A bbc.co.uk account password to use with --bbciplayer-username.
+    """
+)
 
 # Deprecated options
 stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -930,6 +930,17 @@ def setup_plugin_options():
     if pcyourfreetv_password:
         streamlink.set_plugin_option("pcyourfreetv", "password", pcyourfreetv_password)
 
+    if args.bbciplayer_username:
+        streamlink.set_plugin_option("bbciplayer", "username", args.bbciplayer_username)
+
+    if args.bbciplayer_username and not args.bbciplayer_password:
+        bbciplayer_password = console.askpass("Enter bbc.co.uk account password: ")
+    else:
+        bbciplayer_password = args.bbciplayer_password
+
+    if bbciplayer_password:
+        streamlink.set_plugin_option("bbciplayer", "password", bbciplayer_password)
+
     # Deprecated options
     if args.jtv_legacy_names:
         console.logger.warning("The option --jtv/twitch-legacy-names is "


### PR DESCRIPTION
This PR sits on-top of the earlier PR (#925) and adds login support. Two new options were added to facilitate this:
 * `--bbciplayer-username` the email/username used to register with bbc.co.uk
 * `--bbciplayer-password` the password corresponding to that bbc account

The login is currently optional, but will be enforced at some point in the future ("weeks" according to the BBC). 

I have add a info level log message that states that the user should have a TV License. 