### PR TITLE
http_server: handle socket closed exception for Python 2.7

### DIFF
--- a/src/streamlink_cli/utils/http_server.py
+++ b/src/streamlink_cli/utils/http_server.py
@@ -114,6 +114,6 @@ class HTTPServer(object):
         if not client_only:
             try:
                 self.socket.shutdown(2)
-            except OSError:
+            except (OSError, socket.error):
                 pass
             self.socket.close()


### PR DESCRIPTION
The exception generated when closing a socket that is already closed if different in Python 2 and Python 3. This PR updates the `except` statement to handle both cases.

Intended to fix #919 