### PR TITLE
[codecov] use pytest and upload all data

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,10 +5,9 @@ source =
 
 [report]
 omit =
-  */python?.?/*
-  *__init__*
   src/streamlink/packages/*
   src/streamlink_cli/packages/*
+  src/streamlink/_version.py
 
 exclude_lines =
     pragma: no cover

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ lib/
 local/
 share/
 pip-selfcheck.json
+.pytest_cache/
 
 # coverage
+.coverage
+coverage.xml
 htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,16 @@ matrix:
   - python: '3.7-dev'
 
 before_install:
-  - pip install --disable-pip-version-check --upgrade pip
+  - pip install --disable-pip-version-check --upgrade pip setuptools
   - pip install -r dev-requirements.txt
-  - pip install pycountry 
+  - pip install pycountry
   - pip install -r docs-requirements.txt
 
 install:
-  - python setup.py install
+  - pip install -e .
 
 script:
-  - python -m pytest tests/
-  - coverage run -m pytest tests/
+  - pytest --cov
   # test building the docs
   - if [[ $BUILD_DOCS == 'yes' ]]; then make --directory=docs html; fi
   - if [[ $BUILD_INSTALLER == 'yes' ]]; then ./script/makeinstaller.sh; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,13 +40,13 @@ install:
 
   # install dev requirements, for testing, etc.
   - "pip install -r dev-requirements.txt"
-  - "pip install pycountry" 
-  - "build.cmd %PYTHON%\\python.exe -m pip install ."
+  - "pip install pycountry"
+  - "build.cmd %PYTHON%\\python.exe -m pip install -e ."
 
 build: off
 
 test_script:
-  - "build.cmd %PYTHON%\\python.exe -m coverage run setup.py test"
+  - "build.cmd %PYTHON%\\python.exe -m pytest --cov"
 
 after_test:
   - rm -rf tests/coverages

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,7 +14,6 @@ coverage:
   status:
     changes: false
     patch: false
-    project: 
+    project:
       default:
-        target: 40
-
+        target: 30


### PR DESCRIPTION
- use **pytest** not coverage for windows
- fixed not working linux upload, only windows upload worked before this.
- `pip install -e .` or pytest upload won't work
- don't run tests twice in travis
- don't ignore init files
- codecov target to 30
- ignore _version.py for #1413

---

`pip install .` will fix the 3.7 build,
`python setup.py install` is still broken on 3.7

---

codecov will go down from 50% to ~30%
with this it will now show the real %, because it will upload the 0% files as well.