### PR TITLE
plugins.kanal7: update to stream player URL config

### DIFF
--- a/src/streamlink/plugins/kanal7.py
+++ b/src/streamlink/plugins/kanal7.py
@@ -11,7 +11,7 @@ from streamlink.stream import HLSStream
 class Kanal7(Plugin):
     url_re = re.compile(r"https?://(?:www.)?kanal7.com/canli-izle")
     iframe_re = re.compile(r'iframe .*?src="(http://[^"]*?)"')
-    stream_re = re.compile(r'src="(http[^"]*?)"')
+    stream_re = re.compile(r'''tp_file\s+=\s+['"](http[^"]*?)['"]''')
 
     @classmethod
     def can_handle_url(cls, url):


### PR DESCRIPTION
They changed the way the player is setup to get the streaming URL.

Fixes #1350 