### PR TITLE
plugins.tf1: add lci url to the main tf1 domain

### DIFF
--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -9,7 +9,7 @@ from streamlink.stream import HLSStream
 
 
 class TF1(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/(tf1|tmc|tfx|tf1-series-films)/direct|(lci).fr/direct)/?")
+    url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/(tf1|tmc|tfx|tf1-series-films|lci)/direct|(lci).fr/direct)/?")
     embed_url = "http://www.wat.tv/embedframe/live{0}"
     embed_re = re.compile(r"urlLive.*?:.*?\"(http.*?)\"", re.MULTILINE)
     api_url = "http://www.wat.tv/get/{0}/591997"

--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -9,13 +9,20 @@ from streamlink.stream import HLSStream
 
 
 class TF1(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/(tf1|tmc|tfx|tf1-series-films|lci)/direct|(lci).fr/direct)/?")
+    url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/([\w-]+)/direct|(lci).fr/direct)/?")
     embed_url = "http://www.wat.tv/embedframe/live{0}"
     embed_re = re.compile(r"urlLive.*?:.*?\"(http.*?)\"", re.MULTILINE)
     api_url = "http://www.wat.tv/get/{0}/591997"
     swf_url = "http://www.wat.tv/images/v70/PlayerLite.swf"
-    hds_channel_remap = {"tf1": "androidliveconnect", "lci": "androidlivelci", "tfx" : "nt1live", "tf1-series-films" : "hd1live" }
-    hls_channel_remap = {"lci": "LCI", "tf1": "V4", "tfx" : "nt1", "tf1-series-films" : "hd1" }
+    hds_channel_remap = {"tf1": "androidliveconnect",
+                         "lci": "androidlivelci",
+                         "tfx": "nt1live",
+                         "hd1": "hd1live",  # renamed to tfx
+                         "tf1-series-films": "hd1live"}
+    hls_channel_remap = {"lci": "LCI",
+                         "tf1": "V4",
+                         "tfx": "nt1",
+                         "tf1-series-films": "hd1"}
 
     @classmethod
     def can_handle_url(cls, url):
@@ -23,6 +30,7 @@ class TF1(Plugin):
 
     def _get_hds_streams(self, channel):
         channel = self.hds_channel_remap.get(channel, "{0}live".format(channel))
+        self.logger.debug("Using HDS channel name: {0}".format(channel))
         manifest_url = http.get(self.api_url.format(channel),
                                 params={"getURL": 1},
                                 headers={"User-Agent": useragents.FIREFOX}).text

--- a/tests/test_plugin_tf1.py
+++ b/tests/test_plugin_tf1.py
@@ -12,11 +12,11 @@ class TestPluginTF1(unittest.TestCase):
         self.assertTrue(TF1.can_handle_url("http://lci.fr/direct"))
         self.assertTrue(TF1.can_handle_url("http://www.lci.fr/direct"))
         self.assertTrue(TF1.can_handle_url("http://tf1.fr/tmc/direct"))
+        self.assertTrue(TF1.can_handle_url("http://tf1.fr/lci/direct"))
 
+    def test_can_handle_url_negative(self):
         # shouldn't match
         self.assertFalse(TF1.can_handle_url("http://tf1.fr/direct"))
-#       self.assertFalse(TF1.can_handle_url("http://tf1.fr/nt1/direct")) NOTE : TF1 redirect old channel names to new ones (for now).
-#       self.assertFalse(TF1.can_handle_url("http://tf1.fr/hd1/direct"))
         self.assertFalse(TF1.can_handle_url("http://www.tf1.fr/direct"))
         self.assertFalse(TF1.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(TF1.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
Fixes #1659.

The set of pages supported is hardcoded because some need to be remapped, any others that are not listed should be considered unsupported. 

Update: Reverted the site URL regex back to the original style of matching all channels - it's more robust and gives better error messages if new channels are added or renamed. 