### PR TITLE
Feature/france.tv sport

### DIFF
--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -166,7 +166,9 @@ class Pluzz(Plugin):
             if '.mpd' in video_url:
                 continue
 
-            if '.f4m' in video_url or 'france.tv' in self.url:
+            if ('.f4m' in video_url or
+                'france.tv' in self.url or
+                'sport.francetvinfo.fr' in self.url):
                 res = http.get(self.TOKEN_URL.format(video_url))
                 video_url = res.text
 
@@ -184,11 +186,6 @@ class Pluzz(Plugin):
                     if match is None:
                         streams.append((bitrate, stream))
             elif '.m3u8' in video_url:
-                # Roland Garros 2018
-                # uses TOKEN to generate stream URL
-                if 'sport.francetvinfo.fr' in self.url:
-                    res = http.get(self.TOKEN_URL.format(video_url))
-                    video_url = res.text
                 for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
                     streams.append(stream)
             # HBB TV streams are not provided anymore by France Televisions

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -175,6 +175,11 @@ class Pluzz(Plugin):
                     if match is None:
                         streams.append((bitrate, stream))
             elif '.m3u8' in video_url:
+                # Roland Garros 2018
+                # uses TOKEN to generate stream URL
+                if 'sport.francetvinfo.fr' in self.url:
+                    res = http.get(self.TOKEN_URL.format(video_url))
+                    video_url = res.text
                 for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
                     streams.append(stream)
             # HBB TV streams are not provided anymore by France Televisions


### PR DESCRIPTION
Hello,

Just like last year, the French Open (Roland Garros) is currently airing, Pluzz plugin wasn't working anymore on the dedicated website "sport.francetvinfo.fr".

This commit just fixes the ability to retrieve the stream URL correctly.

Before:
`streamlink https://sport.francetvinfo.fr/roland-garros/direct/ best --player mpv`
`[cli][info] Found matching plugin pluzz for URL https://sport.francetvinfo.fr/roland-garros/direct/`
`error: Unable to open URL: https://ftvensport04hls-i.akamaihd.net/hls/live/664098/SPORT_LV1/master.m3u8 (403 Client Error: Forbidden for url: https://ftvensport04hls-i.akamaihd.net/hls/live/664098/SPORT_LV17/master.m3u8)`

After:
`streamlink https://sport.francetvinfo.fr/roland-garros/direct/ best --player mpv`
`[cli][info] Found matching plugin pluzz for URL https://sport.francetvinfo.fr/roland-garros/direct/`
`[cli][info] Available streams: 216p (worst), 360p, 432p, 540p, 720p (best)`
`[cli][info] Opening stream: 720p (hls)`
`[cli][info] Starting player: mpv`

Best regards.