### PR TITLE
plugins: store cookies between sessions

### DIFF
--- a/src/streamlink/cache.py
+++ b/src/streamlink/cache.py
@@ -90,5 +90,23 @@ class Cache(object):
         else:
             return default
 
+    def get_all(self):
+        ret = {}
+        self._load()
+
+        if self._prune():
+            self._save()
+
+        for key, value in self._cache.items():
+            if self.key_prefix:
+                prefix = self.key_prefix + ":"
+            else:
+                prefix = ""
+            if key.startswith(prefix):
+                okey = key[len(prefix):]
+                ret[okey] = value["value"]
+
+        return ret
+
 
 __all__ = ["Cache"]

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -401,7 +401,7 @@ class Plugin(object):
         by supplying a filter method. eg. ``lambda c: "auth" in c.name``. If no expiry date is given in the
         cookie then the ``default_expires`` value will be used.
 
-        :param cookie_filter: a function to filter the cookies by name
+        :param cookie_filter: a function to filter the cookies
         :type cookie_filter: function
         :param default_expires: time (in seconds) until cookies with no expiry will expire
         :type default_expires: int
@@ -457,9 +457,11 @@ class Plugin(object):
 
     def clear_cookies(self, cookie_filter=None):
         """
-        Removes all of the saved cookies for this Plugin. It is possible to filter the cookies that are deleted
-        by specifying the ``cookie_filter`` argument (see ``save_cookies``)
+        Removes all of the saved cookies for this Plugin. To filter the cookies that are deleted
+        specify the ``cookie_filter`` argument (see :func:`save_cookies`).
 
+        :param cookie_filter: a function to filter the cookies
+        :type cookie_filter: function
         :return: list of the removed cookie names
         """
         if not self.session and not self.cache:

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -2,12 +2,15 @@ import ast
 import logging
 import operator
 import re
-from collections import OrderedDict
-from functools import partial
+import time
+import requests.cookies
 
-from ..cache import Cache
-from ..exceptions import PluginError, NoStreamsError
-from ..options import Options, Arguments
+from functools import partial
+from collections import OrderedDict
+
+from streamlink.cache import Cache
+from streamlink.exceptions import PluginError, NoStreamsError
+from streamlink.options import Options, Arguments
 
 # FIXME: This is a crude attempt at making a bitrate's
 # weight end up similar to the weight of a resolution.
@@ -31,14 +34,12 @@ QUALITY_WEIGTHS_EXTRA = {
     },
 }
 
-
 FILTER_OPERATORS = {
     "<": operator.lt,
     "<=": operator.le,
     ">": operator.gt,
     ">=": operator.ge,
 }
-
 
 PARAMS_REGEX = r"(\w+)=({.+?}|\[.+?\]|\(.+?\)|'(?:[^'\\]|\\')*'|\"(?:[^\"\\]|\\\")*\"|\S+)"
 
@@ -177,6 +178,7 @@ class Plugin(object):
 
     def __init__(self, url):
         self.url = url
+        self.load_cookies()
 
     @classmethod
     def can_handle_url(cls, url):
@@ -357,6 +359,7 @@ class Plugin(object):
         def stream_weight_only(s):
             return (self.stream_weight(s)[0] or
                     (len(streams) == 1 and 1))
+
         stream_names = filter(stream_weight_only, streams.keys())
         sorted_streams = sorted(stream_names, key=stream_weight_only)
 
@@ -391,6 +394,84 @@ class Plugin(object):
 
     def _get_streams(self):
         raise NotImplementedError
+
+    def save_cookies(self, cookie_filter=None, default_expires=60 * 60 * 24 * 7):
+        """
+        Store the cookies from ``http`` in the plugin cache until they expire. The cookies can be filtered
+        by supplying a filter method. eg. ``lambda c: "auth" in c.name``. If no expiry date is given in the
+        cookie then the ``default_expires`` value will be used.
+
+        :param cookie_filter: a function to filter the cookies by name
+        :type cookie_filter: function
+        :param default_expires: time (in seconds) until cookies with no expiry will expire
+        :type default_expires: int
+        :return: list of the saved cookie names
+        """
+        if not self.session and not self.cache:
+            raise RuntimeError("Cannot cache cookies in unbound plugin")
+
+        cookie_filter = cookie_filter or (lambda c: True)
+        saved = []
+
+        for cookie in filter(cookie_filter, self.session.http.cookies):
+            cookie_dict = {}
+            for attr in ("version", "name", "value", "port", "domain", "path", "secure", "expires", "discard",
+                         "comment", "comment_url", "rest", "rfc2109"):
+                cookie_dict[attr] = getattr(cookie, attr, None)
+
+            expires = default_expires
+            if cookie_dict['expires']:
+                expires = int(cookie_dict['expires'] - time.time())
+            key = "__cookie:{0}:{1}:{2}:{3}".format(cookie.name,
+                                                    cookie.domain,
+                                                    cookie.port_specified and cookie.port or "80",
+                                                    cookie.path_specified and cookie.path or "*")
+            self.cache.set(key, cookie_dict, expires)
+            saved.append(cookie.name)
+
+        if saved:
+            self.logger.debug("Saved cookies: {0}".format(", ".join(saved)))
+        return saved
+
+    def load_cookies(self):
+        """
+        Load any stored cookies for the plugin that have not expired.
+
+        :return: list of the restored cookie names
+        """
+        if not self.session and not self.cache:
+            return RuntimeError("Cannot loaded cached cookies in unbound plugin")
+
+        restored = []
+
+        for key, value in self.cache.get_all().items():
+            if key.startswith("__cookie"):
+                cookie = requests.cookies.create_cookie(**value)
+                self.session.http.cookies.set_cookie(cookie)
+                restored.append(cookie.name)
+
+        if restored:
+            self.logger.debug("Restored cookies: {0}".format(", ".join(restored)))
+        return restored
+
+    def clear_cookies(self):
+        """
+        Removes all of the saved cookies for this Plugin
+
+        :return: list of the removed cookie names
+        """
+        if not self.session and not self.cache:
+            return RuntimeError("Cannot loaded cached cookies in unbound plugin")
+
+        removed = []
+
+        for key, cookie in self.cache.get_all().items():
+            if key.startswith("__cookie"):
+                del self.session.http.cookies[cookie['name']]
+                self.cache.set(key, None, 0)
+                removed.append(key)
+
+        return removed
 
 
 __all__ = ["Plugin"]

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -416,8 +416,9 @@ class Plugin(object):
         for cookie in filter(cookie_filter, self.session.http.cookies):
             cookie_dict = {}
             for attr in ("version", "name", "value", "port", "domain", "path", "secure", "expires", "discard",
-                         "comment", "comment_url", "rest", "rfc2109"):
+                         "comment", "comment_url", "rfc2109"):
                 cookie_dict[attr] = getattr(cookie, attr, None)
+            cookie_dict["rest"] = getattr(cookie, "rest", getattr(cookie, "_rest", None))
 
             expires = default_expires
             if cookie_dict['expires']:

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -178,7 +178,10 @@ class Plugin(object):
 
     def __init__(self, url):
         self.url = url
-        self.load_cookies()
+        try:
+            self.load_cookies()
+        except RuntimeError:
+            pass  # unbound cannot load
 
     @classmethod
     def can_handle_url(cls, url):
@@ -407,7 +410,7 @@ class Plugin(object):
         :type default_expires: int
         :return: list of the saved cookie names
         """
-        if not self.session and not self.cache:
+        if not self.session or not self.cache:
             raise RuntimeError("Cannot cache cookies in unbound plugin")
 
         cookie_filter = cookie_filter or (lambda c: True)
@@ -440,8 +443,8 @@ class Plugin(object):
 
         :return: list of the restored cookie names
         """
-        if not self.session and not self.cache:
-            return RuntimeError("Cannot loaded cached cookies in unbound plugin")
+        if not self.session or not self.cache:
+            raise RuntimeError("Cannot loaded cached cookies in unbound plugin")
 
         restored = []
 
@@ -464,8 +467,8 @@ class Plugin(object):
         :type cookie_filter: function
         :return: list of the removed cookie names
         """
-        if not self.session and not self.cache:
-            return RuntimeError("Cannot loaded cached cookies in unbound plugin")
+        if not self.session or not self.cache:
+            raise RuntimeError("Cannot loaded cached cookies in unbound plugin")
 
         cookie_filter = cookie_filter or (lambda c: True)
         removed = []

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -95,3 +95,12 @@ class TestCache(unittest.TestCase):
         self.assertDictEqual(
             {"test3": 3, "test4": 4},
             self.cache.get_all())
+
+    def test_get_all_prune(self):
+        self.cache.set("test1", 1)
+        self.cache.set("test2", 2, -1)
+
+
+        self.assertDictEqual(
+            {"test1": 1},
+            self.cache.get_all())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -75,3 +75,23 @@ class TestCache(unittest.TestCase):
             self.assertFalse(os.path.exists(cache.filename))
         finally:
             rmtree(streamlink.cache.cache_dir, ignore_errors=True)
+
+    def test_get_all(self):
+        self.cache.set("test1", 1)
+        self.cache.set("test2", 2)
+
+        self.assertDictEqual(
+            {"test1": 1, "test2": 2},
+            self.cache.get_all())
+
+    def test_get_all_prefix(self):
+        self.cache.set("test1", 1)
+        self.cache.set("test2", 2)
+        self.cache.key_prefix = "test"
+        self.cache.set("test3", 3)
+        self.cache.set("test4", 4)
+
+
+        self.assertDictEqual(
+            {"test3": 3, "test4": 4},
+            self.cache.get_all())

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -10,6 +10,7 @@ from streamlink.plugin import Plugin
 
 
 class TestPlugin(unittest.TestCase):
+
     def _create_cookie_dict(self, name, value, expires):
         return {'version': 0, 'name': name, 'value': value,
                 'port': None, 'domain': "test.se", 'path': "/", 'secure': False,
@@ -23,6 +24,12 @@ class TestPlugin(unittest.TestCase):
             r[name] = getattr(cookie, name, None)
         r["rest"] = getattr(cookie, "rest", getattr(cookie, "_rest", None))
         return r
+
+    def tearDown(self):
+        Plugin.session = None
+        Plugin.cache = None
+        Plugin.module = None
+        Plugin.logger = None
 
     def test_cookie_store_save(self):
         session = Mock()
@@ -123,3 +130,15 @@ class TestPlugin(unittest.TestCase):
             list(map(self._cookie_to_dict, session.http.cookies)),
             [self._cookie_to_dict(requests.cookies.create_cookie("test-name", "test-value", domain="test.se"))]
         )
+
+    def test_cookie_load_unbound(self):
+        plugin = Plugin("http://test.se")
+        self.assertRaises(RuntimeError, plugin.load_cookies)
+
+    def test_cookie_save_unbound(self):
+        plugin = Plugin("http://test.se")
+        self.assertRaises(RuntimeError, plugin.save_cookies)
+
+    def test_cookie_clear_unbound(self):
+        plugin = Plugin("http://test.se")
+        self.assertRaises(RuntimeError, plugin.clear_cookies)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,101 @@
+import unittest
+import time
+import datetime
+import freezegun
+import requests.cookies
+
+
+from tests.mock import Mock, ANY, call
+from streamlink.plugin import Plugin
+
+
+class TestPlugin(unittest.TestCase):
+    def _create_cookie_dict(self, name, value, expires):
+        return {'version': 0, 'name': name, 'value': value,
+                'port': None, 'domain': "test.se", 'path': "/", 'secure': False,
+                'expires': expires, 'discard': True, 'comment': None,
+                'comment_url': None, 'rest': None, 'rfc2109': False}
+
+    def _cookie_to_dict(self, cookie):
+        r = {}
+        for name in ("version", "name", "value", "port", "domain", "path",
+                     "secure", "expires", "discard", "comment", "comment_url"):
+            r[name] = getattr(cookie, name, None)
+        return r
+
+    def test_cookie_store_save(self):
+        session = Mock()
+        session.http.cookies = [
+            requests.cookies.create_cookie("test-name", "test-value", domain="test.se", rest=None)
+        ]
+
+        Plugin.bind(session, 'tests.test_plugin')
+        Plugin.cache = Mock()
+        Plugin.cache.get_all.return_value = {}
+
+        plugin = Plugin("http://test.se")
+        plugin.save_cookies(default_expires=3600)
+
+        Plugin.cache.set.assert_called_with("__cookie:test-name:test.se:80:/",
+                                            self._create_cookie_dict("test-name", "test-value", None),
+                                            3600)
+
+    def test_cookie_store_save_expires(self):
+        with freezegun.freeze_time(lambda: datetime.datetime(2018, 1, 1)):
+            session = Mock()
+            session.http.cookies = [
+                requests.cookies.create_cookie("test-name", "test-value", domain="test.se", expires=time.time() + 3600,
+                                               rest={'HttpOnly': None})
+            ]
+
+            Plugin.bind(session, 'tests.test_plugin')
+            Plugin.cache = Mock()
+            Plugin.cache.get_all.return_value = {}
+
+            plugin = Plugin("http://test.se")
+            plugin.save_cookies(default_expires=60)
+
+            Plugin.cache.set.assert_called_with("__cookie:test-name:test.se:80:/",
+                                                self._create_cookie_dict("test-name", "test-value", 1514768400),
+                                                3600)
+
+    def test_cookie_store_load(self):
+        session = Mock()
+        session.http.cookies = requests.cookies.RequestsCookieJar()
+
+        Plugin.bind(session, 'tests.test_plugin')
+        Plugin.cache = Mock()
+        Plugin.cache.get_all.return_value = {
+            "__cookie:test-name:test.se:80:/": self._create_cookie_dict("test-name", "test-value", None)
+        }
+        plugin = Plugin("http://test.se")
+        #plugin.load_cookies()
+        self.assertSequenceEqual(
+            list(map(self._cookie_to_dict, session.http.cookies)),
+            [self._cookie_to_dict(requests.cookies.create_cookie("test-name", "test-value", domain="test.se"))]
+        )
+
+    def test_cookie_store_clear(self):
+        self.maxDiff = None
+        session = Mock()
+        session.http.cookies = requests.cookies.RequestsCookieJar()
+
+        Plugin.bind(session, 'tests.test_plugin')
+        Plugin.cache = Mock()
+        Plugin.cache.get_all.return_value = {
+            "__cookie:test-name:test.se:80:/": self._create_cookie_dict("test-name", "test-value", None),
+            "__cookie:test-name2:test.se:80:/": self._create_cookie_dict("test-name2", "test-value2", None)
+        }
+        plugin = Plugin("http://test.se")
+        #plugin.load_cookies()
+        print(list(session.http.cookies))
+        # non-empty cookiejar
+        self.assertTrue(len(session.http.cookies.get_dict()) > 0)
+
+
+        plugin.clear_cookies()
+        self.assertSequenceEqual(
+            Plugin.cache.set.mock_calls,
+            [call("__cookie:test-name:test.se:80:/", None, 0),
+             call("__cookie:test-name2:test.se:80:/", None, 0)])
+        self.assertSequenceEqual(session.http.cookies, [])

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -14,19 +14,20 @@ class TestPlugin(unittest.TestCase):
         return {'version': 0, 'name': name, 'value': value,
                 'port': None, 'domain': "test.se", 'path': "/", 'secure': False,
                 'expires': expires, 'discard': True, 'comment': None,
-                'comment_url': None, 'rest': None, 'rfc2109': False}
+                'comment_url': None, 'rest': {"HttpOnly": None}, 'rfc2109': False}
 
     def _cookie_to_dict(self, cookie):
         r = {}
         for name in ("version", "name", "value", "port", "domain", "path",
                      "secure", "expires", "discard", "comment", "comment_url"):
             r[name] = getattr(cookie, name, None)
+        r["rest"] = getattr(cookie, "rest", getattr(cookie, "_rest", None))
         return r
 
     def test_cookie_store_save(self):
         session = Mock()
         session.http.cookies = [
-            requests.cookies.create_cookie("test-name", "test-value", domain="test.se", rest=None)
+            requests.cookies.create_cookie("test-name", "test-value", domain="test.se")
         ]
 
         Plugin.bind(session, 'tests.test_plugin')


### PR DESCRIPTION
Adds some new methods to Plugin to simplify the process of storing and loading cookies between sessions. It makes use of the existing cache mechanism, cookies can be filtered before storing and clearing, and are loaded automatically. 

I wanted this feature to store longer lived cookies for anti-robot scripts, eg. in #1721. It can also be used to store auth cookies. 