### PR TITLE
dash: fix for manifest reload - should be more reliable

### DIFF
--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import copy
 import logging
 import datetime
 import re
@@ -48,6 +49,13 @@ def count_dt(firstval=datetime.datetime.now(tz=utc), step=datetime.timedelta(sec
     while True:
         yield x
         x += step
+
+
+@contextmanager
+def freeze_timeline(mpd):
+    timelines = copy.copy(mpd.timelines)
+    yield
+    mpd.timelines = timelines
 
 
 @contextmanager
@@ -219,6 +227,7 @@ class MPD(MPDNode):
                                                default=datetime.datetime.fromtimestamp(0, utc),  # earliest date
                                                required=self.type == "dynamic")
         self.publishTime = self.attr(u"publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
+        self.availabilityEndTime = self.attr(u"availabilityEndTime", parser=MPDParsers.datetime)
         self.mediaPresentationDuration = self.attr(u"mediaPresentationDuration", parser=MPDParsers.duration)
         self.suggestedPresentationDelay = self.attr(u"suggestedPresentationDelay", parser=MPDParsers.duration)
 

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -1,4 +1,5 @@
 from streamlink.stream.dash import DASHStreamWorker
+from streamlink.stream.dash_manifest import MPD
 
 from tests import unittest
 from tests.mock import MagicMock, patch, ANY, Mock, call
@@ -135,7 +136,7 @@ class TestDASHStream(unittest.TestCase):
 
 class TestDASHStreamWorker(unittest.TestCase):
 
-    @patch('streamlink.stream.dash_manifest.time.sleep')
+    @patch("streamlink.stream.dash_manifest.time.sleep")
     @patch('streamlink.stream.dash.MPD')
     def test_dynamic_reload(self, mpdClass, sleep):
         reader = MagicMock()
@@ -169,7 +170,8 @@ class TestDASHStreamWorker(unittest.TestCase):
         self.assertSequenceEqual([next(segment_iter), next(segment_iter)], segments[1:])
         representation.segments.assert_called_with(init=False)
 
-    def test_static(self):
+    @patch("streamlink.stream.dash_manifest.time.sleep")
+    def test_static(self, sleep):
         reader = MagicMock()
         worker = DASHStreamWorker(reader)
         reader.representation_id = 1


### PR DESCRIPTION
Should fix the issue @back-to pointed out here: https://github.com/streamlink/streamlink/issues/1723#issuecomment-393961866

It would be good to get some people to test dash streams with this change, I tested a few :)