### PR TITLE
docs: add new line before codeblock to fix them

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -340,6 +340,7 @@ options if the plugin you use makes HTTP and HTTPS requests.
 Both HTTP and SOCKS5 proxies are supported, authentication is supported for both types.
 
 For example:
+
 .. code-block:: console
 
     $ streamlink --http-proxy "http://user:pass@10.10.1.10:3128/" --https-proxy "socks5://10.10.1.10:1242"


### PR DESCRIPTION
Hi,

A codeblock without an empty new line before cause bad docs generation in man and html formats.

This causes a `man` warning: `warning: macro `.' not defined`.
The manpage contains `.. code\-block:: console` which it does not recognize.

In html format, the  generated line is `For example: .. code-block:: console` and the following codeblock is not correctly formatted.

When adding a empty new line before (as this PR does), the docs are correctly generated.
I've not investigated much if this is a sphinx issue or not (as I don't know much reStructuredText language) but this fix docs generation.