### PR TITLE
docs: fix parameters being linked in code blocks

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -29,7 +29,7 @@ _Argument = namedtuple("Argument", ["args", "options"])
 _block_re = re.compile(r":\n{2}\s{2}")
 _default_re = re.compile(r"Default is (.+)\.\n")
 _note_re = re.compile(r"Note: (.*)\n\n", re.DOTALL)
-_option_re = re.compile(r"(--[\w-]+)")
+_option_re = re.compile(r"(?m)^((?!\s{2}).*)(--[\w-]+)")
 
 
 class ArgumentParser(object):
@@ -73,6 +73,17 @@ class ArgparseDirective(Directive):
         # non-indented text.
         help = dedent(help)
 
+        # Replace option references with links.
+        # Do this before indenting blocks and notes.
+        help = _option_re.sub(
+            lambda m: (
+                "{0}:option:`{1}`".format(m.group(1), m.group(2))
+                if m.group(2) in self._available_options
+                else m.group(0)
+            ),
+            help
+        )
+
         # Create simple blocks.
         help = _block_re.sub("::\n\n  ", help)
 
@@ -82,16 +93,6 @@ class ArgparseDirective(Directive):
         # Create note directives from "Note: " paragraphs.
         help = _note_re.sub(
             lambda m: ".. note::\n\n" + indent(m.group(1)) + "\n\n",
-            help
-        )
-
-        # Replace option references with links.
-        help = _option_re.sub(
-            lambda m: (
-                ":option:`{0}`".format(m.group(1))
-                if m.group(1) in self._available_options
-                else m.group(1)
-            ),
             help
         )
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -311,22 +311,20 @@ player.add_argument(
 
     This is a shell-like syntax to support using a specific player:
 
-      "streamlink --player=vlc <url> <quality>"
+      streamlink --player=vlc <url> <quality>
 
     Absolute or relative paths can also be passed via this option
     in the event the player's executable can not be resolved:
 
       streamlink --player=/path/to/vlc <url> <quality>
-
       streamlink --player=./vlc-player/vlc <url> <quality>
 
     To use a player that is located in a path with spaces you must
     quote the parameter or its value:
 
       streamlink "--player=/path/with spaces/vlc" <url> <quality>
+      streamlink --player "C:\path\with spaces\mpc-hc64.exe" <url> <quality>
 
-      streamlink --player "C:\path\with spaces\mpc-hc64.exe" <url> <quality
-    
     Options may also be passed to the player. For example:
 
       streamlink --player "vlc --file-caching=5000" <url> <quality>


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/pull/896#issuecomment-303317718...
I should have built the docs myself before merging, sorry.

Parameters will now only be linked if the text is not indented. I couldn't find a better way of fixing this. The order of regexp substitutions needed to be changed, so that text inside normal and note blocks can still link to parameters.

I've also fixed the missing closing angle bracket and the unnecessary quotation in the first --player example.

The docs are now looking good to me, but there's a chance I have missing something, so please check it first before merging.