### PR TITLE
MPEG DASH Support (initial)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,5 @@ coverage
 mock
 requests-mock
 pynsist
+freezegun
 unittest2; python_version < '2.7'

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -69,6 +69,9 @@ different properties are available depending on stream type.
 .. autoclass:: RTMPStream
     :members:
 
+.. autoclass:: DASHStream
+    :members:
+
 
 Exceptions
 ----------

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ else:
     deps.append("iso-639")
     deps.append("iso3166")
 
+deps.append("isodate")
 deps.append("websocket-client")
 
 # Support for SOCKS proxies

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -20,6 +20,7 @@ if is_py2:
     _str = str
     str = unicode
     range = xrange
+    from itertools import izip
 
     def bytes(b, enc="ascii"):
         return _str(b)
@@ -28,14 +29,15 @@ elif is_py3:
     bytes = bytes
     str = str
     range = range
+    izip = zip
 
 try:
     from urllib.parse import (
-        urlparse, urlunparse, urljoin, quote, unquote, parse_qsl, urlencode
+        urlparse, urlunparse, urljoin, quote, unquote, parse_qsl, urlencode, urlsplit, urlunsplit
     )
     import queue
 except ImportError:
-    from urlparse import urlparse, urlunparse, urljoin, parse_qsl
+    from urlparse import urlparse, urlunparse, urljoin, parse_qsl, urlsplit, urlunsplit
     from urllib import quote, unquote, urlencode
     import Queue as queue
 
@@ -47,4 +49,5 @@ except ImportError:
 
 __all__ = ["is_py2", "is_py3", "is_py33", "is_win32", "str", "bytes",
            "urlparse", "urlunparse", "urljoin", "parse_qsl", "quote",
-           "unquote", "queue", "range", "urlencode", "devnull", "which"]
+           "unquote", "queue", "range", "urlencode", "devnull", "which",
+           "izip", "urlsplit", "urlunsplit"]

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -9,8 +9,8 @@ from streamlink.stream.dash import DASHStream
 log = logging.getLogger(__name__)
 
 
-class DASHPlugin(Plugin):
-    _url_re = re.compile(r"dash://(http://.*)")
+class MPEGDASH(Plugin):
+    _url_re = re.compile(r"dash://(https?://.*)")
 
     @classmethod
     def stream_weight(cls, stream):
@@ -31,4 +31,4 @@ class DASHPlugin(Plugin):
 
         return DASHStream.parse_manifest(self.session, mpdurl)
 
-__plugin__ = DASHPlugin
+__plugin__ = MPEGDASH

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+import logging
+
+import re
+from streamlink.plugin import Plugin
+from streamlink.plugin.plugin import stream_weight
+from streamlink.stream.dash import DASHStream
+
+log = logging.getLogger(__name__)
+
+
+class DASHPlugin(Plugin):
+    _url_re = re.compile(r"dash://(http://.*)")
+
+    @classmethod
+    def stream_weight(cls, stream):
+        match = re.match("^(.*)+a(\d+)k$", stream)
+        if match and match.group(2):
+            weight, group = stream_weight(match.group(1))
+            weight += int(match.group(2))
+            return weight, group
+        else:
+            return stream_weight(stream)
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    def _get_streams(self):
+        mpdurl = self._url_re.match(self.url).group(1)
+
+        return DASHStream.parse_manifest(self.session, mpdurl)
+
+__plugin__ = DASHPlugin

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -47,7 +47,9 @@ class MPEGDASH(Plugin):
         return cls._url_re.match(url) is not None
 
     def _get_streams(self):
-        mpdurl = self._url_re.match(self.url).group(1)
+        mpdurl = self._url_re.match(self.url).group(2)
+
+        self.logger.debug("Parsing MPD URL: {0}".format(mpdurl))
 
         return DASHStream.parse_manifest(self.session, mpdurl)
 

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -34,11 +34,13 @@ class MPEGDASH(Plugin):
 
     @classmethod
     def stream_weight(cls, stream):
-        match = re.match(r"^(.*)\+a(\d+)k$", stream)
-        if match and match.group(2):
-            weight, group = stream_weight(match.group(1))
-            weight += int(match.group(2))
-            return weight, group
+        match = re.match(r"^(?:(.*)\+)?(?:a(\d+)k)$", stream)
+        if match and match.group(1) and match.group(2):
+                weight, group = stream_weight(match.group(1))
+                weight += int(match.group(2))
+                return weight, group
+        elif match and match.group(2):
+                return stream_weight(match.group(2) + 'k')
         else:
             return stream_weight(stream)
 

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -44,7 +44,10 @@ class MPEGDASH(Plugin):
 
     @classmethod
     def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
+        m = cls._url_re.match(url)
+        if m:
+            url_path = urlparse(m.group(2)).path
+            return m.group(1) is not None or url_path.endswith(".mpd")
 
     def _get_streams(self):
         mpdurl = self._url_re.match(self.url).group(2)

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -34,7 +34,7 @@ class MPEGDASH(Plugin):
 
     @classmethod
     def stream_weight(cls, stream):
-        match = re.match("^(.*)+a(\d+)k$", stream)
+        match = re.match(r"^(.*)\+a(\d+)k$", stream)
         if match and match.group(2):
             weight, group = stream_weight(match.group(1))
             weight += int(match.group(2))

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -591,7 +591,7 @@ class Twitch(Plugin):
 
             # only get the token once the channel has been resolved
             sig, token = self._access_token(stream_type)
-            url = self.usher.channel(self.channel, sig=sig, token=token)
+            url = self.usher.channel(self.channel, sig=sig, token=token, fast_bread=True)
         elif stream_type == "video":
             sig, token = self._access_token(stream_type)
             url = self.usher.video(self.video_id, nauthsig=sig, nauth=token)

--- a/src/streamlink/stream/__init__.py
+++ b/src/streamlink/stream/__init__.py
@@ -6,6 +6,7 @@ from streamlink.stream.hds import HDSStream
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.rtmpdump import RTMPStream
+from streamlink.stream.dash import DASHStream
 from streamlink.stream.streamprocess import StreamProcess
 from streamlink.stream.wrappers import StreamIOWrapper, StreamIOIterWrapper, StreamIOThreadWrapper
 

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -1,0 +1,113 @@
+import itertools
+from streamlink import StreamError
+from streamlink.compat import urlparse, urlunparse
+from streamlink.plugin.api import http
+from streamlink.stream import Stream
+from streamlink.stream import StreamIOIterWrapper
+from streamlink.stream.dash_manifest import MPD
+from streamlink.stream.ffmpegmux import FFMPEGMuxer
+from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
+
+
+class DASHStreamWriter(SegmentedStreamWriter):
+    def __init__(self, reader, *args, **kwargs):
+        options = reader.stream.session.options
+        kwargs["retries"] = options.get("dash-segment-attempts")
+        kwargs["threads"] = options.get("dash-segment-threads")
+        kwargs["timeout"] = options.get("dash-segment-timeout")
+        SegmentedStreamWriter.__init__(self, reader, *args, **kwargs)
+
+    def fetch(self, segment, retries=None):
+        if self.closed or not retries:
+            return
+
+        try:
+            return self.session.http.get(segment.url,
+                                         stream=True,
+                                         timeout=self.timeout,
+                                         exception=StreamError)
+        except StreamError as err:
+            self.logger.error("Failed to open segment {0}: {1}", segment.url, err)
+            return self.fetch(segment, retries - 1)
+
+    def write(self, segment, res, chunk_size=8192):
+        for chunk in StreamIOIterWrapper(res.iter_content(chunk_size)):
+            if not self.closed:
+                self.reader.buffer.write(chunk)
+            else:
+                self.logger.debug("Download of segment: {} aborted".format(segment.url))
+                return
+
+        self.logger.debug("Download of segment: {} complete".format(segment.url))
+
+
+class DASHStreamWorker(SegmentedStreamWorker):
+    def __init__(self, *args, **kwargs):
+        SegmentedStreamWorker.__init__(self, *args, **kwargs)
+        self.mpd = self.stream.mpd
+        self.period = self.stream.period
+
+    def iter_segments(self):
+        for segment in self.reader.representation.segments():
+            if self.closed:
+                break
+            yield segment
+            self.logger.debug("Adding segment {0} to queue", segment.url)
+
+
+class DASHStreamReader(SegmentedStreamReader):
+    __worker__ = DASHStreamWorker
+    __writer__ = DASHStreamWriter
+
+    def __init__(self, stream, representation, *args, **kwargs):
+        SegmentedStreamReader.__init__(self, stream, *args, **kwargs)
+        self.logger = stream.session.logger.new_module("stream.dash")
+        self.representation = representation
+
+
+class DASHStream(Stream):
+    __shortname__ = "dash"
+
+    def __init__(self,
+                 session,
+                 mpd,
+                 video_representation,
+                 audio_representation=None,
+                 period=0):
+        super(DASHStream, self).__init__(session)
+        self.mpd = mpd
+        self.video_representation = video_representation
+        self.audio_representation = audio_representation
+        self.period = period
+
+    @classmethod
+    def parse_manifest(cls, session, url):
+        res = http.get(url)
+
+        urlp = list(urlparse(url))
+        urlp[2], _ = urlp[2].rsplit("/", 1)
+
+        mpd = MPD(http.xml(res, ignore_ns=True), base_url=urlunparse(urlp))
+        video, audio = [], []
+
+        for aset in mpd.periods[0].adaptionSets:
+            for rep in aset.representations:
+                if rep.mimeType.startswith("video"):
+                    video.append(rep)
+                elif rep.mimeType.startswith("audio"):
+                    audio.append(rep)
+
+        for vid, aud in itertools.product(video, audio):
+            stream = DASHStream(session, mpd, vid, aud)
+            vid_name = "{:0.0f}{}".format(vid.height or vid.bandwidth, "p" if vid.height else "k")
+            if len(audio) > 1:
+                vid_name += "+a{:0.0f}k".format(aud.bandwidth)
+            yield vid_name, stream
+
+    def open(self):
+        video = DASHStreamReader(self, self.video_representation)
+        audio = DASHStreamReader(self, self.audio_representation)
+        video.open()
+        audio.open()
+        muxer = FFMPEGMuxer(self.session, video, audio).open()
+        return muxer

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -119,6 +119,7 @@ class DASHStream(Stream):
         """
         ret = {}
         res = session.http.get(url)
+        url = res.url
 
         urlp = list(urlparse(url))
         urlp[2], _ = urlp[2].rsplit("/", 1)

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -61,7 +61,7 @@ class DASHStreamWorker(SegmentedStreamWorker):
                         if self.closed:
                             break
                         yield segment
-                        self.logger.debug("Adding segment {0} to queue", segment.url)
+                        #self.logger.debug("Adding segment {0} to queue", segment.url)
 
                     if self.mpd.type == "dynamic":
                         self.reload()

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -1,7 +1,6 @@
 import itertools
 from streamlink import StreamError, PluginError
 from streamlink.compat import urlparse, urlunparse
-from streamlink.plugin.api import http
 from streamlink.stream.stream import Stream
 from streamlink.stream.wrappers import StreamIOIterWrapper
 from streamlink.stream.dash_manifest import MPD, sleeper
@@ -78,7 +77,7 @@ class DASHStreamWorker(SegmentedStreamWorker):
         self.logger.debug("Reloading manifest")
         res = self.session.http.get(self.mpd.url, exception=StreamError)
 
-        self.mpd = MPD(http.xml(res, ignore_ns=True),
+        self.mpd = MPD(self.session.http.xml(res, ignore_ns=True),
                        base_url=self.mpd.base_url,
                        url=self.mpd.url,
                        timelines=self.mpd.timelines)

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -175,7 +175,7 @@ class DASHStream(Stream):
             audio.open()
 
         if self.video_representation and self.audio_representation:
-            return FFMPEGMuxer(self.session, video, audio).open()
+            return FFMPEGMuxer(self.session, video, audio, copyts=True).open()
         elif self.video_representation:
             return video
         elif self.audio_representation:

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -51,7 +51,7 @@ class DASHStreamWorker(SegmentedStreamWorker):
         while not self.closed:
             # find the representation by ID
             representation = None
-            for aset in self.mpd.periods[0].adaptionSets:
+            for aset in self.mpd.periods[0].adaptationSets:
                 for rep in aset.representations:
                     if rep.id == self.reader.representation_id:
                         representation = rep
@@ -139,7 +139,7 @@ class DASHStream(Stream):
         video, audio = [], []
 
         # Search for suitable video and audio representations
-        for aset in mpd.periods[0].adaptionSets:
+        for aset in mpd.periods[0].adaptationSets:
             if aset.contentProtection:
                 raise PluginError("{} is protected by DRM".format(url))
             for rep in aset.representations:

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -1,5 +1,5 @@
 import itertools
-from streamlink import StreamError
+from streamlink import StreamError, PluginError
 from streamlink.compat import urlparse, urlunparse
 from streamlink.plugin.api import http
 from streamlink.stream import Stream
@@ -122,6 +122,8 @@ class DASHStream(Stream):
         video, audio = [], []
 
         for aset in mpd.periods[0].adaptionSets:
+            if aset.contentProtection:
+                raise PluginError("{} is protected by DRM".format(url))
             for rep in aset.representations:
                 if rep.mimeType.startswith("video"):
                     video.append(rep)

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -2,8 +2,8 @@ import itertools
 from streamlink import StreamError, PluginError
 from streamlink.compat import urlparse, urlunparse
 from streamlink.plugin.api import http
-from streamlink.stream import Stream
-from streamlink.stream import StreamIOIterWrapper
+from streamlink.stream.stream import Stream
+from streamlink.stream.wrappers import StreamIOIterWrapper
 from streamlink.stream.dash_manifest import MPD, sleeper
 from streamlink.stream.ffmpegmux import FFMPEGMuxer
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
@@ -111,6 +111,13 @@ class DASHStream(Stream):
 
     @classmethod
     def parse_manifest(cls, session, url):
+        """
+        Attempt to parse a DASH manifest file and return its streams
+
+        :param session: Streamlink session instance
+        :param url: URL of the manifest file
+        :return: a dict of name -> DASHStream instances
+        """
         ret = {}
         res = http.get(url)
 

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -23,7 +23,6 @@ class DASHStreamWriter(SegmentedStreamWriter):
 
         try:
             return self.session.http.get(segment.url,
-                                         stream=True,
                                          timeout=self.timeout,
                                          exception=StreamError)
         except StreamError as err:
@@ -112,6 +111,7 @@ class DASHStream(Stream):
 
     @classmethod
     def parse_manifest(cls, session, url):
+        ret = {}
         res = http.get(url)
 
         urlp = list(urlparse(url))
@@ -135,7 +135,9 @@ class DASHStream(Stream):
             vid_name = "{:0.0f}{}".format(vid.height or vid.bandwidth, "p" if vid.height else "k")
             if len(audio) > 1:
                 vid_name += "+a{:0.0f}k".format(aud.bandwidth)
-            yield vid_name, stream
+            ret[vid_name] = stream
+
+        return ret
 
     def open(self):
         video = DASHStreamReader(self, self.video_representation.id)

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -1,0 +1,403 @@
+import datetime
+import re
+import time
+from collections import namedtuple
+from itertools import count
+
+from streamlink.compat import urlparse, urljoin
+
+if hasattr(datetime, "timezone"):
+    utc = datetime.timezone.utc
+
+else:
+    class UTC(datetime.tzinfo):
+        def utcoffset(self, dt):
+            return datetime.timedelta(0)
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
+
+    utc = UTC()
+
+from isodate import parse_datetime, parse_duration, Duration
+from contextlib import contextmanager
+
+Segment = namedtuple("Segment", "url duration init content available_at")
+
+
+@contextmanager
+def sleeper(duration):
+    s = time.time()
+    yield
+    time.sleep(duration - (time.time() - s))
+
+
+def sleep_until(walltime):
+    c = time.time()
+    time_to_wait = walltime - c
+    if time_to_wait > 0:
+        time.sleep(time_to_wait)
+
+
+class MPDParsers(object):
+    @staticmethod
+    def parse_bool_str(v):
+        if v.lower() not in ("true", "false"):
+            raise MPDParsingError("bool must be true or false")
+        return v.lower() == "true"
+
+    @staticmethod
+    def parse_type(type_):
+        if type_ not in (u"static", u"dynamic"):
+            raise MPDParsingError("@type must be static or dynamic")
+        return type_
+
+    @staticmethod
+    def parse_duration(duration):
+        return parse_duration(duration)
+
+    @staticmethod
+    def parse_datetime(dt):
+        return parse_datetime(dt)
+
+    @staticmethod
+    def parse_segment_template(url_template):
+        return re.compile(r"\$(\w+)\$").sub(r"{\1}", url_template)
+
+
+class MPDParsingError(Exception):
+    pass
+
+
+class MPDNode(object):
+    __tag__ = None
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        self.node = node
+        self.root = root
+        self.parent = parent
+        self._base_url = kwargs.get(u"base_url")
+        self.attributes = set([])
+        if self.__tag__ and self.node.tag.lower() != self.__tag__.lower():
+            raise MPDParsingError("root tag did not match the expected tag: {}".format(self.__tag__))
+
+    @property
+    def attrib(self):
+        return self.node.attrib
+
+    def __str__(self):
+        return "<{tag} {attrs}>".format(
+            tag=self.__tag__,
+            attrs=" ".join("@{}={}".format(attr, getattr(self, attr)) for attr in self.attributes)
+        )
+
+    def attr(self, key, default=None, parser=None, required=False):
+        self.attributes.add(key)
+        if key in self.attrib:
+            value = self.attrib.get(key)
+            if parser and callable(parser):
+                return parser(value)
+            else:
+                return value
+        elif required:
+            raise MPDParsingError("could not find required attribute {tag}@{attr} ".format(attr=key, tag=self.__tag__))
+        else:
+            return default
+
+    def children(self, cls, minimum=0, maximum=None):
+
+        children = self.node.findall(cls.__tag__)
+        if len(children) < minimum or (maximum and len(children) > maximum):
+            raise MPDParsingError("expected to find {}/{} required [{}..{})".format(
+                self.__tag__, cls.__tag__, minimum, maximum or "unbound"))
+
+        return map(lambda x: cls(x[1], root=self.root, parent=self, i=x[0], base_url=self.base_url),
+                   enumerate(children))
+
+    def only_child(self, cls, minimum=0):
+        children = self.children(cls, minimum=minimum, maximum=1)
+        return children[0] if len(children) else None
+
+    def walk_back(self, cls=None, f=lambda x: x):
+        node = self.parent
+        while node:
+            if cls is None or cls.__tag__ == node.__tag__:
+                yield f(node)
+            node = node.parent
+
+    @property
+    def base_url(self):
+        base_url = self._base_url
+        if hasattr(self, "baseURLs") and len(self.baseURLs):
+            base_url = BaseURL.join(base_url, self.baseURLs[0].url)
+        return base_url
+
+
+class MPD(MPDNode):
+    """
+    Represents the MPD as a whole
+
+    Should validate the XML input and provide methods to get segment URLs for each Period, AdaptationSet and
+    Representation.
+
+    """
+    __tag__ = u"MPD"
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        # top level has no parent
+        super(MPD, self).__init__(node, root=self, *args, **kwargs)
+        # parser attributes
+        self.id = self.attr(u"id", parser=int)
+        self.profiles = self.attr(u"profiles", required=True)
+        self.type = self.attr(u"type", default=u"static", parser=MPDParsers.parse_type)
+        self.minimumUpdatePeriod = self.attr(u"minimumUpdatePeriod", parser=MPDParsers.parse_duration)
+        self.minBufferTime = self.attr(u"minBufferTime", parser=MPDParsers.parse_duration, required=True)
+        self.timeShiftBufferDepth = self.attr(u"timeShiftBufferDepth", parser=MPDParsers.parse_duration)
+        self.availabilityStartTime = self.attr(u"availabilityStartTime", parser=parse_datetime,
+                                               default=datetime.datetime.fromtimestamp(0, utc),  # earliest date
+                                               required=self.type == "dynamic")
+        self.publishTime = self.attr(u"publishTime", parser=parse_datetime, required=self.type == "dynamic")
+        self.mediaPresentationDuration = self.attr(u"mediaPresentationDuration", parser=MPDParsers.parse_duration)
+        self.suggestedPresentationDelay = self.attr(u"suggestedPresentationDelay", parser=MPDParsers.parse_duration)
+
+        # parse children
+        self.baseURLs = self.children(BaseURL)
+        self.periods = self.children(Period, minimum=1)
+        self.programInformation = self.children(ProgramInformation)
+        self.locations = self.children(Location)
+
+
+class ProgramInformation(MPDNode):
+    __tag__ = "ProgramInformation"
+
+
+class BaseURL(MPDNode):
+    __tag__ = "BaseURL"
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        super(BaseURL, self).__init__(node, root, parent, *args, **kwargs)
+        self.url = self.node.text.strip()
+
+    @property
+    def is_absolute(self):
+        return urlparse(self.url).scheme
+
+    @staticmethod
+    def join(url, other):
+        # if the other URL is an absolute url, then return that
+        if urlparse(other).scheme:
+            return other
+        elif url:
+            if not url.endswith("/"):
+                url += "/"
+            return urljoin(url, other)
+        else:
+            return other
+
+
+class Location(MPDNode):
+    __tag__ = "Location"
+
+
+class Period(MPDNode):
+    __tag__ = u"Period"
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        super(Period, self).__init__(node, root, parent, *args, **kwargs)
+        self.i = kwargs.get(u"i", 0)
+        self.id = self.attr(u"id")
+        self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.parse_bool_str)
+        self.duration = self.attr(u"duration", default=Duration(), parser=MPDParsers.parse_duration)
+        self.start = self.attr(u"start", default=Duration(), parser=MPDParsers.parse_duration)
+
+        if self.start is None and self.i == 0 and self.root.type == "static":
+            self.start = 0
+
+        # TODO: Early Access Periods
+
+        self.baseURLs = self.children(BaseURL)
+        self.segmentBase = self.only_child(SegmentBase)
+        self.adaptionSets = self.children(AdaptationSet, minimum=1)
+        self.segmentList = self.only_child(SegmentList)
+        self.segmentTemplate = self.only_child(SegmentTemplate)
+        self.sssetIdentifier = self.only_child(AssetIdentifier)
+        self.eventStream = self.children(EventStream)
+        self.subset = self.children(Subset)
+
+
+class SegmentBase(MPDNode):
+    __tag__ = "SegmentBase"
+
+
+class AssetIdentifier(MPDNode):
+    __tag__ = "AssetIdentifier"
+
+
+class Subset(MPDNode):
+    __tag__ = "Subset"
+
+
+class EventStream(MPDNode):
+    __tag__ = "EventStream"
+
+
+class SegmentList(MPDNode):
+    __tag__ = "SegmentList"
+
+
+class AdaptationSet(MPDNode):
+    __tag__ = u"AdaptationSet"
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        super(AdaptationSet, self).__init__(node, root, parent, *args, **kwargs)
+
+        self.id = self.attr(u"id")
+        self.group = self.attr(u"group")
+        self.lang = self.attr(u"lang")
+        self.contentType = self.attr(u"contentType")
+        self.par = self.attr(u"par")
+        self.minBandwidth = self.attr(u"minBandwidth")
+        self.maxBandwidth = self.attr(u"maxBandwidth")
+        self.minWidth = self.attr(u"minWidth")
+        self.maxWidth = self.attr(u"maxWidth")
+        self.minHeight = self.attr(u"minHeight")
+        self.maxHeight = self.attr(u"maxHeight")
+        self.minFrameRate = self.attr(u"minFrameRate")
+        self.maxFrameRate = self.attr(u"maxFrameRate")
+        self.segmentAlignment = self.attr(u"segmentAlignment", default=False, parser=MPDParsers.parse_bool_str)
+        self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.parse_bool_str)
+        self.subsegmentAlignment = self.attr(u"subsegmentAlignment", default=False, parser=MPDParsers.parse_bool_str)
+        self.subsegmentStartsWithSAP = self.attr(u"subsegmentStartsWithSAP", default=0, parser=int)
+
+        self.baseURLs = self.children(BaseURL)
+        self.representations = self.children(Representation, minimum=1)
+        self.segmentTemplate = self.only_child(SegmentTemplate)
+
+
+class SegmentTemplate(MPDNode):
+    __tag__ = "SegmentTemplate"
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        super(SegmentTemplate, self).__init__(node, root, parent, *args, **kwargs)
+        self.initialization = self.attr(u"initialization", parser=MPDParsers.parse_segment_template)
+        self.media = self.attr(u"media", parser=MPDParsers.parse_segment_template)
+        self.duration = self.attr(u"duration", parser=int)
+        self.timescale = self.attr(u"timescale", parser=int)
+        self.startNumber = self.attr(u"startNumber", parser=int)
+        self.seconds = self.duration / float(self.timescale)
+        self.period = list(self.walk_back(Period))[0]
+
+    def segments(self, **kwargs):
+        init_url = self.format_initialization(**kwargs)
+        if init_url:
+            yield Segment(init_url, 0, True, False, 0)
+        for media_url, available_at in self.format_media(**kwargs):
+            yield Segment(media_url, self.seconds, False, True, available_at)
+
+    def make_url(self, url):
+        """
+        Join the URL with the base URL, unless it's an absolute URL
+        :param url: maybe relative URL
+        :return: joined URL
+        """
+        return BaseURL.join(self.base_url, url)
+
+    def format_initialization(self, **kwargs):
+        if self.initialization:
+            return self.make_url(self.initialization.format(**kwargs))
+
+    def starting_segment(self):
+        if self.root.type == "dynamic":
+            seconds_since_start = (datetime.datetime.now(utc) - self.root.availabilityStartTime).seconds - 3
+            seconds_per_segment = (self.duration / self.timescale)
+
+            return self.startNumber + (seconds_since_start / seconds_per_segment)
+        else:
+            return self.startNumber
+
+    def available_at(self, n):
+        if self.root.type == "dynamic":
+            seconds_per_segment = (self.duration / self.timescale)
+            available_since = (self.root.availabilityStartTime - datetime.datetime(1970, 1, 1, tzinfo=utc)).total_seconds()
+            return available_since + ((n - self.startNumber) * seconds_per_segment)
+        else:
+            return 0
+
+    def format_media(self, **kwargs):
+        if self.startNumber:
+
+            if self.period.duration.seconds:
+                number_iter = range(self.starting_segment(), (self.period.duration.seconds / self.seconds) + 1)
+            else:
+                number_iter = count(self.starting_segment())
+
+            for n in number_iter:
+                yield self.make_url(self.media.format(Number=n, **kwargs)), self.available_at(n)
+        else:
+            yield self.make_url(self.media.format(**kwargs)), 0
+
+
+class Representation(MPDNode):
+    __tag__ = u"Representation"
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        super(Representation, self).__init__(node, root, parent, *args, **kwargs)
+        self.id = self.attr(u"id", required=True)
+        self.bandwidth = self.attr(u"bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
+        self.mimeType = self.attr(u"mimeType", required=True)
+
+        self.codecs = self.attr(u"codecs")
+        self.startWithSAP = self.attr(u"startWithSAP")
+
+        # video
+        self.width = self.attr(u"width", parser=int)
+        self.height = self.attr(u"height", parser=int)
+        self.frameRate = self.attr(u"frameRate", parser=float)
+
+        # audio
+        self.audioSamplingRate = self.attr(u"audioSamplingRate", parser=int)
+        self.numChannels = self.attr(u"numChannels", parser=int)
+
+
+        self.baseURLs = self.children(BaseURL)
+        self.subRepresentation = self.children(SubRepresentation)
+        self.segmentBase = self.only_child(SegmentBase)
+        self.segmentList = self.only_child(SegmentList)
+        self.segmentTemplate = self.only_child(SegmentTemplate)
+
+    def segments(self, **kwargs):
+        """
+        Segments are yielded when they are available
+
+        Segments appear on a time line, for dynamic content they are only available at a certain time
+        and sometimes for a limited time. For static content they are all available at the time same.
+
+        :param kwargs: extra args to pass to the segment template
+        :return: yields Segments
+        """
+
+        def walk_back_get_attr(attr):
+            parent_attrs = [getattr(n, attr) for n in self.walk_back() if hasattr(n, attr)]
+            return parent_attrs[0] if len(parent_attrs) else None
+
+        segmentBase = self.segmentBase or walk_back_get_attr("segmentBase")
+        segmentList = self.segmentList or walk_back_get_attr("segmentList")
+        segmentTemplate = self.segmentTemplate or walk_back_get_attr("segmentTemplate")
+
+        if segmentTemplate:
+            for segment in segmentTemplate.segments(RepresentationID=self.id, **kwargs):
+                if segment.init:
+                    yield segment
+                else:
+                    sleep_until(segment.available_at)
+                    yield segment
+        else:
+            yield Segment(self.base_url, 0, True, True, 0)
+
+
+class SubRepresentation(MPDNode):
+    __tag__ = "SubRepresentation"

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -9,7 +9,6 @@ from streamlink.compat import urlparse, urljoin, urlunparse, izip, urlsplit, url
 
 if hasattr(datetime, "timezone"):
     utc = datetime.timezone.utc
-
 else:
     class UTC(datetime.tzinfo):
         def utcoffset(self, dt):
@@ -421,6 +420,7 @@ class SegmentTemplate(MPDNode):
             suggested_delay = self.root.suggestedPresentationDelay.total_seconds() if self.root.suggestedPresentationDelay else 3
 
             t = 0
+            n = self.startNumber
             available_at = datetime_to_seconds(self.root.publishTime)
 
             for segment in self.segmentTimeline.segments:
@@ -430,10 +430,11 @@ class SegmentTemplate(MPDNode):
                     available_at += (segment.d / self.timescale)
 
                     if t > self.root.timelines[self.parent.id]:
-                        yield (self.make_url(self.media(Time=t, **kwargs)),
+                        yield (self.make_url(self.media(Time=t, Number=n, **kwargs)),
                                available_at + suggested_delay)
                         self.root.timelines[self.parent.id] = t
                     t += segment.d
+                    n += 1
         else:
             for number, available_at in self.segment_numbers():
                 yield (self.make_url(self.media(Number=number, **kwargs)),

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -6,6 +6,9 @@ import time
 from collections import defaultdict, namedtuple
 from itertools import repeat, count
 
+from isodate import parse_datetime, parse_duration, Duration
+from contextlib import contextmanager
+
 from streamlink.compat import urlparse, urljoin, urlunparse, izip, urlsplit, urlunsplit
 
 if hasattr(datetime, "timezone"):
@@ -21,11 +24,7 @@ else:
         def dst(self, dt):
             return datetime.timedelta(0)
 
-
     utc = UTC()
-
-from isodate import parse_datetime, parse_duration, Duration
-from contextlib import contextmanager
 
 epoch_start = datetime.datetime(1970, 1, 1, tzinfo=utc)
 
@@ -431,8 +430,8 @@ class SegmentTemplate(MPDNode):
 
             # the number of the segment that is available at NOW - SUGGESTED_DELAY - BUFFER_TIME
             number_iter = count(self.startNumber +
-                                int((
-                                        since_start - suggested_delay - self.root.minBufferTime).total_seconds() / self.duration_seconds))
+                                int((since_start - suggested_delay - self.root.minBufferTime).total_seconds() /
+                                    self.duration_seconds))
 
             # the time the segment number is available at NOW
             available_iter = count_dt(available_start,

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 import re
 import time
@@ -72,7 +73,7 @@ class MPDParsers(object):
     def segment_template(url_template):
         end = 0
         res = ""
-        for m in re.compile(r"(.*?)\$(\w+)(?:%(\w+))?\$").finditer(url_template):
+        for m in re.compile(r"(.*?)\$(\w+)(?:%([\w.]+))?\$").finditer(url_template):
             _, end = m.span()
             res += "{0}{{{1}{2}}}".format(m.group(1),
                                           m.group(2),
@@ -211,7 +212,8 @@ class MPD(MPDNode):
         if self.location:
             self.url = self.location.text
             urlp = list(urlparse(self.url))
-            urlp[2], _ = urlp[2].rsplit("/", 1)
+            if urlp[2]:
+                urlp[2], _ = urlp[2].rsplit("/", 1)
             self._base_url = urlunparse(urlp)
 
         self.baseURLs = self.children(BaseURL)
@@ -271,7 +273,7 @@ class Period(MPDNode):
 
         self.baseURLs = self.children(BaseURL)
         self.segmentBase = self.only_child(SegmentBase)
-        self.adaptionSets = self.children(AdaptationSet, minimum=1)
+        self.adaptationSets = self.children(AdaptationSet, minimum=1)
         self.segmentList = self.only_child(SegmentList)
         self.segmentTemplate = self.only_child(SegmentTemplate)
         self.sssetIdentifier = self.only_child(AssetIdentifier)

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -315,6 +315,7 @@ class AdaptationSet(MPDNode):
         self.baseURLs = self.children(BaseURL)
         self.representations = self.children(Representation, minimum=1)
         self.segmentTemplate = self.only_child(SegmentTemplate)
+        self.contentProtection = self.children(ContentProtection, minimum=1)
 
 
 class SegmentTemplate(MPDNode):
@@ -493,3 +494,15 @@ class TimelineSegment(MPDNode):
 
         self.t = self.attr("t", parser=int)
         self.d = self.attr("d", parser=int)
+
+
+class ContentProtection(MPDNode):
+    __tag__ = "ContentProtection"
+
+
+    def __init__(self, node, root=None, parent=None, *args, **kwargs):
+        super(ContentProtection, self).__init__(node, root, parent, *args, **kwargs)
+
+        self.schemeIdUri = self.attr(u"schemeIdUri")
+        self.value = self.attr(u"value")
+        self.default_KID = self.attr(u"default_KID")

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -329,7 +329,7 @@ class SegmentTemplate(MPDNode):
         self.media = self.attr(u"media", parser=MPDParsers.segment_template)
         self.duration = self.attr(u"duration", parser=int)
         self.timescale = self.attr(u"timescale", parser=int, default=1)
-        self.startNumber = self.attr(u"startNumber", parser=int)
+        self.startNumber = self.attr(u"startNumber", parser=int, default=1)
         self.presentationTimeOffset = self.attr(u"presentationTimeOffset", parser=MPDParsers.timedelta(self.timescale))
 
         if self.duration:
@@ -409,11 +409,9 @@ class SegmentTemplate(MPDNode):
                     yield self.make_url(self.media.format(Time=t, **kwargs)), 0
                     self.root.timelines[self.parent.id] = t
                 t += segment.d
-        elif self.startNumber is not None:
+        else:
             for number, available_at in self.segment_numbers():
                 yield self.make_url(self.media.format(Number=number, **kwargs)), available_at
-        else:
-            yield self.make_url(self.media.format(**kwargs)), 0
 
 
 class Representation(MPDNode):

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -28,10 +28,10 @@ from isodate import parse_datetime, parse_duration, Duration
 from contextlib import contextmanager
 
 Segment = namedtuple("Segment", "url duration init content available_at")
-
+epoch_start = datetime.datetime(1970, 1, 1, tzinfo=utc)
 
 def datetime_to_seconds(dt):
-    return (dt - datetime.datetime(1970, 1, 1, tzinfo=utc)).total_seconds()
+    return (dt - epoch_start).total_seconds()
 
 
 @contextmanager
@@ -191,7 +191,7 @@ class MPD(MPDNode):
         super(MPD, self).__init__(node, root=self, *args, **kwargs)
         # parser attributes
         self.url = url
-        self.timelines = defaultdict(int)
+        self.timelines = defaultdict(lambda: -1)
         self.timelines.update(kwargs.pop("timelines", {}))
         self.id = self.attr(u"id")
         self.profiles = self.attr(u"profiles", required=True)
@@ -423,7 +423,7 @@ class SegmentTemplate(MPDNode):
 
             t = 0
             n = self.startNumber
-            available_at = datetime_to_seconds(self.root.publishTime)
+            available_at = datetime_to_seconds(self.root.publishTime) if self.root.publishTime else 0
 
             for segment in self.segmentTimeline.segments:
                 t = t or segment.t

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -1,14 +1,14 @@
 from __future__ import unicode_literals
 
+import logging
 import datetime
 import re
 import time
+
 from collections import defaultdict, namedtuple
 from itertools import repeat, count
-
 from isodate import parse_datetime, parse_duration, Duration
 from contextlib import contextmanager
-
 from streamlink.compat import urlparse, urljoin, urlunparse, izip, urlsplit, urlunsplit
 
 if hasattr(datetime, "timezone"):
@@ -26,6 +26,7 @@ else:
 
     utc = UTC()
 
+log = logging.getLogger(__name__)
 epoch_start = datetime.datetime(1970, 1, 1, tzinfo=utc)
 
 
@@ -406,6 +407,7 @@ class SegmentTemplate(MPDNode):
         in the simplest case the segment number is based on the time since the availabilityStartTime
         :return:
         """
+        log.debug("Generating segment numbers for {0} playlist (id={1})".format(self.root.type, self.parent.id))
         if self.root.type == u"static":
             available_iter = repeat(epoch_start)
             duration = self.period.duration.seconds or self.root.mediaPresentationDuration.seconds
@@ -442,6 +444,7 @@ class SegmentTemplate(MPDNode):
 
     def format_media(self, **kwargs):
         if self.segmentTimeline:
+            log.debug("Generating segment timeline for {0} playlist (id={1}))".format(self.root.type, self.parent.id))
             if self.root.type == "dynamic":
                 # if there is no delay, use a delay of 3 seconds
                 suggested_delay = datetime.timedelta(seconds=(self.root.suggestedPresentationDelay.total_seconds()

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -67,7 +67,7 @@ class MPDParsers(object):
 
     @staticmethod
     def datetime(dt):
-        return parse_datetime(dt)
+        return parse_datetime(dt).replace(tzinfo=utc)
 
     @staticmethod
     def segment_template(url_template):
@@ -196,13 +196,13 @@ class MPD(MPDNode):
         self.id = self.attr(u"id")
         self.profiles = self.attr(u"profiles", required=True)
         self.type = self.attr(u"type", default=u"static", parser=MPDParsers.type)
-        self.minimumUpdatePeriod = self.attr(u"minimumUpdatePeriod", parser=MPDParsers.duration)
+        self.minimumUpdatePeriod = self.attr(u"minimumUpdatePeriod", parser=MPDParsers.duration, default=Duration())
         self.minBufferTime = self.attr(u"minBufferTime", parser=MPDParsers.duration, required=True)
         self.timeShiftBufferDepth = self.attr(u"timeShiftBufferDepth", parser=MPDParsers.duration)
-        self.availabilityStartTime = self.attr(u"availabilityStartTime", parser=parse_datetime,
+        self.availabilityStartTime = self.attr(u"availabilityStartTime", parser=MPDParsers.datetime,
                                                default=datetime.datetime.fromtimestamp(0, utc),  # earliest date
                                                required=self.type == "dynamic")
-        self.publishTime = self.attr(u"publishTime", parser=parse_datetime, required=self.type == "dynamic")
+        self.publishTime = self.attr(u"publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
         self.mediaPresentationDuration = self.attr(u"mediaPresentationDuration", parser=MPDParsers.duration)
         self.suggestedPresentationDelay = self.attr(u"suggestedPresentationDelay", parser=MPDParsers.duration)
 

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -98,6 +98,7 @@ class FFMPEGMuxer(StreamIO):
         audiocodec = session.options.get("ffmpeg-audio-transcode") or options.pop("acodec", "copy")
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
+        copyts = options.pop("copyts", False)
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:
@@ -108,6 +109,9 @@ class FFMPEGMuxer(StreamIO):
 
         for m in maps:
             self._cmd.extend(["-map", str(m)])
+
+        if copyts:
+            self._cmd.extend(["-copyts"])
 
         for stream, data in metadata.items():
             for datum in data:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -248,9 +248,11 @@ def open_stream(stream):
         log.debug("Pre-buffering 8192 bytes")
         prebuffer = stream_fd.read(8192)
     except IOError as err:
+        stream_fd.close()
         raise StreamError("Failed to read data from stream: {0}".format(err))
 
     if not prebuffer:
+        stream_fd.close()
         raise StreamError("No data returned from stream")
 
     return stream_fd, prebuffer

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import sys
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+__all__ = ['unittest']

--- a/tests/mock.py
+++ b/tests/mock.py
@@ -1,0 +1,9 @@
+from __future__ import absolute_import
+try:
+    from unittest.mock import *
+    import unittest.mock as mock
+    __all__ = mock.__all__
+except ImportError:
+    from mock import *
+    import mock
+    __all__ = mock.__all__

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,0 +1,45 @@
+import codecs
+import os.path
+import six
+from io import BytesIO
+
+try:
+    import xml.etree.cElementTree as ET
+except ImportError:  # pragma: no cover
+    import xml.etree.ElementTree as ET
+
+from contextlib import contextmanager
+
+__here__ = os.path.abspath(os.path.dirname(__file__))
+
+
+def _parse_xml(data, strip_ns=False):
+    if six.PY2 and isinstance(data, six.text_type):
+        data = data.encode("utf8")
+    elif six.PY3:
+        data = bytearray(data, "utf8")
+    try:
+        it = ET.iterparse(BytesIO(data))
+        for _, el in it:
+            if '}' in el.tag and strip_ns:
+                # strip all namespaces
+                el.tag = el.tag.split('}', 1)[1]
+        return it.root
+    except Exception as err:
+        snippet = repr(data)
+        if len(snippet) > 35:
+            snippet = snippet[:35] + " ..."
+
+        raise ValueError("Unable to parse XML: {0} ({1})".format(err, snippet))
+
+
+@contextmanager
+def text(path, encoding="utf8"):
+    with codecs.open(os.path.join(__here__, path), 'r', encoding=encoding) as resource_fh:
+        yield resource_fh
+
+
+@contextmanager
+def xml(path, encoding="utf8"):
+    with codecs.open(os.path.join(__here__, path), 'r', encoding=encoding) as resource_fh:
+        yield _parse_xml(resource_fh.read(), strip_ns=True)

--- a/tests/resources/dash/test_1.mpd
+++ b/tests/resources/dash/test_1.mpd
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD id='dash' type="dynamic" xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  minBufferTime="PT11S"
+  suggestedPresentationDelay="PT11S"
+  availabilityStartTime="2018-01-01T00:00:00Z"
+  publishTime="2018-05-20T19:56:59Z"
+  minimumUpdatePeriod="PT3.5S"
+  maxSegmentDuration="PT6S"
+  timeShiftBufferDepth='PT30S'>
+    <Location>http://test.se/</Location>
+    <Period id='1526842800' start="PT12078000.272S" >
+        <AdaptationSet mimeType="video/mp4" contentType="video" id="4"
+ maxWidth="1920" maxHeight="1080" maxFrameRate="25" segmentAlignment="true"
+ startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+            <Representation id="tracks-v3" width="512" height="288" bandwidth="505000" codecs="avc1.420015">
+              <SegmentTemplate initialization="$RepresentationID$/init-1526842800.g_m4v" media="$RepresentationID$/dvr-1526842800-$Number$.g_m4v?t=$Time$" timescale="1000"  startNumber="695">
+                 <SegmentTimeline>
+   <S t="3388000" d="5000" r="5"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+            <Representation id="tracks-v4" width="720" height="404" bandwidth="944000" codecs="avc1.4d001e">
+              <SegmentTemplate initialization="$RepresentationID$/init-1526842800.g_m4v" media="$RepresentationID$/dvr-1526842800-$Number$.g_m4v?t=$Time$" timescale="1000"  startNumber="695">
+                 <SegmentTimeline>
+   <S t="3388000" d="5000" r="5"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+            <Representation id="tracks-v5" width="1024" height="576" bandwidth="1966000" codecs="avc1.4d001f">
+              <SegmentTemplate initialization="$RepresentationID$/init-1526842800.g_m4v" media="$RepresentationID$/dvr-1526842800-$Number$.g_m4v?t=$Time$" timescale="1000"  startNumber="695">
+                 <SegmentTimeline>
+   <S t="3388000" d="5000" r="5"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+            <Representation id="tracks-v6" width="1280" height="720" bandwidth="3351000" codecs="avc1.4d001f">
+              <SegmentTemplate initialization="$RepresentationID$/init-1526842800.g_m4v" media="$RepresentationID$/dvr-1526842800-$Number$.g_m4v?t=$Time$" timescale="1000"  startNumber="695">
+                 <SegmentTimeline>
+   <S t="3388000" d="5000" r="5"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+            <Representation id="tracks-v7" width="1920" height="1080" bandwidth="5870000" codecs="avc1.4d0028">
+              <SegmentTemplate initialization="$RepresentationID$/init-1526842800.g_m4v" media="$RepresentationID$/dvr-1526842800-$Number$.g_m4v?t=$Time$" timescale="1000"  startNumber="695">
+                 <SegmentTimeline>
+   <S t="3388000" d="5000" r="5"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet id="2" mimeType="audio/mp4" contentType="audio" lang="ces" segmentAlignment="true" startWithSAP="1">
+            <Representation mimeType="audio/mp4" id="tracks-a1" bandwidth="126000" codecs="mp4a.40.2">
+              <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+              <SegmentTemplate initialization="$RepresentationID$/init-1526842800.g_m4v" media="$RepresentationID$/dvr-1526842800-$Number$.g_m4v?t=$Time$" timescale="1000"  startNumber="695">
+                 <SegmentTimeline>
+   <S t="3388000" d="5000" r="5"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+    <UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="2018-05-20T19:56:59Z" />
+</MPD>

--- a/tests/resources/dash/test_2.mpd
+++ b/tests/resources/dash/test_2.mpd
@@ -1,0 +1,71 @@
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="static" mediaPresentationDuration="PT0H14M48.00S" timeShiftBufferDepth="PT1S" minimumUpdatePeriod="PT1H" maxSegmentDuration="PT3S" minBufferTime="PT1S" profiles="urn:mpeg:dash:profile:isoff-live:2011,urn:com:dashif:dash264">
+  <Period id="1" start="PT0S">
+    <AdaptationSet group="1" lang="en_stereo" mimeType="audio/mp4" minBandwidth="130358" maxBandwidth="130358" segmentAlignment="true">
+      <Representation id="128kbps en" bandwidth="130358" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <SegmentTemplate timescale="48000" duration="95232" media="audio/stereo/en/128kbit/segment_$Number$.m4s" initialization="audio/stereo/en/128kbit/init.mp4" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="2" lang="no-voices_stereo" mimeType="audio/mp4" minBandwidth="130395" maxBandwidth="130395" segmentAlignment="true">
+      <Representation id="128kbps karaoke" bandwidth="130395" codecs="mp4a.40.2" audioSamplingRate="48000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"/>
+        <SegmentTemplate timescale="48000" duration="95232" media="audio/stereo/none/128kbit/segment_$Number$.m4s" initialization="audio/stereo/none/128kbit/init.mp4" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="3" lang="en_surround" mimeType="audio/mp4" minBandwidth="321836" maxBandwidth="321836" segmentAlignment="true">
+      <Representation id="320kbps en" bandwidth="321836" codecs="mp4a.40.5" audioSamplingRate="48000">
+        <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="6"/>
+        <SegmentTemplate timescale="48000" duration="95232" media="audio/surround/en/320kbit/segment_$Number$.m4s" initialization="audio/surround/en/320kbit/init.mp4" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="4" mimeType="video/mp4" par="4096:1744" minBandwidth="258157" maxBandwidth="10285391" minWidth="426" maxWidth="4096" minHeight="180" maxHeight="1744" segmentAlignment="true" startWithSAP="1">
+      <Representation id="240p 250kbps" frameRate="24" bandwidth="258157" codecs="avc1.4d400d" width="426" height="180">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/250kbit/segment_$Number$.m4s" initialization="video/250kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="480p 500kbps" frameRate="24" bandwidth="520929" codecs="avc1.4d4015" width="638" height="272">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/500kbit/segment_$Number$.m4s" initialization="video/500kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="480p 800kbps" frameRate="24" bandwidth="831270" codecs="avc1.4d4015" width="638" height="272">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/800kbit/segment_$Number$.m4s" initialization="video/800kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="576p 1100kbps" frameRate="24" bandwidth="1144430" codecs="avc1.4d401f" width="958" height="408">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/1100kbit/segment_$Number$.m4s" initialization="video/1100kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="720p 1500kbps" frameRate="24" bandwidth="1558322" codecs="avc1.4d401f" width="1277" height="544">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/1500kbit/segment_$Number$.m4s" initialization="video/1500kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="720p 2400kbps" frameRate="24" bandwidth="2487897" codecs="avc1.4d401f" width="1277" height="544">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/2400kbit/segment_$Number$.m4s" initialization="video/2400kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="1080p 3000kbps" frameRate="24" bandwidth="3113198" codecs="avc1.4d4028" width="1920" height="818">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/3000kbit/segment_$Number$.m4s" initialization="video/3000kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="1080p 4000kbps" frameRate="24" bandwidth="4149264" codecs="avc1.4d4028" width="1920" height="818">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/4000kbit/segment_$Number$.m4s" initialization="video/4000kbit/init.mp4" startNumber="1"/>
+      </Representation>
+      <Representation id="1080p 6000kbps" frameRate="24" bandwidth="6214307" codecs="avc1.4d4028" width="1920" height="818">
+        <SegmentTemplate timescale="1000" duration="2000" media="video/6000kbit/segment_$Number$.m4s" initialization="video/6000kbit/init.mp4" startNumber="1"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="14" mimeType="text/vtt" lang="en">
+      <Representation id="caption_en" bandwidth="256">
+        <BaseURL>subtitles/subtitles_en.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="15" mimeType="text/vtt" lang="de">
+      <Representation id="caption_de" bandwidth="256">
+        <BaseURL>subtitles/subtitles_de.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="16" mimeType="text/vtt" lang="es">
+      <Representation id="caption_es" bandwidth="256">
+        <BaseURL>subtitles/subtitles_es.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet group="17" mimeType="text/vtt" lang="fr">
+      <Representation id="caption_fr" bandwidth="256">
+        <BaseURL>subtitles/subtitles_fr.vtt</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/resources/dash/test_3.mpd
+++ b/tests/resources/dash/test_3.mpd
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="urn:mpeg:dash:schema:mpd:2011"
+ xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+ minBufferTime="PT1S"
+ profiles="urn:mpeg:dash:profile:isoff-live:2011"
+ type="dynamic"
+ timeShiftBufferDepth="PT16S"
+ minimumUpdatePeriod="PT4S"
+ publishTime="2018-05-04T16:21:16Z"
+ availabilityStartTime="1970-01-01T00:00:00Z">
+  <Period id="1" start="PT0S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video" segmentAlignment="true" startWithSAP="1">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="main"/>
+      <SegmentTemplate presentationTimeOffset="0" media="video-time=$Time$-$Bandwidth$-0.m4s?z32=" initialization="video-$Bandwidth$-0.mp4?z32=" timescale="1000" startNumber="381362716">
+        <SegmentTimeline>
+          <S t="1525450860000" d="4000" r="3"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="0" codecs="avc1.4d401f" width="1280" height="720" frameRate="25" bandwidth="2800000"/>
+      <Representation id="1" codecs="avc1.4d401e" width="768" height="432" frameRate="25" bandwidth="1300000"/>
+      <Representation id="2" codecs="avc1.4d4015" width="512" height="288" frameRate="25" bandwidth="700000"/>
+      <Representation id="3" codecs="avc1.4d4015" width="512" height="288" frameRate="25" bandwidth="500000"/>
+    </AdaptationSet>
+    <AdaptationSet id="1" lang="de" mimeType="audio/mp4" contentType="audio" codecs="mp4a.40.2" segmentAlignment="true" startWithSAP="1">
+      <AudioChannelConfiguration schemeIdUri="urn:mpeg:mpegB:cicp:ChannelConfiguration" value="2"/>
+      <SegmentTemplate presentationTimeOffset="0" media="audio-time=$Time$-$Bandwidth$-0.m4s?z32=" initialization="audio-$Bandwidth$-0.mp4?z32=" timescale="1000" startNumber="476703395">
+        <SegmentTimeline>
+          <S t="1525450860800" d="3200" r="3"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="4" bandwidth="128000"/>
+    </AdaptationSet>
+    <AdaptationSet id="2" lang="de" mimeType="application/mp4" contentType="text" codecs="stpp">
+      <Role schemeIdUri="urn:mpeg:dash:role:2011" value="alternate"/>
+      <SegmentTemplate presentationTimeOffset="0" media="subs-time=$Time$-3000000-0.m4s?z32=" initialization="subs-3000000-0.mp4?z32=" timescale="1000" startNumber="381362716">
+        <SegmentTimeline>
+          <S t="1525450860000" d="4000" r="3"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="5" bandwidth="100"/>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/resources/dash/test_4.mpd
+++ b/tests/resources/dash/test_4.mpd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="dynamic" publishTime="2018-05-10T09:27:09" minimumUpdatePeriod="PT10S" availabilityStartTime="2018-05-04T13:20:07Z" minBufferTime="PT2S" suggestedPresentationDelay="PT40S" timeShiftBufferDepth="PT24H0M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period start="PT0S" id="1">
+    <AdaptationSet mimeType="video/mp4" frameRate="25/1" segmentAlignment="true" subsegmentAlignment="true" startWithSAP="1" subsegmentStartsWithSAP="1" bitstreamSwitching="false">
+      <SegmentTemplate timescale="90000" duration="450000" startNumber="1"/>
+      <Representation id="1" width="1280" height="720" bandwidth="2400000" codecs="avc1.64001f">
+        <SegmentTemplate duration="450000" startNumber="1" media="hd-5_$Number%09d$.mp4" initialization="hd-5-init.mp4"/>
+      </Representation>
+      <Representation id="2" width="1280" height="720" bandwidth="1250000" codecs="avc1.64001f">
+        <SegmentTemplate duration="450000" startNumber="1" media="hd-4_$Number%09d$.mp4" initialization="hd-4-init.mp4"/>
+      </Representation>
+      <Representation id="3" width="640" height="360" bandwidth="950000" codecs="avc1.4d401e">
+        <SegmentTemplate duration="450000" startNumber="1" media="hd-3_$Number%09d$.mp4" initialization="hd-3-init.mp4"/>
+      </Representation>
+      <Representation id="4" width="640" height="360" bandwidth="650000" codecs="avc1.4d401e">
+        <SegmentTemplate duration="450000" startNumber="1" media="hd-2_$Number%09d$.mp4" initialization="hd-2-init.mp4"/>
+      </Representation>
+      <Representation id="5" width="640" height="360" bandwidth="350000" codecs="avc1.4d401e">
+        <SegmentTemplate duration="450000" startNumber="1" media="hd-1_$Number%09d$.mp4" initialization="hd-1-init.mp4"/>
+      </Representation>
+      <Representation id="6" width="160" height="90" bandwidth="110000" codecs="avc1.4d400b">
+        <SegmentTemplate duration="450000" startNumber="1" media="hd-0_$Number%09d$.mp4" initialization="hd-0-init.mp4"/>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet mimeType="audio/mp4" lang="rus" segmentAlignment="0">
+      <SegmentTemplate timescale="48000" media="hd-audio_$Number%09d$.mp4" initialization="hd-audio-init.mp4" duration="240000" startNumber="1"/>
+      <Representation id="7" bandwidth="96000" audioSamplingRate="48000" codecs="mp4a.40.2"/>
+    </AdaptationSet>
+    <AdaptationSet mimeType="application/mp4" lang="rus">
+      <Role schemeIdUri="urn:mpeg:dash:role" value="subtitle"/>
+      <SegmentTemplate timescale="90000" media="hd-caption_$Number%09d$.mp4" initialization="hd-caption-init.mp4" duration="450000" startNumber="1"/>
+      <Representation id="8" bandwidth="256" codecs="stpp"/>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/resources/dash/test_5.mpd
+++ b/tests/resources/dash/test_5.mpd
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Created with Unified Streaming Platform(version=1.7.10) -->
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="static"
+  mediaPresentationDuration="PT1M23.847347S"
+  maxSegmentDuration="PT3S"
+  minBufferTime="PT10S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period>
+    <BaseURL>dash/</BaseURL>
+    <AdaptationSet
+      group="1"
+      contentType="audio"
+      lang="en"
+      minBandwidth="128000"
+      maxBandwidth="152000"
+      segmentAlignment="true"
+      audioSamplingRate="44100"
+      mimeType="audio/mp4"
+      codecs="mp4a.40.2">
+      <AudioChannelConfiguration
+        schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011"
+        value="2">
+      </AudioChannelConfiguration>
+      <SegmentTemplate
+        timescale="44100"
+        initialization="150633-$RepresentationID$.dash"
+        media="150633-$RepresentationID$-$Time$.dash"
+        startNumber="1">
+        <SegmentTimeline>
+          <S t="0" d="90113" />
+          <S d="88064" r="5" />
+          <S d="89088" />
+          <S d="88064" r="6" />
+          <S d="89088" />
+          <S d="88064" r="5" />
+          <S d="89088" />
+          <S d="88064" r="6" />
+          <S d="89088" />
+          <S d="88064" r="5" />
+          <S d="89088" />
+          <S d="88064" r="2" />
+          <S d="79875" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="audio_eng=128000"
+        bandwidth="128000">
+      </Representation>
+      <Representation
+        id="audio_eng=152000"
+        bandwidth="152000">
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet
+      group="2"
+      contentType="video"
+      lang="en"
+      par="16:9"
+      minBandwidth="194000"
+      maxBandwidth="4858000"
+      minWidth="426"
+      maxWidth="1920"
+      minHeight="240"
+      maxHeight="1080"
+      segmentAlignment="true"
+      mimeType="video/mp4"
+      startWithSAP="1">
+      <SegmentTemplate
+        timescale="1000"
+        initialization="150633-$RepresentationID$.dash"
+        media="150633-$RepresentationID$-$Time$.dash"
+        startNumber="1">
+        <SegmentTimeline>
+          <S t="0" d="2000" r="40" />
+          <S d="1680" />
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        id="video_eng=194000"
+        bandwidth="194000"
+        width="426"
+        height="240"
+        sar="640:639"
+        codecs="avc1.42C015"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video_eng=436000"
+        bandwidth="436000"
+        width="640"
+        height="360"
+        codecs="avc1.42C01E"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video_eng=869000"
+        bandwidth="869000"
+        width="854"
+        height="480"
+        sar="1280:1281"
+        codecs="avc1.42C01E"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video_eng=1703000"
+        bandwidth="1703000"
+        width="1024"
+        height="576"
+        codecs="avc1.4D401F"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video_eng=2362000"
+        bandwidth="2362000"
+        width="1280"
+        height="720"
+        codecs="avc1.64001F"
+        scanType="progressive">
+      </Representation>
+      <Representation
+        id="video_eng=4858000"
+        bandwidth="4858000"
+        width="1920"
+        height="1080"
+        codecs="avc1.640028"
+        scanType="progressive">
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/resources/dash/test_6_p1.mpd
+++ b/tests/resources/dash/test_6_p1.mpd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  type="dynamic" xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  minBufferTime="PT5S"
+  suggestedPresentationDelay="PT5S"
+  availabilityStartTime="2018-01-01T00:00:00Z"
+  publishTime="2018-01-01T13:00:00Z"
+  minimumUpdatePeriod="PT5S"
+  maxSegmentDuration="PT1S"
+  timeShiftBufferDepth='PT30S'>
+    <Location>http://test.se/</Location>
+    <Period id='1' start="PT3600.0S" >
+        <AdaptationSet mimeType="video/mp4" contentType="video" id="4" maxWidth="1920" maxHeight="1080" maxFrameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+            <Representation id="video" width="512" height="288" bandwidth="505000" codecs="avc1.420015">
+              <SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Time$.mp4" timescale="1000">
+                 <SegmentTimeline>
+                    <S t="1000000" d="1000" r="10"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/tests/resources/dash/test_6_p2.mpd
+++ b/tests/resources/dash/test_6_p2.mpd
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  type="dynamic" xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  minBufferTime="PT5S"
+  suggestedPresentationDelay="PT5S"
+  availabilityStartTime="2018-01-01T00:00:00Z"
+  publishTime="2018-01-01T13:00:05Z"
+  minimumUpdatePeriod="PT5S"
+  maxSegmentDuration="PT1S"
+  timeShiftBufferDepth='PT30S'>
+    <Location>http://test.se/</Location>
+    <Period id='1' start="PT3600.0S" >
+        <AdaptationSet mimeType="video/mp4" contentType="video" id="4" maxWidth="1920" maxHeight="1080" maxFrameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+            <Representation id="video" width="512" height="288" bandwidth="505000" codecs="avc1.420015">
+              <SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/$Time$.mp4" timescale="1000">
+                 <SegmentTimeline>
+                    <S t="1005000" d="1000" r="10"/>
+                 </SegmentTimeline>
+              </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -1,16 +1,7 @@
-import sys
-
 from streamlink.stream.dash import DASHStreamWorker
 
-if sys.version_info[0:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
-
-try:
-    from unittest.mock import MagicMock, patch, ANY, Mock, call
-except ImportError:
-    from mock import MagicMock, patch, ANY, Mock, call
+from tests import unittest
+from tests.mock import MagicMock, patch, ANY, Mock, call
 
 from streamlink import PluginError
 from streamlink.stream import *
@@ -25,7 +16,7 @@ class TestDASHStream(unittest.TestCase):
     @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_video_only(self, mpdClass):
         mpd = mpdClass.return_value = Mock(periods=[
-            Mock(adaptionSets=[
+            Mock(adaptationSets=[
                 Mock(contentProtection=None,
                      representations=[
                          Mock(id=1, mimeType="video/mp4", height=720),
@@ -45,7 +36,7 @@ class TestDASHStream(unittest.TestCase):
     @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_audio_only(self, mpdClass):
         mpd = mpdClass.return_value = Mock(periods=[
-            Mock(adaptionSets=[
+            Mock(adaptationSets=[
                 Mock(contentProtection=None,
                      representations=[
                          Mock(id=1, mimeType="audio/mp4", bandwidth=128.0),
@@ -65,7 +56,7 @@ class TestDASHStream(unittest.TestCase):
     @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_audio_single(self, mpdClass):
         mpd = mpdClass.return_value = Mock(periods=[
-            Mock(adaptionSets=[
+            Mock(adaptationSets=[
                 Mock(contentProtection=None,
                      representations=[
                          Mock(id=1, mimeType="video/mp4", height=720),
@@ -86,7 +77,7 @@ class TestDASHStream(unittest.TestCase):
     @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_audio_multi(self, mpdClass):
         mpd = mpdClass.return_value = Mock(periods=[
-            Mock(adaptionSets=[
+            Mock(adaptationSets=[
                 Mock(contentProtection=None,
                      representations=[
                          Mock(id=1, mimeType="video/mp4", height=720),
@@ -107,7 +98,7 @@ class TestDASHStream(unittest.TestCase):
 
     @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_drm(self, mpdClass):
-        mpd = mpdClass.return_value = Mock(periods=[Mock(adaptionSets=[Mock(contentProtection="DRM")])])
+        mpd = mpdClass.return_value = Mock(periods=[Mock(adaptationSets=[Mock(contentProtection="DRM")])])
 
         self.assertRaises(PluginError,
                           DASHStream.parse_manifest,
@@ -157,7 +148,7 @@ class TestDASHStreamWorker(unittest.TestCase):
         mpdClass.return_value = worker.mpd = Mock(dynamic=True,
                                                   publishTime=1,
                                                   periods=[
-                                                      Mock(adaptionSets=[
+                                                      Mock(adaptationSets=[
                                                           Mock(contentProtection=None,
                                                                representations=[
                                                                    representation
@@ -177,6 +168,7 @@ class TestDASHStreamWorker(unittest.TestCase):
         representation.segments.return_value = segments[1:]
         self.assertSequenceEqual([next(segment_iter), next(segment_iter)], segments[1:])
         representation.segments.assert_called_with(init=False)
+
     def test_static(self):
         reader = MagicMock()
         worker = DASHStreamWorker(reader)
@@ -188,7 +180,7 @@ class TestDASHStreamWorker(unittest.TestCase):
         worker.mpd = Mock(dynamic=False,
                           publishTime=1,
                           periods=[
-                              Mock(adaptionSets=[
+                              Mock(adaptationSets=[
                                   Mock(contentProtection=None,
                                        representations=[
                                            representation

--- a/tests/streams/test_dash_parser.py
+++ b/tests/streams/test_dash_parser.py
@@ -64,6 +64,9 @@ class TestMPDParsers(unittest.TestCase):
 
 
 class TestMPDParser(unittest.TestCase):
+    maxDiff = None
+
+
     def test_segments_number_time(self):
         with xml("dash/test_1.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")
@@ -124,19 +127,14 @@ class TestMPDParser(unittest.TestCase):
                 for _ in range(3):
                     seg = next(segments)
                     video_segments.append((seg.url,
-                                           seg.available_at,
-                                           datetime.datetime.now(tz=utc)))
-                    frozen_datetime.tick(5)
+                                           seg.available_at))
 
                 self.assertSequenceEqual(video_segments,
                                          [('http://test.se/hd-5_000311235.mp4',
-                                           datetime.datetime(2018, 5, 22, 13, 36, 20, tzinfo=utc),
                                            datetime.datetime(2018, 5, 22, 13, 37, 0, tzinfo=utc)),
                                           ('http://test.se/hd-5_000311236.mp4',
-                                           datetime.datetime(2018, 5, 22, 13, 36, 25, tzinfo=utc),
                                            datetime.datetime(2018, 5, 22, 13, 37, 5, tzinfo=utc)),
                                           ('http://test.se/hd-5_000311237.mp4',
-                                           datetime.datetime(2018, 5, 22, 13, 36, 30, tzinfo=utc),
                                            datetime.datetime(2018, 5, 22, 13, 37, 10, tzinfo=utc))
                                           ])
 

--- a/tests/streams/test_dash_parser.py
+++ b/tests/streams/test_dash_parser.py
@@ -1,0 +1,78 @@
+from __future__ import unicode_literals
+
+import datetime
+
+import itertools
+from operator import attrgetter
+
+from streamlink.stream.dash_manifest import MPD, MPDParsers, MPDParsingError, utc
+from tests import unittest
+from tests.resources import xml
+
+
+class TestMPDParsers(unittest.TestCase):
+    def test_utc(self):
+        self.assertIn(utc.tzname(None), ("UTC", "UTC+00:00"))  # depends on the implementation
+        self.assertIn(utc.dst(None), (None, datetime.timedelta(0)))  # depends on the implementation
+        self.assertEqual(utc.utcoffset(None), datetime.timedelta(0))
+
+    def test_bool_str(self):
+        self.assertEquals(MPDParsers.bool_str("true"), True)
+        self.assertEquals(MPDParsers.bool_str("TRUE"), True)
+        self.assertEquals(MPDParsers.bool_str("True"), True)
+
+        self.assertEquals(MPDParsers.bool_str("0"), False)
+        self.assertEquals(MPDParsers.bool_str("False"), False)
+        self.assertEquals(MPDParsers.bool_str("false"), False)
+        self.assertEquals(MPDParsers.bool_str("FALSE"), False)
+
+    def test_type(self):
+        self.assertEquals(MPDParsers.type("dynamic"), "dynamic")
+        self.assertEquals(MPDParsers.type("static"), "static")
+        with self.assertRaises(MPDParsingError):
+            MPDParsers.type("other")
+
+    def test_duration(self):
+        self.assertEquals(MPDParsers.duration("PT1S"), datetime.timedelta(0, 1))
+
+    def test_datetime(self):
+        self.assertEquals(MPDParsers.datetime("2018-01-01T00:00:00Z"),
+                          datetime.datetime(2018, 1, 1, 0, 0, 0, tzinfo=utc))
+
+    def test_segment_template(self):
+        self.assertEqual(MPDParsers.segment_template("$Time$-$Number$-$Other$")(Time=1, Number=2, Other=3),
+                         "1-2-3")
+        self.assertEqual(MPDParsers.segment_template("$Number%05d$")(Number=123),
+                         "00123")
+        self.assertEqual(MPDParsers.segment_template("$Time%0.02f$")(Time=100.234),
+                         "100.23")
+
+    def test_frame_rate(self):
+        self.assertAlmostEqual(MPDParsers.frame_rate("1/25"),
+                               1 / 25.0)
+        self.assertAlmostEqual(MPDParsers.frame_rate("0.2"),
+                               0.2)
+
+    def test_timedelta(self):
+        self.assertEqual(MPDParsers.timedelta(1)(100),
+                         datetime.timedelta(0, 100.0))
+        self.assertEqual(MPDParsers.timedelta(10)(100),
+                         datetime.timedelta(0, 10.0))
+
+
+class TestMPDParser(unittest.TestCase):
+    def test_segments_number_time(self):
+        with xml("dash/test_1.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")
+
+            segments = mpd.periods[0].adaptationSets[0].representations[0].segments()
+            init_segment = next(segments)
+            self.assertEqual(init_segment.url, "http://test.se/tracks-v3/init-1526842800.g_m4v")
+
+            video_segments = list(map(attrgetter("url"), (itertools.islice(segments, 5))))
+            self.assertSequenceEqual(video_segments,
+                                     ['http://test.se/tracks-v3/dvr-1526842800-695.g_m4v?t=3388000',
+                                      'http://test.se/tracks-v3/dvr-1526842800-696.g_m4v?t=3393000',
+                                      'http://test.se/tracks-v3/dvr-1526842800-697.g_m4v?t=3398000',
+                                      'http://test.se/tracks-v3/dvr-1526842800-698.g_m4v?t=3403000',
+                                      'http://test.se/tracks-v3/dvr-1526842800-699.g_m4v?t=3408000'])

--- a/tests/test_docs_plugins.py
+++ b/tests/test_docs_plugins.py
@@ -15,7 +15,7 @@ class TestPluginMatrix(unittest.TestCase):
     Test that each plugin has an entry in the plugin matrix
     """
     longMessage = False
-    built_in_plugins = ['akamaihd', 'http', 'hds', 'rtmp', 'hls']
+    built_in_plugins = ['akamaihd', 'http', 'hds', 'rtmp', 'hls', 'dash']
 
     title_re = re.compile("\n[= ]+\n")
     plugin_re = re.compile("^([\w_]+)\s", re.MULTILINE)

--- a/tests/test_plugin_dash.py
+++ b/tests/test_plugin_dash.py
@@ -3,7 +3,7 @@ import unittest
 from mock import patch
 
 from streamlink import Streamlink
-from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
+from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, BIT_RATE_WEIGHT_RATIO
 from streamlink.plugins.dash import MPEGDASH
 
 
@@ -29,10 +29,11 @@ class TestPluginMPEGDASH(unittest.TestCase):
         self.assertEqual(MPEGDASH.priority("http://example.com/bar"), NO_PRIORITY)
 
     def test_stream_weight(self):
-        self.assertEqual(MPEGDASH.stream_weight("720p"), (720, 'pixels'))
-        self.assertEqual(MPEGDASH.stream_weight("1080p"), (1080, 'pixels'))
-        self.assertEqual(MPEGDASH.stream_weight("720p+a128k"), (720+128, 'pixels'))
-        self.assertEqual(MPEGDASH.stream_weight("720p+a0k"), (720, 'pixels'))
+        self.assertAlmostEqual(MPEGDASH.stream_weight("720p"), (720, 'pixels'))
+        self.assertAlmostEqual(MPEGDASH.stream_weight("1080p"), (1080, 'pixels'))
+        self.assertAlmostEqual(MPEGDASH.stream_weight("720p+a128k"), (720+128, 'pixels'))
+        self.assertAlmostEqual(MPEGDASH.stream_weight("720p+a0k"), (720, 'pixels'))
+        self.assertAlmostEqual(MPEGDASH.stream_weight("a128k"), (128 / BIT_RATE_WEIGHT_RATIO, 'bitrate'))
 
     @patch("streamlink.stream.DASHStream.parse_manifest")
     def test_get_streams_prefix(self, parse_manifest):

--- a/tests/test_plugin_dash.py
+++ b/tests/test_plugin_dash.py
@@ -1,12 +1,19 @@
 import unittest
 
+from mock import patch
+
+from streamlink import Streamlink
+from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.plugins.dash import MPEGDASH
 
 
 class TestPluginMPEGDASH(unittest.TestCase):
+    def setUp(self):
+        self.session = Streamlink()
+
     def test_can_handle_url(self):
         # should match
-        self.assertTrue(MPEGDASH.can_handle_url("http://example.com/fpo.mpd"))
+        self.assertTrue(MPEGDASH.can_handle_url("http://example.com/foo.mpd"))
         self.assertTrue(MPEGDASH.can_handle_url("dash://http://www.testing.cat/directe"))
         self.assertTrue(MPEGDASH.can_handle_url("dash://https://www.testing.cat/directe"))
 
@@ -14,3 +21,29 @@ class TestPluginMPEGDASH(unittest.TestCase):
         # shouldn't match
         self.assertFalse(MPEGDASH.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(MPEGDASH.can_handle_url("http://www.youtube.com/"))
+
+    def test_priority(self):
+        self.assertEqual(MPEGDASH.priority("http://example.com/fpo.mpd"), LOW_PRIORITY)
+        self.assertEqual(MPEGDASH.priority("dash://http://example.com/foo.mpd"), NORMAL_PRIORITY)
+        self.assertEqual(MPEGDASH.priority("dash://http://example.com/bar"), NORMAL_PRIORITY)
+        self.assertEqual(MPEGDASH.priority("http://example.com/bar"), NO_PRIORITY)
+
+    def test_stream_weight(self):
+        self.assertEqual(MPEGDASH.stream_weight("720p"), (720, 'pixels'))
+        self.assertEqual(MPEGDASH.stream_weight("1080p"), (1080, 'pixels'))
+        self.assertEqual(MPEGDASH.stream_weight("720p+a128k"), (720+128, 'pixels'))
+        self.assertEqual(MPEGDASH.stream_weight("720p+a0k"), (720, 'pixels'))
+
+    @patch("streamlink.stream.DASHStream.parse_manifest")
+    def test_get_streams_prefix(self, parse_manifest):
+        p = MPEGDASH("dash://http://example.com/foo.mpd")
+        p.bind(self.session, 'dash')
+        p.streams()
+        parse_manifest.assert_called_with(self.session, "http://example.com/foo.mpd")
+
+    @patch("streamlink.stream.DASHStream.parse_manifest")
+    def test_get_streams(self, parse_manifest):
+        p = MPEGDASH("http://example.com/foo.mpd")
+        p.bind(self.session, 'dash')
+        p.streams()
+        parse_manifest.assert_called_with(self.session, "http://example.com/foo.mpd")

--- a/tests/test_plugin_dash.py
+++ b/tests/test_plugin_dash.py
@@ -1,0 +1,16 @@
+import unittest
+
+from streamlink.plugins.dash import MPEGDASH
+
+
+class TestPluginMPEGDASH(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(MPEGDASH.can_handle_url("http://example.com/fpo.mpd"))
+        self.assertTrue(MPEGDASH.can_handle_url("dash://http://www.testing.cat/directe"))
+        self.assertTrue(MPEGDASH.can_handle_url("dash://https://www.testing.cat/directe"))
+
+    def test_can_handle_url_negative(self):
+        # shouldn't match
+        self.assertFalse(MPEGDASH.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(MPEGDASH.can_handle_url("http://www.youtube.com/"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,9 @@
 import os
-import unittest
+import sys
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
 
 from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY
 
@@ -21,11 +25,7 @@ class TestSession(unittest.TestCase):
         self.session.load_plugins(self.PluginPath)
 
     def test_exceptions(self):
-        try:
-            self.session.resolve_url("invalid url")
-            self.assertTrue(False)
-        except NoPluginError:
-            self.assertTrue(True)
+        self.assertRaises(NoPluginError, self.session.resolve_url, "invalid url")
 
     def test_load_plugins(self):
         plugins = self.session.get_plugins()

--- a/tests/test_stream_dash.py
+++ b/tests/test_stream_dash.py
@@ -1,0 +1,180 @@
+import sys
+
+from streamlink.stream.dash import DASHStreamWorker
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+try:
+    from unittest.mock import MagicMock, patch, ANY, Mock, call
+except ImportError:
+    from mock import MagicMock, patch, ANY, Mock, call
+
+from streamlink import PluginError
+from streamlink.stream import *
+
+
+class TestDASHStream(unittest.TestCase):
+    def setUp(self):
+        self.session = MagicMock()
+
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_video_only(self, mpdClass):
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptionSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=720),
+                         Mock(id=2, mimeType="video/mp4", height=1080)
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, "http://test.bar/foo.mpd")
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p", "1080p"])
+        )
+
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_audio_single(self, mpdClass):
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptionSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=720),
+                         Mock(id=2, mimeType="video/mp4", height=1080),
+                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0)
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, "http://test.bar/foo.mpd")
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p", "1080p"])
+        )
+
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_audio_multi(self, mpdClass):
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptionSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=720),
+                         Mock(id=2, mimeType="video/mp4", height=1080),
+                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0),
+                         Mock(id=4, mimeType="audio/aac", bandwidth=256.0)
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, "http://test.bar/foo.mpd")
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p+a128k", "1080p+a128k", "720p+a256k", "1080p+a256k"])
+        )
+
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_drm(self, mpdClass):
+        mpd = mpdClass.return_value = Mock(periods=[Mock(adaptionSets=[Mock(contentProtection="DRM")])])
+
+        self.assertRaises(PluginError,
+                          DASHStream.parse_manifest,
+                          self.session, "http://test.bar/foo.mpd")
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+    @patch('streamlink.stream.dash.DASHStreamReader')
+    @patch('streamlink.stream.dash.FFMPEGMuxer')
+    def test_stream_open_video_only(self, muxer, reader):
+        stream = DASHStream(self.session, Mock(), Mock(id=1))
+        open_reader = reader.return_value = Mock()
+
+        stream.open()
+
+        reader.assert_called_with(stream, 1)
+        open_reader.open.assert_called_with()
+        muxer.assert_not_called()
+
+    @patch('streamlink.stream.dash.DASHStreamReader')
+    @patch('streamlink.stream.dash.FFMPEGMuxer')
+    def test_stream_open_video_audio(self, muxer, reader):
+        stream = DASHStream(self.session, Mock(), Mock(id=1), Mock(id=2))
+        open_reader = reader.return_value = Mock()
+
+        stream.open()
+
+        self.assertSequenceEqual(reader.mock_calls, [call(stream, 1),
+                                                     call().open(),
+                                                     call(stream, 2),
+                                                     call().open()])
+        self.assertSequenceEqual(muxer.mock_calls, [call(self.session, open_reader, open_reader),
+                                                    call().open()])
+
+
+class TestDASHStreamWorker(unittest.TestCase):
+    @patch('streamlink.stream.dash.MPD')
+    def test_dynamic_reload(self, mpdClass):
+        reader = MagicMock()
+        worker = DASHStreamWorker(reader)
+        reader.representation_id = 1
+
+        representation = Mock(id=1, mimeType="video/mp4", height=720)
+        segments = [Mock(url="init_segment"), Mock(url="first_segment"), Mock(url="second_segment")]
+        representation.segments.return_value = [segments[0]]
+        mpdClass.return_value = worker.mpd = Mock(dynamic=True,
+                                                  periods=[
+                                                      Mock(adaptionSets=[
+                                                          Mock(contentProtection=None,
+                                                               representations=[
+                                                                   representation
+                                                               ])
+                                                      ])
+                                                  ])
+        worker.mpd.type = "dynamic"
+        worker.mpd.minimumUpdatePeriod.total_seconds.return_value = 0
+        segment_iter = worker.iter_segments()
+
+        representation.segments.return_value = segments[:1]
+        self.assertEqual(next(segment_iter), segments[0])
+        representation.segments.assert_called_with(init=True)
+
+        representation.segments.return_value = segments[1:]
+        self.assertSequenceEqual([next(segment_iter), next(segment_iter)], segments[1:])
+        representation.segments.assert_called_with(init=False)
+
+    def test_static(self):
+        reader = MagicMock()
+        worker = DASHStreamWorker(reader)
+        reader.representation_id = 1
+
+        representation = Mock(id=1, mimeType="video/mp4", height=720)
+        segments = [Mock(url="init_segment"), Mock(url="first_segment"), Mock(url="second_segment")]
+        representation.segments.return_value = [segments[0]]
+        worker.mpd = Mock(dynamic=True,
+                          periods=[
+                              Mock(adaptionSets=[
+                                  Mock(contentProtection=None,
+                                       representations=[
+                                           representation
+                                       ])
+                              ])
+                          ])
+        worker.mpd.type = "static"
+        worker.mpd.minimumUpdatePeriod.total_seconds.return_value = 0
+
+        representation.segments.return_value = segments
+        self.assertSequenceEqual(list(worker.iter_segments()), segments)
+        representation.segments.assert_called_with(init=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_stream_dash.py
+++ b/tests/test_stream_dash.py
@@ -41,6 +41,26 @@ class TestDASHStream(unittest.TestCase):
         )
 
     @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_audio_only(self, mpdClass):
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptionSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="audio/mp4", bandwidth=128.0),
+                         Mock(id=2, mimeType="audio/mp4", bandwidth=256.0)
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, "http://test.bar/foo.mpd")
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["a128k", "a256k"])
+        )
+
+    @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_audio_single(self, mpdClass):
         mpd = mpdClass.return_value = Mock(periods=[
             Mock(adaptionSets=[

--- a/tests/test_stream_dash.py
+++ b/tests/test_stream_dash.py
@@ -138,7 +138,7 @@ class TestDASHStream(unittest.TestCase):
                                                      call().open(),
                                                      call(stream, 2),
                                                      call().open()])
-        self.assertSequenceEqual(muxer.mock_calls, [call(self.session, open_reader, open_reader),
+        self.assertSequenceEqual(muxer.mock_calls, [call(self.session, open_reader, open_reader, copyts=True),
                                                     call().open()])
 
 


### PR DESCRIPTION
This PR adds support to MPEG DASH (mpd) streams (it **does not support DRM**). 

This is something I have been working on for a while (started 2 years ago) and I have just gotten round to getting it to a state that it should be OK to merge. 

`DASHStream.parse_manifest` is the method to use if you wanna using DASHStreams in your plugins, and if you have a stream URL that you wanna try out you can use the `dash://` prefix.

**Test URLs**

- http://www-itec.uni-klu.ac.at/ftp/datasets/DASHDataset2014/BigBuckBunny/15sec/BigBuckBunny_15s_simple_2014_05_09.mpd
- http://bitmovin-a.akamaihd.net/content/sintel/sintel.mpd
- http://bitmovin-a.akamaihd.net/content/MI201109210084_1/mpds/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.mpd
- http://yt-dash-mse-test.commondatastorage.googleapis.com/media/car-20120827-manifest.mpd (many audio variations) 
- http://yt-dash-mse-test.commondatastorage.googleapis.com/media/oops_cenc-20121114-signedlicenseurl-manifest.mpd (DRMed, doesn't work)

**Known Issues**

For streams with separate audio and video tracks some versions of FFMPEG do not start playing the stream until it has completely downloaded - this is a problem for live streams and long VOD. I have not managed to work out the cause.

I would like some people to test it out and we can iron out the bugs as we go. 