### PR TITLE
Update donation docs to note open collective

### DIFF
--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -4,13 +4,13 @@ Donating
 Thank you for considering a donation to the Streamlink team! Streamlink is an
 organization composed of a geographically diverse group of individuals.
 We accept donations/tips in a variety of ways. If you would like to donate
-directly to a specific user please review their details in the team section
-below. If you would prefer to donate to the team as a whole please use our
+directly to a specific user, please review their details in the team section
+below. If you would prefer to donate to the team as a whole, please use our
 `Open Collective <https://opencollective.com/streamlink>`_. Note that
 donations are not tax deductible as Streamlink does not operate as a charitable
 organization. Your donation to the team or a team member may be used in any
 way and does not come with expectations of work to be provided or as payment
-for future work. If you would like a specific feature implemented considering
+for future work. If you would like a specific feature implemented consider
 creating a bounty on
 `Bountysource <https://www.bountysource.com/teams/streamlink>`_.
 

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -2,13 +2,17 @@ Donating
 --------
 
 Thank you for considering a donation to the Streamlink team! Streamlink is an
-organization composed of a geographically diverse group of individuals. As such
-please make your donation directly to the appropriate team member. Note that
+organization composed of a geographically diverse group of individuals.
+We accept donations/tips in a variety of ways. If you would like to donate
+directly to a specific user please review their details in the team section
+below. If you would prefer to donate to the team as a whole please use our
+`Open Collective <https://opencollective.com/streamlink>`_. Note that
 donations are not tax deductible as Streamlink does not operate as a charitable
-organization. Your donation to a team member may be used in any way and does
-not come with expectations of work to be provided or as payment for future
-work. If you would like a specific feature implemented considering creating a
-bounty on `Bountysource <https://www.bountysource.com/teams/streamlink>`_.
+organization. Your donation to the team or a team member may be used in any
+way and does not come with expectations of work to be provided or as payment
+for future work. If you would like a specific feature implemented considering
+creating a bounty on
+`Bountysource <https://www.bountysource.com/teams/streamlink>`_.
 
 ---------------
 Streamlink Team


### PR DESCRIPTION
This goes along with #1122, if anyone has feedback on the wording please let me know. I considered adding sections for tips based on the payment method, but figured that was too complicated. Open Collective is still using PayPal for payouts so I know some of us can't benefit from it (myself included) but at least we can get the ball rolling so people can make credit card donations easily.