### PR TITLE
tests: freezegun: use object instead of lambda

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -49,7 +49,7 @@ class TestPlugin(unittest.TestCase):
                                             3600)
 
     def test_cookie_store_save_expires(self):
-        with freezegun.freeze_time(lambda: datetime.datetime(2018, 1, 1)):
+        with freezegun.freeze_time(datetime.datetime(2018, 1, 1)):
             session = Mock()
             session.http.cookies = [
                 requests.cookies.create_cookie("test-name", "test-value", domain="test.se", expires=time.time() + 3600,


### PR DESCRIPTION
Lambda support is a recent addition in freezegun (in the latest release, 0.3.10) and
might not be available everywhere yet (as of now: Debian stable and sid)