### PR TITLE
tests: test to ensure that all plugins are listed in the plugin matrix

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -9,268 +9,272 @@ they support. Streamlink's primary focus is live streams, so VOD support
 is limited.
 
 
-=================== ==================== ===== ===== ===========================
-Name                URL(s)               Live  VOD   Notes
-=================== ==================== ===== ===== ===========================
-abweb               abweb.com            Yes   No    Requires a login and a subscription.
-adultswim           adultswim.com        Yes   Yes   Streams may be geo-restricted, some VOD streams are protected by DRM.
-afreeca             afreecatv.com        Yes   No
-afreecatv           afreeca.tv           Yes   No
-aftonbladet         aftonbladet.se       Yes   Yes
-alieztv             aliez.tv             Yes   Yes
-aljazeeraen         aljazeera.com        Yes   Yes   English version of the site.
-animelab            animelab.com         --    Yes   Requires a login. Streams may be geo-restricted to Australia and New Zealand.
-antenna             antenna.gr           --    Yes
-app17               17app.co             Yes   --
-arconai             arconai.tv           Yes   Yes   Only SD quality streams
-ard_live            daserste.de          Yes   Yes   Streams may be geo-restricted to Germany.
-ard_mediathek       - ardmediathek.de    Yes   Yes   Streams may be geo-restricted to Germany.
-                    - mediathek... [5]_
-artetv              arte.tv              Yes   Yes
-atresplayer         atresplayer.com      Yes   No    Streams are geo-restricted to Spain.
-bbciplayer          bbc.co.uk/iplayer    Yes   Yes   Streams may be geo-restricted to the United Kingdom.
-beattv              be-at.tv             Yes   Yes   Playlist not implemented yet.
-bfmtv               bfmtv.com            Yes   Yes
-                    01net.com
-bigo                - live.bigo.tv       Yes   --
-                    - bigoweb.co
-bilibili            live.bilibili.com    Yes   ?
-bloomberg           bloomberg.com        Yes   Yes
-bongacams           bongacams.com        Yes   No
-brightcove          players.brig... [6]_ Yes   Yes
-brittv              brittv.co.uk         Yes   --
-btv                 btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
-btsports            sport.bt.com         Yes   Yes   Requires subscription account
-cam4                cam4.com             Yes   No
-camsoda             camsoda.com          Yes   No
-canalplus           - mycanal.fr         No    Yes   Streams may be geo-restricted to France.
-                    - cnews.fr
-canlitv             - canlitv.com        Yes   --
-                    - canlitv.life
-                    - canlitvlive.co
-                    - canlitvlive.live
-                    - ecanlitvizle.net
-cdnbg               - tv.bnt.bg          Yes   No    Streams may be geo-restricted to Bulgaria.
-                    - bgonair.bg
-                    - kanal3.bg
-                    - bitelevision.com
-                    - nova.bg
-ceskatelevize       ceskatelevize.cz     Yes   Yes   Streams may be geo-restricted to Czechia.
-chaturbate          chaturbate.com       Yes   No
-cinergroup          - showtv.com.tr      Yes   No
-                    - haberturk.com
-                    - showmax.com.tr
-                    - showturk.com.tr
-                    - bloomberght.com
-crunchyroll         crunchyroll.com      --    Yes
-cybergame           cybergame.tv         Yes   Yes
-cyro                cyro.se              --    Yes
-dailymotion         dailymotion.com      Yes   Yes
-deutschewelle       dw.com               Yes   Yes
-dingittv            dingit.tv            Yes   Yes
-dogan               - teve2.com.tr       Yes   Yes   VOD is supported for teve2 and kanald
-                    - kanald.com.tr
-                    - dreamtv.com.tr
-                    - cnnturk.com
-                    - dreamturk.com.tr
-dogus               - ntvspor.net        Yes   No
-                    - kralmuzik.com.tr
-                    - ntv.com.tr
-                    - eurostartv.com.tr
-dommune             dommune.com          Yes   --
-douyutv             - douyu.com          Yes   Yes
-                    - v.douyu.com
-dplay               - dplay.se           --    Yes   Streams may be geo-restricted.
-                                                     Only non-premium streams currently supported.
-                    - dplay.no
-                    - dplay.dk
-drdk                dr.dk                Yes   Yes   Streams may be geo-restricted to Denmark.
-earthcam            earthcam.com         Yes   Yes   Only works for the cams hosted on EarthCam.
-ellobo              ellobo106.com        Yes   -
-eltrecetv           eltrecetv.com.ar     Yes   Yes   Streams may be geo-restricted to Argentina.
-eurocom             eurocom.bg           Yes   No
-euronews            euronews.com         Yes   No
-expressen           expressen.se         Yes   Yes
-facebook            facebook.com         Yes   No    Only 360p HLS streams.
-filmon              filmon.com           Yes   Yes   Only SD quality streams.
-filmon_us           filmon.us            Yes   Yes
-foxtr               fox.com.tr           Yes   No
-funimationnow       - funimation.com     --    Yes
-                    - funimationnow.uk
-gardenersworld      gardenersworld.com   --    Yes
-garena              garena.live          Yes   --
-goodgame            goodgame.ru          Yes   No    Only HLS streams are available.
-googledrive         - docs.google.com    --    Yes
-                    - drive.google.com
-gulli               replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France.
-hitbox              - hitbox.tv          Yes   Yes
-                    - smashcast.tv
-huajiao             huajiao.com          Yes   No
-huomao              huomao.com           Yes   No
-huya                huya.com             Yes   No    Temporarily only HLS streams available.
-idf1                idf1.fr              Yes   Yes
-ine                 ine.com              ---   Yes
-itvplayer           itv.com/itvplayer    Yes   Yes   Streams may be geo-restricted to Great Britain.
-kanal7              kanal7.com           Yes   No
-kingkong            www.kingkong.com.tw  Yes   Yes
-liveedu             - liveedu.tv         Yes   --    Some streams require a login.
-                    - livecoding.tv
-liveme              liveme.com           Yes   --
-livestream          new.livestream.com   Yes   --
-looch               looch.tv             Yes   Yes
-media_ccc_de        - media.ccc.de       Yes   Yes   Only mp4 and HLS are supported.
-                    - streaming... [4]_
-mediaklikk          mediaklikk.hu        Yes   No    Streams may be geo-restricted to Hungary.
-mips                mips.tv              Yes   --    Requires rtmpdump with K-S-V patches.
-mitele              mitele.es            Yes   No    Streams may be geo-restricted to Spain.
-mixer               mixer.com            Yes   Yes
-mlgtv               mlg.tv               Yes   --
-nbc                 nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
-nbcsports           nbcsports.com        No    Yes   Streams maybe be geo-restricted to USA. Authentication is not supported.
-nhkworld            nhk.or.jp/nhkworld   Yes   No
-nineanime           9anime.to            --    Yes
-nos                 nos.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.
-npo                 - npo.nl             Yes   Yes   Streams may be geo-restricted to Netherlands.
-                    - zapp.nl
-                    - zappelin.nl
-nrk                 - tv.nrk.no          Yes   Yes   Streams may be geo-restricted to Norway.
-                    - radio.nrk.no
-oldlivestream       - original.li.. [3]_ Yes   No    Only mobile streams are supported.
-                    - cdn.livestream.com
-olympicchannel      olympicchannel.com   Yes   Yes   Only non-premium content is available.
-openrectv           openrec.tv           Yes   Yes
-orf_tvthek          tvthek.orf.at        Yes   Yes
-ovvatv              ovva.tv              Yes   No
-pandatv             panda.tv             Yes   ?
-periscope           periscope.tv         Yes   Yes   Replay/VOD is supported.
-picarto             picarto.tv           Yes   Yes
-pixiv               sketch.pixiv.net     Yes   --
-playtv              - playtv.fr          Yes   --    Streams may be geo-restricted to France.
-                    - play.tv
-pluzz               - france.tv          Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
-                    - ludo.fr
-                    - zouzous.fr
-                    - france3-reg.. [8]_
-powerapp            powerapp.com.tr      Yes   No
-qq                  live.qq.com          Yes   No
-radionet            - radio.net          Yes   --
-                    - radio.at
-                    - radio.de
-                    - radio.dk
-                    - radio.es
-                    - radio.fr
-                    - radio.it
-                    - radio.pl
-                    - radio.pt
-                    - radio.se
-raiplay             raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
-rtbf                - rtbf.be/auvio      Yes   Yes   Streams may be geo-restricted to Belgium or Europe.
-                    - rtbfradioplayer.be
-rtlxl               rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.
-rte                 rte.ie/player        Yes   Yes
-rtpplay             rtp.pt/play          Yes   Yes   Streams may be geo-restricted to Portugal.
-rtve                rtve.es              Yes   No
-rtvs                rtvs.sk              Yes   No    Streams may be geo-restricted to Slovakia.
-ruv                 ruv.is               Yes   Yes   Streams may be geo-restricted to Iceland.
-schoolism           schoolism.com        --    Yes   Requires a login and a subscription.
-seemeplay           seemeplay.ru         Yes   Yes
-seetv               seetv.tv             Yes   No    Streams that are embedded from other sites will not work.
-servustv            servustv.com         ?     ?
-showroom            showroom-live.com    Yes   No    Only RTMP streams are available.
-skai                skai.gr              Yes   No    Only embedded youtube live streams are supported
-speedrunslive       speedrunslive.com    Yes   --    URL forwarder to Twitch channels.
-sportal             sportal.bg           Yes   No
-sportschau          sportschau.de        Yes   No
-srgssr              - srf.ch             Yes   No    Streams are geo-restricted to Switzerland.
-                    - rts.ch
-                    - rsi.ch
-                    - rtr.ch
-ssh101              ssh101.com           Yes   No
-startv              startv.com.tr        Yes   No
-streamable          streamable.com       -     Yes
-streamboat          streamboat.tv        Yes   No
-streamingvi... [1]_ streamingvid... [2]_ Yes   --    RTMP streams requires rtmpdump with
-                                                     K-S-V patches.
-streamlive          streamlive.to        Yes   --
-streamme            stream.me            Yes   --
-svtplay             - svtplay.se         Yes   Yes   Streams may be geo-restricted to Sweden.
-                    - svtflow.se
-                    - oppetarkiv.se
-swisstxt            - srf.ch             Yes   No    Streams are geo-restricted to Switzerland.
-                    - rsi.ch
-telefe              telefe.com           No    Yes   Streams are geo-restricted to Argentina.
-tf1                 - tf1.fr             Yes   No    Streams may be geo-restricted to France.
-                    - lci.fr
-tga                 - star.plu.cn        Yes   No
-                    - star.tga.plu.cn
-                    - star.longzhu.com
-theplatform         player.thepl... [7]_ No    Yes
-tigerdile           tigerdile.com        Yes   --
-trt                 trt.net.tr           Yes   No    Some streams may be geo-restricted to Turkey.
-trtspor             trtspor.com          Yes   No    Some streams are geo-restricted to Turkey.
-turkuvaz            - atv.com.tr         Yes   No
-                    - a2tv.com.tr
-                    - ahaber.com.tr
-                    - aspor.com.tr
-                    - minikago.com.tr
-                    - minikacocuk.com.tr
-tv1channel          tv1channel.org       Yes   Yes
-tv3cat              tv3.cat              Yes   Yes   Streams may be geo-restricted to Spain.
-tv4play             - tv4play.se         Yes   Yes   Streams may be geo-restricted to Sweden.
-                                                     Only non-premium streams currently supported.
-                    - fotbollskanalen.se
-tv5monde            - tv5monde.com       Yes   Yes   Streams may be geo-restricted to France, Belgium and Switzerland.
-                    - tv5mondeplus.com
-                    - tv5mondepl... [9]_
-tv8                 tv8.com.tr           Yes   No
-tv8cat              tv8.cat              Yes   No    Streams may be geo-restricted to Spain/Catalunya.
-tv360               tv360.com.tr         Yes   No
-tvcatchup           tvcatchup.com        Yes   No    Streams may be geo-restricted to Great Britain.
-tvnbg               - tvn.bg             Yes   -
-                    - live.tvn.bg
-tvp                 tvpstream.vod.tvp.pl Yes   No    Streams may be geo-restricted to Poland.
-tvplayer            tvplayer.com         Yes   No    Streams may be geo-restricted to Great Britain. Premium streams are not supported.
-tvrby               tvr.by               Yes   No    Streams may be geo-restricted to Belarus.
-tvrplus             tvrplus.ro           Yes   No    Streams may be geo-restricted to Romania.
-twitch              twitch.tv            Yes   Yes   Possible to authenticate for access to
-                                                     subscription streams.
-ustreamtv           ustream.tv           Yes   Yes
-vaughnlive          - vaughnlive.tv      Yes   --
-                    - breakers.tv
-                    - instagib.tv
-                    - vapers.tv
-vgtv                vgtv.no              Yes   Yes
-viasat              - juicyplay.dk       Yes   Yes   Streams may be geo-restricted.
-                    - play.nova.bg
-                    - skaties.lv
-                    - tv3.dk
-                    - tv3.ee
-                    - tv3.lt
-                    - tv6play.no
-                    - viafree.dk
-                    - viafree.no
-                    - viafree.se
-vidio               vidio.com            Yes   Yes
-vk                  vk.com               Yes   Yes
-vrtbe               vrt.be/vrtnu         Yes   Yes
-webcast_india_gov   webcast.gov.in       Yes   No    You can use #Channel to indicate CH number.
-webtv               web.tv               Yes   --
-weeb                weeb.tv              Yes   --    Requires rtmpdump with K-S-V patches.
-welt                welt.de              Yes   Yes   Streams may be geo-restricted to Germany.
-wwenetwork          network.wwe.com      Yes   Yes   Requires an account to access any content.
-younow              younow.com           Yes   --
-youtube             - youtube.com        Yes   Yes   Protected videos are not supported.
-                    - youtu.be
-zattoo              - zattoo.com         Yes   Yes
-                    - nettv.net... [10]_
-                    - tvonline.ewe.de
-zdf_mediathek       zdf.de               Yes   Yes   Streams may be geo-restricted to Germany.
-zengatv             zengatv.com          Yes   No
-zhanqitv            zhanqi.tv            Yes   No
-=================== ==================== ===== ===== ===========================
+======================= ==================== ===== ===== ===========================
+Name                    URL(s)               Live  VOD   Notes
+======================= ==================== ===== ===== ===========================
+abweb                   abweb.com            Yes   No    Requires a login and a subscription.
+adultswim               adultswim.com        Yes   Yes   Streams may be geo-restricted, some VOD streams are protected by DRM.
+afreeca                 - afreecatv.com      Yes   No
+                        - afreeca.tv
+aftonbladet             aftonbladet.se       Yes   Yes
+aliez                   aliez.tv             Yes   Yes
+aljazeeraen             aljazeera.com        Yes   Yes   English version of the site.
+animelab                animelab.com         --    Yes   Requires a login. Streams may be geo-restricted to Australia and New Zealand.
+antenna                 antenna.gr           --    Yes
+app17                   17app.co             Yes   --
+arconai                 arconai.tv           Yes   Yes   Only SD quality streams
+ard_live                daserste.de          Yes   Yes   Streams may be geo-restricted to Germany.
+ard_mediathek           - ardmediathek.de    Yes   Yes   Streams may be geo-restricted to Germany.
+                        - mediathek... [5]_
+artetv                  arte.tv              Yes   Yes
+atresplayer             atresplayer.com      Yes   No    Streams are geo-restricted to Spain.
+bbciplayer              bbc.co.uk/iplayer    Yes   Yes   Streams may be geo-restricted to the United Kingdom.
+beattv                  be-at.tv             Yes   Yes   Playlist not implemented yet.
+bfmtv                   bfmtv.com            Yes   Yes
+                        01net.com
+bigo                    - live.bigo.tv       Yes   --
+                        - bigoweb.co
+bilibili                live.bilibili.com    Yes   ?
+bloomberg               bloomberg.com        Yes   Yes
+bongacams               bongacams.com        Yes   No
+brightcove              players.brig... [6]_ Yes   Yes
+brittv                  brittv.co.uk         Yes   --
+btsports                sport.bt.com         Yes   Yes   Requires subscription account
+btv                     btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
+cam4                    cam4.com             Yes   No
+camsoda                 camsoda.com          Yes   No
+canalplus               - mycanal.fr         No    Yes   Streams may be geo-restricted to France.
+                        - cnews.fr
+canlitv                 - canlitv.com        Yes   --
+                        - canlitv.life
+                        - canlitvlive.co
+                        - canlitvlive.live
+                        - ecanlitvizle.net
+cdnbg                   - tv.bnt.bg          Yes   No    Streams may be geo-restricted to Bulgaria.
+                        - bgonair.bg
+                        - kanal3.bg
+                        - bitelevision.com
+                        - nova.bg
+ceskatelevize           ceskatelevize.cz     Yes   Yes   Streams may be geo-restricted to Czechia.
+chaturbate              chaturbate.com       Yes   No
+cinergroup              - showtv.com.tr      Yes   No
+                        - haberturk.com
+                        - showmax.com.tr
+                        - showturk.com.tr
+                        - bloomberght.com
+crunchyroll             crunchyroll.com      --    Yes
+cybergame               cybergame.tv         Yes   Yes
+cyro                    cyro.se              --    Yes
+dailymotion             dailymotion.com      Yes   Yes
+deutschewelle           dw.com               Yes   Yes
+dingittv                dingit.tv            Yes   Yes
+dogan                   - teve2.com.tr       Yes   Yes   VOD is supported for teve2 and kanald
+                        - kanald.com.tr
+                        - dreamtv.com.tr
+                        - cnnturk.com
+                        - dreamturk.com.tr
+dogus                   - ntvspor.net        Yes   No
+                        - kralmuzik.com.tr
+                        - ntv.com.tr
+                        - eurostartv.com.tr
+dommune                 dommune.com          Yes   --
+douyutv                 - douyu.com          Yes   Yes
+                        - v.douyu.com
+dplay                   - dplay.se           --    Yes   Streams may be geo-restricted.
+                                                         Only non-premium streams currently supported.
+                        - dplay.no
+                        - dplay.dk
+drdk                    dr.dk                Yes   Yes   Streams may be geo-restricted to Denmark.
+earthcam                earthcam.com         Yes   Yes   Only works for the cams hosted on EarthCam.
+ellobo                  ellobo106.com        Yes   -
+eltrecetv               eltrecetv.com.ar     Yes   Yes   Streams may be geo-restricted to Argentina.
+eurocom                 eurocom.bg           Yes   No
+euronews                euronews.com         Yes   No
+expressen               expressen.se         Yes   Yes
+facebook                facebook.com         Yes   No    Only 360p HLS streams.
+filmon                  filmon.com           Yes   Yes   Only SD quality streams.
+filmon_us               filmon.us            Yes   Yes
+foxtr                   fox.com.tr           Yes   No
+funimationnow           - funimation.com     --    Yes
+                        - funimationnow.uk
+gardenersworld          gardenersworld.com   --    Yes
+garena                  garena.live          Yes   --
+goodgame                goodgame.ru          Yes   No    Only HLS streams are available.
+googledrive             - docs.google.com    --    Yes
+                        - drive.google.com
+gulli                   replay.gulli.fr      Yes   Yes   Streams may be geo-restricted to France.
+hitbox                  - hitbox.tv          Yes   Yes
+                        - smashcast.tv
+huajiao                 huajiao.com          Yes   No
+huomao                  huomao.com           Yes   No
+huya                    huya.com             Yes   No    Temporarily only HLS streams available.
+idf1                    idf1.fr              Yes   Yes
+ine                     ine.com              ---   Yes
+itvplayer               itv.com/itvplayer    Yes   Yes   Streams may be geo-restricted to Great Britain.
+kanal7                  kanal7.com           Yes   No
+kingkong                kingkong.com.tw      Yes   --
+live_russia_tv          live.russia.tv       Yes   --
+liveedu                 - liveedu.tv         Yes   --    Some streams require a login.
+                        - livecoding.tv
+liveme                  liveme.com           Yes   --
+livestream              new.livestream.com   Yes   --
+looch                   looch.tv             Yes   Yes
+media_ccc_de            - media.ccc.de       Yes   Yes   Only mp4 and HLS are supported.
+                        - streaming... [4]_
+mediaklikk              mediaklikk.hu        Yes   No    Streams may be geo-restricted to Hungary.
+mips                    mips.tv              Yes   --    Requires rtmpdump with K-S-V patches.
+mitele                  mitele.es            Yes   No    Streams may be geo-restricted to Spain.
+mixer                   mixer.com            Yes   Yes
+mlgtv                   mlg.tv               Yes   --
+nbc                     nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
+nbcsports               nbcsports.com        No    Yes   Streams maybe be geo-restricted to USA. Authentication is not supported.
+nhkworld                nhk.or.jp/nhkworld   Yes   No
+nineanime               9anime.to            --    Yes
+nos                     nos.nl               Yes   Yes   Streams may be geo-restricted to Netherlands.
+npo                     - npo.nl             Yes   Yes   Streams may be geo-restricted to Netherlands.
+                        - zapp.nl
+                        - zappelin.nl
+nrk                     - tv.nrk.no          Yes   Yes   Streams may be geo-restricted to Norway.
+                        - radio.nrk.no
+ok_live                 ok.ru                Yes   --
+oldlivestream           - original.li.. [3]_ Yes   No    Only mobile streams are supported.
+                        - cdn.livestream.com
+olympicchannel          olympicchannel.com   Yes   Yes   Only non-premium content is available.
+openrectv               openrec.tv           Yes   Yes
+orf_tvthek              tvthek.orf.at        Yes   Yes
+ovvatv                  ovva.tv              Yes   No
+pandatv                 panda.tv             Yes   ?
+periscope               periscope.tv         Yes   Yes   Replay/VOD is supported.
+picarto                 picarto.tv           Yes   Yes
+piczel                  piczel.tv            Yes   No
+pixiv                   sketch.pixiv.net     Yes   --
+playtv                  - playtv.fr          Yes   --    Streams may be geo-restricted to France.
+                        - play.tv
+pluzz                   - france.tv          Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
+                        - ludo.fr
+                        - zouzous.fr
+                        - france3-reg.. [8]_
+powerapp                powerapp.com.tr      Yes   No
+qq                      live.qq.com          Yes   No
+radionet                - radio.net          Yes   --
+                        - radio.at
+                        - radio.de
+                        - radio.dk
+                        - radio.es
+                        - radio.fr
+                        - radio.it
+                        - radio.pl
+                        - radio.pt
+                        - radio.se
+raiplay                 raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
+rtbf                    - rtbf.be/auvio      Yes   Yes   Streams may be geo-restricted to Belgium or Europe.
+                        - rtbfradioplayer.be
+rtlxl                   rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.
+rte                     rte.ie/player        Yes   Yes
+rtpplay                 rtp.pt/play          Yes   Yes   Streams may be geo-restricted to Portugal.
+rtve                    rtve.es              Yes   No
+rtvs                    rtvs.sk              Yes   No    Streams may be geo-restricted to Slovakia.
+ruv                     ruv.is               Yes   Yes   Streams may be geo-restricted to Iceland.
+schoolism               schoolism.com        --    Yes   Requires a login and a subscription.
+seemeplay               seemeplay.ru         Yes   Yes
+seetv                   seetv.tv             Yes   No    Streams that are embedded from other sites will not work.
+servustv                servustv.com         ?     ?
+showroom                showroom-live.com    Yes   No    Only RTMP streams are available.
+skai                    skai.gr              Yes   No    Only embedded youtube live streams are supported
+speedrunslive           speedrunslive.com    Yes   --    URL forwarder to Twitch channels.
+sportal                 sportal.bg           Yes   No
+sportschau              sportschau.de        Yes   No
+srgssr                  - srf.ch             Yes   No    Streams are geo-restricted to Switzerland.
+                        - rts.ch
+                        - rsi.ch
+                        - rtr.ch
+ssh101                  ssh101.com           Yes   No
+startv                  startv.com.tr        Yes   No
+streamable              streamable.com       -     Yes
+streamboat              streamboat.tv        Yes   No
+streamingvideoprovider  streamingvid... [2]_ Yes   --    RTMP streams requires rtmpdump with
+                                                         K-S-V patches.
+streamlive              streamlive.to        Yes   --
+streamme                stream.me            Yes   --
+streann                 ott.streann.com      Yes   Yes
+svtplay                 - svtplay.se         Yes   Yes   Streams may be geo-restricted to Sweden.
+                        - svtflow.se
+                        - oppetarkiv.se
+swisstxt                - srf.ch             Yes   No    Streams are geo-restricted to Switzerland.
+                        - rsi.ch
+teamliquid              teamliquid.net       Yes   Yes
+telefe                  telefe.com           No    Yes   Streams are geo-restricted to Argentina.
+tf1                     - tf1.fr             Yes   No    Streams may be geo-restricted to France.
+                        - lci.fr
+tga                     - star.plu.cn        Yes   No
+                        - star.tga.plu.cn
+                        - star.longzhu.com
+theplatform             player.thepl... [7]_ No    Yes
+tigerdile               tigerdile.com        Yes   --
+trt                     trt.net.tr           Yes   No    Some streams may be geo-restricted to Turkey.
+trtspor                 trtspor.com          Yes   No    Some streams are geo-restricted to Turkey.
+turkuvaz                - atv.com.tr         Yes   No
+                        - a2tv.com.tr
+                        - ahaber.com.tr
+                        - aspor.com.tr
+                        - minikago.com.tr
+                        - minikacocuk.com.tr
+tv1channel              tv1channel.org       Yes   Yes
+tv3cat                  tv3.cat              Yes   Yes   Streams may be geo-restricted to Spain.
+tv4play                 - tv4play.se         Yes   Yes   Streams may be geo-restricted to Sweden.
+                                                         Only non-premium streams currently supported.
+                        - fotbollskanalen.se
+tv5monde                - tv5monde.com       Yes   Yes   Streams may be geo-restricted to France, Belgium and Switzerland.
+                        - tv5mondeplus.com
+                        - tv5mondepl... [9]_
+tv8                     tv8.com.tr           Yes   No
+tv8cat                  tv8.cat              Yes   No    Streams may be geo-restricted to Spain/Catalunya.
+tv360                   tv360.com.tr         Yes   No
+tvcatchup               tvcatchup.com        Yes   No    Streams may be geo-restricted to Great Britain.
+tvnbg                   - tvn.bg             Yes   -
+                        - live.tvn.bg
+tvp                     tvpstream.vod.tvp.pl Yes   No    Streams may be geo-restricted to Poland.
+tvplayer                tvplayer.com         Yes   No    Streams may be geo-restricted to Great Britain. Premium streams are not supported.
+tvrby                   tvr.by               Yes   No    Streams may be geo-restricted to Belarus.
+tvrplus                 tvrplus.ro           Yes   No    Streams may be geo-restricted to Romania.
+twitch                  twitch.tv            Yes   Yes   Possible to authenticate for access to
+                                                         subscription streams.
+ustreamtv               ustream.tv           Yes   Yes
+vaughnlive              - vaughnlive.tv      Yes   --
+                        - breakers.tv
+                        - instagib.tv
+                        - vapers.tv
+vgtv                    vgtv.no              Yes   Yes
+viasat                  - juicyplay.dk       Yes   Yes   Streams may be geo-restricted.
+                        - play.nova.bg
+                        - skaties.lv
+                        - tv3.dk
+                        - tv3.ee
+                        - tv3.lt
+                        - tv6play.no
+                        - viafree.dk
+                        - viafree.no
+                        - viafree.se
+vidio                   vidio.com            Yes   Yes
+vk                      vk.com               Yes   Yes
+vrtbe                   vrt.be/vrtnu         Yes   Yes
+webcast_india_gov       webcast.gov.in       Yes   No    You can use #Channel to indicate CH number.
+webtv                   web.tv               Yes   --
+weeb                    weeb.tv              Yes   --    Requires rtmpdump with K-S-V patches.
+welt                    welt.de              Yes   Yes   Streams may be geo-restricted to Germany.
+wwenetwork              network.wwe.com      Yes   Yes   Requires an account to access any content.
+younow                  younow.com           Yes   --
+youtube                 - youtube.com        Yes   Yes   Protected videos are not supported.
+                        - youtu.be
+zattoo                  - zattoo.com         Yes   Yes
+                        - nettv.net... [10]_
+                        - tvonline.ewe.de
+zdf_mediathek           zdf.de               Yes   Yes   Streams may be geo-restricted to Germany.
+zengatv                 zengatv.com          Yes   No
+zhanqi                  zhanqi.tv            Yes   No
+======================= ==================== ===== ===== ===========================
 
 
-.. [1] streamingvideoprovider
 .. [2] streamingvideoprovider.co.uk
 .. [3] original.livestream.com
 .. [4] streaming.media.ccc.de

--- a/tests/test_docs_plugins.py
+++ b/tests/test_docs_plugins.py
@@ -1,0 +1,35 @@
+import os.path
+import re
+import sys
+
+from streamlink import Streamlink
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestPluginMatrix(unittest.TestCase):
+    """
+    Test that each plugin has an entry in the plugin matrix
+    """
+    longMessage = False
+    built_in_plugins = ['akamaihd', 'http', 'hds', 'rtmp', 'hls']
+
+    title_re = re.compile("\n[= ]+\n")
+    plugin_re = re.compile("^([\w_]+)\s", re.MULTILINE)
+
+    def setUp(self):
+        self.session = Streamlink()
+        self.docs_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../docs"))
+
+    def test_plugin_docs_matrix(self):
+        with open(os.path.join(self.docs_dir, "plugin_matrix.rst")) as plfh:
+            parts = self.title_re.split(plfh.read())
+            plugins_in_docs = list(self.plugin_re.findall(parts[3]))
+
+        for pname in self.session.plugins.keys():
+            if pname not in self.built_in_plugins:
+                self.assertIn(pname, plugins_in_docs, "{0} is not in plugin matrix".format(pname))
+


### PR DESCRIPTION
I wrote a test that tests to ensure that each plugin exists in the plugin matrix in the docs (excluding the built in plugins). I found these plugins didn't have a row in the docs: live_russia_tv, ok_live, piczel, streann, and teamliquid. I updated it as best I could, please point out an omissions/mistakes.