### PR TITLE
Homebrew package

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -64,6 +64,11 @@ Platform                             Installing
 Mac OS X                             .. code-block:: console
 
                                         # easy_install -U streamlink
+`Homebrew`_                          .. code-block:: console
+
+                                        # brew install streamlink
+
+                                     `Installing Homebrew packages`_
 Microsoft Windows                    See `Windows binaries`_ and `Windows portable version`_.
 
 `Chocolatey`_                        .. code-block:: console
@@ -71,7 +76,10 @@ Microsoft Windows                    See `Windows binaries`_ and `Windows portab
                                         C:\> choco install streamlink
 ==================================== ===========================================
 
+.. _Homebrew: https://github.com/Homebrew/homebrew-core/blob/master/Formula/streamlink.rb
 .. _Chocolatey: https://chocolatey.org/packages/streamlink
+
+.. _Installing Homebrew packages: https://brew.sh
 
 Package maintainers
 -------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -74,12 +74,15 @@ Microsoft Windows                    See `Windows binaries`_ and `Windows portab
 `Chocolatey`_                        .. code-block:: console
 
                                         C:\> choco install streamlink
+
+                                     `Installing Chocolatey packages`_
 ==================================== ===========================================
 
 .. _Homebrew: https://github.com/Homebrew/homebrew-core/blob/master/Formula/streamlink.rb
 .. _Chocolatey: https://chocolatey.org/packages/streamlink
 
 .. _Installing Homebrew packages: https://brew.sh
+.. _Installing Chocolatey packages: https://chocolatey.org
 
 Package maintainers
 -------------------


### PR DESCRIPTION
I think the homebrew package should be listed on the website.

This is the homebrew formula:
https://github.com/Homebrew/homebrew-core/blame/master/Formula/streamlink.rb
Unfortunately, there's no better way of linking to the package. And since there are no dedicated maintainers, there's no one to be added to the package maintainer list.

#398 can be closed then, I guess.

Oh, and I also added a link to the main chocolatey website. I think it's confusing to primarily link to the package url.