### PR TITLE
hls: new option session reload

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -45,6 +45,7 @@ class Streamlink(object):
        options and log settings."""
 
     def __init__(self):
+        self.cached_data = {}
         self.http = api.HTTPSession()
         self.options = Options({
             "hds-live-edge": 10.0,
@@ -79,7 +80,6 @@ class Streamlink(object):
         self.plugins = {}
         self.load_builtin_plugins()
         self._logger = None
-
 
     @property
     def logger(self):

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -146,6 +146,12 @@ def hours_minutes_seconds(value):
     :param value: hh:mm:ss
     :return: seconds
     """
+    try:
+        if int(value):
+            return value
+    except ValueError:
+        pass
+
     match = _hours_minutes_seconds_re.match(value)
     if not match:
         raise ValueError
@@ -762,6 +768,48 @@ def build_parser():
         Note: The --hls-timeout must be increased, to a time that is longer than the ignored break.
         """
     )
+    transport.add_argument(
+        "--hls-segment-ignore-number",
+        type=num(int, min=5),
+        metavar="SEGMENTS",
+        help="""
+        Ignore invalid segment numbers,
+        this option is the max. difference between the valid and invalid number.
+
+        If the valid segment is 100 and this option is set to 20,
+
+        only a segment of 1-80 will be allowed and added,
+        everything between 81-99 will be invalid and not added.
+
+        Default is Disabled.
+        """
+    )
+    transport.add_argument(
+        "--hls-session-reload-segment",
+        action="store_true",
+        help="""
+        Reloads a Streamlink session, if the playlist reload fails twice.
+
+        Default is False.
+
+        Note: This command is meant as a fallback for --hls-session-reload-time
+        if the time is set incorrectly, it might not work for every stream.
+        """)
+    transport.add_argument(
+        "--hls-session-reload-time",
+        type=hours_minutes_seconds,
+        metavar="HH:MM:SS",
+        default=None,
+        help="""
+        Reloads a Streamlink session after the given time.
+
+        Useful for playlists that expire after an amount of time.
+
+        Default is Disabled.
+
+        Note: --hls-segment-ignore-number can be used for new playlists
+        that contain different segment numbers
+        """)
     transport.add_argument(
         "--hls-audio-select",
         type=comma_list,

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -147,8 +147,7 @@ def hours_minutes_seconds(value):
     :return: seconds
     """
     try:
-        if int(value):
-            return value
+        return int(value)
     except ValueError:
         pass
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -16,6 +16,7 @@ from functools import partial
 from itertools import chain
 from socks import __version__ as socks_version
 from time import sleep
+from time import time
 from websocket import __version__ as websocket_version
 
 from streamlink import __version__ as streamlink_version
@@ -384,6 +385,13 @@ def handle_stream(plugin, streams, stream_name):
         file_output = args.output or args.stdout
 
         for stream_name in [stream_name] + alt_streams:
+            # caches the current streamurl and streamname in to the session
+            cached_data = {
+                "url": args.url,
+                "stream_name": stream_name,
+                "timestamp": int(time()),
+            }
+            streamlink.cached_data.update(cached_data)
             stream = streams[stream_name]
             stream_type = type(stream).shortname()
 
@@ -763,6 +771,15 @@ def setup_options():
 
     if args.hls_segment_ignore_names:
         streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
+
+    if args.hls_segment_ignore_number:
+        streamlink.set_option("hls-segment-ignore-number", args.hls_segment_ignore_number)
+
+    if args.hls_session_reload_segment:
+        streamlink.set_option("hls-session-reload-segment", args.hls_session_reload_segment)
+
+    if args.hls_session_reload_time:
+        streamlink.set_option("hls-session-reload-time", args.hls_session_reload_time)
 
     if args.hls_timeout:
         streamlink.set_option("hls-timeout", args.hls_timeout)

--- a/tests/test_cli_argparser.py
+++ b/tests/test_cli_argparser.py
@@ -1,0 +1,19 @@
+import unittest
+
+from streamlink_cli.argparser import hours_minutes_seconds
+
+
+class TestCLIArgparser(unittest.TestCase):
+
+    def test_hours_minutes_seconds(self):
+        self.assertEqual(hours_minutes_seconds("00:01:30"), 90)
+        self.assertEqual(hours_minutes_seconds("01:20:15"), 4815)
+        self.assertEqual(hours_minutes_seconds("26:00:00"), 93600)
+        self.assertEqual(hours_minutes_seconds("444"), 444)
+        self.assertEqual(hours_minutes_seconds("8888"), 8888)
+
+        with self.assertRaises(ValueError):
+            hours_minutes_seconds("FOO")
+
+        with self.assertRaises(ValueError):
+            hours_minutes_seconds("BAR")


### PR DESCRIPTION
**TL;DR**

New command to replace the current hls stream with a new one.

`--hls-session-reload-time` New session after a given time.

`--hls-session-reload-segment` New session if a normal playlist fails twice.

`--hls-segment-ignore-number` Allow invalid segment numbers

also reload on **StreamError** 

---

`--hls-session-reload-time`

It will **replace** the current stream with a new **stream**
after the given time, **self.session** will be **updated** at the same time,

The command must **cache** the stream **url** and the stream **name** somewhere in the self.session,
as it's only available in **streamlink_cli**

If someone want's to reuse this command from an API, it must be done there aswell
or it will print a warning message.

**Example**

HLS-URL timesout after 10 minutes
SESSION-RELOAD is set to 9 minutes

The stream will be reloaded/replaced every 9 minutes,
it can never hit the 10 minutes timeout.

---

`--hls-session-reload-segment`

This can be used as a fallback, for wrong set-up time with the other command

and also for errors like this:

```
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Reloading playlist
error: Error when reading from stream: Read timeout, exiting
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[console][info] Stream ended
[console][info] Closing currently open stream...
```

when the stream gets replaces by an invalid stream

normal playlist

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-ALLOW-CACHE:YES
#EXT-X-TARGETDURATION:5
#EXT-X-MEDIA-SEQUENCE:41031
#EXTINF:5.000000,
44-41031.ts
#EXTINF:5.000000,
44-41032.ts
#EXTINF:5.000000,
44-41033.ts
```

invalid replacement

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-ALLOW-CACHE:NO
#EXT-X-TARGETDURATION:10
#EXT-X-MEDIA-SEQUENCE:0
#EXTINF:10.000000,
errors/403/403-000.ts
#EXTINF:10.000000,
errors/403/403-001.ts
#EXTINF:10.000000,
errors/403/403-002.ts
#EXTINF:0.280000,
errors/403/403-003.ts
#EXT-X-ENDLIST
```

---

`--hls-segment-ignore-number`

This allows invalid segment numbers.

required for some streams
if they get different segment numbers on different playlists.

---

allow **seconds passthrough** with **hours_minutes_seconds**

---

**Known issues**

1. plugins with authentication

  It might error because you are already logged in,
  the plugin can't find items that are only presented for guests.

2. MuxedStream

  not implemented, lack of test streams and might not work the same way like this.

3. might not work because of different segment numbers

  use `--hls-segment-ignore-number`

---

I tried to create tests with unittest/requests_mock,

but it does not really work with it.

So for now there are no tests.

---

It's completely build as **opt-in**, so if it's not used it can't error anything.

---

it might need some namechanges, if these are not wanted

---

can be used for this
Fixed https://github.com/streamlink/streamlink/issues/1567

Not directly what was asked but it can be done with this differently
Fixed https://github.com/streamlink/streamlink/issues/664

should allow a reload here
Fixed https://github.com/streamlink/streamlink/issues/1231

ref https://github.com/streamlink/streamlink/issues/1058
ref https://github.com/streamlink/streamlink/issues/1370
ref https://github.com/streamlink/streamlink/issues/1380