### PR TITLE
Resolve issue regarding picarto.tv

### DIFF
--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -88,7 +88,7 @@ class Picarto(Plugin):
                     yield s
                 return
 
-        if "does not exist" in page.text:
+        if "This channel does not exist" in page.text:
             self.logger.error("The channel {0} does not exist".format(page_channel))
             return
 


### PR DESCRIPTION
As mentioned in #1193 the page always contains the string "does not exist". Changing it to compare against the full string on the 404 page fixes the issue.