### PR TITLE
logging: rename logger for main back to 'cli'

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -43,7 +43,7 @@ QUIET_OPTIONS = ("json", "stream_url", "subprocess_cmdline", "quiet")
 
 args = console = streamlink = plugin = stream_fd = output = None
 
-log = logging.getLogger("streamlink.console")
+log = logging.getLogger("streamlink.cli")
 
 
 def check_file_output(filename, force):


### PR DESCRIPTION
Perhaps we should do a `0.13.1` release with just this fix - can branch from `0.13.0` (`release-0.13.x`?), apply this fix and tag on the release branch. 