### PR TITLE
tests: coverage on src instead of the modules

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 source =
-    streamlink
-    streamlink_cli
+    src
 
 [report]
 omit =


### PR DESCRIPTION
This appears to fix an issue with counting the coverage of the tests. 