### PR TITLE
Ruv plugin updated. Fixes #643.

### DIFF
--- a/src/streamlink/plugins/ruv.py
+++ b/src/streamlink/plugins/ruv.py
@@ -3,40 +3,38 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.stream import RTMPStream, HLSStream
+from streamlink.stream import HLSStream
 
 from streamlink.plugin.api import http
 
-RTMP_LIVE_URL = "rtmp://ruv{0}livefs.fplive.net/ruv{0}live-live/stream{1}"
-RTMP_SARPURINN_URL = "rtmp://sipvodfs.fplive.net/sipvod/{0}/{1}{2}.{3}"
+HLS_RUV_LIVE_URL = """http://ruvruv-live.hls.adaptive.level3.net/ruv/{0}/\
+index/stream{1}.m3u8"""
 
-HLS_RUV_LIVE_URL = "http://ruvruv-live.hls.adaptive.level3.net/ruv/ruv/index/stream{0}.m3u8"
-HLS_RADIO_LIVE_URL = "http://sip-live.hds.adaptive.level3.net/hls-live/ruv-{0}/_definst_/live/stream1.m3u8"
-HLS_SARPURINN_URL = "http://sip-ruv-vod.dcp.adaptive.level3.net/{0}/{1}{2}.{3}.m3u8"
+HLS_RADIO_LIVE_URL = """http://sip-live.hds.adaptive.level3.net/hls-live/\
+ruv-{0}/_definst_/live/stream1.m3u8"""
+
+HLS_SARPURINN_URL = """http://sip-ruv-vod.dcp.adaptive.level3.net/\
+{0}/{1}{2}"""
 
 
 _live_url_re = re.compile(r"""^(?:https?://)?(?:www\.)?ruv\.is/
-                                (?P<channel_path>
-                                    ruv|
-                                    ras1|
-                                    ras-1|
-                                    ras2|
-                                    ras-2|
-                                    rondo
+                                (?P<stream_id>
+                                    ruv/?$|
+                                    ruv2/?$|
+                                    ruv-2/?$|
+                                    ras1/?$|
+                                    ras2/?$|
+                                    rondo/?$
                                 )
                                 /?
                                 """, re.VERBOSE)
 
-_sarpurinn_url_re = re.compile(r"""^(?:https?://)?(?:www\.)?ruv\.is/sarpurinn/
-                                    (?:
+_sarpurinn_url_re = re.compile(r"""^(?:https?://)?(?:www\.)?ruv\.is/spila/
+                                    (?P<stream_id>
                                         ruv|
                                         ruv2|
                                         ruv-2|
                                         ruv-aukaras|
-                                        ras1|
-                                        ras-1|
-                                        ras2|
-                                        ras-2
                                     )
                                     /
                                     [a-zA-Z0-9_-]+
@@ -45,35 +43,31 @@ _sarpurinn_url_re = re.compile(r"""^(?:https?://)?(?:www\.)?ruv\.is/sarpurinn/
                                     /?
                                     """, re.VERBOSE)
 
-_rtmp_url_re = re.compile(r"""rtmp://sipvodfs\.fplive.net/sipvod/
-                                (?P<status>
-                                    lokad|
-                                    opid
-                                )
-                                /
-                                (?P<date>[0-9]+/[0-9][0-9]/[0-9][0-9]/)?
-                                (?P<id>[A-Z0-9\$_]+)
-                                \.
-                                (?P<ext>
-                                    mp4|
-                                    mp3
-                                )""", re.VERBOSE)
+_single_re = re.compile(r"""(?:http://)?sip-ruv-vod.dcp.adaptive.level3.net/
+                            (?P<status>
+                                lokad|
+                                opid
+                            )
+                            /
+                            (?P<date>[0-9]+/[0-9][0-9]/[0-9][0-9]/)?
+                            (?P<id>[A-Z0-9\$_]+)
+                            \.mp4\.m3u8
+                         """, re.VERBOSE)
 
-_id_map = {
-    "ruv": "ruv",
-    "ras1": "ras1",
-    "ras-1": "ras1",
-    "ras2": "ras2",
-    "ras-2": "ras2",
-    "rondo": "ras3"
-}
-
+_multi_re = re.compile(r"""(?:http://)?sip-ruv-vod.dcp.adaptive.level3.net/
+                            (?P<status>
+                                lokad|
+                                opid
+                            )
+                            /manifest.m3u8\?tlm=hls&streams=
+                            (?P<streams>[0-9a-zA-Z\/\.\,:]+)
+                         """, re.VERBOSE)
 
 class Ruv(Plugin):
     @classmethod
     def can_handle_url(cls, url):
         if _live_url_re.match(url):
-            return _live_url_re.match(url)
+            return True
         else:
             return _sarpurinn_url_re.match(url)
 
@@ -83,75 +77,83 @@ class Ruv(Plugin):
 
         if live_match:
             self.live = True
-            self.channel_path = live_match.group("channel_path")
+            self.stream_id = live_match.group("stream_id")
+
+            # Remove slashes
+            self.stream_id.replace("/", "")
+
+            # Remove dashes
+            self.stream_id.replace("-", "")
+
+            if self.stream_id == "rondo":
+                self.stream_id = "ras3"
         else:
             self.live = False
 
     def _get_live_streams(self):
-        stream_id = _id_map[self.channel_path]
-
-        if stream_id == "ruv":
-            qualities_rtmp = ["720p", "480p", "360p", "240p"]
-
-            for i, quality in enumerate(qualities_rtmp):
-                yield quality, RTMPStream(
-                    self.session,
-                    {
-                        "rtmp": RTMP_LIVE_URL.format(stream_id, i + 1),
-                        "pageUrl": self.url,
-                        "live": True
-                    }
-                )
-
+        if self.stream_id == "ruv" or self.stream_id == "ruv2":
             qualities_hls = ["240p", "360p", "480p", "720p"]
             for i, quality_hls in enumerate(qualities_hls):
                 yield quality_hls, HLSStream(
                     self.session,
-                    HLS_RUV_LIVE_URL.format(i + 1)
+                    HLS_RUV_LIVE_URL.format(self.stream_id, i+1)
                 )
-
         else:
-            yield "audio", RTMPStream(self.session, {
-                "rtmp": RTMP_LIVE_URL.format(stream_id, 1),
-                "pageUrl": self.url,
-                "live": True
-            })
-
             yield "audio", HLSStream(
                 self.session,
-                HLS_RADIO_LIVE_URL.format(stream_id)
+                HLS_RADIO_LIVE_URL.format(self.stream_id)
             )
 
     def _get_sarpurinn_streams(self):
         res = http.get(self.url)
-        match = _rtmp_url_re.search(res.text)
 
-        if not match:
-            yield
+        multi_stream_match = _multi_re.search(res.text)
 
-        token = match.group("id")
-        status = match.group("status")
-        extension = match.group("ext")
-        date = match.group("date")
-        if not date:
-            date = ""
+        if multi_stream_match and multi_stream_match.group("streams") is not None:
+            status = multi_stream_match.group("status")
+            streams = multi_stream_match.group("streams").split(",")
 
-        if extension == "mp3":
-            key = "audio"
+            for stream in streams:
+                if stream.count(":") != 1:
+                    continue
+
+                [url, quality] = stream.split(":")
+                quality = int(quality)
+                key = ""
+
+                if quality <= 500:
+                  key = "240p"
+                elif quality <= 800:
+                  key = "360p"
+                elif quality <= 1200:
+                  key = "480p"
+                elif quality <= 2400:
+                  key = "720p"
+                else:
+                  key = "1080p"
+
+                yield key, HLSStream(
+                    self.session,
+                    HLS_SARPURINN_URL.format(status, "", url)
+                )
+
         else:
-            key = "576p"
+            single_stream_match = _single_re.search(res.text)
 
-            # HLS on Sarpurinn is currently only available on videos
-            yield key, HLSStream(
-                self.session,
-                HLS_SARPURINN_URL.format(status, date, token, extension)
-            )
+            if single_stream_match:
+                status = single_stream_match.group("status")
+                date = single_stream_match.group("date")
+                token = single_stream_match.group("id")
+                key = "576p"
 
-        yield key, RTMPStream(self.session, {
-            "rtmp": RTMP_SARPURINN_URL.format(status, date, token, extension),
-            "pageUrl": self.url,
-            "live": True
-        })
+                # Set date as an empty string instread of None
+                if date is None:
+                    date = ""
+
+                yield key, HLSStream(
+                    self.session,
+                    HLS_SARPURINN_URL.format(status, date, token + ".mp4.m3u8")
+                )
 
     def _get_streams(self):
         if self.live:

--- a/src/streamlink/plugins/ruv.py
+++ b/src/streamlink/plugins/ruv.py
@@ -6,15 +6,11 @@ from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream
 
 from streamlink.plugin.api import http
+from streamlink.plugin.api import validate
 
-HLS_RUV_LIVE_URL = """http://ruvruv-live.hls.adaptive.level3.net/ruv/{0}/\
-index/stream{1}.m3u8"""
-
-HLS_RADIO_LIVE_URL = """http://sip-live.hds.adaptive.level3.net/hls-live/\
-ruv-{0}/_definst_/live/stream1.m3u8"""
-
-HLS_SARPURINN_URL = """http://sip-ruv-vod.dcp.adaptive.level3.net/\
-{0}/{1}{2}"""
+# URL to the RUV LIVE API
+RUV_LIVE_API = """http://www.ruv.is/sites/all/themes/at_ruv/scripts/\
+ruv-stream.php?channel={0}&format=json"""
 
 
 _live_url_re = re.compile(r"""^(?:https?://)?(?:www\.)?ruv\.is/
@@ -43,33 +39,26 @@ _sarpurinn_url_re = re.compile(r"""^(?:https?://)?(?:www\.)?ruv\.is/spila/
                                     /?
                                     """, re.VERBOSE)
 
-_single_re = re.compile(r"""(?:http://)?sip-ruv-vod.dcp.adaptive.level3.net/
-                            (?P<status>
-                                lokad|
-                                opid
-                            )
+_single_re = re.compile(r"""(?P<url>http://[0-9a-zA-Z\-\.]*/
+                            (lokad|opid)
                             /
-                            (?P<date>[0-9]+/[0-9][0-9]/[0-9][0-9]/)?
-                            (?P<id>[A-Z0-9\$_]+)
-                            \.mp4\.m3u8
+                            ([0-9]+/[0-9][0-9]/[0-9][0-9]/)?
+                            ([A-Z0-9\$_]+\.mp4\.m3u8)
+                            )
                          """, re.VERBOSE)
 
-_multi_re = re.compile(r"""(?:http://)?sip-ruv-vod.dcp.adaptive.level3.net/
-                            (?P<status>
-                                lokad|
-                                opid
-                            )
-                            /manifest.m3u8\?tlm=hls&streams=
+_multi_re = re.compile(r"""(?P<base_url>http://[0-9a-zA-Z\-\.]*/
+                            (lokad|opid)
+                            /)
+                            manifest.m3u8\?tlm=hls&streams=
                             (?P<streams>[0-9a-zA-Z\/\.\,:]+)
                          """, re.VERBOSE)
+
 
 class Ruv(Plugin):
     @classmethod
     def can_handle_url(cls, url):
-        if _live_url_re.match(url):
-            return True
-        else:
-            return _sarpurinn_url_re.match(url)
+        return _live_url_re.match(url) or _sarpurinn_url_re.match(url)
 
     def __init__(self, url):
         Plugin.__init__(self, url)
@@ -85,75 +74,69 @@ class Ruv(Plugin):
             # Remove dashes
             self.stream_id.replace("-", "")
 
+            # Rondo is identified as ras3
             if self.stream_id == "rondo":
                 self.stream_id = "ras3"
         else:
             self.live = False
 
     def _get_live_streams(self):
-        if self.stream_id == "ruv" or self.stream_id == "ruv2":
-            qualities_hls = ["240p", "360p", "480p", "720p"]
-            for i, quality_hls in enumerate(qualities_hls):
-                yield quality_hls, HLSStream(
-                    self.session,
-                    HLS_RUV_LIVE_URL.format(self.stream_id, i+1)
-                )
-        else:
-            yield "audio", HLSStream(
-                self.session,
-                HLS_RADIO_LIVE_URL.format(self.stream_id)
-            )
+        # Get JSON API
+        res = http.get(RUV_LIVE_API.format(self.stream_id))
+
+        # Parse the JSON API
+        json_res = http.json(res)
+
+        for url in json_res["result"]:
+            if url.startswith("rtmp:"):
+                continue
+
+            # Get available streams
+            streams = HLSStream.parse_variant_playlist(self.session, url)
+
+            for quality, hls in streams.items():
+                yield quality, hls
 
     def _get_sarpurinn_streams(self):
-        res = http.get(self.url)
+        # Get HTML page
+        res = http.get(self.url).text
+        lines = "\n".join([l for l in res.split("\n") if "video.src" in l])
+        multi_stream_match = _multi_re.search(lines)
 
-        multi_stream_match = _multi_re.search(res.text)
-
-        if multi_stream_match and multi_stream_match.group("streams") is not None:
-            status = multi_stream_match.group("status")
+        if multi_stream_match and multi_stream_match.group("streams"):
+            base_url = multi_stream_match.group("base_url")
             streams = multi_stream_match.group("streams").split(",")
 
             for stream in streams:
                 if stream.count(":") != 1:
                     continue
 
-                [url, quality] = stream.split(":")
+                [token, quality] = stream.split(":")
                 quality = int(quality)
                 key = ""
 
                 if quality <= 500:
-                  key = "240p"
+                    key = "240p"
                 elif quality <= 800:
-                  key = "360p"
+                    key = "360p"
                 elif quality <= 1200:
-                  key = "480p"
+                    key = "480p"
                 elif quality <= 2400:
-                  key = "720p"
+                    key = "720p"
                 else:
-                  key = "1080p"
+                    key = "1080p"
 
                 yield key, HLSStream(
                     self.session,
-                    HLS_SARPURINN_URL.format(status, "", url)
+                    base_url + token
                 )
 
         else:
-            single_stream_match = _single_re.search(res.text)
+            single_stream_match = _single_re.search(lines)
 
             if single_stream_match:
-                status = single_stream_match.group("status")
-                date = single_stream_match.group("date")
-                token = single_stream_match.group("id")
-                key = "576p"
-
-                # Set date as an empty string instread of None
-                if date is None:
-                    date = ""
-
-                yield key, HLSStream(
-                    self.session,
-                    HLS_SARPURINN_URL.format(status, date, token + ".mp4.m3u8")
-                )
+                url = single_stream_match.group("url")
+                yield "576p", HLSStream(self.session, url)
 
     def _get_streams(self):
         if self.live:

--- a/tests/test_plugin_ruv.py
+++ b/tests/test_plugin_ruv.py
@@ -1,0 +1,28 @@
+import unittest
+
+from streamlink.plugins.ruv import Ruv
+
+
+class TestPluginRuv(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(Ruv.can_handle_url("ruv.is/ruv"))
+        self.assertTrue(Ruv.can_handle_url("http://ruv.is/ruv"))
+        self.assertTrue(Ruv.can_handle_url("http://ruv.is/ruv/"))
+        self.assertTrue(Ruv.can_handle_url("https://ruv.is/ruv/"))
+        self.assertTrue(Ruv.can_handle_url("http://www.ruv.is/ruv"))
+        self.assertTrue(Ruv.can_handle_url("http://www.ruv.is/ruv/"))
+        self.assertTrue(Ruv.can_handle_url("ruv.is/ruv2"))
+        self.assertTrue(Ruv.can_handle_url("ruv.is/ras1"))
+        self.assertTrue(Ruv.can_handle_url("ruv.is/ras2"))
+        self.assertTrue(Ruv.can_handle_url("ruv.is/rondo"))
+        self.assertTrue(Ruv.can_handle_url("http://www.ruv.is/spila/ruv/ol-2018-ishokki-karla/20180217"))
+        self.assertTrue(Ruv.can_handle_url("http://www.ruv.is/spila/ruv/frettir/20180217"))
+
+        # shouldn't match
+        self.assertFalse(Ruv.can_handle_url("rruv.is/ruv"))
+        self.assertFalse(Ruv.can_handle_url("ruv.is/ruvnew"))
+        self.assertFalse(Ruv.can_handle_url("https://www.bloomberg.com/live/"))
+        self.assertFalse(Ruv.can_handle_url("https://www.bloomberg.com/politics/articles/2017-04-17/french-race-up-for-grabs-days-before-voters-cast-first-ballots"))
+        self.assertFalse(Ruv.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(Ruv.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
Hey all,

I have updated the RUV plugin since the current version is highly out-of-date. This PR fixes #643 and contains both many bug fixes and a new feature (support for VODs with multiple qualities available). I have also removed the RTMP stream, since RUV no longer provides that stream.

Note that these streams are usually restricted to Icelandic IP addresses. The only exception is when RUV are showing something they have a full copyright of (i.e. their evening news). Here are some example usages:

**Live stream**
`streamlink http://ruv.is/ruv best`

**Sarpurinn/VOD (with 240p, 360p, 480p, 720p and 1080p available)**
`streamlink ruv.is/spila/ruv/ol-2018-skidafimi-kvenna/20180216 best`

**Sarpurinn/VOD (with only 576p available)**
`streamlink ruv.is/spila/ruv/ol-2018-svig-kvenna-seinni-ferd/20180216 worst`


All the best,
Hannes