### PR TITLE
URL builder utils

### DIFF
--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -17,11 +17,13 @@ def itertags(html, tag):
     """
     Brute force regex based HTML tag parser. This is a rough-and-ready searcher to find HTML tags when
     standards compliance is not required. Will find tags that are commented out, or inside script tag etc.
+
     :param html: HTML page
     :param tag: tag name to find
     :return: generator with Tags
     """
     for match in tag_re.finditer(html):
         if match.group("tag") == tag:
-            attrs = dict((a.group("key").lower(), a.group("value")) for a in attr_re.finditer(match.group("attr")))
+            attrs = {a.group("key").lower(): a.group("value") for a in attr_re.finditer(match.group("attr"))}
             yield Tag(match.group("tag"), attrs, match.group("inner"))
+

--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -24,6 +24,6 @@ def itertags(html, tag):
     """
     for match in tag_re.finditer(html):
         if match.group("tag") == tag:
-            attrs = {a.group("key").lower(): a.group("value") for a in attr_re.finditer(match.group("attr"))}
+            attrs = dict((a.group("key").lower(), a.group("value")) for a in attr_re.finditer(match.group("attr")))
             yield Tag(match.group("tag"), attrs, match.group("inner"))
 

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -4,12 +4,13 @@ import re
 
 from streamlink import NoPluginError
 from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api.utils import itertags
 from streamlink.utils import update_scheme
 
 
 class GardenersWorld(Plugin):
     url_re = re.compile(r"https?://(?:www\.)?gardenersworld\.com/")
-    iframe_re = re.compile('''iframe src=(?P<quote>["'])(?P<url>.*?)(?P=quote)''')
 
     @classmethod
     def can_handle_url(cls, url):
@@ -17,13 +18,13 @@ class GardenersWorld(Plugin):
 
     def _get_streams(self):
         page = self.session.http.get(self.url)
-        iframe = self.iframe_re.search(page.text)
-        if iframe:
-            self.logger.debug("Handing off of {0}".format(iframe.group("url")))
+        for iframe in itertags(page.text, u"iframe"):
+            url = iframe.attributes["src"]
+            self.logger.debug("Handing off of {0}".format(url))
             try:
-                return self.session.streams(update_scheme(self.url, iframe.group("url")))
+                return self.session.streams(update_scheme(self.url, url))
             except NoPluginError:
-                self.logger.error("Handing off of {0} failed".format(iframe.group("url")))
+                self.logger.error("Handing off of {0} failed".format(url))
                 return None
 
 

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -4,7 +4,6 @@ import re
 
 from streamlink import NoPluginError
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import http
 from streamlink.plugin.api.utils import itertags
 from streamlink.utils import update_scheme
 

--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -6,6 +6,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HDSStream
 from streamlink.stream import HLSStream
+from streamlink.utils.url import update_qsd
 
 
 class TF1(Plugin):
@@ -50,9 +51,8 @@ class TF1(Plugin):
 
         m = self.embed_re.search(embed_page.text)
         if m:
-            o = urlparse(m.group(1))
-            prms = dict(parse_qsl(o.query))
-            hls_stream_url = "{0}://{1}{2}?hdnea={3}".format(o.scheme, o.netloc, o.path, prms["hdnea"])
+            # remove all query string arguments except hdnea
+            hls_stream_url = update_qsd(m.group(1), {"hdnea": None}, remove="*")
             try:
                 for s in HLSStream.parse_variant_playlist(self.session, hls_stream_url).items():
                     yield s

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -143,6 +143,65 @@ def rtmpparse(url):
     return tcurl, playpath
 
 
+def memoize(obj):
+    cache = obj.cache = {}
+
+    @functools.wraps(obj)
+    def memoizer(*args, **kwargs):
+        key = str(args) + str(kwargs)
+        if key not in cache:
+            cache[key] = obj(*args, **kwargs)
+        return cache[key]
+    return memoizer
+
+
+def search_dict(data, key):
+    """
+    Search for a key in a nested dict, or list of nested dicts, and return the values.
+
+    :param data: dict/list to search
+    :param key: key to find
+    :return: matches for key
+    """
+    if isinstance(data, dict):
+        for dkey, value in data.items():
+            if dkey == key:
+                yield value
+            for result in search_dict(value, key):
+                yield result
+    elif isinstance(data, list):
+        for value in data:
+            for result in search_dict(value, key):
+                yield result
+
+
+def load_module(name, path=None):
+    if is_py3:
+        import importlib.machinery
+        import importlib.util
+        import sys
+
+        loader_details = [(importlib.machinery.SourceFileLoader, importlib.machinery.SOURCE_SUFFIXES)]
+        finder = importlib.machinery.FileFinder(path, *loader_details)
+        spec = finder.find_spec(name)
+        if not spec or not spec.loader:
+            raise ImportError("no module named {0}".format(name))
+        if sys.version_info[1] > 4:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod
+        else:
+            return spec.loader.load_module(name)
+
+    else:
+        import imp
+        fd, filename, desc = imp.find_module(name, path and [path])
+        try:
+            return imp.load_module(name, fd, filename, desc)
+        finally:
+            if fd:
+                fd.close()
+
 #####################################
 # Deprecated functions, do not use. #
 #####################################

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -13,6 +13,7 @@ from streamlink.exceptions import PluginError
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.lazy_formatter import LazyFormatter
 from streamlink.utils.encoding import get_filesystem_encoding, maybe_decode, maybe_encode
+from streamlink.utils.url import update_scheme, url_equal
 
 
 def swfdecompress(data):
@@ -140,112 +141,6 @@ def rtmpparse(url):
                                                app=app)
 
     return tcurl, playpath
-
-
-def update_scheme(current, target):
-    """
-    Take the scheme from the current URL and applies it to the
-    target URL if the target URL startswith // or is missing a scheme
-    :param current: current URL
-    :param target: target URL
-    :return: target URL with the current URLs scheme
-    """
-    target_p = urlparse(target)
-    if not target_p.scheme and target_p.netloc:
-        return "{0}:{1}".format(urlparse(current).scheme,
-                                urlunparse(target_p))
-    elif not target_p.scheme and not target_p.netloc:
-        return "{0}://{1}".format(urlparse(current).scheme,
-                                  urlunparse(target_p))
-    else:
-        return target
-
-
-def url_equal(first, second, ignore_scheme=False, ignore_netloc=False, ignore_path=False, ignore_params=False,
-              ignore_query=False, ignore_fragment=False):
-    """
-    Compare two URLs and return True if they are equal, some parts of the URLs can be ignored
-    :param first: URL
-    :param second: URL
-    :param ignore_scheme: ignore the scheme
-    :param ignore_netloc: ignore the netloc
-    :param ignore_path: ignore the path
-    :param ignore_params: ignore the params
-    :param ignore_query: ignore the query string
-    :param ignore_fragment: ignore the fragment
-    :return: result of comparison
-    """
-    # <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
-
-    firstp = urlparse(first)
-    secondp = urlparse(second)
-
-    return ((firstp.scheme == secondp.scheme or ignore_scheme) and
-            (firstp.netloc == secondp.netloc or ignore_netloc) and
-            (firstp.path == secondp.path or ignore_path) and
-            (firstp.params == secondp.params or ignore_params) and
-            (firstp.query == secondp.query or ignore_query) and
-            (firstp.fragment == secondp.fragment or ignore_fragment))
-
-
-def memoize(obj):
-    cache = obj.cache = {}
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
-        key = str(args) + str(kwargs)
-        if key not in cache:
-            cache[key] = obj(*args, **kwargs)
-        return cache[key]
-    return memoizer
-
-
-def search_dict(data, key):
-    """
-    Search for a key in a nested dict, or list of nested dicts, and return the values.
-
-    :param data: dict/list to search
-    :param key: key to find
-    :return: matches for key
-    """
-    if isinstance(data, dict):
-        for dkey, value in data.items():
-            if dkey == key:
-                yield value
-            for result in search_dict(value, key):
-                yield result
-    elif isinstance(data, list):
-        for value in data:
-            for result in search_dict(value, key):
-                yield result
-
-
-def load_module(name, path=None):
-    if is_py3:
-        import importlib.machinery
-        import importlib.util
-        import sys
-
-        loader_details = [(importlib.machinery.SourceFileLoader, importlib.machinery.SOURCE_SUFFIXES)]
-        finder = importlib.machinery.FileFinder(path, *loader_details)
-        spec = finder.find_spec(name)
-        if not spec or not spec.loader:
-            raise ImportError("no module named {0}".format(name))
-        if sys.version_info[1] > 4:
-            mod = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(mod)
-            return mod
-        else:
-            return spec.loader.load_module(name)
-
-    else:
-        import imp
-        fd, filename, desc = imp.find_module(name, path and [path])
-        try:
-            return imp.load_module(name, fd, filename, desc)
-        finally:
-            if fd:
-                fd.close()
 
 
 #####################################

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -1,0 +1,96 @@
+from streamlink.compat import urljoin, urlparse, urlunparse, parse_qsl, urlencode
+
+
+def update_scheme(current, target):
+    """
+    Take the scheme from the current URL and applies it to the
+    target URL if the target URL startswith // or is missing a scheme
+    :param current: current URL
+    :param target: target URL
+    :return: target URL with the current URLs scheme
+    """
+    target_p = urlparse(target)
+    if not target_p.scheme and target_p.netloc:
+        return "{0}:{1}".format(urlparse(current).scheme,
+                                urlunparse(target_p))
+    elif not target_p.scheme and not target_p.netloc:
+        return "{0}://{1}".format(urlparse(current).scheme,
+                                  urlunparse(target_p))
+    else:
+        return target
+
+
+def url_equal(first, second, ignore_scheme=False, ignore_netloc=False, ignore_path=False, ignore_params=False,
+              ignore_query=False, ignore_fragment=False):
+    """
+    Compare two URLs and return True if they are equal, some parts of the URLs can be ignored
+    :param first: URL
+    :param second: URL
+    :param ignore_scheme: ignore the scheme
+    :param ignore_netloc: ignore the netloc
+    :param ignore_path: ignore the path
+    :param ignore_params: ignore the params
+    :param ignore_query: ignore the query string
+    :param ignore_fragment: ignore the fragment
+    :return: result of comparison
+    """
+    # <scheme>://<netloc>/<path>;<params>?<query>#<fragment>
+
+    firstp = urlparse(first)
+    secondp = urlparse(second)
+
+    return ((firstp.scheme == secondp.scheme or ignore_scheme) and
+            (firstp.netloc == secondp.netloc or ignore_netloc) and
+            (firstp.path == secondp.path or ignore_path) and
+            (firstp.params == secondp.params or ignore_params) and
+            (firstp.query == secondp.query or ignore_query) and
+            (firstp.fragment == secondp.fragment or ignore_fragment))
+
+
+def url_concat(base, *parts, **kwargs):
+    """
+    Join extra paths to a URL, does not join absolute paths
+    :param base: the base URL
+    :param parts: a list of the parts to join
+    :param allow_fragments: include url fragments
+    :return: the joined URL
+    """
+    allow_fragments = kwargs.get("allow_fragments", True)
+    for part in parts:
+        base = urljoin(base.rstrip("/") + "/", part.strip("/"), allow_fragments)
+    return base
+
+
+def update_qsd(url, qsd=None, remove=None):
+    """
+    Update or remove keys from a query string in a URL
+
+    :param url: URL to update
+    :param qsd: dict of keys to update, a None value leaves it unchanged
+    :param remove: list of keys to remove, or "*" to remove all
+                   note: updated keys are never removed, even if unchanged
+    :return: updated URL
+    """
+    qsd = qsd or {}
+    remove = remove or []
+
+    # parse current query string
+    parsed = urlparse(url)
+    current_qsd = dict(parse_qsl(parsed.query))
+
+    # * removes all possible keys
+    if remove == "*":
+        remove = list(current_qsd.keys())
+
+    # remove keys before updating, but leave updated keys untouched
+    for key in remove:
+        if key not in qsd:
+            del current_qsd[key]
+
+    # and update the query string
+    for key, value in qsd.items():
+        if value:
+            current_qsd[key] = value
+
+    return parsed._replace(query=urlencode(current_qsd)).geturl()
+

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -1,3 +1,5 @@
+from collections import OrderedDict
+
 from streamlink.compat import urljoin, urlparse, urlunparse, parse_qsl, urlencode
 
 
@@ -76,7 +78,7 @@ def update_qsd(url, qsd=None, remove=None):
 
     # parse current query string
     parsed = urlparse(url)
-    current_qsd = dict(parse_qsl(parsed.query))
+    current_qsd = OrderedDict(parse_qsl(parsed.query))
 
     # * removes all possible keys
     if remove == "*":

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,0 +1,74 @@
+from __future__ import unicode_literals
+import sys
+
+from streamlink.plugin.api.utils import itertags
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestPluginUtil(unittest.TestCase):
+    test_html = """
+<title>Title</title>
+<meta property="og:type" content= "website" />
+<meta property="og:url" content="http://test.se/"/>
+<meta property="og:site_name" content="Test" />
+<script src="https://test.se/test.js"></script>
+<link rel="stylesheet" type="text/css" href="https://test.se/test.css">
+<script>Tester.ready(function () {
+alert("Hello, world!"); });</script>
+<a 
+href="http://test.se/foo">bar</a>
+        """
+
+    def test_itertags_single_text(self):
+        title = list(itertags(self.test_html, "title"))
+        self.assertTrue(len(title), 1)
+        self.assertEqual(title[0].tag, "title")
+        self.assertEqual(title[0].text, "Title")
+        self.assertEqual(title[0].attributes, {})
+
+    def test_itertags_attrs_text(self):
+        script = list(itertags(self.test_html, "script"))
+        self.assertTrue(len(script), 2)
+        self.assertEqual(script[0].tag, "script")
+        self.assertEqual(script[0].text, "")
+        self.assertEqual(script[0].attributes, {"src": "https://test.se/test.js"})
+
+        self.assertEqual(script[1].tag, "script")
+        self.assertEqual(script[1].text.strip(), """Tester.ready(function () {\nalert("Hello, world!"); });""")
+        self.assertEqual(script[1].attributes, {})
+
+    def test_itertags_multi_attrs(self):
+        metas = list(itertags(self.test_html, "meta"))
+        self.assertTrue(len(metas), 3)
+        self.assertTrue(all(meta.tag == "meta" for meta in metas))
+
+        self.assertEqual(metas[0].text, None)
+        self.assertEqual(metas[1].text, None)
+        self.assertEqual(metas[2].text, None)
+
+        self.assertEqual(metas[0].attributes, {"property": "og:type", "content": "website"})
+        self.assertEqual(metas[1].attributes, {"property": "og:url", "content": "http://test.se/"})
+        self.assertEqual(metas[2].attributes, {"property": "og:site_name", "content": "Test"})
+
+    def test_multi_line_a(self):
+        anchor = list(itertags(self.test_html, "a"))
+        self.assertTrue(len(anchor), 1)
+        self.assertEqual(anchor[0].tag, "a")
+        self.assertEqual(anchor[0].text, "bar")
+        self.assertEqual(anchor[0].attributes, {"href": "http://test.se/foo"})
+
+    def test_no_end_tag(self):
+        links = list(itertags(self.test_html, "link"))
+        self.assertTrue(len(links), 1)
+        self.assertEqual(links[0].tag, "link")
+        self.assertEqual(links[0].text, None)
+        self.assertEqual(links[0].attributes, {"rel": "stylesheet",
+                                               "type": "text/css",
+                                               "href": "https://test.se/test.css"})
+
+
+

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import sys
 
+import pytest
+
 from streamlink.plugin.api.utils import itertags
 
 if sys.version_info[0:2] == (2, 6):
@@ -46,6 +48,9 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(script[1].text.strip(), """Tester.ready(function () {\nalert("Hello, world!"); });""")
         self.assertEqual(script[1].attributes, {})
 
+
+    @pytest.mark.xfail(sys.version_info >= (3, 7),
+                       reason="python3.7 issue, see bpo-34294")
     def test_itertags_multi_attrs(self):
         metas = list(itertags(self.test_html, "meta"))
         self.assertTrue(len(metas), 3)
@@ -66,6 +71,8 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(anchor[0].text, "bar")
         self.assertEqual(anchor[0].attributes, {"href": "http://test.se/foo"})
 
+    @pytest.mark.xfail(sys.version_info >= (3, 7),
+                       reason="python3.7 issue, see bpo-34294")
     def test_no_end_tag(self):
         links = list(itertags(self.test_html, "link"))
         self.assertTrue(len(links), 1)

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -11,6 +11,8 @@ else:
 
 class TestPluginUtil(unittest.TestCase):
     test_html = """
+<!doctype html>
+<html lang="en" class="no-js">
 <title>Title</title>
 <meta property="og:type" content= "website" />
 <meta property="og:url" content="http://test.se/"/>
@@ -19,8 +21,11 @@ class TestPluginUtil(unittest.TestCase):
 <link rel="stylesheet" type="text/css" href="https://test.se/test.css">
 <script>Tester.ready(function () {
 alert("Hello, world!"); });</script>
+<p>
 <a 
 href="http://test.se/foo">bar</a>
+</p>
+</html>
         """
 
     def test_itertags_single_text(self):
@@ -70,5 +75,11 @@ href="http://test.se/foo">bar</a>
                                                "type": "text/css",
                                                "href": "https://test.se/test.css"})
 
+    def test_tag_inner_tag(self):
+        links = list(itertags(self.test_html, "p"))
+        self.assertTrue(len(links), 1)
+        self.assertEqual(links[0].tag, "p")
+        self.assertEqual(links[0].text.strip(), '<a \nhref="http://test.se/foo">bar</a>')
+        self.assertEqual(links[0].attributes, {})
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,18 +97,6 @@ class TestUtil(unittest.TestCase):
             {"test": "1", "foo": "bar"},
             parse_qsd("test=1&foo=bar", schema=validate.Schema({"test": validate.text, "foo": "bar"})))
 
-    def test_url_equal(self):
-        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test"))
-        self.assertFalse(url_equal("http://test.com/test", "http://test.com/test2"))
-
-        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test2", ignore_path=True))
-        self.assertTrue(url_equal("http://test.com/test", "https://test.com/test", ignore_scheme=True))
-        self.assertFalse(url_equal("http://test.com/test", "https://test.com/test"))
-
-        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test#hello", ignore_fragment=True))
-        self.assertTrue(url_equal("http://test.com/test", "http://test2.com/test", ignore_netloc=True))
-        self.assertFalse(url_equal("http://test.com/test", "http://test2.com/test1", ignore_netloc=True))
-
     def test_rtmpparse(self):
         self.assertEquals(
             ("rtmp://testserver.com:1935/app", "playpath?arg=1"),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,24 +97,6 @@ class TestUtil(unittest.TestCase):
             {"test": "1", "foo": "bar"},
             parse_qsd("test=1&foo=bar", schema=validate.Schema({"test": validate.text, "foo": "bar"})))
 
-    def test_update_scheme(self):
-        self.assertEqual(
-            "https://example.com/foo",  # becomes https
-            update_scheme("https://other.com/bar", "//example.com/foo")
-        )
-        self.assertEqual(
-            "http://example.com/foo",  # becomes http
-            update_scheme("http://other.com/bar", "//example.com/foo")
-        )
-        self.assertEqual(
-            "http://example.com/foo",  # remains unchanged
-            update_scheme("https://other.com/bar", "http://example.com/foo")
-        )
-        self.assertEqual(
-            "https://example.com/foo",  # becomes https
-            update_scheme("https://other.com/bar", "example.com/foo")
-        )
-
     def test_url_equal(self):
         self.assertTrue(url_equal("http://test.com/test", "http://test.com/test"))
         self.assertFalse(url_equal("http://test.com/test", "http://test.com/test2"))

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,0 +1,50 @@
+import sys
+from streamlink.utils.url import *
+
+if sys.version_info[0:2] == (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestUtilURL(unittest.TestCase):
+    def test_update_scheme(self):
+        self.assertEqual(
+            "https://example.com/foo",  # becomes https
+            update_scheme("https://other.com/bar", "//example.com/foo")
+        )
+        self.assertEqual(
+            "http://example.com/foo",  # becomes http
+            update_scheme("http://other.com/bar", "//example.com/foo")
+        )
+        self.assertEqual(
+            "http://example.com/foo",  # remains unchanged
+            update_scheme("https://other.com/bar", "http://example.com/foo")
+        )
+        self.assertEqual(
+            "https://example.com/foo",  # becomes https
+            update_scheme("https://other.com/bar", "example.com/foo")
+        )
+
+    def test_url_equal(self):
+        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test"))
+        self.assertFalse(url_equal("http://test.com/test", "http://test.com/test2"))
+
+        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test2", ignore_path=True))
+        self.assertTrue(url_equal("http://test.com/test", "https://test.com/test", ignore_scheme=True))
+        self.assertFalse(url_equal("http://test.com/test", "https://test.com/test"))
+
+        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test#hello", ignore_fragment=True))
+        self.assertTrue(url_equal("http://test.com/test", "http://test2.com/test", ignore_netloc=True))
+        self.assertFalse(url_equal("http://test.com/test", "http://test2.com/test1", ignore_netloc=True))
+
+    def test_url_concat(self):
+        self.assertEqual(url_concat("http://test.se", "one", "two", "three"), "http://test.se/one/two/three")
+        self.assertEqual(url_concat("http://test.se", "/one", "/two", "/three"), "http://test.se/one/two/three")
+        self.assertEqual(url_concat("http://test.se/one", "../two", "three"), "http://test.se/two/three")
+        self.assertEqual(url_concat("http://test.se/one", "../two", "../three"), "http://test.se/three")
+
+    def test_update_qsd(self):
+        self.assertEqual(update_qsd("http://test.se?one=1&two=3", {"two": 2}), "http://test.se?one=1&two=2")
+        self.assertEqual(update_qsd("http://test.se?one=1&two=3", remove=["two"]), "http://test.se?one=1")
+        self.assertEqual(update_qsd("http://test.se?one=1&two=3", {"one": None}, remove="*"), "http://test.se?one=1")


### PR DESCRIPTION
As part of the solution for the issues raised in #1519 by @amurzeau, I have started adding some URL utils that can be used in plugins to better manipulate URLs. 

As well as a useful method for iterating through HTML tags, using regex in a brute force kind of way - like most of the plugins do. 

`update_qsd` and `url_concat` are the two URL manipulation methods. `url_concat` will join together URL parts to make a URL, and `update_qsd` can be used to add, remove or update query string parameters in a URL. 

I updated a couple of plugins as examples. 