### PR TITLE
exit with code 130 after a KeyboardInterrupt

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1043,18 +1043,21 @@ def main():
             setup_options()
             setup_plugin_options()
             handle_url()
-        except KeyboardInterrupt:
+        except KeyboardInterrupt as keyboard_interrupt:
             # Close output
             if output:
                 output.close()
             console.msg("Interrupted! Exiting...")
+            interrupt = keyboard_interrupt
         finally:
             if stream_fd:
                 try:
                     console.logger.info("Closing currently open stream...")
                     stream_fd.close()
+                    if 'interrupt' in locals():
+                        sys.exit(130)
                 except KeyboardInterrupt:
-                    sys.exit()
+                    sys.exit(130)
     elif args.twitch_oauth_authenticate:
         authenticate_twitch_oauth()
     elif args.help:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1030,16 +1030,12 @@ def main():
         try:
             streamlink.resolve_url(args.can_handle_url)
         except NoPluginError:
-            sys.exit(1)
-        else:
-            sys.exit(0)
+            error_code = 1
     elif args.can_handle_url_no_redirect:
         try:
             streamlink.resolve_url_no_redirect(args.can_handle_url_no_redirect)
         except NoPluginError:
-            sys.exit(1)
-        else:
-            sys.exit(0)
+            error_code = 1
     elif args.url:
         try:
             setup_options()
@@ -1058,8 +1054,6 @@ def main():
                     stream_fd.close()
                 except KeyboardInterrupt:
                     error_code = 130
-                finally:
-                    sys.exit(error_code)
     elif args.twitch_oauth_authenticate:
         authenticate_twitch_oauth()
     elif args.help:
@@ -1071,3 +1065,5 @@ def main():
             "read the manual at https://streamlink.github.io"
         ).format(usage=usage)
         console.msg(msg)
+
+    sys.exit(error_code)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1010,6 +1010,8 @@ def check_version(force=False):
 
 
 def main():
+    error_code = 0
+
     setup_args()
     setup_streamlink()
     setup_plugins()
@@ -1043,21 +1045,21 @@ def main():
             setup_options()
             setup_plugin_options()
             handle_url()
-        except KeyboardInterrupt as keyboard_interrupt:
+        except KeyboardInterrupt:
             # Close output
             if output:
                 output.close()
             console.msg("Interrupted! Exiting...")
-            interrupt = keyboard_interrupt
+            error_code = 130
         finally:
             if stream_fd:
                 try:
                     console.logger.info("Closing currently open stream...")
                     stream_fd.close()
-                    if 'interrupt' in locals():
-                        sys.exit(130)
                 except KeyboardInterrupt:
-                    sys.exit(130)
+                    error_code = 130
+                finally:
+                    sys.exit(error_code)
     elif args.twitch_oauth_authenticate:
         authenticate_twitch_oauth()
     elif args.help:


### PR DESCRIPTION
Adds sys.exit(130) where applicable after a KeyboardInterrupt occurs. Notably there are two consecutive KeyboardInterrupt checks; this commit causes a code 130 even if only the first occurs and not the additional "panic" one.

130 is the correct exit code in this case because KeyboardInterrupt causes a SIGINT which has value n=2 and the appropriate exit code is 128+n (see: http://tldp.org/LDP/abs/html/exitcodes.html)

Fixes #1234 