### PR TITLE
[cli-debug] Show current installed versions with -l debug

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -29,14 +29,17 @@
 2. ...
 3. ...
 
-### Environment details
+### Logs
 
-Operating system and version: ...
-Streamlink and Python version: ...
+_Logs are always required for bugs, use `-l debug` [(help)](https://streamlink.github.io/cli.html#cmdoption-l)
+Make sure to **remove username and password** from it.
+For the log use https://gist.github.com/ or_
 
-...
+```
+REPLACE THIS TEXT WITH YOUR LOG
+```
 
-### Comments, logs, screenshots, etc.
+### Comments, screenshots, etc.
 
 ...
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -31,9 +31,9 @@
 
 ### Logs
 
-_Logs are always required for bugs, use `-l debug` [(help)](https://streamlink.github.io/cli.html#cmdoption-l)
-Make sure to **remove username and password** from it.
-For the log use https://gist.github.com/ or_
+_Logs are always required for a bug report, use `-l debug` [(help)](https://streamlink.github.io/cli.html#cmdoption-l)
+Make sure to **remove username and password**
+You can upload your logs to https://gist.github.com/ or_
 
 ```
 REPLACE THIS TEXT WITH YOUR LOG

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import platform
 import requests
 import sys
 import signal
@@ -9,8 +10,11 @@ from contextlib import closing
 from distutils.version import StrictVersion
 from functools import partial
 from itertools import chain
+from socks import __version__ as socks_version
 from time import sleep
+from websocket import __version__ as websocket_version
 
+from streamlink import __version__ as streamlink_version
 from streamlink import (Streamlink, StreamError, PluginError,
                         NoPluginError)
 from streamlink.cache import Cache
@@ -984,6 +988,26 @@ def check_root():
             console.logger.info("streamlink is running as root! Be careful!")
 
 
+def check_current_versions():
+    """Show current installed versions"""
+    if args.loglevel == "debug":
+        # MAC OS X
+        if sys.platform == "darwin":
+            os_version = "macOS {0}".format(platform.mac_ver()[0])
+        # Windows
+        elif sys.platform.startswith("win"):
+            os_version = "{0} {1}".format(platform.system(), platform.release())
+        # linux / other
+        else:
+            os_version = platform.platform()
+
+        console.logger.debug("OS:         {0}".format(os_version))
+        console.logger.debug("Python:     {0}".format(platform.python_version()))
+        console.logger.debug("Streamlink: {0}".format(streamlink_version))
+        console.logger.debug("Requests({0}), Socks({1}), Websocket({2})".format(
+            requests.__version__, socks_version, websocket_version))
+
+
 def check_version(force=False):
     cache = Cache(filename="cli.json")
     latest_version = cache.get("latest_version")
@@ -1023,6 +1047,7 @@ def main():
     setup_console()
     setup_http_session()
     check_root()
+    check_current_versions()
 
     if args.version_check or (not args.no_version_check and args.auto_version_check):
         with ignored(Exception):

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -988,7 +988,7 @@ def check_root():
             console.logger.info("streamlink is running as root! Be careful!")
 
 
-def check_current_versions():
+def log_current_versions():
     """Show current installed versions"""
     if args.loglevel == "debug":
         # MAC OS X
@@ -1047,7 +1047,7 @@ def main():
     setup_console()
     setup_http_session()
     check_root()
-    check_current_versions()
+    log_current_versions()
 
     if args.version_check or (not args.no_version_check and args.auto_version_check):
         with ignored(Exception):


### PR DESCRIPTION
Maybe not exactly what was requested,
but this won't break any third party applications

_Example:_

```
[cli][debug] OS:         Linux-4.14.4-1-ARCH-x86_64-with-arch
[cli][debug] Python:     3.6.3
[cli][debug] Streamlink: 0.9.0
[cli][debug] Requests(2.18.4), Socks(1.6.7), Websocket(0.44.0)
```
Fixed https://github.com/streamlink/streamlink/issues/1323