### PR TITLE
sdist and wheel release fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,15 +54,6 @@ deploy:
       tags: true
       condition: $BUILD_INSTALLER = yes
       repo: streamlink/streamlink
-  - provider: releases
-    api_key: "${RELEASES_API_KEY}"
-    file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}*"
-    file_glob: true
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: "$BUILD_SDIST = yes"
-      repo: streamlink/streamlink
   - provider: script
     script: python script/github_releases.py
     skip_cleanup: true
@@ -81,9 +72,19 @@ deploy:
       repo: streamlink/streamlink
   - provider: script
     script: ./script/sdistsign.sh
+    skip_cleanup: true
     on:
       tags: true
       condition: $BUILD_SDIST == yes
+      repo: streamlink/streamlink
+  - provider: releases
+    api_key: "${RELEASES_API_KEY}"
+    file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}*"
+    file_glob: true
+    skip_cleanup: true
+    on:
+      tags: true
+      condition: $BUILD_SDIST = yes
       repo: streamlink/streamlink
 
 after_deploy:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,10 +3,13 @@ include CHANGELOG.md
 include README.md
 include LICENSE*
 include *requirements.txt
+include src/streamlink/_version.py
+include versioneer.py
 
 recursive-include docs *
-prune docs/_build
 recursive-include examples *
 recursive-include tests *py
-include versioneer.py
-include src/streamlink/_version.py
+
+prune docs/_build
+prune */__pycache__
+global-exclude *.pyc *~ *.bak *.swp *.pyo

--- a/script/sdistsign.sh
+++ b/script/sdistsign.sh
@@ -13,7 +13,7 @@ if [[ -n "${TRAVIS}" ]]; then
 fi
 
 echo "build: Installing twine and wheel" >&2
-pip -q install twine wheel
+pip -q install -U setuptools twine wheel
 
 echo "build: Building streamlink sdist and wheel" >&2
 python setup.py -q sdist bdist_wheel --dist-dir "${dist_dir}"
@@ -31,7 +31,8 @@ if [[ "${DEPLOY_PYPI}" == "yes" ]]; then
     echo "build: Uploading sdist and wheel to PyPI" >&2
     twine upload --username "${PYPI_USER}" --password "${PYPI_PASSWORD}" \
         "${dist_dir}/streamlink-${version}.tar.gz" \
-        "${dist_dir}/streamlink-${version}.tar.gz.asc" \
+        "${dist_dir}/streamlink-${version}.tar.gz.asc"
+    twine upload --username "${PYPI_USER}" --password "${PYPI_PASSWORD}" \
         "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl" \
         "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl.asc"
 fi

--- a/script/sdistsign.sh
+++ b/script/sdistsign.sh
@@ -18,10 +18,14 @@ pip -q install twine wheel
 echo "build: Building streamlink sdist and wheel" >&2
 python setup.py -q sdist bdist_wheel --dist-dir "${dist_dir}"
 
-echo "build: Signing sdist and wheel files" >&2
-gpg --homedir "${temp_keyring}" --import "${KEY_FILE}" 2>&1 > /dev/null
-gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${dist_dir}/streamlink-${version}.tar.gz"
-gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl"
+if [ -f "${KEY_FILE}" ]; then
+    echo "build: Signing sdist and wheel files" >&2
+    gpg --homedir "${temp_keyring}" --import "${KEY_FILE}" 2>&1 > /dev/null
+    gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${dist_dir}/streamlink-${version}.tar.gz"
+    gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl"
+else
+    echo "warning: no signing key, files not signed" >&2
+fi
 
 if [[ "${DEPLOY_PYPI}" == "yes" ]]; then
     echo "build: Uploading sdist and wheel to PyPI" >&2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,31 @@
 #!/usr/bin/env python
 import codecs
-import os
-import versioneer
-
 from os import environ
 from os import path
-from sys import version_info, path as sys_path
+from sys import path as sys_path
+
 from setuptools import setup, find_packages
 
-deps = []
+import versioneer
 
-if version_info[0] == 2:
+deps = [
     # Require backport of concurrent.futures on Python 2
-    deps.append("futures")
-
-    if version_info[1] <= 6:
-        # Require backport of argparse on Python 2.6
-        deps.append("argparse")
-
-    if version_info[1] < 7 or (version_info[1] == 7 and version_info[2] <= 9):
-        deps.append("urllib3[secure]")
-
-# Require singledispatch on Python <3.4
-if version_info[0] == 2 or (version_info[0] == 3 and version_info[1] < 4):
-    deps.append("singledispatch")
-
-deps.append("requests>=2.2,!=2.12.0,!=2.12.1,!=2.16.0,!=2.16.1,!=2.16.2,!=2.16.3,!=2.16.4,!=2.16.5,!=2.17.1,<3.0")
+    'futures;python_version<"3.0"',
+    # Require singledispatch on Python <3.4
+    'singledispatch;python_version<"3.4"',
+    "requests>=2.2,!=2.12.0,!=2.12.1,!=2.16.0,!=2.16.1,!=2.16.2,!=2.16.3,!=2.16.4,!=2.16.5,!=2.17.1,<3.0",
+    'urllib3[secure]<1.23,>=1.21.1;python_version<"3.0"',
+    "isodate",
+    "websocket-client",
+    # Support for SOCKS proxies
+    "PySocks!=1.5.7,>=1.5.6",
+    # win-inet-pton is missing a dependency in PySocks, this has been fixed but not released yet
+    # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
+    'win-inet-pton;python_version<"3.0" and platform_system=="Windows"',
+    # shutil.get_terminal_size and which were added in Python 3.3
+    'backports.shutil_which;python_version<"3.3"',
+    'backports.shutil_get_terminal_size;python_version<"3.3"'
+]
 
 # for encrypted streams
 if environ.get("STREAMLINK_USE_PYCRYPTO"):
@@ -34,28 +34,12 @@ else:
     # this version of pycryptodome is known to work and has a Windows wheel for py2.7, py3.3-3.6
     deps.append("pycryptodome>=3.4.3,<4")
 
-# shutil.get_terminal_size and which were added in Python 3.3
-if version_info[0] == 2:
-    deps.append("backports.shutil_which")
-    deps.append("backports.shutil_get_terminal_size")
-
 # for localization
 if environ.get("STREAMLINK_USE_PYCOUNTRY"):
     deps.append("pycountry")
 else:
     deps.append("iso-639")
     deps.append("iso3166")
-
-deps.append("isodate")
-deps.append("websocket-client")
-
-# Support for SOCKS proxies
-deps.append("PySocks!=1.5.7,>=1.5.6")  # requests[socks] uses this version
-
-# win-inet-pton is missing a dependency in PySocks, this has been fixed but not released yet
-if os.name == "nt" and version_info < (3, 0):
-    # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
-    deps.append("win-inet-pton")
 
 # When we build an egg for the Win32 bootstrap we don"t want dependency
 # information built into it.
@@ -85,7 +69,8 @@ setup(name="streamlink",
           "Funding": "https://opencollective.com/streamlink"
       },
       author="Streamlink",
-      author_email="charlie@charliedrage.com",  # temp until we have a mailing list / global email
+      # temp until we have a mailing list / global email
+      author_email="charlie@charliedrage.com",
       license="Simplified BSD",
       packages=find_packages("src"),
       package_dir={"": "src"},


### PR DESCRIPTION
The script to build the sdist and wheel packages is run before the script that uploads them to PyPI. The sdist script doesn't clean up the environment, but extra prune options have been added to the MANIFEST.in file (thanks @back-to).

All the requirements have been changed to use PEP 345 environment markers, instead of deciding the packages to include based on the current interpreter. This means you can build a wheel on Python 3.6.3 and have it work on Python 2.7.14 :) It also tidies up the setup.py quite a bit. 

I'd like to get confirmation from @mmetak that this will work as expected on the streamlink-git AUR before merging :)