### PR TITLE
installer: include the socks proxy modules

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -52,7 +52,7 @@ format=bundled
 ;           - certifi
 ;           - idna
 ;           - urllib3
-;           - PySocks
+;           - socks / sockshandler
 ;       - websocket-client
 packages=streamlink
          streamlink_cli
@@ -66,6 +66,8 @@ packages=streamlink
          chardet
          certifi
          websocket
+         socks
+         sockshandler
 pypi_wheels=pycryptodome==3.4.3
 
 files=../win32/LICENSE.txt > \$INSTDIR


### PR DESCRIPTION
Noticed that the PySocks module isn't actually included in the Windows installer version :) The `win-inet-pton` module isn't required as we're using Python 3 for the installer version. 