### PR TITLE
Fix test_plugins.py encoding errors in containerized environnement

### DIFF
--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -12,7 +12,7 @@ from streamlink.stream import HLSStream
 
 class Dogan(Plugin):
     """
-    Support for the live streams from Dogan Media Group channels
+    Support for the live streams from Doğan Media Group channels
     """
     url_re = re.compile(r"""
         https?://(?:www.)?


### PR DESCRIPTION
Plugins get loaded at multiple locations:
 - find_module at line 21 create a file instance
 - load_module at line 22 can use that file instance and close it
 - Streamlink() at line 26 load plugins too via load_builtin_plugins()
   but use already loaded instances if available.
 - Generated tests use load_plugin with the previously opened file

An encoding error might happen when loading plugins when load_plugin is
given a closed file instance.

In some cases, load_module (called by load_plugin) can reopen the file
instance if it is closed.
See open() call in imp._HackedGetData.get_data function.

This causes the file to be opened using default system encoding which is
ASCII when in a container chroot.

This commit ensure the file instance is opened when calling load_plugin.

This PR also revert previous commit 99c9eeb which was more a workaround that a fix. Other plugins are using utf-8 characters (like showroom.py) but were not failing reproducibly on any environment.