### PR TITLE
Add ignore filter to warnings in http_session

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -24,6 +24,9 @@ except (ImportError, AttributeError):
 from ...exceptions import PluginError
 from ...utils import parse_json, parse_xml
 
+import warnings
+warnings.simplefilter("ignore")
+
 __all__ = ["HTTPSession"]
 
 


### PR DESCRIPTION
Somehow urllib3 isn't reacting to the disable_warnings function. As a
workaround, we'll set a ignore filter to warnings in the http_session
module.

Closes: #963