### PR TITLE
plugins.chaturbate: only open a stream if the url is not empty

### DIFF
--- a/src/streamlink/plugins/chaturbate.py
+++ b/src/streamlink/plugins/chaturbate.py
@@ -46,7 +46,8 @@ class Chaturbate(Plugin):
         res = http.post(API_HLS, headers=headers, cookies=cookies, data=post_data)
         data = http.json(res, schema=_post_schema)
 
-        if data["success"] is True and data["room_status"] == "public":
+        self.logger.info("Stream status: {0}".format(data["room_status"]))
+        if (data["success"] is True and data["room_status"] == "public" and data["url"]):
             for s in HLSStream.parse_variant_playlist(self.session, data["url"]).items():
                 yield s
 


### PR DESCRIPTION
- `""` is not a valid url anymore
- Added **log info** "Stream status: public,offline,hidden,private" ...
- the api doesn't return a geo blocked msg (it's just public),
  so it can't be added but streamlink won't start a invalid stream now

Fixed https://github.com/streamlink/streamlink/issues/1179