### PR TITLE
[zattoo] New plugin for zattoo.com / tvonline.ewe.de / nettv.netcologne.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -261,6 +261,9 @@ wwenetwork          network.wwe.com      Yes   Yes   Requires an account to acce
 younow              younow.com           Yes   --
 youtube             - youtube.com        Yes   Yes   Protected videos are not supported.
                     - youtu.be
+zattoo              - zattoo.com         Yes   Yes
+                    - nettv.netcologne.de
+                    - tvonline.ewe.de
 zdf_mediathek       zdf.de               Yes   Yes   Streams may be geo-restricted to Germany.
 zhanqitv            zhanqi.tv            Yes   No
 =================== ==================== ===== ===== ===========================

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -154,18 +154,18 @@ playtv              playtv.fr            Yes   --    Streams may be geo-restrict
 pluzz               - france.tv          Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
                     - ludo.fr
                     - zouzous.fr
-		    - france3-reg.. [8]_
+                    - france3-reg.. [8]_
 powerapp            powerapp.com.tr      Yes   No
 radionet            - radio.net          Yes   --
                     - radio.at
-		    - radio.de
-		    - radio.dk
-		    - radio.es
-		    - radio.fr
-		    - radio.it
-		    - radio.pl
-		    - radio.pt
-		    - radio.se
+                    - radio.de
+                    - radio.dk
+                    - radio.es
+                    - radio.fr
+                    - radio.it
+                    - radio.pl
+                    - radio.pt
+                    - radio.se
 raiplay             raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
 rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.
 rte                 rte.ie/player        Yes   Yes
@@ -262,7 +262,7 @@ younow              younow.com           Yes   --
 youtube             - youtube.com        Yes   Yes   Protected videos are not supported.
                     - youtu.be
 zattoo              - zattoo.com         Yes   Yes
-                    - nettv.netcologne.de
+                    - nettv.net... [10]_
                     - tvonline.ewe.de
 zdf_mediathek       zdf.de               Yes   Yes   Streams may be geo-restricted to Germany.
 zhanqitv            zhanqi.tv            Yes   No
@@ -278,3 +278,4 @@ zhanqitv            zhanqi.tv            Yes   No
 .. [7] player.theplatform.com
 .. [8] france3-regions.francetvinfo.fr
 .. [9] tv5mondeplusafrique.com
+.. [10] nettv.netcologne.de

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -1,0 +1,206 @@
+import re
+import time
+import uuid
+
+from streamlink.cache import Cache
+from streamlink.plugin import Plugin
+from streamlink.plugin import PluginOptions
+from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+
+
+class Zattoo(Plugin):
+    API_HELLO = '{0}/zapi/session/hello'
+    API_LOGIN = '{0}/zapi/v2/account/login'
+    API_CHANNELS = '{0}/zapi/v2/cached/channels/{1}?details=False'
+    API_WATCH = '{0}/zapi/watch'
+    API_WATCH_VOD = '{0}/zapi/avod/videos/{1}/watch'
+
+    _url_re = re.compile(r'''
+        (?P<base_url>https?://
+        (?:
+        zattoo\.com
+        |
+        tvonline\.ewe\.de
+        |
+        nettv\.netcologne\.de
+        ))/(?:watch/(?P<channel>[^/\s]+)
+        |
+        ondemand/watch/(?P<vod_id>[^-]+)-)''', re.VERBOSE)
+
+    _app_token_re = re.compile(r"""window\.appToken\s+=\s+'([^']+)'""")
+
+    _channels_schema = validate.Schema({
+        'success': int,
+        'channel_groups': [{
+            'channels': [
+                {
+                    'display_alias': validate.text,
+                    'cid': validate.text
+                },
+            ]
+        }]},
+        validate.get('channel_groups'),
+    )
+
+    options = PluginOptions({
+        'email': None,
+        'password': None
+    })
+
+    def __init__(self, url):
+        super(Zattoo, self).__init__(url)
+        self._session_attributes = Cache(filename='plugin-cache.json', key_prefix='zattoo:attributes')
+        self._authed = self._session_attributes.get('beaker.session.id') and self._session_attributes.get('pzuid') and self._session_attributes.get('power_guide_hash')
+        self._uuid = self._session_attributes.get('uuid')
+        self._expires = self._session_attributes.get('expires')
+
+        self.base_url = Zattoo._url_re.match(url).group('base_url')
+        self.headers = {
+            'User-Agent': useragents.CHROME,
+            'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+            'X-Requested-With': 'XMLHttpRequest',
+            'Referer': self.base_url
+        }
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return Zattoo._url_re.match(url)
+
+    def _hello(self):
+        self.logger.debug('_hello ...')
+        res = http.get(self.base_url)
+        match = self._app_token_re.search(res.text)
+
+        app_token = match.group(1)
+        hello_url = self.API_HELLO.format(self.base_url)
+
+        if self._uuid:
+            __uuid = self._uuid
+        else:
+            __uuid = str(uuid.uuid4())
+            self._session_attributes.set('uuid', __uuid, expires=3600 * 24)
+
+        params = {
+            'client_app_token': app_token,
+            'uuid': __uuid,
+            'lang': 'en',
+            'format': 'json'
+        }
+        res = http.post(hello_url, headers=self.headers, data=params)
+        return res
+
+    def _login(self, email, password, _hello):
+        self.logger.debug('_login ... Attempting login as {0}'.format(email))
+
+        login_url = self.API_LOGIN.format(self.base_url)
+
+        params = {
+            'login': email,
+            'password': password,
+            'remember': 'true'
+        }
+
+        res = http.post(login_url, headers=self.headers, data=params, cookies=_hello.cookies)
+        data = http.json(res)
+
+        self._authed = data['success']
+        if self._authed:
+            self.logger.debug('New Session Data')
+            self._session_attributes.set('beaker.session.id', res.cookies.get('beaker.session.id'), expires=3600 * 24)
+            self._session_attributes.set('pzuid', res.cookies.get('pzuid'), expires=3600 * 24)
+            self._session_attributes.set('power_guide_hash', data['session']['power_guide_hash'], expires=3600 * 24)
+            return self._authed
+        else:
+            return None
+
+    def _watch(self):
+        self.logger.debug('_watch ...')
+        match = self._url_re.match(self.url)
+        if not match:
+            return
+        channel = match.group('channel')
+        vod_id = match.group('vod_id')
+
+        cookies = {
+            'beaker.session.id': self._session_attributes.get('beaker.session.id'),
+            'pzuid': self._session_attributes.get('pzuid')
+        }
+
+        if channel:
+            params, watch_url = self._watch_live(channel, cookies)
+        elif vod_id:
+            params, watch_url = self._watch_vod(vod_id, cookies)
+
+        res = http.post(watch_url, headers=self.headers, data=params, cookies=cookies)
+        data = http.json(res)
+
+        if data['success']:
+            for hls_url in data['stream']['watch_urls']:
+                for s in HLSStream.parse_variant_playlist(self.session, hls_url['url']).items():
+                    yield s
+
+    def _watch_live(self, channel, cookies):
+        self.logger.debug('_watch_live ...')
+        watch_url = self.API_WATCH.format(self.base_url)
+
+        # get CID from channels list
+        channels_url = self.API_CHANNELS.format(self.base_url, self._session_attributes.get('power_guide_hash'))
+        res = http.get(channels_url, headers=self.headers, cookies=cookies)
+        data = http.json(res, schema=self._channels_schema)
+
+        c_list = []
+        for d in data:
+            for c in d['channels']:
+                c_list.append(c)
+
+        cid = []
+        for c in c_list:
+            if c['display_alias'] == channel:
+                cid = c['cid']
+                self.logger.debug('CHANNEL ID: {0}'.format(cid))
+        if not cid:
+            return
+
+        params = {
+            'cid': cid,
+            'https_watch_urls': True,
+            'stream_type': 'hls'
+        }
+        return params, watch_url
+
+    def _watch_vod(self, vod_id, cookies):
+        self.logger.debug('_watch_vod ...')
+        watch_url = self.API_WATCH_VOD.format(self.base_url, vod_id)
+        params = {
+            'https_watch_urls': True,
+            'stream_type': 'hls'
+        }
+        return params, watch_url
+
+    def _get_streams(self):
+        email = self.get_option('email')
+        password = self.get_option('password')
+
+        if not self._authed and (not email and not password):
+            self.logger.error('A login for Zattoo is required, use --zattoo-email EMAIL --zattoo-password PASSWORD to set them')
+            return
+
+        if self._expires:
+            if self._expires < time.time():
+                # login after 24h
+                expires = time.time() + 3600 * 24
+                self._session_attributes.set('expires', expires, expires=3600 * 24)
+                self._authed = False
+
+        if not self._authed:
+            __hello = self._hello()
+            if not self._login(email, password, __hello):
+                self.logger.error('Failed to login, check your username/password')
+                return
+
+        return self._watch()
+
+__plugin__ = Zattoo

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1299,6 +1299,14 @@ plugin.add_argument(
     A zattoo account password to use with --zattoo-email.
     """
 )
+plugin.add_argument(
+    "--zattoo-purge-credentials",
+    action="store_true",
+    help="""
+    Purge cached zattoo credentials to initiate a new session
+    and reauthenticate.
+    """
+)
 
 # Deprecated options
 stream.add_argument(

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1285,6 +1285,20 @@ plugin.add_argument(
     A ufc.tv account password to use with --ufctv-username.
     """
 )
+plugin.add_argument(
+    "--zattoo-email",
+    metavar="EMAIL",
+    help="""
+    The email associated with your zattoo account, required to access any zattoo stream.
+    """
+)
+plugin.add_argument(
+    "--zattoo-password",
+    metavar="PASSWORD",
+    help="""
+    A zattoo account password to use with --zattoo-email.
+    """
+)
 
 # Deprecated options
 stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -950,6 +950,10 @@ def setup_plugin_options():
     if zattoo_password:
         streamlink.set_plugin_option("zattoo", "password", zattoo_password)
 
+    if args.zattoo_purge_credentials:
+        streamlink.set_plugin_option("zattoo", "purge_credentials",
+                                     args.zattoo_purge_credentials)
+
     # Deprecated options
     if args.jtv_legacy_names:
         console.logger.warning("The option --jtv/twitch-legacy-names is "

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -941,6 +941,15 @@ def setup_plugin_options():
     if ufctv_password:
         streamlink.set_plugin_option("ufctv", "password", ufctv_password)
 
+    if args.zattoo_email:
+        streamlink.set_plugin_option("zattoo", "email", args.zattoo_email)
+    if args.zattoo_email and not args.zattoo_password:
+        zattoo_password = console.askpass("Enter zattoo password: ")
+    else:
+        zattoo_password = args.zattoo_password
+    if zattoo_password:
+        streamlink.set_plugin_option("zattoo", "password", zattoo_password)
+
     # Deprecated options
     if args.jtv_legacy_names:
         console.logger.warning("The option --jtv/twitch-legacy-names is "

--- a/tests/test_plugin_zattoo.py
+++ b/tests/test_plugin_zattoo.py
@@ -1,0 +1,24 @@
+import unittest
+
+from streamlink.plugins.zattoo import Zattoo
+
+
+class TestPluginZattoo(unittest.TestCase):
+    def test_can_handle_url(self):
+        # ewe live
+        self.assertTrue(Zattoo.can_handle_url('http://tvonline.ewe.de/watch/daserste'))
+        self.assertTrue(Zattoo.can_handle_url('http://tvonline.ewe.de/watch/zdf'))
+        # netcologne live
+        self.assertTrue(Zattoo.can_handle_url('https://nettv.netcologne.de/watch/daserste'))
+        self.assertTrue(Zattoo.can_handle_url('https://nettv.netcologne.de/watch/zdf'))
+        # zattoo live
+        self.assertTrue(Zattoo.can_handle_url('https://zattoo.com/watch/daserste'))
+        self.assertTrue(Zattoo.can_handle_url('https://zattoo.com/watch/zdf'))
+        # zattoo vod
+        self.assertTrue(Zattoo.can_handle_url('https://zattoo.com/ondemand/watch/ibR2fpisWFZGvmPBRaKnFnuT-alarm-am-airport'))
+        self.assertTrue(Zattoo.can_handle_url('https://zattoo.com/ondemand/watch/G8S7JxcewY2jEwAgMzvFWK8c-berliner-schnauzen'))
+
+        # shouldn't match
+        self.assertFalse(Zattoo.can_handle_url('https://ewe.de'))
+        self.assertFalse(Zattoo.can_handle_url('https://netcologne.de'))
+        self.assertFalse(Zattoo.can_handle_url('https://zattoo.com'))


### PR DESCRIPTION
**New plugin for zattoo**

- zattoo.com
- tvonline.ewe.de
- nettv.netcologne.com

Should work fine. I tested it over the last weeks.

---

Some part of this code is is not necessary, but it's **easier to debug if something fails**.
like this one, you can see what channels are available in your country.

```py
zattoo_list = []
for c in c_list:
    zattoo_list.append(c['display_alias'])
    if c['display_alias'] == channel:
        cid = c['cid']

self.logger.debug('Available zattoo channels in this country: {0}'.format(', '.join(sorted(zattoo_list))))
```

---

For every login it will **cache** the cookies for **24h**.
If you want to use a different Account you need to wait 24h or delete `plugin-cache.json`

---

Fixed #804 