### PR TITLE
plugins.rtve: fix invalid character entities

### DIFF
--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -1,5 +1,6 @@
 import base64
 import re
+from functools import partial
 
 from Crypto.Cipher import Blowfish
 
@@ -59,7 +60,7 @@ class Rtve(Plugin):
         https?://(?:www\.)?rtve\.es/(?:directo|noticias|television|deportes|alacarta|drmn)/.*?/?
     """, re.VERBOSE)
     cdn_schema = validate.Schema(
-        validate.transform(parse_xml),
+        validate.transform(partial(parse_xml, invalid_char_entities=True)),
         validate.xml_findall(".//preset"),
         [
             validate.union({

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -7,7 +7,7 @@ try:
 except ImportError:  # pragma: no cover
     import xml.etree.ElementTree as ET
 
-from streamlink.compat import urljoin, urlparse, parse_qsl, is_py2, urlunparse
+from streamlink.compat import urljoin, urlparse, parse_qsl, is_py2, urlunparse, is_py3
 from streamlink.exceptions import PluginError
 from streamlink.utils.named_pipe import NamedPipe
 
@@ -67,7 +67,7 @@ def parse_json(data, name="JSON", exception=PluginError, schema=None):
     return json_data
 
 
-def parse_xml(data, name="XML", ignore_ns=False, exception=PluginError, schema=None):
+def parse_xml(data, name="XML", ignore_ns=False, exception=PluginError, schema=None, invalid_char_entities=False):
     """Wrapper around ElementTree.fromstring with some extras.
 
     Provides these extra features:
@@ -77,9 +77,14 @@ def parse_xml(data, name="XML", ignore_ns=False, exception=PluginError, schema=N
     """
     if is_py2 and isinstance(data, unicode):
         data = data.encode("utf8")
+    elif is_py3:
+        data = bytearray(data, "utf8")
 
     if ignore_ns:
-        data = re.sub(" xmlns=\"(.+?)\"", "", data)
+        data = re.sub(br" xmlns=\"(.+?)\"", b"", data)
+
+    if invalid_char_entities:
+        data = re.sub(br'&(?!(?:#(?:[0-9]+|[Xx][0-9A-Fa-f]+)|[A-Za-z0-9]+);)', b'&amp;', data)
 
     try:
         tree = ET.fromstring(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,6 +76,20 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
+    def test_parse_xml_entities_fail(self):
+        self.assertRaises(PluginError,
+                          parse_xml, u"""<test foo="bar &"/>""")
+
+
+    def test_parse_xml_entities(self):
+        expected = ET.Element("test", {"foo": "bar &"})
+        actual = parse_xml(u"""<test foo="bar &"/>""",
+                           schema=validate.Schema(xml_element(tag="test", attrib={"foo": text})),
+                           invalid_char_entities=True)
+        self.assertEqual(expected.tag, actual.tag)
+        self.assertEqual(expected.attrib, actual.attrib)
+
+
     def test_parse_qsd(self):
         self.assertEqual(
             {"test": "1", "foo": "bar"},


### PR DESCRIPTION
This adds an argument to `parse_xml` to try to fix invalid character entities, for example when a plain `&` is in an XML document, ie. it is poorly formed. 

Fixes #1577 