### PR TITLE
build/deploy: do not deploy streamlink-latest, and remove old nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,14 +63,6 @@ deploy:
     on:
       branch: master
       condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron
-  - provider: bintray
-    file: build/bintray-latest.json
-    user: "${BINTRAY_USER}"
-    key: "${BINTRAY_KEY}"
-    skip_cleanup: true
-    on:
-      branch: master
-      condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron
 
 after_deploy:
   - if [[ "$BUILD_INSTALLER" == 'yes' && "$TRAVIS_EVENT_TYPE" == 'cron' ]]; then ./script/bintrayupdate.sh; fi

--- a/script/bintrayconfig.sh
+++ b/script/bintrayconfig.sh
@@ -21,37 +21,6 @@ else
     STREAMLINK_INSTALLER="streamlink-${STREAMLINK_VERSION}"
 fi
 
-cat > "${build_dir}/bintray-latest.json" <<EOF
-{
-  "package": {
-    "subject": "streamlink",
-    "repo": "streamlink-nightly",
-    "name": "streamlink"
-  },
-
-  "version": {
-    "name": "latest",
-    "released": "$(date +'%Y-%m-%d')",
-    "desc": "Latest version of the installer (${STREAMLINK_VERSION})"
-  },
-
-  "files": [
-    {
-      "includePattern": "${dist_dir}/${STREAMLINK_INSTALLER}.exe",
-      "uploadPattern": "streamlink-latest.exe",
-      "matrixParams": {
-        "override": 1,
-        "publish": 1
-      }
-    }
-  ],
-
-  "publish": true
-}
-EOF
-
-echo "Wrote Bintray config to: ${build_dir}/bintray-latest.json"
-
 cat > "${build_dir}/bintray-nightly.json" <<EOF
 {
   "package": {

--- a/script/bintrayupdate.sh
+++ b/script/bintrayupdate.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
+set -e
 # Update the Bintray release
 
+old_date=$(date +"%Y.%m.%d" -d "30 days ago")
 build_dir="$(pwd)/build"
-current_api_url="https://api.bintray.com/packages/streamlink/streamlink-nightly/streamlink/versions/$(date +'%Y.%m.%d')/release_notes"
-latest_api_url="https://api.bintray.com/packages/streamlink/streamlink-nightly/streamlink/versions/latest/release_notes"
-curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -H "Content-Type: application/json" -d @"${build_dir}/bintray-changelog.json" ${current_api_url}
-curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -H "Content-Type: application/json" -d @"${build_dir}/bintray-changelog.json" ${latest_api_url}
+api_base="https://api.bintray.com/packages/streamlink/streamlink-nightly/streamlink"
+current_api_url="${api_base}/versions/$(date +'%Y.%m.%d')/release_notes"
+files_api_url="${api_base}/files"
+versions_api_url="${api_base}/versions"
+
+curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -H "Content-Type: application/json" -d @"${build_dir}/bintray-changelog.json" "${current_api_url}"
+
+echo "Deleting versions older than ${old_date}..."
+versions=$(curl -s -u "${BINTRAY_USER}:${BINTRAY_KEY}" "${files_api_url}" | grep -Po '(?<="version":")[^"]+(?=")')
+
+for version in $versions; do
+    if [[ "$version" < "$old_date" ]]; then
+        curl -s -u "${BINTRAY_USER}:${BINTRAY_KEY}" -X DELETE "${versions_api_url}/${version}" -o /dev/null && echo "Deleted version: ${version}"
+    fi
+done

--- a/script/bintrayupdate.sh
+++ b/script/bintrayupdate.sh
@@ -12,7 +12,7 @@ versions_api_url="${api_base}/versions"
 curl -u "${BINTRAY_USER}:${BINTRAY_KEY}" -H "Content-Type: application/json" -d @"${build_dir}/bintray-changelog.json" "${current_api_url}"
 
 echo "Deleting versions older than ${old_date}..."
-versions=$(curl -s -u "${BINTRAY_USER}:${BINTRAY_KEY}" "${files_api_url}" | grep -Po '(?<="version":")[^"]+(?=")')
+versions=$(curl -s -u "${BINTRAY_USER}:${BINTRAY_KEY}" "${files_api_url}" | jq -r '.[].version')
 
 for version in $versions; do
     if [[ "$version" < "$old_date" ]]; then


### PR DESCRIPTION
This updates the Travis/BinTray deploy to stop deploying `streamlink-latest.exe` and to delete old nightly versions so we don't run out of quota on BinTray. 