### PR TITLE
[TVRPlus] Fix for hls_re and use headers for HLSStream

### DIFF
--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -2,18 +2,19 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import http
+from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 
 class TVRPlus(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)tvrplus.ro/live-")
-    hls_file_re = re.compile(r"file: (?P<q>[\"'])(?P<url>http.+?m3u8.*?)(?P=q)")
+    url_re = re.compile(r"https?://(?:www\.)?tvrplus\.ro/live-")
+    hls_file_re = re.compile(r"""["'](?P<url>[^"']+\.m3u8(?:[^"']+)?)["']""")
 
     stream_schema = validate.Schema(
         validate.all(
-            validate.transform(hls_file_re.search),
-            validate.any(None, validate.get("url"))
+            validate.transform(hls_file_re.findall),
+            validate.any(None, [validate.text])
         ),
     )
 
@@ -22,9 +23,17 @@ class TVRPlus(Plugin):
         return cls.url_re.match(url) is not None
 
     def _get_streams(self):
+        headers = {
+            "User-Agent": useragents.FIREFOX,
+            "Referer": self.url
+        }
         stream_url = self.stream_schema.validate(http.get(self.url).text)
         if stream_url:
-            return HLSStream.parse_variant_playlist(self.session, stream_url)
+            stream_url = list(set(stream_url))
+            for url in stream_url:
+                self.logger.debug("URL={0}".format(url))
+                for s in HLSStream.parse_variant_playlist(self.session, url, headers=headers).items():
+                    yield s
 
 
 __plugin__ = TVRPlus

--- a/tests/test_plugin_tvrplus.py
+++ b/tests/test_plugin_tvrplus.py
@@ -1,0 +1,21 @@
+import unittest
+
+from streamlink.plugins.tvrplus import TVRPlus
+
+
+class TestPluginTVRPlus(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            "http://tvrplus.ro/live-tvr-1",
+            "http://www.tvrplus.ro/live-tvr-1",
+            "http://www.tvrplus.ro/live-tvr-3",
+            "http://www.tvrplus.ro/live-tvr-international",
+        ]
+        for url in should_match:
+            self.assertTrue(TVRPlus.can_handle_url(url))
+
+        should_not_match = [
+            "http://www.tvrplus.ro/",
+        ]
+        for url in should_not_match:
+            self.assertFalse(TVRPlus.can_handle_url(url))


### PR DESCRIPTION
`best` and `worst` won't work, the source is **404**

`streamlink "http://www.tvrplus.ro/live-tvr-international" 1200k`

```
360k (worst) - broken 404
1200k - works
2500k (best) - broken 404
```

Closes https://github.com/streamlink/streamlink/issues/1435