### PR TITLE
plugins: add priority ordering to plugins

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -42,6 +42,11 @@ FILTER_OPERATORS = {
 
 PARAMS_REGEX = r"(\w+)=({.+?}|\[.+?\]|\(.+?\)|'(?:[^'\\]|\\')*'|\"(?:[^\"\\]|\\\")*\"|\S+)"
 
+HIGH_PRIORITY = 30
+NORMAL_PRIORITY = 20
+LOW_PRIORITY = 10
+NO_PRIORITY = 0
+
 
 def stream_weight(stream):
     for group, weights in QUALITY_WEIGTHS_EXTRA.items():
@@ -217,6 +222,15 @@ class Plugin(object):
             return func
 
         return decorator
+
+    @classmethod
+    def priority(cls, url):
+        """
+        Return the plugin priority for a given URL, by default it returns
+        NORMAL priority.
+        :return: priority level
+        """
+        return NORMAL_PRIORITY
 
     def streams(self, stream_types=None, sorting_excludes=None):
         """Attempts to extract available streams.

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -1,22 +1,44 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params
+from streamlink.plugin.plugin import parse_url_params, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.stream import HDSStream
 from streamlink.utils import update_scheme
+from streamlink.compat import urlparse
 
 
 class HDSPlugin(Plugin):
-    _url_re = re.compile(r"hds://(.+)")
+    _url_re = re.compile(r"(hds://)?(.+(?:\.f4m)?.*)")
+
+    @classmethod
+    def priority(cls, url):
+        """
+        Returns LOW priority if the URL is not prefixed with hds:// but ends with
+        .f4m and return NORMAL priority if the URL is prefixed.
+        :param url: the URL to find the plugin priority for
+        :return: plugin priority for the given URL
+        """
+        m = cls._url_re.match(url)
+        if m:
+            prefix, url = cls._url_re.match(url).groups()
+            url_path = urlparse(url).path
+            if prefix is None and url_path.endswith(".f4m"):
+                return LOW_PRIORITY
+            elif prefix is not None:
+                return NORMAL_PRIORITY
+        return NO_PRIORITY
 
     @classmethod
     def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
+        m = cls._url_re.match(url)
+        if m:
+            url_path = urlparse(m.group(2)).path
+            return m.group(1) is not None or url_path.endswith(".f4m")
 
     def _get_streams(self):
         url, params = parse_url_params(self.url)
 
-        urlnoproto = self._url_re.match(url).group(1)
+        urlnoproto = self._url_re.match(url).group(2)
         urlnoproto = update_scheme("http://", urlnoproto)
 
         return HDSStream.parse_manifest(self.session, urlnoproto, **params)

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -1,21 +1,43 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params
+from streamlink.plugin.plugin import parse_url_params, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
+from streamlink.compat import urlparse
 
 
 class HLSPlugin(Plugin):
-    _url_re = re.compile(r"hls(?:variant)?://(.+)")
+    _url_re = re.compile(r"(hls(?:variant)?://)?(.+(?:\.m3u8)?.*)")
+
+    @classmethod
+    def priority(cls, url):
+        """
+        Returns LOW priority if the URL is not prefixed with hls:// but ends with
+        .m3u8 and return NORMAL priority if the URL is prefixed.
+        :param url: the URL to find the plugin priority for
+        :return: plugin priority for the given URL
+        """
+        m = cls._url_re.match(url)
+        if m:
+            prefix, url = cls._url_re.match(url).groups()
+            url_path = urlparse(url).path
+            if prefix is None and url_path.endswith(".m3u8"):
+                return LOW_PRIORITY
+            elif prefix is not None:
+                return NORMAL_PRIORITY
+        return NO_PRIORITY
 
     @classmethod
     def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
+        m = cls._url_re.match(url)
+        if m:
+            url_path = urlparse(m.group(2)).path
+            return m.group(1) is not None or url_path.endswith(".m3u8")
 
     def _get_streams(self):
         url, params = parse_url_params(self.url)
-        urlnoproto = self._url_re.match(url).group(1)
+        urlnoproto = self._url_re.match(url).group(2)
         urlnoproto = update_scheme("http://", urlnoproto)
 
         self.logger.debug("URL={0}; params={1}", urlnoproto, params)


### PR DESCRIPTION
Plugins can return a priority level for the URLs that they support.
If two plugins match the same URLs then the plugin with the higher priority will be used. This means that the built-in HLS and HDS plugins can support `.m3u8` and `.f4m` URLs with a lower priority without causing issues with overlapping URL patterns.

By default plugins return NORMAL priority for any URL. It is expected that the `priority` method will only be called with URLs that are actually supported by the plugin.

Thoughts? 