### PR TITLE
Allow live YouTube channel links without '/c/' prefix

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -107,7 +107,7 @@ _url_re = re.compile(r"""
         )
         |
         (?:
-            /c/(?P<liveChannel>[^/?]+)/live
+            /(c/)?(?P<liveChannel>[^/?]+)/live
         )
     )
 """, re.VERBOSE)


### PR DESCRIPTION
Solution for #978, tiny 3 character commit to allow removing the `/c/` prefix from YouTube live channel links.