### PR TITLE
HLS "Seeking" support

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -52,6 +52,8 @@ class Streamlink(object):
             "hls-segment-timeout": 10.0,
             "hls-timeout": 60.0,
             "hls-playlist-reload-attempts": 3,
+            "hls-offset-start": 0,
+            "hls-offset-end": None,
             "http-stream-timeout": 60.0,
             "ringbuffer-size": 1024 * 1024 * 16,  # 16 MB
             "rtmp-timeout": 60.0,

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -52,8 +52,8 @@ class Streamlink(object):
             "hls-segment-timeout": 10.0,
             "hls-timeout": 60.0,
             "hls-playlist-reload-attempts": 3,
-            "hls-offset-start": 0,
-            "hls-offset-end": None,
+            "hls-start-offset": 0,
+            "hls-duration": None,
             "http-stream-timeout": 60.0,
             "ringbuffer-size": 1024 * 1024 * 16,  # 16 MB
             "rtmp-timeout": 60.0,

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -124,6 +124,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
         self.playlist_reload_retries = self.session.options.get("hls-playlist-reload-attempts")
         self.duration_offset_start = self.session.options.get("hls-offset-start")
         self.duration_offset_end = self.session.options.get("hls-offset-end")
+        self.hls_live_restart = self.stream.force_restart or self.session.options.get("hls-live-restart")
 
         self.reload_playlist()
 
@@ -186,7 +187,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
             self.playlist_end = last_sequence.num
 
         if self.playlist_sequence < 0:
-            if self.playlist_end is None and not self.stream.force_restart:
+            if self.playlist_end is None and not self.hls_live_restart:
                 edge_index = -(min(len(sequences), max(int(self.live_edge), 1)))
                 edge_sequence = sequences[edge_index]
                 self.playlist_sequence = edge_sequence.num

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -208,7 +208,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
         d = 0
         default = -1
 
-        sequences_order = sequences if duration > 0 else reversed(sequences)
+        sequences_order = sequences if duration >= 0 else reversed(sequences)
 
         for sequence in sequences_order:
             if d >= abs(duration):

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -124,7 +124,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
         self.live_edge = self.session.options.get("hls-live-edge")
         self.playlist_reload_retries = self.session.options.get("hls-playlist-reload-attempts")
         self.duration_offset_start = int(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0))
-        self.duration_limit = int(self.session.options.get("hls-duration") or self.stream.duration)
+        self.duration_limit = self.stream.duration or (int(self.session.options.get("hls-duration")) if self.session.options.get("hls-duration") else None)
         self.hls_live_restart = self.stream.force_restart or self.session.options.get("hls-live-restart")
 
         self.reload_playlist()

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -23,6 +23,7 @@ _option_re = re.compile("""
     \s*
     (?P<value>.*) # The value, anything goes.
 """, re.VERBOSE)
+_hours_minutes_seconds_re = re.compile(r"(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)")
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -136,6 +137,23 @@ def boolean(value):
         raise argparse.ArgumentTypeError("{0} was not one of {{{1}}}".format(value, ', '.join(truths+falses)))
 
     return value.lower() in truths
+
+def hours_minutes_seconds(value):
+    """
+    converts hours:minutes:seconds to seconds
+    :param value: hh:mm:ss
+    :return: seconds
+    """
+    match = _hours_minutes_seconds_re.match(value)
+    if not match:
+        raise ValueError
+    s = 0
+    s += int(match.group("hours")) * 60 * 60
+    s += int(match.group("minutes")) * 60
+    s += int(match.group("seconds"))
+
+    return s
+
 
 parser = ArgumentParser(
     fromfile_prefix_chars="@",
@@ -697,6 +715,26 @@ transport.add_argument(
     Timeout for reading data from HLS streams.
 
     Default is 60.0.
+    """)
+transport.add_argument(
+    "--hls-offset-start",
+    type=hours_minutes_seconds,
+    metavar="HH:MM:SS",
+    default=None,
+    help="""
+    Amount of time to skip from the beginning of the stream, VOD streams only.
+
+    Default is 00:00:00.
+    """)
+transport.add_argument(
+    "--hls-offset-end",
+    type=hours_minutes_seconds,
+    metavar="HH:MM:SS",
+    default=None,
+    help="""
+    The time in the stream to end at, VOD streams only.
+
+    Default is END.
     """)
 transport.add_argument(
     "--hls-audio-select",

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -23,7 +23,7 @@ _option_re = re.compile("""
     \s*
     (?P<value>.*) # The value, anything goes.
 """, re.VERBOSE)
-_hours_minutes_seconds_re = re.compile(r"(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)")
+_hours_minutes_seconds_re = re.compile(r"-?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)")
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -137,6 +137,7 @@ def boolean(value):
         raise argparse.ArgumentTypeError("{0} was not one of {{{1}}}".format(value, ', '.join(truths+falses)))
 
     return value.lower() in truths
+
 
 def hours_minutes_seconds(value):
     """
@@ -726,24 +727,28 @@ transport.add_argument(
     Default is 60.0.
     """)
 transport.add_argument(
-    "--hls-offset-start",
+    "--hls-start-offset",
     type=hours_minutes_seconds,
     metavar="HH:MM:SS",
     default=None,
     help="""
-    Amount of time to skip from the beginning of the stream, VOD streams only.
+    Amount of time to skip from the beginning of the stream.
+    For live streams, this is a negative offset from the end of the stream.
 
     Default is 00:00:00.
     """)
 transport.add_argument(
-    "--hls-offset-end",
+    "--hls-duration",
     type=hours_minutes_seconds,
     metavar="HH:MM:SS",
     default=None,
     help="""
-    The time in the stream to end at, VOD streams only.
+    Limit the playback duration, useful for watching segments of a stream. The actual duration may be slightly
+    longer, as it is rounded to the nearest HLS segment.
 
-    Default is END.
+    Has no effect on live streams.
+
+    Default is unlimited.
     """)
 transport.add_argument(
     "--hls-live-restart",

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -708,6 +708,15 @@ transport.add_argument(
     Default is 10.0.
     """)
 transport.add_argument(
+    "--hls-audio-select",
+    type=str,
+    metavar="CODE",
+    help="""
+    Selects a specific audio source, by language code, when multiple audio sources are available.
+
+    Note: This is only useful in special circumstances where the regular locale option fails.
+    """)
+transport.add_argument(
     "--hls-timeout",
     type=num(float, min=0),
     metavar="TIMEOUT",
@@ -737,15 +746,10 @@ transport.add_argument(
     Default is END.
     """)
 transport.add_argument(
-    "--hls-audio-select",
-    type=str,
-    metavar="CODE",
+    "--hls-live-restart",
+    action="store_true",
     help="""
-    Selects a specific audio source by language code
-    when multiple audio sources are available.
-
-    Note: This is only useful in special circumstances
-    where the regular locale option fails.
+    Skip to the beginning of a live stream, or as far back as possible.
     """)
 transport.add_argument(
     "--http-stream-timeout",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -721,11 +721,11 @@ def setup_options():
     if args.hls_audio_select:
         streamlink.set_option("hls-audio-select", args.hls_audio_select)
 
-    if args.hls_offset_start:
-        streamlink.set_option("hls-offset-start", args.hls_offset_start)
+    if args.hls_start_offset:
+        streamlink.set_option("hls-start-offset", args.hls_start_offset)
 
-    if args.hls_offset_end:
-        streamlink.set_option("hls-offset-end", args.hls_offset_end)
+    if args.hls_duration:
+        streamlink.set_option("hls-duration", args.hls_duration)
 
     if args.hls_live_restart:
         streamlink.set_option("hls-live-restart", args.hls_live_restart)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -727,6 +727,9 @@ def setup_options():
     if args.hls_offset_end:
         streamlink.set_option("hls-offset-end", args.hls_offset_end)
 
+    if args.hls_live_restart:
+        streamlink.set_option("hls-live-restart", args.hls_live_restart)
+
     if args.hds_live_edge:
         streamlink.set_option("hds-live-edge", args.hds_live_edge)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -721,6 +721,12 @@ def setup_options():
     if args.hls_audio_select:
         streamlink.set_option("hls-audio-select", args.hls_audio_select)
 
+    if args.hls_offset_start:
+        streamlink.set_option("hls-offset-start", args.hls_offset_start)
+
+    if args.hls_offset_end:
+        streamlink.set_option("hls-offset-end", args.hls_offset_end)
+
     if args.hds_live_edge:
         streamlink.set_option("hds-live-edge", args.hds_live_edge)
 


### PR DESCRIPTION
It's not really seeking because you can only skip the beginning and end of the streams, but it should go some way to bridging the gap between no seeking and full seeking support. The seeking support is also added to the HLSStream API - which I added for forthcoming plugins. 

I don't expect this to be merged right away, but rather I'm opening it now because it's been in the works and on-hold for a while and I'd like some feedback.