### PR TITLE
plugins.raiplay: add user-agent header to stream redirect request

### DIFF
--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import http
+from streamlink.plugin.api import http, useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
@@ -29,7 +29,7 @@ class RaiPlay(Plugin):
         self.logger.debug("Found channel: {0}", channel)
         stream_url = http.get(self.url, schema=self.stream_schema)
         if stream_url:
-            return HLSStream.parse_variant_playlist(self.session, stream_url)
+            return HLSStream.parse_variant_playlist(self.session, stream_url, headers={"User-Agent": useragents.CHROME})
 
 
 __plugin__ = RaiPlay


### PR DESCRIPTION
Fixes #1628 by adding a standard browser User-Agent string to the headers. 