### PR TITLE
hls: support for live streams when using --hls-duration

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -797,7 +797,7 @@ def build_parser():
         default=None,
         help="""
         Amount of time to skip from the beginning of the stream.
-        For live streams, this is a negative offset from the end of the stream.
+        For live streams, this is a negative offset from the end of the stream (rewind).
 
         Default is 00:00:00.
         """)
@@ -809,8 +809,6 @@ def build_parser():
         help="""
         Limit the playback duration, useful for watching segments of a stream. The actual duration may be slightly
         longer, as it is rounded to the nearest HLS segment.
-
-        Has no effect on live streams.
 
         Default is unlimited.
         """)

--- a/tests/test_hls.py
+++ b/tests/test_hls.py
@@ -1,19 +1,19 @@
-import sys
+import logging
 import os
-if sys.version_info[0:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
-
-from Crypto.Cipher import AES
+import unittest
 from binascii import hexlify
-
-from streamlink.stream import hls
-from streamlink.session import Streamlink
 from functools import partial
-from mock import patch, Mock
-import requests_mock
+
 import pytest
+import requests_mock
+from Crypto.Cipher import AES
+from mock import patch, Mock
+
+from streamlink.session import Streamlink
+from streamlink.stream import hls
+
+log = logging.getLogger(__name__)
+
 
 def pkcs7_encode(data, keySize):
     val = keySize - (len(data) % keySize)
@@ -79,8 +79,9 @@ audio_only.m3u8
 
         return playlist + playlistEnd
 
-    def start_streamlink(self, masterPlaylist, kwargs={}):
-        print("Executing streamlink")
+    def start_streamlink(self, masterPlaylist, kwargs=None):
+        kwargs = kwargs or {}
+        log.info("Executing streamlink")
         streamlink = Streamlink()
 
         # Set to default value to avoid a test fail if the default change
@@ -91,11 +92,11 @@ audio_only.m3u8
         stream = masterStream["1080p (source)"].open()
         data = b"".join(iter(partial(stream.read, 8192), b""))
         stream.close()
-        print("End of streamlink execution")
+        log.info("End of streamlink execution")
         return data
 
     def test_hls_non_encrypted(self):
-        streams = [os.urandom(1024) for i in range(4)]
+        streams = [os.urandom(1024) for _ in range(4)]
         masterPlaylist = self.getMasterPlaylist()
         firstSequence = self.mediaSequence
         playlist = self.getPlaylist(None, "stream{0}.ts") + "#EXT-X-ENDLIST\n"
@@ -106,10 +107,11 @@ audio_only.m3u8
                 mock.get("http://mocked/path/stream{0}.ts".format(i), content=stream)
 
             # Start streamlink on the generated stream
-            streamlinkResult = self.start_streamlink("http://mocked/path/master.m3u8", {'start_offset': 1, 'duration': 1})
+            streamlinkResult = self.start_streamlink("http://mocked/path/master.m3u8",
+                                                     {'start_offset': 1, 'duration': 1})
 
-        # Check result
-        expectedResult = b''.join(streams[1:3])
+        # Check result, each segment is 1 second, with duration=1 only one segment should be returned
+        expectedResult = b''.join(streams[1:2])
         self.assertEqual(streamlinkResult, expectedResult)
 
     def test_hls_encryted_aes128(self):


### PR DESCRIPTION
@pcolmer asked if it was possible to stop a live stream after a given time in #1709. This PR enhances the functionality of the existing `--hls-duration` option to include support for live streams. 

Had to fix a test too, it didn't seem to be working as intended anyway.