### PR TITLE
cli: remove the deprecation warnings for some of the http options

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -673,18 +673,12 @@ def setup_http_session():
         streamlink.set_option("http-timeout", args.http_timeout)
 
     if args.http_cookies:
-        console.logger.warning("The option --http-cookies is deprecated since "
-                               "version 1.11.0, use --http-cookie instead.")
         streamlink.set_option("http-cookies", args.http_cookies)
 
     if args.http_headers:
-        console.logger.warning("The option --http-headers is deprecated since "
-                               "version 1.11.0, use --http-header instead.")
         streamlink.set_option("http-headers", args.http_headers)
 
     if args.http_query_params:
-        console.logger.warning("The option --http-query-params is deprecated since "
-                               "version 1.11.0, use --http-query-param instead.")
         streamlink.set_option("http-query-params", args.http_query_params)
 
 


### PR DESCRIPTION
The deprecation warning has been removed from the `--http-{cookies,headers,query-params}` options. The options are not listed in the help or in the docs, but they will continue to work.

They should be considered unsupported.

Fixes #573.