### PR TITLE
plugin.youtube: find video id in page, fall back to API

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -215,15 +215,15 @@ class YouTube(Plugin):
         return streams, protected
 
     def _find_channel_video(self):
-        res = http.get(self.url, headers={"User-Agent": useragents.CHROME})
+        res = http.get(self.url)
 
         datam = _ytdata_re.search(res.text)
         if datam:
             data = parse_json(datam.group(1))
             # find the videoRenderer object, where there is a LVE NOW badge
             for x in search_dict(data, 'videoRenderer'):
-                for blabel in search_dict(x.get("badges", {}), "label"):
-                    if blabel == "LIVE NOW":
+                for bstyle in search_dict(x.get("badges", {}), "style"):
+                    if bstyle == "BADGE_STYLE_TYPE_LIVE_NOW":
                         if x.get("videoId"):
                             self.logger.debug("Found channel video ID via HTML: {0}", x["videoId"])
                             return x["videoId"]
@@ -319,6 +319,7 @@ class YouTube(Plugin):
         return info_parsed
 
     def _get_streams(self):
+        http.headers.update({'User-Agent': useragents.CHROME})
         is_live = False
 
         info = self._get_stream_info(self.url)

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -3,7 +3,7 @@ import re
 from requests import codes
 
 from streamlink.compat import urlparse, parse_qsl
-from streamlink.plugin import Plugin, PluginError
+from streamlink.plugin import Plugin, PluginError, PluginArguments, PluginArgument
 from streamlink.plugin.api import http, validate, useragents
 from streamlink.plugin.api.utils import parse_query
 from streamlink.stream import HTTPStream, HLSStream
@@ -142,6 +142,14 @@ class YouTube(Plugin):
         258: 258,
     }
 
+    arguments = PluginArguments(
+        PluginArgument(
+            "api-key",
+            sensitive=True,
+            help="API key to use for YouTube API requests"
+        )
+    )
+
     @classmethod
     def can_handle_url(cls, url):
         return _url_re.match(url)
@@ -237,7 +245,7 @@ class YouTube(Plugin):
             "type": "video",
             "eventType": "live",
             "part": "id",
-            "key": API_KEY
+            "key": self.get_option("api_key") or API_KEY
         }
         res = http.get(API_SEARCH_URL, params=query, raise_for_status=False)
         if res.status_code == codes.ok:
@@ -292,6 +300,7 @@ class YouTube(Plugin):
         _params_3 = {"eurl": "https://youtube.googleapis.com/v/{0}".format(video_id)}
 
         count = 0
+        info_parsed = None
         for _params in (_params_1, _params_2, _params_3):
             count += 1
             params = {"video_id": video_id}

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -199,6 +199,26 @@ def memoize(obj):
     return memoizer
 
 
+def search_dict(data, key):
+    """
+    Search for a key in a nested dict, or list of nested dicts, and return the values.
+
+    :param data: dict/list to search
+    :param key: key to find
+    :return: matches for key
+    """
+    if isinstance(data, dict):
+        for dkey, value in data.items():
+            if dkey == key:
+                yield value
+            for result in search_dict(value, key):
+                yield result
+    elif isinstance(data, list):
+        for value in data:
+            for result in search_dict(value, key):
+                yield result
+
+
 #####################################
 # Deprecated functions, do not use. #
 #####################################

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -139,15 +139,15 @@ class TestUtil(unittest.TestCase):
             list(search_dict({"one": "test1", "two": "test2"}, "one")),
             ["test1"]
         )
-        self.assertEqual(
+        self.assertSequenceEqual(
             list(search_dict({"one": {"inner": "test1"}, "two": "test2"}, "inner")),
             ["test1"]
         )
-        self.assertEqual(
+        self.assertSequenceEqual(
             list(search_dict({"one": [{"inner": "test1"}], "two": "test2"}, "inner")),
             ["test1"]
         )
-        self.assertEqual(
-            list(search_dict({"one": [{"inner": "test1"}], "two": {"inner": "test2"}}, "inner")),
-            ["test1", "test2"]
+        self.assertSequenceEqual(
+            list(sorted(search_dict({"one": [{"inner": "test1"}], "two": {"inner": "test2"}}, "inner"))),
+            list(sorted(["test1", "test2"]))
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import sys
 
 from streamlink.plugin.api.validate import xml_element, text
-from streamlink.utils import update_scheme, url_equal
+from streamlink.utils import update_scheme, url_equal, search_dict
 
 try:
     import xml.etree.cElementTree as ET
@@ -124,3 +124,30 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(url_equal("http://test.com/test", "http://test.com/test#hello", ignore_fragment=True))
         self.assertTrue(url_equal("http://test.com/test", "http://test2.com/test", ignore_netloc=True))
         self.assertFalse(url_equal("http://test.com/test", "http://test2.com/test1", ignore_netloc=True))
+
+    def test_search_dict(self):
+
+        self.assertSequenceEqual(
+            list(search_dict(["one", "two"], "one")),
+            []
+        )
+        self.assertSequenceEqual(
+            list(search_dict({"two": "test2"}, "one")),
+            []
+        )
+        self.assertSequenceEqual(
+            list(search_dict({"one": "test1", "two": "test2"}, "one")),
+            ["test1"]
+        )
+        self.assertEqual(
+            list(search_dict({"one": {"inner": "test1"}, "two": "test2"}, "inner")),
+            ["test1"]
+        )
+        self.assertEqual(
+            list(search_dict({"one": [{"inner": "test1"}], "two": "test2"}, "inner")),
+            ["test1"]
+        )
+        self.assertEqual(
+            list(search_dict({"one": [{"inner": "test1"}], "two": {"inner": "test2"}}, "inner")),
+            ["test1", "test2"]
+        )


### PR DESCRIPTION
As discussed in #1728 with @back-to, this PR modifies the YouTube plugin to search for the channel's video ID in the page first before trying the API. This should alleviate the pressure on the YouTube API key. 

Also added some better error logging if there is an error when calling the API.

**Requires testing on more channels**

Fixes #1728 

