### PR TITLE
[orf_tvthek] Work around broken HTTP connection persistence

### DIFF
--- a/src/streamlink/plugins/orf_tvthek.py
+++ b/src/streamlink/plugins/orf_tvthek.py
@@ -47,7 +47,8 @@ class ORFTVThek(Plugin):
             except KeyError:
                 continue
             stream = HLSStream.parse_variant_playlist(self.session, url)
-            self.session.new_http_session()
+            # work around broken HTTP connection persistence by acquiring a new connection
+            http.close()
             streams.update(stream)
 
         return streams

--- a/src/streamlink/plugins/orf_tvthek.py
+++ b/src/streamlink/plugins/orf_tvthek.py
@@ -47,6 +47,7 @@ class ORFTVThek(Plugin):
             except KeyError:
                 continue
             stream = HLSStream.parse_variant_playlist(self.session, url)
+            self.session.new_http_session()
             streams.update(stream)
 
         return streams

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -454,9 +454,6 @@ class Streamlink(object):
         if file:
             file.close()
 
-    def new_http_session(self):
-        self.http.close()
-
     @property
     def version(self):
         return __version__

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -454,6 +454,9 @@ class Streamlink(object):
         if file:
             file.close()
 
+    def new_http_session(self):
+        self.http.close()
+
     @property
     def version(self):
         return __version__


### PR DESCRIPTION
The server hosting the HLS playlists for tvthek.orf.at does not respect HTTP connection persistence. It closes the connection after a second request is made instead of responding to the request, making streamlink crash with an error while stream sources are collected.

This pull request adds a function to swap out an existing HTTP session for a new one to the Streamlink session object, and calls this function in the appropriate place to have stream enumeration succeed in the orf_tvthek plugin.