### PR TITLE
docs: update Sphinx config to fix the rendering of --

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,1 +1,2 @@
-sphinx
+sphinx>=1.6,<1.7
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,10 +135,6 @@ html_static_path = ['_static']
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'
 
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
-
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 

--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,0 +1,3 @@
+[restructuredtext parser]
+smart_quotes=no
+


### PR DESCRIPTION
Fixes the documentation error in #934. 

For some reason `html_use_smartypants` has started working and it's broken the `--` in the command line options. This PR updates the `conf.py` and adds `docutils.conf` to disable `smart_quotes`.