### PR TITLE
plugins.webtv: decrypt the stream URL when applicable

### DIFF
--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -29,7 +29,7 @@ from ...exceptions import PluginError
 
 __all__ = [
     "any", "all", "filter", "get", "getattr", "hasattr", "length", "optional",
-    "transform", "text", "union", "url", "startswith", "endswith",
+    "transform", "text", "union", "url", "startswith", "endswith", "contains",
     "xml_element", "xml_find", "xml_findall", "xml_findtext",
     "validate", "Schema", "SchemaContainer"
 ]
@@ -138,6 +138,17 @@ def endswith(string):
         return True
 
     return ends_with
+
+
+def contains(string):
+    """Checks if the string value contains another string."""
+    def contains_str(value):
+        validate(text, value)
+        if not string in value:
+            raise ValueError("'{0}' does not contain '{1}'".format(value, string))
+        return True
+
+    return contains_str
 
 
 def get(item, default=None):

--- a/src/streamlink/utils/crypto.py
+++ b/src/streamlink/utils/crypto.py
@@ -1,5 +1,4 @@
 import hashlib
-import math
 
 from Crypto.Cipher import AES
 
@@ -28,7 +27,11 @@ def decrypt_openssl(data, passphrase, key_length=32):
         key, iv = evp_bytestokey(passphrase, salt, key_length, AES.block_size)
         d = AES.new(key, AES.MODE_CBC, iv)
         out = d.decrypt(data[AES.block_size:])
-        if is_py3:
-            return out[:-out[-1]]
-        else:
-            return out[:-ord(out[-1])]
+        return unpad_pkcs5(out)
+
+
+def unpad_pkcs5(padded):
+    if is_py3:
+        return padded[:-padded[-1]]
+    else:
+        return padded[:-ord(padded[-1])]


### PR DESCRIPTION
Some (all?) of the stream URLs are now encrypted using AES encryption - the key and IV are prepended to the cipher text.

Added some additional util functions to support the decryption.
 - An unpad method which performs "standard" pkcs5 unpadding.
 - A new validation rule for text; `validate.contains` which validates that the string contains a given substring.