### PR TITLE
[ffmpegmux] Fixed bug of an invisible terminal

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -126,7 +126,7 @@ class FFMPEGMuxer(StreamIO):
         for t in self.pipe_threads:
             t.daemon = True
             t.start()
-        self.process = subprocess.Popen(self._cmd, stdout=subprocess.PIPE, stderr=self.errorlog)
+        self.process = subprocess.Popen(self._cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=self.errorlog)
 
         return self
 


### PR DESCRIPTION
if a ffmpeg stream gets closed with `ctrl + c` the terminal will get invisible,
this patch will fix it.