### PR TITLE
plugins.twitch: enable certificate verification for twitch api

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -203,8 +203,7 @@ class TwitchAPI(object):
         headers = {'Accept': 'application/vnd.twitchtv.v{0}+json'.format(self.version),
                    'Client-ID': TWITCH_CLIENT_ID}
 
-        # The certificate used by Twitch cannot be verified on some OpenSSL versions.
-        res = http.get(url, params=params, verify=False, headers=headers)
+        res = http.get(url, params=params, headers=headers)
 
         if format == "json":
             return http.json(res, schema=schema)


### PR DESCRIPTION
Re-enables the certificate verification for the twitch API calls. 

The `--http-no-ssl-verify` flag can be used if users have incompatible versions of OpenSSL or if they want to use a MITM proxy. 

Fixes #966, should also fix #963.