### PR TITLE
plugins.bilibili: fix checking live status

### DIFF
--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -10,8 +10,9 @@ from streamlink.stream import HTTPStream
 API_URL = "http://live.bilibili.com/api/playurl?cid={0}&player=1&quality=0&sign={1}&otype=json"
 ROOM_API = "https://api.live.bilibili.com/room/v1/Room/room_init?id={}"
 API_SECRET = "95acd7f6cc3392f3"
+SHOW_STATUS_OFFLINE = 0
 SHOW_STATUS_ONLINE = 1
-SHOW_STATUS_OFFLINE = 2
+SHOW_STATUS_ROUND = 2
 STREAM_WEIGHTS = {
     "source": 1080
 }
@@ -24,7 +25,8 @@ _url_re = re.compile(r"""
 _room_id_schema = validate.Schema(
     {
         "data": validate.any(None, {
-            "room_id": int
+            "room_id": int,
+            "live_status": int
         })
     },
     validate.get("data")
@@ -51,6 +53,8 @@ class Bilibili(Plugin):
         res_room_id = http.get(ROOM_API.format(channel))
         room_id_json = http.json(res_room_id, schema=_room_id_schema)
         room_id = room_id_json['room_id']
+        if room_id_json['live_status'] != SHOW_STATUS_ONLINE:
+            return
 
         ts = int(time.time() / 60)
         sign = hashlib.md5(("{0}{1}".format(channel, API_SECRET, ts)).encode("utf-8")).hexdigest()


### PR DESCRIPTION
BiliBili's player api always returns the stream URLs even though the live is stopped.

It could be avoided via the field `live_status` which is returned by the room api.