### PR TITLE
New option to limit the number of fetch retries

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -541,8 +541,23 @@ stream.add_argument(
     metavar="DELAY",
     type=num(float, min=0),
     help="""
-    Will retry fetching streams until streams are found while
-    waiting DELAY (seconds) between each attempt.
+    Retry fetching the list of available streams until streams are found
+    while waiting DELAY second(s) between each attempt. If unset, only one
+    attempt will be made to fetch the list of streams available.
+
+    The number of fetch retry attempts can be capped with --retry-max.
+    """
+)
+stream.add_argument(
+    "--retry-max",
+    metavar="COUNT",
+    type=num(int, min=-1),
+    help="""
+    When using --retry-streams, stop retrying the fetch after COUNT retry
+    attempt(s). Fetch will retry infinitely if COUNT is zero or unset.
+
+    If --retry-max is set without setting --retry-streams, the delay between
+    retries will default to 1 second.
     """
 )
 stream.add_argument(
@@ -551,7 +566,8 @@ stream.add_argument(
     type=num(int, min=0),
     default=1,
     help="""
-    Will try ATTEMPTS times to open the stream until giving up.
+    After a successful fetch, try ATTEMPTS time(s)
+    to open the stream until giving up.
 
     Default is 1.
     """

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -402,8 +402,9 @@ def fetch_streams(plugin):
                               sorting_excludes=args.stream_sorting_excludes)
 
 
-def fetch_streams_infinite(plugin, interval):
-    """Attempts to fetch streams until some are returned."""
+def fetch_streams_with_retry(plugin, interval, count):
+    """Attempts to fetch streams repeatedly
+       until some are returned or limit hit."""
 
     try:
         streams = fetch_streams(plugin)
@@ -414,6 +415,8 @@ def fetch_streams_infinite(plugin, interval):
     if not streams:
         console.logger.info("Waiting for streams, retrying every {0} "
                             "second(s)", interval)
+    attempts = 0
+
     while not streams:
         sleep(interval)
 
@@ -421,6 +424,11 @@ def fetch_streams_infinite(plugin, interval):
             streams = fetch_streams(plugin)
         except PluginError as err:
             console.logger.error(u"{0}", err)
+
+        if count > 0:
+            attempts += 1
+            if attempts >= count:
+                break
 
     return streams
 
@@ -484,8 +492,15 @@ def handle_url():
         console.logger.info("Found matching plugin {0} for URL {1}",
                             plugin.module, args.url)
 
-        if args.retry_streams:
-            streams = fetch_streams_infinite(plugin, args.retry_streams)
+        if args.retry_max or args.retry_streams:
+            retry_streams = 1
+            retry_max = 0
+            if args.retry_streams:
+                retry_streams = args.retry_streams
+            if args.retry_max:
+                retry_max = args.retry_max
+            streams = fetch_streams_with_retry(plugin, retry_streams,
+                                               retry_max)
         else:
             streams = fetch_streams(plugin)
     except NoPluginError:


### PR DESCRIPTION
Sometimes I want to launch streamlink before a stream has gone live. The --retry-streams argument lets me loop until the stream starts, but there was no way to tell it to give up after a while. I've added a new argument, --retry-fetch-max, to make streamlink only try N fetch retries before giving up.

I also reworded the documentation for --retry-streams and --retry-open, since I had gotten confused and thought that --retry-open did what I've now done with --retry-fetch-max.

Suggestions / criticisms welcome. I was thinking about implementing an exponential backoff, but I figured I'd keep it simple for now.