### PR TITLE
Handle repeated keys in parse_params

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -149,7 +149,13 @@ def parse_params(params):
         except Exception:
             pass
 
-        rval[key] = value
+        if key in rval:
+            if not isinstance(rval[key], list):
+                rval[key] = [rval[key], value]
+            else:
+                rval[key].append(value)
+        else:
+            rval[key] = value
 
     return rval
 


### PR DESCRIPTION
The conn option for rtmpdump my need to be added multiple depending on the target server, but parse_params overwrites repeated keys with the last value processed. This patch creates and adds values into a list that the function bake in streamprocess.py handles.