### PR TITLE
logging: fixed issue with logging from plugins using logging module

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -15,7 +15,6 @@ _nameToLevel = dict([(name, level) for level, name in _levelToName.items()])
 for level, name in _levelToName.items():
     logging.addLevelName(level, name)
 
-root = logging.getLogger("streamlink")
 levels = [name for _, name in _levelToName.items()]
 _config_lock = Lock()
 
@@ -48,8 +47,8 @@ class _LogRecord(_CompatLogRecord):
 
 
 class StreamlinkLogger(logging.getLoggerClass()):
-    def __init__(self, name):
-        super(StreamlinkLogger, self).__init__(name)
+    def __init__(self, name, level=logging.NOTSET):
+        super(StreamlinkLogger, self).__init__(name, level)
 
     def trace(self, message, *args, **kws):
         if self.isEnabledFor(TRACE):
@@ -72,7 +71,8 @@ class StreamlinkLogger(logging.getLoggerClass()):
                 rv.__dict__[key] = extra[key]
         return rv
 
-    set_level = root.setLevel  # set log level for the root streamlink logger
+    def set_level(self, level):
+        self.setLevel(level)
 
     @staticmethod
     def new_module(name):
@@ -90,6 +90,8 @@ class StreamlinkLogger(logging.getLoggerClass()):
 
 
 logging.setLoggerClass(StreamlinkLogger)
+root = logging.getLogger("streamlink")
+root.setLevel(logging.WARNING)
 
 
 class StringFormatter(logging.Formatter):

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -728,13 +728,13 @@ def setup_http_session():
         streamlink.set_option("http-query-params", args.http_query_params)
 
 
-def setup_plugins():
+def setup_plugins(extra_plugin_dir=None):
     """Loads any additional plugins."""
     if os.path.isdir(PLUGINS_DIR):
         load_plugins([PLUGINS_DIR])
 
-    if args.plugin_dirs:
-        load_plugins(args.plugin_dirs)
+    if extra_plugin_dir:
+        load_plugins(extra_plugin_dir)
 
 
 def setup_streamlink():
@@ -957,7 +957,8 @@ def main():
         console_out = sys.stdout
     setup_logging(console_out, args.loglevel)
     setup_streamlink()
-    setup_plugins()
+    # load additional plugins
+    setup_plugins(args.plugin_dirs)
     setup_plugin_args(streamlink, parser)
     # call setup args again once the plugin specific args have been added
     setup_args(parser)

--- a/tests/test_plugin_tvplayer.py
+++ b/tests/test_plugin_tvplayer.py
@@ -1,13 +1,9 @@
 import unittest
 
 from streamlink import Streamlink
-
-try:
-    from unittest.mock import patch, Mock, ANY, MagicMock, call
-except ImportError:
-    from mock import patch, Mock, ANY, mock, MagicMock, call
 from streamlink.plugins.tvplayer import TVPlayer
 from streamlink.stream import HLSStream
+from tests.mock import patch, Mock, ANY, MagicMock, call
 
 
 class TestPluginTVPlayer(unittest.TestCase):
@@ -54,7 +50,7 @@ class TestPluginTVPlayer(unittest.TestCase):
         mock_http.get.return_value = page_resp
         hlsstream.parse_variant_playlist.return_value = {"test": HLSStream(self.session, "http://test.se/stream1")}
 
-        TVPlayer.bind(self.session, "test.plugin.tvplayer")
+        TVPlayer.bind(self.session, "test.tvplayer")
         plugin = TVPlayer("http://tvplayer.com/watch/dave")
 
         streams = plugin.get_streams()
@@ -77,7 +73,7 @@ class TestPluginTVPlayer(unittest.TestCase):
         """
         mock_http.get.return_value = page_resp
 
-        TVPlayer.bind(self.session, "test.plugin.tvplayer")
+        TVPlayer.bind(self.session, "test.tvplayer")
         plugin = TVPlayer("http://tvplayer.com/watch/dave")
 
         streams = plugin.get_streams()


### PR DESCRIPTION
Previously plugins would be loaded with the module name set to the plugin name, eg. `twitch`, this PR changes that so that plugins are loaded within the `streamlink.plugin` hierarchy. 
I also tweaked the way that the plugin load setup is called (I am slowly chipping away at the global variables). There is also now a debugging log message when a plugin is overridden by an external plugin file - this should help us when debugging issues with plugins, in case the user is using a non-standard plugin version. 