### PR TITLE
[plugins.pluzz] Fix video ID regex for France 3 Régions streams

### DIFF
--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -18,7 +18,7 @@ class Pluzz(Plugin):
     _url_re = re.compile(r'https?://((?:www)\.france\.tv/.+\.html|www\.(ludo|zouzous)\.fr/heros/[\w-]+|(sport|france3-regions)\.francetvinfo\.fr/.+?/(tv/direct)?)')
     _pluzz_video_id_re = re.compile(r'data-main-video="(?P<video_id>.+?)"')
     _jeunesse_video_id_re = re.compile(r'playlist: \[{.*?,"identity":"(?P<video_id>.+?)@(?P<catalogue>Ludo|Zouzous)"')
-    _f3_regions_video_id_re = re.compile(r'"http://videos\.francetv\.fr/video/(?P<video_id>.+)@Regions"')
+    _f3_regions_video_id_re = re.compile(r'"http://videos\.francetv\.fr/video/(?P<video_id>.+?)@Regions"')
     _sport_video_id_re = re.compile(r'data-video="(?P<video_id>.+?)"')
     _player_re = re.compile(r'src="(?P<player>//staticftv-a\.akamaihd\.net/player/jquery\.player.+?-[0-9a-f]+?\.js)"></script>')
     _swf_re = re.compile(r'//staticftv-a\.akamaihd\.net/player/bower_components/player_flash/dist/FranceTVNVPVFlashPlayer\.akamai-[0-9a-f]+\.swf')


### PR DESCRIPTION
This PR fixes broken support for France 3 Régions streams:

```
$ /usr/bin/streamlink http://france3-regions.francetvinfo.fr/bourgogne-franche-comte/tv/direct/franche-comte
[cli][info] Found matching plugin pluzz for URL http://france3-regions.francetvinfo.fr/bourgogne-franche-comte/tv/direct/franche-comte
error: Unable to open URL: http://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion=SIM_franche_comte@Regions"></a><div id="lavideo"></div></div><div class="emission-direct-container"><div class="emission-horaire fr3r-livetv-infos"> <span class="tab-hour text-light fr3r-livetv-program-time"></span><p class="tab-emission-title text-medium fr3r-livetv-program-name"> <a href="http://videos.francetv.fr/video/SIM_franche_comte (403 Client Error: Forbidden for url: http://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion=SIM_franche_comte@Regions%22%3E%3C/a%3E%3Cdiv%20id=%22lavideo%22%3E%3C/div%3E%3C/div%3E%3Cdiv%20class=%22emission-direct-container%22%3E%3Cdiv%20class=%22emission-horaire%20fr3r-livetv-infos%22%3E%20%3Cspan%20class=%22tab-hour%20text-light%20fr3r-livetv-program-time%22%3E%3C/span%3E%3Cp%20class=%22tab-emission-title%20text-medium%20fr3r-livetv-program-name%22%3E%20%3Ca%20href=%22http://videos.francetv.fr/video/SIM_franche_comte)
```