### PR TITLE
plugins.live_russia_tv New Plugin implementation for live.russia.tv

### DIFF
--- a/src/streamlink/plugins/live_russia_tv.py
+++ b/src/streamlink/plugins/live_russia_tv.py
@@ -14,16 +14,20 @@ class LiveRussia(Plugin):
 
     def _get_streams(self):
         res = http.get(self.url)
-        iframe_url = self.check_re(self.iframe_re, res.text)
-        res = http.get(iframe_url)
-        stream_url = self.check_re(self.stream_re, res.text)
-        return HLSStream.parse_variant_playlist(self.session, stream_url)
+        iframe_result = re.search(self.iframe_re, res.text)
 
-    def check_re(self, search, text):
-        re_result = re.search(search, text)
-        if re_result:
-            return re_result.group(1)
-        self.logger.error("The requested content is unavailable.")
+        if not iframe_result:
+            self.logger.error("The requested content is unavailable.")
+            return
+
+        res = http.get(iframe_result.group(1))
+        stream_url_result = re.search(self.stream_re, res.text)
+
+        if not stream_url_result:
+            self.logger.error("The requested content is unavailable.")
+            return
+
+        return HLSStream.parse_variant_playlist(self.session, stream_url_result.group(1))
 
 
 __plugin__ = LiveRussia

--- a/src/streamlink/plugins/live_russia_tv.py
+++ b/src/streamlink/plugins/live_russia_tv.py
@@ -5,8 +5,8 @@ from streamlink.stream import HLSStream
 
 class LiveRussia(Plugin):
     url_re = re.compile(r"https?://(?:www.)?live.russia.tv/index/index/channel_id/")
-    iframe_re = re.compile(r"<iframe[^>]*src=[\"|']([^'\"]+)[\"|'][^>]*>")
-    stream_re = re.compile(r"window.pl.data(.*m3u8\":\"(.*)\"}.*)};")
+    iframe_re = re.compile(r"""<iframe[^>]*src=["']([^'"]+)["'][^>]*>""")
+    stream_re = re.compile(r"""window.pl.data.*m3u8":"(.*)"}.*};""")
 
     @classmethod
     def can_handle_url(cls, url):
@@ -14,9 +14,16 @@ class LiveRussia(Plugin):
 
     def _get_streams(self):
         res = http.get(self.url)
-        iframe_url = re.search(self.iframe_re, res.text).group(1)
+        iframe_url = self.check_re(self.iframe_re, res.text)
         res = http.get(iframe_url)
-        stream_url = re.search(self.stream_re, res.text).group(2)
+        stream_url = self.check_re(self.stream_re, res.text)
         return HLSStream.parse_variant_playlist(self.session, stream_url)
+
+    def check_re(self, search, text):
+        re_result = re.search(search, text)
+        if re_result:
+            return re_result.group(1)
+        self.logger.error("The requested content is unavailable.")
+
 
 __plugin__ = LiveRussia

--- a/tests/test_plugin_liverussiatv.py
+++ b/tests/test_plugin_liverussiatv.py
@@ -1,0 +1,13 @@
+import unittest
+
+from streamlink.plugins.live_russia_tv import LiveRussia
+
+class TestPluginLiveRussiaTv(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(LiveRussia.can_handle_url('https://live.russia.tv/index/index/channel_id/1'))
+        self.assertTrue(LiveRussia.can_handle_url('https://live.russia.tv/index/index/channel_id/199'))
+
+        # shouldn't match
+        self.assertFalse(LiveRussia.can_handle_url('https://live.russia.tv/'))
+        self.assertFalse(LiveRussia.can_handle_url('http://live.russia.tv/wrongURI'))


### PR DESCRIPTION
Adds support for Russian TV channels from https://live.russia.tv/
E.g.
$ streamlink https://live.russia.tv/index/index/channel_id/4 best