### PR TITLE
[dailymotion] fix for broken .f4m file that is a .m3u8 file 

### DIFF
--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -128,7 +128,12 @@ class DailyMotion(Plugin):
                 continue
 
             if quality == "hds":
-                streams = HDSStream.parse_manifest(self.session, res.url)
+                self.logger.debug('PLAYLIST URL: {0}'.format(res.url))
+                try:
+                    streams = HDSStream.parse_manifest(self.session, res.url)
+                except:
+                    streams = HLSStream.parse_variant_playlist(self.session, res.url)
+
                 for name, stream in streams.items():
                     if key == "source":
                         name += "+"


### PR DESCRIPTION
Fixed broken livestream from `http://www.dailymotion.com/video/x3b68jn`

Not sure why this .f4m file is a .m3u8 file,
most likely a bug on dailymotion end

as long as they don't fix it, streamlink should just try to open hls instead of hds if it fails for livestreams.



Fixed #959