### PR TITLE
win32: fix missing modules when using windows installer

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -45,6 +45,14 @@ packages=requests
          iso639
          iso3166
          pkg_resources
+         six
+         appdirs
+         packaging
+         pyparsing
+         urllib3
+         idna
+         chardet
+         certifi
 pypi_wheels=pycryptodome==3.4.3
 
 files=../win32/LICENSE.txt > \$INSTDIR


### PR DESCRIPTION
`pkg_resources` (`setuptool`) and `requests` have changed the way their packages are structured so that they no longer vendor packages, this means those previously vendored packages have to be included by the installer builder.

This should fix #945, plus an unreported issue with `requests`. 