### PR TITLE
[Pandatv] use http instead of https

### DIFF
--- a/src/streamlink/plugins/pandatv.py
+++ b/src/streamlink/plugins/pandatv.py
@@ -10,9 +10,9 @@ from streamlink.stream import HTTPStream
 
 ROOM_API = "https://www.panda.tv/api_room_v3?token=&hostid={0}&roomid={1}&roomkey={2}&_={3}&param={4}&time={5}&sign={6}"
 ROOM_API_V2 = "https://www.panda.tv/api_room_v21?token=&roomid={0}&_={1}"
-SD_URL_PATTERN = "https://pl{0}.live.panda.tv/live_panda/{1}.flv?sign={2}&ts={3}&rid={4}"
-HD_URL_PATTERN = "https://pl{0}.live.panda.tv/live_panda/{1}_mid.flv?sign={2}&ts={3}&rid={4}"
-OD_URL_PATTERN = "https://pl{0}.live.panda.tv/live_panda/{1}_small.flv?sign={2}&ts={3}&rid={4}"
+SD_URL_PATTERN = "http://pl{0}.live.panda.tv/live_panda/{1}.flv?sign={2}&ts={3}&rid={4}"
+HD_URL_PATTERN = "http://pl{0}.live.panda.tv/live_panda/{1}_mid.flv?sign={2}&ts={3}&rid={4}"
+OD_URL_PATTERN = "http://pl{0}.live.panda.tv/live_panda/{1}_small.flv?sign={2}&ts={3}&rid={4}"
 
 _url_re = re.compile(r"http(s)?://(\w+.)?panda.tv/(?P<channel>[^/&?]+)")
 _room_id_re = re.compile(r'data-room-id="(\d+)"')
@@ -54,7 +54,6 @@ class Pandatv(Plugin):
         match = _url_re.match(self.url)
         channel = match.group("channel")
 
-        http.verify = False
         res = http.get(self.url)
 
         try:

--- a/src/streamlink/plugins/pandatv.py
+++ b/src/streamlink/plugins/pandatv.py
@@ -9,7 +9,7 @@ from streamlink.plugin.api import http, validate
 from streamlink.stream import HTTPStream
 
 ROOM_API = "https://www.panda.tv/api_room_v3?token=&hostid={0}&roomid={1}&roomkey={2}&_={3}&param={4}&time={5}&sign={6}"
-ROOM_API_V2 = "https://www.panda.tv/api_room_v2?roomid={0}&_={1}"
+ROOM_API_V2 = "https://www.panda.tv/api_room_v21?token=&roomid={0}&_={1}"
 SD_URL_PATTERN = "https://pl{0}.live.panda.tv/live_panda/{1}.flv?sign={2}&ts={3}&rid={4}"
 HD_URL_PATTERN = "https://pl{0}.live.panda.tv/live_panda/{1}_mid.flv?sign={2}&ts={3}&rid={4}"
 OD_URL_PATTERN = "https://pl{0}.live.panda.tv/live_panda/{1}_small.flv?sign={2}&ts={3}&rid={4}"
@@ -54,6 +54,7 @@ class Pandatv(Plugin):
         match = _url_re.match(self.url)
         channel = match.group("channel")
 
+        http.verify = False
         res = http.get(self.url)
 
         try:
@@ -75,7 +76,7 @@ class Pandatv(Plugin):
             hd = _hd_re.search(res.text).group(1)
             od = _od_re.search(res.text).group(1)
         except AttributeError:
-            self.logger.info("Not a valid room url.")
+            self.logger.info("API error, please create a new issue.")
             return
 
         if status != '2':
@@ -89,19 +90,19 @@ class Pandatv(Plugin):
         room = http.get(url)
         data = http.json(room, schema=_room_schema)
         if not isinstance(data, dict):
-            self.logger.info("Please Check PandaTV Room API")
+            self.logger.info("API error, please create a new issue.")
             return
 
         videoinfo = data.get('videoinfo')
         plflag_list = videoinfo.get('plflag_list')
         if not videoinfo or not plflag_list:
-            self.logger.info("Please Check PandaTV Room API")
+            self.logger.info("API error, please create a new issue.")
             return
 
         streams = {}
         plflag = videoinfo.get('plflag')
         if not plflag or '_' not in plflag:
-            self.logger.info("Please Check PandaTV Room API")
+            self.logger.info("API error, please create a new issue.")
             return
 
         plflag_list = json.loads(plflag_list)
@@ -120,7 +121,7 @@ class Pandatv(Plugin):
         try:
             plflag1 = [i for i in plflag0 if i in lines][0]
         except IndexError:
-            plflag1 = plflag0[0]
+            plflag1 = plflag0[::-1][0]
 
         if sd == '1':
             streams['ehq'] = HTTPStream(self.session, SD_URL_PATTERN.format(plflag1, room_key, sign, ts, rid))


### PR DESCRIPTION
Use http instead of https, because the SSL certificate is self-signed by third party. [ref: PEP 476](https://www.python.org/dev/peps/pep-0476/)
[Check pl30.live.panda.tv SSL Certificate Verify](https://sslanalyzer.comodoca.com/?url=pl30.live.panda.tv)
[Check pl29.live.panda.tv SSL Certificate Verify](https://sslanalyzer.comodoca.com/?url=pl29.live.panda.tv)
```
[cli][info] Found matching plugin pandatv for URL https://www.panda.tv/35723
[cli][info] Available streams: hq (worst), ehq (best)
[cli][info] Opening stream: ehq (http)
[cli][error] Try 1/1: Could not open stream <HTTPStream('https://pl30.live.panda.tv/live_panda/98136e97f549e01b24095ad85bbeb12f.flv?sign=8d00a9bbbf6a30738cf3f15aba5cd3a8&ts=5a3e6f6e&rid=-8654221')> (Could not open stream: Unable to open URL: https://pl30.live.panda.tv/live_panda/98136e97f549e01b24095ad85bbeb12f.flv?sign=8d00a9bbbf6a30738cf3f15aba5cd3a8&ts=5a3e6f6e&rid=-8654221 ([SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:719)))
error: Could not open stream <HTTPStream('https://pl30.live.panda.tv/live_panda/98136e97f549e01b24095ad85bbeb12f.flv?sign=8d00a9bbbf6a30738cf3f15aba5cd3a8&ts=5a3e6f6e&rid=-8654221')>, tried 1 times, exiting
pipe:: could not find codec parameters
```