### PR TITLE
plugins.europaplus: support for the europaplustv stream

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -90,6 +90,7 @@ ellobo                  ellobo106.com        Yes   -
 eltrecetv               eltrecetv.com.ar     Yes   Yes   Streams may be geo-restricted to Argentina.
 eurocom                 eurocom.bg           Yes   No
 euronews                euronews.com         Yes   No
+europaplus              europaplus.ru        Yes   --
 expressen               expressen.se         Yes   Yes
 facebook                facebook.com         Yes   No    Only 360p HLS streams.
 filmon                  filmon.com           Yes   Yes   Only SD quality streams.

--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -1,5 +1,28 @@
 """Useful wrappers and other tools."""
+import re
+from collections import namedtuple
+
+from ...utils import parse_qsd as parse_query, parse_json, parse_xml
 
 __all__ = ["parse_json", "parse_xml", "parse_query"]
 
-from ...utils import parse_qsd as parse_query, parse_json, parse_xml
+
+tag_re = re.compile('''(?=<(?P<tag>[a-zA-Z]+)(?P<attr>.*?)(?P<end>/)?>(?:(?P<inner>.*?)</\s*(?P=tag)\s*>)?)''',
+                    re.MULTILINE | re.DOTALL)
+attr_re = re.compile('''\s*(?P<key>[\w-]+)\s*(?:=\s*(?P<quote>["']?)(?P<value>.*?)(?P=quote)\s*)?''')
+Tag = namedtuple("Tag", "tag attributes text")
+
+
+def itertags(html, tag):
+    """
+    Brute force regex based HTML tag parser. This is a rough-and-ready searcher to find HTML tags when
+    standards compliance is not required. Will find tags that are commented out, or inside script tag etc.
+    :param html: HTML page
+    :param tag: tag name to find
+    :return: generator with Tags
+    """
+    for match in tag_re.finditer(html):
+        if match.group("tag") == tag:
+            attrs = {a.group("key").lower(): a.group("value") for a in attr_re.finditer(match.group("attr"))}
+            yield Tag(match.group("tag"), attrs, match.group("inner"))
+

--- a/src/streamlink/plugins/europaplus.py
+++ b/src/streamlink/plugins/europaplus.py
@@ -1,0 +1,31 @@
+from __future__ import print_function
+
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http
+from streamlink.plugin.api.utils import itertags
+from streamlink.stream import HLSStream
+
+
+class EuropaPlusTV(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?europaplus\.ru/europaplustv")
+    src_re = re.compile(r"""['"]file['"]\s*:\s*(?P<quote>['"])(?P<url>.*?)(?P=quote)""")
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = http.get(self.url)
+        for iframe in itertags(res.text, "iframe"):
+            self.logger.debug("Found iframe: {0}".format(iframe))
+            iframe_res = http.get(iframe.attributes['src'], headers={"Referer": self.url})
+            m = self.src_re.search(iframe_res.text)
+            surl = m and m.group("url")
+            if surl:
+                self.logger.debug("Found stream URL: {0}".format(surl))
+                return HLSStream.parse_variant_playlist(self.session, surl)
+
+
+__plugin__ = EuropaPlusTV

--- a/tests/test_plugin_europaplus.py
+++ b/tests/test_plugin_europaplus.py
@@ -1,0 +1,16 @@
+import unittest
+
+from streamlink.plugins.europaplus import EuropaPlusTV
+
+
+class TestPluginEuronews(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(EuropaPlusTV.can_handle_url("http://www.europaplus.ru/europaplustv"))
+        self.assertTrue(EuropaPlusTV.can_handle_url("http://europaplus.ru/europaplustv"))
+        self.assertTrue(EuropaPlusTV.can_handle_url("https://europaplus.ru/europaplustv"))
+        self.assertTrue(EuropaPlusTV.can_handle_url("https://www.europaplus.ru/europaplustv"))
+
+        # shouldn't match
+        self.assertFalse(EuropaPlusTV.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(EuropaPlusTV.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
As requested in #1608.

Sneakily added the `itertags` util method.