### PR TITLE
docs/install: use sudo for Ubuntu and Solus

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,12 +35,12 @@ Distribution                         Installing
 `NixOS`_                             `Installing NixOS packages`_
 `Solus`_                             .. code-block:: console
 
-                                        # eopkg install streamlink
+                                        $ sudo eopkg install streamlink
 `Ubuntu`_                            .. code-block:: console
 
-                                        # add-apt-repository ppa:nilarimogard/webupd8
-                                        # apt update
-                                        # apt install streamlink
+                                        $ sudo add-apt-repository ppa:nilarimogard/webupd8
+                                        $ sudo apt update
+                                        $ sudo apt install streamlink
 `Void`_                              .. code-block:: console
 
                                         # xbps-install streamlink


### PR DESCRIPTION
After a check of which distribution uses sudo with their default
installation, I found that only Ubuntu and Solus use sudo by default.