### PR TITLE
Add arguments to __init__ - super to work on Python 2.7.X

### DIFF
--- a/src/streamlink/plugins/btsports.py
+++ b/src/streamlink/plugins/btsports.py
@@ -35,7 +35,7 @@ class BTSports(Plugin):
     login_url = "https://signin1.bt.com/siteminderagent/forms/login.fcc"
 
     def __init__(self, url):
-        super().__init__(url)
+        super(BTSports, self).__init__(url)
         http.headers = {"User-Agent": useragents.FIREFOX}
 
     @classmethod


### PR DESCRIPTION
Super() without arguments in only supported on Python 3.