### PR TITLE
cli: support for SOCKS proxies

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -329,6 +329,22 @@ Progressive HTTP, HTTPS, etc   httpstream:// [1]_
 .. [1] supports local files using the file:// protocol
 .. _cli-options:
 
+Proxy Support
+-------------
+
+You can use the :option:`--http-proxy` and :option:`--https-proxy` options to
+change the proxy server that Streamlink will use for HTTP and HTTPS requests respectively.
+As HTTP and HTTPS requests can be handled by separate proxies, you may need to specify both
+options if the plugin you use makes HTTP and HTTPS requests.
+
+Both HTTP and SOCKS5 proxies are supported, authentication is supported for both types.
+
+For example:
+.. code-block:: console
+
+    $ streamlink --http-proxy "http://user:pass@10.10.1.10:3128/" --https-proxy "socks5://10.10.1.10:1242"
+
+
 Command-line usage
 ------------------
 

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -52,6 +52,7 @@ format=bundled
 ;           - certifi
 ;           - idna
 ;           - urllib3
+;           - PySocks
 ;       - websocket-client
 packages=streamlink
          streamlink_cli

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,9 @@ else:
 
 deps.append("websocket-client")
 
+# Support for SOCKS proxies
+deps.append("requests[socks]")
+
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.
 if environ.get("NO_DEPS"):

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -1,11 +1,12 @@
 import imp
-import locale
 import pkgutil
 import re
 import sys
 import traceback
 
 import requests
+
+from streamlink.utils import update_scheme
 from streamlink.utils.l10n import Localization
 
 from . import plugins, __version__
@@ -230,13 +231,9 @@ class Streamlink(object):
             key = "subprocess-errorlog-path"
 
         if key == "http-proxy":
-            if not re.match("^http(s)?://", value):
-                value = "http://" + value
-            self.http.proxies["http"] = value
+            self.http.proxies["http"] = update_scheme("http://", value)
         elif key == "https-proxy":
-            if not re.match("^http(s)?://", value):
-                value = "https://" + value
-            self.http.proxies["https"] = value
+            self.http.proxies["https"] = update_scheme("https://", value)
         elif key == "http-cookies":
             if isinstance(value, dict):
                 self.http.cookies.update(value)


### PR DESCRIPTION
Any proxy type that is supported by `requests` can be used.
  
For example, SOCKS proxies are support by `requests`, and can be used:
    - `--http-proxy "socks5://[user:password@]host:port"`
    - `--https-proxy "socks5://[user:password@]host:port"`
to set streamlink to use socks proxies for http and https.

Support for SOCKS proxies provided by an extra dependency: `PySocks` via `requests[socks]`.
Fixes #1138.