### PR TITLE
plugins.goltelevision: support for the live stream

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -99,6 +99,7 @@ funimationnow           - funimation.com     --    Yes
                         - funimationnow.uk
 gardenersworld          gardenersworld.com   --    Yes
 garena                  garena.live          Yes   --
+goltelevision           goltelevision.com    Yes   No    Streams may be geo-restricted to Spain.
 goodgame                goodgame.ru          Yes   No    Only HLS streams are available.
 googledrive             - docs.google.com    --    Yes
                         - drive.google.com

--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -1,0 +1,32 @@
+from __future__ import print_function, absolute_import
+
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http, validate
+from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
+
+
+class GOLTelevision(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?goltelevision\.com/live")
+    api_url = "https://api.goltelevision.com/api/v1/media/hls/service/live"
+    api_schema = validate.Schema(validate.transform(parse_json), {
+        "code": 200,
+        "message": {
+            "success": {
+                "manifest": validate.url()
+            }
+        }
+    }, validate.get("message"), validate.get("success"), validate.get("manifest"))
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        return HLSStream.parse_variant_playlist(self.session,
+                                                http.get(self.api_url, schema=self.api_schema))
+
+
+__plugin__ = GOLTelevision

--- a/tests/test_plugin_goltelevision.py
+++ b/tests/test_plugin_goltelevision.py
@@ -1,0 +1,16 @@
+import unittest
+
+from streamlink.plugins.goltelevision import GOLTelevision
+
+
+class TestPluginEuronews(unittest.TestCase):
+    def test_can_handle_url(self):
+        # should match
+        self.assertTrue(GOLTelevision.can_handle_url("http://www.goltelevision.com/live"))
+        self.assertTrue(GOLTelevision.can_handle_url("http://goltelevision.com/live"))
+        self.assertTrue(GOLTelevision.can_handle_url("https://goltelevision.com/live"))
+        self.assertTrue(GOLTelevision.can_handle_url("https://www.goltelevision.com/live"))
+
+        # shouldn't match
+        self.assertFalse(GOLTelevision.can_handle_url("http://www.tvcatchup.com/"))
+        self.assertFalse(GOLTelevision.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
As requested in #1599. Geo-blocked to Spain. 