### PR TITLE
[build] Fixed AppVeyor build pip10 error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,11 +36,11 @@ install:
 
   # Upgrade to the latest version of pip to avoid it displaying warnings
   # about it being out of date.
-  - "pip install --disable-pip-version-check --user --upgrade pip setuptools"
+  - "build.cmd %PYTHON%\\python.exe -m pip install --disable-pip-version-check --user --upgrade pip setuptools"
 
   # install dev requirements, for testing, etc.
-  - "pip install -r dev-requirements.txt"
-  - "pip install pycountry"
+  - "build.cmd %PYTHON%\\python.exe -m pip install -r dev-requirements.txt"
+  - "build.cmd %PYTHON%\\python.exe -m pip install pycountry"
   - "build.cmd %PYTHON%\\python.exe -m pip install -e ."
 
 build: off


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "c:\python35\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python35\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python35\Scripts\pip.exe\__main__.py", line 5, in <module>
ImportError: cannot import name 'main'
Command exited with code 1
```