### PR TITLE
plugins.rtve: fix for m3u8 stream url formatting

### DIFF
--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -139,7 +139,7 @@ class Rtve(Plugin):
 
             for stream in stream_data:
                 for url in stream["urls"]:
-                    if url.endswith("m3u8"):
+                    if ".m3u8" in url:
                         try:
                             streams.extend(HLSStream.parse_variant_playlist(self.session, url).items())
                         except (IOError, OSError):

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -77,7 +77,7 @@ def parse_xml(data, name="XML", ignore_ns=False, exception=PluginError, schema=N
     """
     if is_py2 and isinstance(data, unicode):
         data = data.encode("utf8")
-    elif is_py3:
+    elif is_py3 and isinstance(data, str):
         data = bytearray(data, "utf8")
 
     if ignore_ns:


### PR DESCRIPTION
Slight change in the way the stream URLs are listed. 