### PR TITLE
[canalplus] Update plugin according to website changes

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -43,7 +43,8 @@ brittv              brittv.co.uk         Yes   --
 btv                 btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
 cam4                cam4.com             Yes   No
 camsoda             camsoda.com          Yes   No
-canalplus           mycanal.fr           No    Yes   Streams may be geo-restricted to France.
+canalplus           - mycanal.fr         No    Yes   Streams may be geo-restricted to France.
+                    - cnews.fr
 canlitv             - canlitv.com        Yes   --
                     - canlitv.life
                     - canlitvlive.co

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -43,10 +43,7 @@ brittv              brittv.co.uk         Yes   --
 btv                 btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
 cam4                cam4.com             Yes   No
 camsoda             camsoda.com          Yes   No
-canalplus           - canalplus.fr       Yes   Yes   Streams may be geo-restricted to France.
-                    - c8.fr
-                    - cstar.fr
-                    - cnews.fr
+canalplus           mycanal.fr           No    Yes   Streams may be geo-restricted to France.
 canlitv             - canlitv.com        Yes   --
                     - canlitv.life
                     - canlitvlive.co

--- a/tests/test_plugin_canalplus.py
+++ b/tests/test_plugin_canalplus.py
@@ -6,7 +6,6 @@ from streamlink.plugins.canalplus import CanalPlus
 class TestPluginCanalPlus(unittest.TestCase):
     def test_can_handle_url(self):
         # should match
-        self.assertTrue(CanalPlus.can_handle_url("http://www.canalplus.fr/emissions/pid8596-the-tonight-show.html"))
         self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/docus-infos/l-info-du-vrai-du-13-12-politique-les-affaires-reprennent/p/1473830"))
         self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/sport/infosport-laurey-et-claudia/p/1473752"))
         self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/docus-infos/ses-debuts-a-madrid-extrait-le-k-benzema/p/1469050"))

--- a/tests/test_plugin_canalplus.py
+++ b/tests/test_plugin_canalplus.py
@@ -6,20 +6,11 @@ from streamlink.plugins.canalplus import CanalPlus
 class TestPluginCanalPlus(unittest.TestCase):
     def test_can_handle_url(self):
         # should match
-        self.assertTrue(CanalPlus.can_handle_url("http://www.canalplus.fr/pid3580-live-tv-clair.html"))
         self.assertTrue(CanalPlus.can_handle_url("http://www.canalplus.fr/emissions/pid8596-the-tonight-show.html"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.canalplus.fr/c-divertissement/pid1787-c-groland.html?vid=1430239"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.c8.fr/pid5323-c8-live.html"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.c8.fr/c8-divertissement/pid8758-c8-la-folle-histoire-de-sophie-marceau.html"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.c8.fr/c8-sport/pid5224-c8-direct-auto.html?vid=1430292"))
-        self.assertTrue(CanalPlus.can_handle_url("http://replay.c8.fr/video/1431076"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.cstar.fr/pid5322-cstar-live.html"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.cstar.fr/emissions/pid8754-wild-transport.html"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.cstar.fr/musique/pid6282-les-tops.html?vid=1430143"))
-        self.assertTrue(CanalPlus.can_handle_url("http://replay.cstar.fr/video/1430245"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.cnews.fr/direct"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.cnews.fr/politique/video/des-electeurs-toujours-autant-indecis-174769"))
-        self.assertTrue(CanalPlus.can_handle_url("http://www.cnews.fr/magazines/plus-de-recul/de-recul-du-14042017-174594"))
+        self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/docus-infos/l-info-du-vrai-du-13-12-politique-les-affaires-reprennent/p/1473830"))
+        self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/sport/infosport-laurey-et-claudia/p/1473752"))
+        self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/docus-infos/ses-debuts-a-madrid-extrait-le-k-benzema/p/1469050"))
+        self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/d8-docs-mags/au-revoir-johnny-hallyday-le-doc/p/1473054"))
 
         # shouldn't match
         self.assertFalse(CanalPlus.can_handle_url("http://www.canalplus.fr/"))

--- a/tests/test_plugin_canalplus.py
+++ b/tests/test_plugin_canalplus.py
@@ -10,7 +10,9 @@ class TestPluginCanalPlus(unittest.TestCase):
         self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/sport/infosport-laurey-et-claudia/p/1473752"))
         self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/docus-infos/ses-debuts-a-madrid-extrait-le-k-benzema/p/1469050"))
         self.assertTrue(CanalPlus.can_handle_url("https://www.mycanal.fr/d8-docs-mags/au-revoir-johnny-hallyday-le-doc/p/1473054"))
-
+        self.assertTrue(CanalPlus.can_handle_url("http://www.cnews.fr/direct"))
+        self.assertTrue(CanalPlus.can_handle_url("http://www.cnews.fr/politique/video/des-electeurs-toujours-autant-indecis-174769"))
+        self.assertTrue(CanalPlus.can_handle_url("http://www.cnews.fr/magazines/plus-de-recul/de-recul-du-14042017-174594"))
         # shouldn't match
         self.assertFalse(CanalPlus.can_handle_url("http://www.canalplus.fr/"))
         self.assertFalse(CanalPlus.can_handle_url("http://www.c8.fr/"))


### PR DESCRIPTION
	C+ has centralized its replay services in mycanal.fr, and remove the old ones (c8.fr, cstar.fr).
	Due to changes, this plugin cannot handle live url (for the moment).