### PR TITLE
EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 matrix:
   include:
   - python: '2.7'
-  - python: '3.3'
   - python: '3.4'
   - python: '3.5'
     env: BUILD_DOCS=yes BUILD_INSTALLER=yes STREAMLINK_INSTALLER_DIST_DIR=$TRAVIS_BUILD_DIR/dist/nsis

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,10 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python27"
-    - PYTHON: "C:\\Python33"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python27-x64"
-    - PYTHON: "C:\\Python33-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -158,7 +158,7 @@ To install Streamlink from source you will need these dependencies.
 ==================================== ===========================================
 Name                                 Notes
 ==================================== ===========================================
-`Python`_                            At least version **2.7** or **3.3**.
+`Python`_                            At least version **2.7** or **3.4**.
 `python-setuptools`_
 
 **Automatically installed by the setup script**


### PR DESCRIPTION
Remove Python 3.3 from the automated testing on travis and appveyor.

fixes #1348 and the build issues with #1345 