### PR TITLE
logging: when using the trace level, log the timestamp

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -103,7 +103,12 @@ class StringFormatter(logging.Formatter):
         self.fmt = fmt
         self.remove_base = remove_base or []
 
+    def usesTime(self):
+        return (self.style == "%" and "%(asctime)" in self.fmt) or (self.style == "{" and "{asctime}" in self.fmt)
+
     def formatMessage(self, record):
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
         if self.style == "{":
             return self.fmt.format(**record.__dict__)
         else:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -514,8 +514,8 @@ def handle_url():
             log.debug("Plugin specific arguments:")
             for parg, value in plugin_args:
                 log.debug(" {0}={1} ({2})".format(parg.argument_name(plugin.module),
-                                                             value if not parg.sensitive else ("*" * 8),
-                                                             parg.dest))
+                                                  value if not parg.sensitive else ("*" * 8),
+                                                  parg.dest))
 
         if args.retry_max or args.retry_streams:
             retry_streams = 1
@@ -936,7 +936,10 @@ def check_version(force=False):
 
 
 def setup_logging(stream=sys.stdout, level="info"):
-    logger.basicConfig(stream=stream, level=level, format="[{name}][{levelname}] {message}", style="{")
+    fmt = ("[{asctime},{msecs:0.0f}]" if level == "trace" else "") + "[{name}][{levelname}] {message}"
+    logger.basicConfig(stream=stream, level=level,
+                       format=fmt, style="{",
+                       datefmt="%H:%M:%S")
 
 
 def main():


### PR DESCRIPTION
Add a timestamp to the logs when using `--loglevel trace`.