### PR TITLE
build: use pynsist<2 to build the windows installer

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,5 @@ pytest-cov
 codecov
 coverage
 mock
-pynsist
+pynsist<2
 unittest2; python_version < '2.7'


### PR DESCRIPTION
There is currently no way to change the install location from the
per-user location to the global location when using pynist>=2. pynist
1.x uses the global install location.

fixes #1340