### PR TITLE
[hls] New option --hls-segment-ignore-names

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -1,3 +1,4 @@
+import re
 import struct
 from collections import defaultdict, namedtuple
 
@@ -35,11 +36,19 @@ class HLSStreamWriter(SegmentedStreamWriter):
         kwargs["retries"] = options.get("hls-segment-attempts")
         kwargs["threads"] = options.get("hls-segment-threads")
         kwargs["timeout"] = options.get("hls-segment-timeout")
+        kwargs["ignore_names"] = options.get("hls-segment-ignore-names")
         SegmentedStreamWriter.__init__(self, reader, *args, **kwargs)
 
         self.byterange_offsets = defaultdict(int)
         self.key_data = None
         self.key_uri = None
+        if self.ignore_names:
+            # creates a regex from a list of segment names,
+            # this will be used to ignore segments.
+            self.ignore_names = list(set(self.ignore_names))
+            self.ignore_names = "|".join(list(map(re.escape, self.ignore_names)))
+            self.ignore_names_re = re.compile(r"(?:{blacklist})\.ts".format(
+                    blacklist=self.ignore_names),  re.IGNORECASE)
 
     def create_decryptor(self, key, sequence):
         if key.method != "AES-128":
@@ -86,6 +95,11 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
         try:
             request_params = self.create_request_params(sequence)
+            # skip ignored segment names
+            if self.ignore_names and self.ignore_names_re.search(sequence.segment.uri):
+                self.logger.debug("Skipping segment {0}".format(sequence.num))
+                return
+
             return self.session.http.get(sequence.segment.uri,
                                          timeout=self.timeout,
                                          exception=StreamError,

--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -68,7 +68,7 @@ class SegmentedStreamWriter(Thread):
     and finally writing the data to the buffer.
     """
 
-    def __init__(self, reader, size=20, retries=None, threads=None, timeout=None):
+    def __init__(self, reader, size=20, retries=None, threads=None, timeout=None, ignore_names=None):
         self.closed = False
         self.reader = reader
         self.stream = reader.stream
@@ -86,6 +86,7 @@ class SegmentedStreamWriter(Thread):
 
         self.retries = retries
         self.timeout = timeout
+        self.ignore_names = ignore_names
         self.executor = futures.ThreadPoolExecutor(max_workers=threads)
         self.futures = queue.Queue(size)
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -709,6 +709,22 @@ transport.add_argument(
     Default is 10.0.
     """)
 transport.add_argument(
+    "--hls-segment-ignore-names",
+    metavar="NAMES",
+    type=comma_list,
+    help="""
+    A comma-delimited list of segment names that will not be fetched.
+
+    Example: --hls-segment-ignore-names 000,001,002
+
+    This will ignore every segment that ends with 000.ts, 001.ts and 002.ts
+
+    Default is None.
+
+    Note: The --hls-timeout must be increased, to a time that is longer than the ignored break.
+    """
+)
+transport.add_argument(
     "--hls-audio-select",
     type=str,
     metavar="CODE",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -719,6 +719,9 @@ def setup_options():
     if args.hls_segment_timeout:
         streamlink.set_option("hls-segment-timeout", args.hls_segment_timeout)
 
+    if args.hls_segment_ignore_names:
+        streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
+
     if args.hls_timeout:
         streamlink.set_option("hls-timeout", args.hls_timeout)
 


### PR DESCRIPTION
You can **ignore segment** names that might **corrupt** or **lag** your output

- this will freeze the player until there is a valid segment name
- this will not add the segment to an output file,
  so it won't be damaged and can be edited.

Note: The `--hls-timeout` must be increased, to a time that is longer
than the ignored break.

Example:
`streamlink URL best --hls-segment-ignore-names 000,001,002
--hls-timeout 1200`

This will ignore every segment that ends with 000.ts, 001.ts and 002.ts

---

some names/text can be changed, if someone has a better idea.

---

Hey @RedPenguin2

it would be nice if you could test this,
if you don't know how to, i can help you.

`streamlink http://www.tbd.com best -l debug --hls-segment-ignore-names 0000,0001,0002 -o test.ts --hls-timeout 2400`
change the url with your hls link

this PR would fix streamlink/streamlink#687
