### PR TITLE
plugins.huya: fix stream URL scheme prefix

### DIFF
--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -1,11 +1,10 @@
 import re
 
-from requests.adapters import HTTPAdapter
-
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HLSStream
 from streamlink.plugin.api import useragents
+from streamlink.utils import update_scheme
 
 HUYA_URL = "http://m.huya.com/%s"
 
@@ -13,17 +12,18 @@ _url_re = re.compile(r'http(s)?://(www\.)?huya.com/(?P<channel>[^/]+)', re.VERBO
 _hls_re = re.compile(r'^\s*<video\s+id="html5player-video"\s+src="(?P<url>[^"]+)"', re.MULTILINE)
 
 _hls_schema = validate.Schema(
-        validate.all(
-            validate.transform(_hls_re.search),
-            validate.any(
-                None,
-                validate.all(
-                    validate.get('url'),
-                    validate.transform(str)
-                    )
-                )
+    validate.all(
+        validate.transform(_hls_re.search),
+        validate.any(
+            None,
+            validate.all(
+                validate.get('url'),
+                validate.transform(str)
             )
         )
+    )
+)
+
 
 class Huya(Plugin):
     @classmethod
@@ -35,9 +35,10 @@ class Huya(Plugin):
         channel = match.group("channel")
 
         http.headers.update({"User-Agent": useragents.IPAD})
-        #Some problem with SSL on huya.com now, do not use https
+        # Some problem with SSL on huya.com now, do not use https
 
         hls_url = http.get(HUYA_URL % channel, schema=_hls_schema)
-        yield "live", HLSStream(self.session, hls_url)
+        yield "live", HLSStream(self.session, update_scheme("http://", hls_url))
+
 
 __plugin__ = Huya


### PR DESCRIPTION
Fixes #1364 by setting the stream URL to `http` if no scheme is given, eg. `//`. 