### PR TITLE
Avoid use of non-ASCII in dogan plugin

### DIFF
--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -12,7 +12,7 @@ from streamlink.stream import HLSStream
 
 class Dogan(Plugin):
     """
-    Support for the live streams from Doğan Media Group channels
+    Support for the live streams from Dogan Media Group channels
     """
     url_re = re.compile(r"""
         https?://(?:www.)?


### PR DESCRIPTION
Plugins get loaded in streamlink/session.py with `imp.load_module`.
`imp.load_module` uses the system locale to read the given python file.

The only way to ensure this will never fail whatever the locale the user
uses is to either:
 - Avoid imp.load_module and use something else to be determined
 - Use only ASCII characters in plugins

`imp.load_module` might be required to support both python 2 and 3
(unless an alternative exists ?).
So replace the non ASCII character with an ASCII one.

For reference, I encountered a load_module failure in the
test_plugins.py test, when loading this plugin in a containerized
environnement (LC_ALL=POSIX)