### PR TITLE
docs.thirdparty: Added LiveProxy

### DIFF
--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -29,6 +29,10 @@
 
 .. include:: _applications.rst
 
+.. |br| raw:: html
+
+  <br />
+
 
 Third Party Applications
 ========================
@@ -36,9 +40,17 @@ Third Party Applications
 
 .. content list start
 
+LiveProxy
+---------
 
-.. replace this line with the first entry
-
+:Description: Local proxy server between Streamlink and an URL
+:OS: |Windows| |MacOS| |Linux|
+:Author: `back-to <https://github.com/back-to>`_
+:Website: https://liveproxy.github.io
+:Source code: https://github.com/back-to/liveproxy
+:Info: LiveProxy allows Streamlink to be easy accessible from **m3u** playlists, |br|
+  it is also available for **Kodi Leia** and **Enigma2** devices. |br|
+  A detailed guide can be found on the website.
 
 .. content list end
 


### PR DESCRIPTION
LiveProxy allows Streamlink to be easy accessible from **m3u** playlists,
it is also available for **Kodi Leia** and **Enigma2** devices.

---

It is only meant for a local network.

---

The argparser is copied from **streamlink_cli**,
this makes it easier to maintain and also allows the usage of all Streamlink commands.

Most of them will work, some not because they make no sense for LiveProxy.

**supported**

- Sideloading Plugins
- config files
- HLS, HTTP, HDS are supported.

**not supported**

- RTMP is not supported
- Dash will be supported at some point, but not right now.

It can play the stream or redirect the streaming url.

---

Example of URLs

```
http://127.0.0.1:53422/play/?url=https%3A%2F%2Fwww.youtube.com%2Fuser%2Ffrance24

http://127.0.0.1:53422/301/?url=https%253A%252F%252Fwww.euronews.com%252Flive
```

A detailed guide can be found on the website.