### PR TITLE
Add the README file to the Python package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
-
+import codecs
 import os
-import versioneer
 from os import environ
-from os.path import abspath, dirname, join
-from setuptools import setup, find_packages
+from os import path
 from sys import version_info, path as sys_path
+
+from setuptools import setup, find_packages
+
+import versioneer
 
 deps = []
 
@@ -60,8 +62,12 @@ if os.name == "nt" and version_info < (3, 0):
 if environ.get("NO_DEPS"):
     deps = []
 
-srcdir = join(dirname(abspath(__file__)), "src/")
+this_directory = path.abspath(path.dirname(__file__))
+srcdir = path.join(this_directory, "src/")
 sys_path.insert(0, srcdir)
+
+with codecs.open(path.join(this_directory, 'README.md'), 'r', 'utf8') as f:
+    long_description = f.read()
 
 setup(name="streamlink",
       version=versioneer.get_version(),
@@ -69,6 +75,8 @@ setup(name="streamlink",
       description="Streamlink is command-line utility that extracts streams "
                   "from various services and pipes them into a video player of "
                   "choice.",
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       url="https://github.com/streamlink/streamlink",
       author="Streamlink",
       author_email="charlie@charliedrage.com",  # temp until we have a mailing list / global email

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 import codecs
 import os
+import versioneer
+
 from os import environ
 from os import path
 from sys import version_info, path as sys_path
-
 from setuptools import setup, find_packages
-
-import versioneer
 
 deps = []
 
@@ -89,12 +88,17 @@ setup(name="streamlink",
       install_requires=deps,
       test_suite="tests",
       classifiers=["Development Status :: 5 - Production/Stable",
+                   "License :: OSI Approved :: BSD License",
                    "Environment :: Console",
+                   "Intended Audience :: End Users/Desktop",
                    "Operating System :: POSIX",
                    "Operating System :: Microsoft :: Windows",
+                   "Operating System :: MacOS",
                    "Programming Language :: Python :: 2.7",
-                   "Programming Language :: Python :: 3.3",
                    "Programming Language :: Python :: 3.4",
+                   "Programming Language :: Python :: 3.5",
+                   "Programming Language :: Python :: 3.6",
+                   "Programming Language :: Python :: 3.7",
                    "Topic :: Internet :: WWW/HTTP",
                    "Topic :: Multimedia :: Sound/Audio",
                    "Topic :: Multimedia :: Video",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ if os.name == "nt" and version_info < (3, 0):
     # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
     deps.append("win-inet-pton")
 
-# When we build an egg for the Win32 bootstrap we don't want dependency
+# When we build an egg for the Win32 bootstrap we don"t want dependency
 # information built into it.
 if environ.get("NO_DEPS"):
     deps = []
@@ -65,7 +65,7 @@ this_directory = path.abspath(path.dirname(__file__))
 srcdir = path.join(this_directory, "src/")
 sys_path.insert(0, srcdir)
 
-with codecs.open(path.join(this_directory, 'README.md'), 'r', 'utf8') as f:
+with codecs.open(path.join(this_directory, "README.md"), 'r', "utf8") as f:
     long_description = f.read()
 
 setup(name="streamlink",
@@ -75,8 +75,14 @@ setup(name="streamlink",
                   "from various services and pipes them into a video player of "
                   "choice.",
       long_description=long_description,
-      long_description_content_type='text/markdown',
+      long_description_content_type="text/markdown",
       url="https://github.com/streamlink/streamlink",
+      project_urls={
+          "Documentation": "https://streamlink.github.io/",
+          "Tracker": "https://github.com/streamlink/streamlink/issues",
+          "Source": "https://github.com/streamlink/streamlink",
+          "Funding": "https://opencollective.com/streamlink"
+      },
       author="Streamlink",
       author_email="charlie@charliedrage.com",  # temp until we have a mailing list / global email
       license="Simplified BSD",
@@ -87,6 +93,7 @@ setup(name="streamlink",
       },
       install_requires=deps,
       test_suite="tests",
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",
       classifiers=["Development Status :: 5 - Production/Stable",
                    "License :: OSI Approved :: BSD License",
                    "Environment :: Console",


### PR DESCRIPTION
Now that PyPI is migrating to their new version (warehouse, I think) we have the ability to include the README as Markdown instead of converting it to RST.

This will make the project page on PyPI look much nicer. You just have to check https://pypi.org/project/streamlink/0.12.1/ to see how great it looks right now 😉 

I also updated the classifiers while I was in `setup.py`... 