### PR TITLE
Fix various typos in comments and documentation

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -222,10 +222,10 @@ instead.
     Installing streamlink into the environment
     (myenv)$ pip install streamlink
 
-    Using streamlink in the enviroment
+    Using streamlink in the environment
     (myenv)$ streamlink ...
 
-    Deactivating the enviroment
+    Deactivating the environment
     (myenv)$ deactivate
 
     Using streamlink without activating the environment

--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -9,7 +9,7 @@ Following channels are working:
     * CT Decko - http://decko.ceskatelevize.cz/zive/
     * CT Art - http://www.ceskatelevize.cz/art/zive/
 
-Additionaly, videos from iVysilani archive should work as well.
+Additionally, videos from iVysilani archive should work as well.
 """
 import re
 

--- a/src/streamlink/plugins/huomao.py
+++ b/src/streamlink/plugins/huomao.py
@@ -7,7 +7,7 @@ When viewing a stream on huomao.com, the base URL references a room_id. This
 room_id is mapped one-to-one to a stream_id which references the actual .flv
 video. Both stream_id, stream_url and stream_quality can be found in the
 HTML and JS source of the mobile_page. Since one stream can occur in many
-different qualities, we scrape all stream_url and stream_quality occurences
+different qualities, we scrape all stream_url and stream_quality occurrences
 and return each option to the user.
 """
 
@@ -68,7 +68,7 @@ class Huomao(Plugin):
         """Returns a nested list of different stream options.
 
         Each entry in the list will contain a stream_url, stream_quality_url
-        and stream_quality_name for each stream occurence that was found in
+        and stream_quality_name for each stream occurrence that was found in
         the JS.
         """
         stream_info = stream_info_pattern.findall(html)

--- a/src/streamlink/plugins/media_ccc_de.py
+++ b/src/streamlink/plugins/media_ccc_de.py
@@ -103,7 +103,7 @@ def parse_media_json(json_object):
 
 
 def parse_streaming_media_json(json_object, room_from_url):
-    """Filter all availabe live streams for given json and room name.
+    """Filter all available live streams for given json and room name.
 
     API-Doku: https://github.com/voc/streaming-website#json-api
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -147,7 +147,7 @@ parser = ArgumentParser(
     various services and pipes them into a video player of choice.
     """),
     epilog=dedent("""
-    For more in-depth documention see:
+    For more in-depth documentation see:
       https://streamlink.github.io
 
     Please report broken plugins or bugs to the issue tracker on Github:


### PR DESCRIPTION
These typos were detected using `codespell` tool when running `check-all-the-things`.