### PR TITLE
sdist: include tests resources

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,7 @@ include versioneer.py
 
 recursive-include docs *
 recursive-include examples *
-recursive-include tests *py
+recursive-include tests *
 
 prune docs/_build
 prune */__pycache__


### PR DESCRIPTION
Tests resources files were not included in the source archive before, while tests might require
them. For example dash *.mpd files in tests/resources.