### PR TITLE
Fix sphinx warning on Directive class

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -17,10 +17,10 @@ from collections import namedtuple
 from textwrap import dedent
 
 from docutils import nodes
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged
 from docutils.statemachine import ViewList
 from sphinx.util.nodes import nested_parse_with_titles
-from sphinx.util.compat import Directive
 
 
 _ArgumentParser = argparse.ArgumentParser


### PR DESCRIPTION
Sphinx 1.6 has deprecated `sphinx.util.compat.Directive` and it will be removed in Sphinx 1.7.
Use the class in `docutils` as recommended by Sphinx.

Sphinx warning was:
```
/usr/lib/python3/dist-packages/sphinx/util/compat.py:40: RemovedInSphinx17Warning: sphinx.util.compat.Directive is deprecated and will be removed in Sphinx 1.7, please use docutils' instead.
  RemovedInSphinx17Warning)
```

Detected with Sphinx 1.6.4.
Since Sphinx 1.0b1, sphinx.util.compat.Directive is exactly the one implemented in docutils 0.5+ (https://github.com/sphinx-doc/sphinx/commit/414816bb373379cf1ca8f4b6ef21a329fff1270f#diff-0001522a669602c5402157e0923a3193L40).