### PR TITLE
plugins.canlitv: simplified and fixed the m3u8 regex

### DIFF
--- a/src/streamlink/plugins/canlitv.py
+++ b/src/streamlink/plugins/canlitv.py
@@ -8,7 +8,7 @@ from streamlink.stream import HLSStream
 EMBED_URL_1 = "http://www.canlitv.life/kanallar.php?kanal={0}"
 EMBED_URL_2 = "http://www.ecanlitvizle.net/embed.php?kanal={0}"
 
-_m3u8_re = re.compile(r"file:(?:\s+)?(?:\'|\")(?P<url>[^\"']+)(?:\'|\")")
+_m3u8_re = re.compile(r"""file\s*:\s*['"](?P<url>[^"']+)['"]""")
 _url_re = re.compile(r"""http(s)?://(?:www\.)?(?P<domain>
     canlitv\.(com|life)
     |

--- a/tests/test_plugin_canlitv.py
+++ b/tests/test_plugin_canlitv.py
@@ -1,9 +1,23 @@
 import unittest
 
-from streamlink.plugins.canlitv import Canlitv
+from streamlink.plugins.canlitv import Canlitv, _m3u8_re
 
 
 class TestPluginCanlitv(unittest.TestCase):
+    def test_m3u8_re(self):
+        def test_re(text):
+            m = _m3u8_re.search(text)
+            self.assertTrue(m and len(m.group("url")) > 0)
+
+        test_re('file: "test" ')
+        test_re('file:"test"')
+        test_re('file : "test"')
+        test_re('file   :   "test"  ')
+        test_re("file: 'test'")
+        test_re("file :'test'")
+        test_re("file : 'test'")
+        test_re("file   :   'test'")
+
     def test_can_handle_url(self):
         # should match
         self.assertTrue(Canlitv.can_handle_url("http://www.canlitv.com/channel"))


### PR DESCRIPTION
On some pages there is a space before the `:`, after `file`. Added a few tests for the regex too. 