### PR TITLE
Add 3rd party app Chatty

### DIFF
--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -36,9 +36,19 @@ Third Party Applications
 
 .. content list start
 
+Chatty for macOS
+----------------
 
-.. replace this line with the first entry
+.. image:: https://raw.githubusercontent.com/dehesselle/chatty/macos/macos/app_screenshot.png
+    :alt: Chatty for macOS
 
+:Description: Chatty packaged for macOS and bundled with Streamlink
+:Type: Twitch chat client
+:OS: |MacOS|
+:Author: `Rene de Hesselle <https://github.com/dehesselle>`_
+:Website: n/a
+:Source code: https://github.com/dehesselle/chatty
+:Info: A Java based chat client for Twitch. It's Chatty from Tduva, I'm just maintaining a macOS version for convenience. It comes bundled with Java and Streamlink, no installation/3rd party runtimes required.
 
 .. content list end
 


### PR DESCRIPTION
As my personal follow-up to #778, this PR asks for the inclusion
of my fork of Chatty to be listed in the "3rd party applications"
documentation.
My fork is basically vanilla-Chatty with very few minor changes
(like using macOS menubar as a default setting), packaged as native
macOS app. It comes bundled with Streamlink.
(FYI I did ask Tduva for permission before starting my fork)

I believe to have followed the rules stated in CONTRIBUTING.md as
well as thirdparty.rst. I did generate the documentation with
makedocs.sh to check the result. Feel free to point out or correct
any errors I have made.