### PR TITLE
docs: add official and 3rd-party applications list

### DIFF
--- a/docs/_applications.rst
+++ b/docs/_applications.rst
@@ -1,0 +1,24 @@
+.. _applications:
+
+:orphan:
+
+
+.. raw:: html
+
+    <style>
+        .rst-content table.field-list td {
+            padding-top: 8px;
+        }
+    </style>
+
+.. |Windows| raw:: html
+
+    <i class="fa fa-fw fa-windows"></i>
+
+.. |MacOS| raw:: html
+
+    <i class="fa fa-fw fa-apple"></i>
+
+.. |Linux| raw:: html
+
+    <i class="fa fa-fw fa-linux"></i>

--- a/docs/applications.rst
+++ b/docs/applications.rst
@@ -1,0 +1,22 @@
+.. include:: _applications.rst
+
+
+Streamlink Applications
+=======================
+
+
+Streamlink Twitch GUI
+---------------------
+
+.. image:: https://user-images.githubusercontent.com/467294/28097570-3415020e-66b1-11e7-928d-4b9da35daf13.jpg
+    :alt: Streamlink Twitch GUI
+
+:Description: A multi platform Twitch.tv browser for Streamlink
+:Type: Graphical User Interface
+:OS: |Windows| |MacOS| |Linux|
+:Author: `Sebastian Meyer <https://github.com/bastimeyer>`_
+:Website: https://streamlink.github.io/streamlink-twitch-gui
+:Source code: https://github.com/streamlink/streamlink-twitch-gui
+:Info: A NW.js based desktop web application, formerly known as *Livestreamer Twitch GUI*. Browse Twitch.tv and watch
+    multiple streams at once. Filter streams by language, receive desktop notifications when followed channels start
+    streaming and access the Twitch chat by using customizable chat applications.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ release = streamlink_version
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build']
+exclude_patterns = ['_build', '_applications.rst']
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,3 +66,4 @@ See their respective sections for more information on how to use them.
     api
     changelog
     donate
+    thirdparty

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,4 +66,5 @@ See their respective sections for more information on how to use them.
     api
     changelog
     donate
+    applications
     thirdparty

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -1,19 +1,16 @@
-Third Party Applications
-========================
-
 ..
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     If you're a developer and want to add your project/application to this list, please
 
-    1. adhere to the same structure
-    2. add your entry to the bottom of the list
+    1. adhere to the same structure and format of the entries of the applications.rst file and this one
+    2. add your new entry to the bottom of the list
     3. at least provide the required fields (in the same order)
-       - Description (a brief text describing your application)
-       - Type (eg. Graphical User Interface, CLI wrapper, etc.)
-       - OS (please use the available substitutions)
-       - Author (if possible, include a link to the creator's Github/Gitlab profile, etc. or a contact email address)
-       - Website
+       - "Description" (a brief text describing your application)
+       - "Type" (eg. Graphical User Interface, CLI wrapper, etc.)
+       - "OS" (please use the available substitutions)
+       - "Author" (if possible, include a link to the creator's Github/Gitlab profile, etc. or a contact email address)
+       - "Website"
     4. use an image
        - in the jpeg or png format
        - with a static and reliable !!!https!!! URL (use Github or an image hoster like Imgur, etc.)
@@ -21,7 +18,7 @@ Third Party Applications
        - with a decent compression quality
        - that is not too large (at most 1 MiB allowed, the smaller the better)
        - that is neutral and only shows your application
-    5. optionally add more fields like an URL to the source code repository or a larger description or features text
+    5. optionally add more fields like a URL to the source code repository, a larger info or features text, etc.
 
     Please be aware that the Streamlink team may edit and remove your entry at any time.
 
@@ -30,48 +27,20 @@ Third Party Applications
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 
-.. raw:: html
-
-    <style>
-        .rst-content table.field-list td {
-            padding-top: 8px;
-        }
-    </style>
-
-.. |Windows| raw:: html
-
-    <i class="fa fa-fw fa-windows"></i>
-
-.. |MacOS| raw:: html
-
-    <i class="fa fa-fw fa-apple"></i>
-
-.. |Linux| raw:: html
-
-    <i class="fa fa-fw fa-linux"></i>
+.. include:: _applications.rst
 
 
-.. header
+Third Party Applications
+========================
 
 
-This is a list of various applications using Streamlink.
+.. content list start
 
 
-.. content list
+.. replace this line with the first entry
 
 
-Streamlink Twitch GUI
----------------------
+.. content list end
 
-.. image:: https://user-images.githubusercontent.com/467294/28097570-3415020e-66b1-11e7-928d-4b9da35daf13.jpg
-    :alt: Streamlink Twitch GUI
 
-:Description: A multi platform Twitch.tv browser for Streamlink
-:Type: Graphical User Interface
-:OS: |Windows| |MacOS| |Linux|
-:Author: `Sebastian Meyer <https://github.com/bastimeyer>`_
-:Website: https://streamlink.github.io/streamlink-twitch-gui
-:Source code: https://github.com/streamlink/streamlink-twitch-gui
-:Info: A NW.js based desktop web application, formerly known as *Livestreamer Twitch GUI*. Browse Twitch.tv and watch
-    multiple streams at once. Filter streams by language, receive desktop notifications when followed channels start
-    streaming and access the Twitch chat by using customizable chat applications.
+Help us extend this list by sending us a pull request on Github. Thanks!

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -1,0 +1,77 @@
+Third Party Applications
+========================
+
+..
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    If you're a developer and want to add your project/application to this list, please
+
+    1. adhere to the same structure
+    2. add your entry to the bottom of the list
+    3. at least provide the required fields (in the same order)
+       - Description (a brief text describing your application)
+       - Type (eg. Graphical User Interface, CLI wrapper, etc.)
+       - OS (please use the available substitutions)
+       - Author (if possible, include a link to the creator's Github/Gitlab profile, etc. or a contact email address)
+       - Website
+    4. use an image
+       - in the jpeg or png format
+       - with a static and reliable !!!https!!! URL (use Github or an image hoster like Imgur, etc.)
+       - with a reasonable size and aspect ratio
+       - with a decent compression quality
+       - that is not too large (at most 1 MiB allowed, the smaller the better)
+       - that is neutral and only shows your application
+    5. optionally add more fields like an URL to the source code repository or a larger description or features text
+
+    Please be aware that the Streamlink team may edit and remove your entry at any time.
+
+    Thank you! :)
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+
+.. raw:: html
+
+    <style>
+        .rst-content table.field-list td {
+            padding-top: 8px;
+        }
+    </style>
+
+.. |Windows| raw:: html
+
+    <i class="fa fa-fw fa-windows"></i>
+
+.. |MacOS| raw:: html
+
+    <i class="fa fa-fw fa-apple"></i>
+
+.. |Linux| raw:: html
+
+    <i class="fa fa-fw fa-linux"></i>
+
+
+.. header
+
+
+This is a list of various applications using Streamlink.
+
+
+.. content list
+
+
+Streamlink Twitch GUI
+---------------------
+
+.. image:: https://user-images.githubusercontent.com/467294/28097570-3415020e-66b1-11e7-928d-4b9da35daf13.jpg
+    :alt: Streamlink Twitch GUI
+
+:Description: A multi platform Twitch.tv browser for Streamlink
+:Type: Graphical User Interface
+:OS: |Windows| |MacOS| |Linux|
+:Author: `Sebastian Meyer <https://github.com/bastimeyer>`_
+:Website: https://streamlink.github.io/streamlink-twitch-gui
+:Source code: https://github.com/streamlink/streamlink-twitch-gui
+:Info: A NW.js based desktop web application, formerly known as *Livestreamer Twitch GUI*. Browse Twitch.tv and watch
+    multiple streams at once. Filter streams by language, receive desktop notifications when followed channels start
+    streaming and access the Twitch chat by using customizable chat applications.


### PR DESCRIPTION
Resolves #778 #873 

This adds a new **Third Party Applications** page to the bottom of the main menu. Should this be added at a different position or is this okay?

I'm not sure if I'm too strict here with the included rules (see the reST comment block), so if anybody has any concerns or suggestions here, please let me know.

Unfortunately, I don't know how to disable the generation of submenu items (it also automatically highlights the first item). The rendered page looks like this:
![screenshot from 2017-07-13 04-31-52](https://user-images.githubusercontent.com/467294/28148082-ffd3ee86-6784-11e7-9710-b3bf33991d80.png)
