### PR TITLE
setup: fix PySocks module dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 
+import os
 from os import environ
 from os.path import abspath, dirname, join
 from setuptools import setup, find_packages
 from sys import version_info, path as sys_path
-import warnings
 
 deps = []
 
@@ -47,7 +47,12 @@ else:
 deps.append("websocket-client")
 
 # Support for SOCKS proxies
-deps.append("requests[socks]")
+deps.append("PySocks!=1.5.7,>=1.5.6")  # requests[socks] uses this version
+
+# win-inet-pton is missing a dependency in PySocks, this has been fixed but not released yet
+if os.name == "nt" and version_info < (3, 0):
+    # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
+    deps.append("win-inet-pton")
 
 # When we build an egg for the Win32 bootstrap we don't want dependency
 # information built into it.


### PR DESCRIPTION
Include `PySocks` instead of `requests[socks]`, due to a pip bug. Also include the `win-inet-pton` module for old versions of Python on Windows.

As discussed in #1291, should fix #1316 (see #1240, #1217, #1219).