### PR TITLE
logging: set the log level once the plugin config files have been loaded

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -962,6 +962,8 @@ def main():
     # call setup args again once the plugin specific args have been added
     setup_args(parser)
     setup_config_args(parser)
+    # update the logging level if changed by a plugin specific config
+    logger.root.setLevel(args.loglevel)
     setup_console(console_out)
     setup_http_session()
     check_root()


### PR DESCRIPTION
As @back-to to pointed out (https://github.com/streamlink/streamlink/pull/1690#pullrequestreview-124594681) there was an issues with changing the `loglevel` when using plugin specific configs. This PR resolves that by resetting the `loglevel` after the plugin configs have been loaded, before that point the `loglevel` will still be the default/set by command line. 