### PR TITLE
plugins.bbciplayer: enable HD for some channels and speed up start-up

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1354,6 +1354,13 @@ plugin.add_argument(
     """
 )
 plugin.add_argument(
+    "--bbciplayer-hd",
+    action="store_true",
+    help="""
+    Prefer HD streams over local SD streams, some live programmes may not be broadcast in HD. 
+    """
+)
+plugin.add_argument(
     "--zattoo-email",
     metavar="EMAIL",
     help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -955,6 +955,9 @@ def setup_plugin_options():
     if bbciplayer_password:
         streamlink.set_plugin_option("bbciplayer", "password", bbciplayer_password)
 
+    if args.bbciplayer_hd:
+        streamlink.set_plugin_option("bbciplayer", "hd", True)
+
     if args.zattoo_email:
         streamlink.set_plugin_option("zattoo", "email", args.zattoo_email)
     if args.zattoo_email and not args.zattoo_password:


### PR DESCRIPTION
New option added to enable HD streams for some live channels (BBC One, BBC Two): `--bbciplayer-hd`. Note that not all programmes are broadcast in HD.

Sped up the stream enumeration by ignoring duplicate manifest entries, reduced number of stream looks from ~70 to ~8 on live streams.

Fixes #1033, with the `--bbciplayer-hd` option.  