### PR TITLE
stream.hls: change --hls-audio-select to take a list and wildcard

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -742,12 +742,22 @@ transport.add_argument(
 )
 transport.add_argument(
     "--hls-audio-select",
-    type=str,
+    type=comma_list,
     metavar="CODE",
     help="""
-    Selects a specific audio source, by language code, when multiple audio sources are available.
+    Selects a specific audio source or sources, by language code or name,
+    when multiple audio sources are available. Can be * to download all audio
+    sources.
 
-    Note: This is only useful in special circumstances where the regular locale option fails.
+    Examples:
+
+      --hls-audio-select "English,German"
+      --hls-audio-select "en,de"
+      --hls-audio-select "*"
+
+    Note: This is only useful in special circumstances where the
+    regular locale option fails, such as when multiple sources of the
+    same language exists.
     """)
 transport.add_argument(
     "--hls-timeout",

--- a/tests/test_hls.py
+++ b/tests/test_hls.py
@@ -11,9 +11,9 @@ from binascii import hexlify
 from streamlink.stream import hls
 from streamlink.session import Streamlink
 from functools import partial
+from mock import patch, Mock
 import requests_mock
 import pytest
-
 
 def pkcs7_encode(data, keySize):
     val = keySize - (len(data) % keySize)
@@ -143,6 +143,7 @@ audio_only.m3u8
         self.assertEqual(streamlinkResult, expectedResult)
 
 
+@patch('streamlink.stream.hls.FFMPEGMuxer.is_usable', Mock(return_value=True))
 class TestHlsExtAudio(unittest.TestCase):
     playlist = """
 #EXTM3U

--- a/tests/test_hls.py
+++ b/tests/test_hls.py
@@ -12,6 +12,7 @@ from streamlink.stream import hls
 from streamlink.session import Streamlink
 from functools import partial
 import requests_mock
+import pytest
 
 
 def pkcs7_encode(data, keySize):
@@ -140,6 +141,116 @@ audio_only.m3u8
         # Live streams starts the last 3 segments from the playlist
         expectedResult = b''.join(clearStreams[1:] + clearStreams)
         self.assertEqual(streamlinkResult, expectedResult)
+
+
+class TestHlsExtAudio(unittest.TestCase):
+    playlist = """
+#EXTM3U
+#EXT-X-INDEPENDENT-SEGMENTS
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aac",LANGUAGE="en",NAME="English",AUTOSELECT=YES,DEFAULT=YES
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aac",NAME="English",LANGUAGE="en",AUTOSELECT=NO,URI="en.m3u8"
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID="aac",NAME="Spanish",LANGUAGE="es",AUTOSELECT=NO,URI="es.m3u8"
+#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="chunked",NAME="video",AUTOSELECT=YES,DEFAULT=YES
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=3982010,RESOLUTION=1920x1080,CODECS="avc1.4D4029,mp4a.40.2",VIDEO="chunked", AUDIO="aac"
+playlist.m3u8
+    """
+
+    def run_streamlink(self, playlist, audio_select=None):
+        streamlink = Streamlink()
+
+        if audio_select:
+            streamlink.set_option("hls-audio-select", audio_select)
+        streamlink.logger.set_level("debug")
+
+        master_stream = hls.HLSStream.parse_variant_playlist(streamlink, playlist)
+
+        return master_stream
+
+    def test_hls_ext_audio_not_selected(self):
+        master_url = "http://mocked/path/master.m3u8"
+
+        with requests_mock.Mocker() as mock:
+            mock.get(master_url, text=self.playlist)
+            master_stream = self.run_streamlink(master_url)['video']
+
+        with pytest.raises(AttributeError):
+            master_stream.substreams
+
+        assert master_stream.url == 'http://mocked/path/playlist.m3u8'
+
+    def test_hls_ext_audio_en(self):
+        """
+        m3u8 with ext audio but no options should not download additional streams
+        :return:
+        """
+
+        master_url = "http://mocked/path/master.m3u8"
+        expected = ['http://mocked/path/playlist.m3u8', 'http://mocked/path/en.m3u8']
+
+        with requests_mock.Mocker() as mock:
+            mock.get(master_url, text=self.playlist)
+            master_stream = self.run_streamlink(master_url, 'en')
+
+        substreams = master_stream['video'].substreams
+        result = [x.url for x in substreams]
+
+        # Check result
+        self.assertEqual(result, expected)
+
+    def test_hls_ext_audio_es(self):
+        """
+        m3u8 with ext audio but no options should not download additional streams
+        :return:
+        """
+
+        master_url = "http://mocked/path/master.m3u8"
+        expected = ['http://mocked/path/playlist.m3u8', 'http://mocked/path/es.m3u8']
+
+        with requests_mock.Mocker() as mock:
+            mock.get(master_url, text=self.playlist)
+            master_stream = self.run_streamlink(master_url, 'es')
+
+        substreams = master_stream['video'].substreams
+
+        result = [x.url for x in substreams]
+
+        # Check result
+        self.assertEqual(result, expected)
+
+    def test_hls_ext_audio_all(self):
+        """
+        m3u8 with ext audio but no options should not download additional streams
+        :return:
+        """
+
+        master_url = "http://mocked/path/master.m3u8"
+        expected = ['http://mocked/path/playlist.m3u8', 'http://mocked/path/en.m3u8', 'http://mocked/path/es.m3u8']
+
+        with requests_mock.Mocker() as mock:
+            mock.get(master_url, text=self.playlist)
+            master_stream = self.run_streamlink(master_url, 'en,es')
+
+        substreams = master_stream['video'].substreams
+
+        result = [x.url for x in substreams]
+
+        # Check result
+        self.assertEqual(result, expected)
+
+    def test_hls_ext_audio_wildcard(self):
+        master_url = "http://mocked/path/master.m3u8"
+        expected = ['http://mocked/path/playlist.m3u8', 'http://mocked/path/en.m3u8', 'http://mocked/path/es.m3u8']
+
+        with requests_mock.Mocker() as mock:
+            mock.get(master_url, text=self.playlist)
+            master_stream = self.run_streamlink(master_url, '*')
+
+        substreams = master_stream['video'].substreams
+
+        result = [x.url for x in substreams]
+
+        # Check result
+        self.assertEqual(result, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This changes the --hls-audio-select flag to take a comma-separated
list of audio source names or language codes. This will cause the
ffmpeg muxer to include all selected audio tracks in the output
stream. It also changes so the option takes an asterisk character to
select all available audio tracks.