### PR TITLE
Add OS + editor file/directory names to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
+# OS and editors
+.DS_Store
+._*
+Thumbs.db
+Desktop.ini
+*.bak
+.cache
+.project
+.settings
+.tmproj
+nbproject
+*.sublime-project
+*.sublime-workspace
+.idea
+
 *.mo
 *.egg-info
 *.egg


### PR DESCRIPTION
This PR improves the gitignore file, which is missing a list of common OS and editor cache files and directories.

My main intention was to just ignore the config folder of PyCharm and since this is the same as all JetBrains IDEs (.idea), I took what I already had from my other projects and added these common files and directories here. The entire gitignore file could be further improved (and cleaned up) with the help of https://github.com/github/gitignore, if desired.