### PR TITLE
rtlxl: use raw string to fix escape sequences

### DIFF
--- a/src/streamlink/plugins/rtlxl.py
+++ b/src/streamlink/plugins/rtlxl.py
@@ -5,7 +5,7 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import http, validate
 from streamlink.stream import HDSStream, HLSStream, RTMPStream
 
-_url_re = re.compile("""http(?:s)?://(?:\w+\.)?rtl.nl/video/(?P<uuid>.*?)\Z""", re.IGNORECASE)
+_url_re = re.compile(r"http(?:s)?://(?:\w+\.)?rtl.nl/video/(?P<uuid>.*?)\Z", re.IGNORECASE)
 
 
 class rtlxl(Plugin):


### PR DESCRIPTION
With only """, the string is still not a raw string (just a multiline
string) and regex escape sequences were read a string escape sequences
by python, with warnings about unknown escape sequences (like \w).