### PR TITLE
api.utils: hours_minutes_seconds update, twitch automate time offset

### DIFF
--- a/src/streamlink/utils/times.py
+++ b/src/streamlink/utils/times.py
@@ -1,0 +1,52 @@
+import re
+
+_hours_minutes_seconds_re = re.compile(r"""
+    ^-?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)$
+""", re.VERBOSE)
+
+_hours_minutes_seconds_2_re = re.compile(r"""^-?
+    (?:
+        (?P<hours>\d+)h
+    )?
+    (?:
+        (?P<minutes>\d+)m
+    )?
+    (?:
+        (?P<seconds>\d+)s
+    )?$
+""", re.VERBOSE | re.IGNORECASE)
+
+
+def hours_minutes_seconds(value):
+    """converts a timestamp to seconds
+
+      - hours:minutes:seconds to seconds
+      - 11h22m33s to seconds
+      - 11h to seconds
+      - 20h15m to seconds
+      - seconds to seconds
+
+    :param value: hh:mm:ss ; 00h00m00s ; seconds
+    :return: seconds
+    """
+    try:
+        return int(value)
+    except ValueError:
+        pass
+
+    match = (_hours_minutes_seconds_re.match(value)
+             or _hours_minutes_seconds_2_re.match(value))
+    if not match:
+        raise ValueError
+
+    s = 0
+    s += int(match.group("hours") or "0") * 60 * 60
+    s += int(match.group("minutes") or "0") * 60
+    s += int(match.group("seconds") or "0")
+
+    return s
+
+
+__all__ = [
+    "hours_minutes_seconds",
+]

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -4,6 +4,7 @@ from string import printable
 from textwrap import dedent
 
 from streamlink import logger
+from streamlink.utils.times import hours_minutes_seconds
 from .constants import (
     LIVESTREAMER_VERSION, STREAM_PASSTHROUGH, DEFAULT_PLAYER_ARGUMENTS
 )
@@ -24,7 +25,6 @@ _option_re = re.compile(r"""
     \s*
     (?P<value>.*) # The value, anything goes.
 """, re.VERBOSE)
-_hours_minutes_seconds_re = re.compile(r"-?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)")
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -138,23 +138,6 @@ def boolean(value):
         raise argparse.ArgumentTypeError("{0} was not one of {{{1}}}".format(value, ', '.join(truths + falses)))
 
     return value.lower() in truths
-
-
-def hours_minutes_seconds(value):
-    """
-    converts hours:minutes:seconds to seconds
-    :param value: hh:mm:ss
-    :return: seconds
-    """
-    match = _hours_minutes_seconds_re.match(value)
-    if not match:
-        raise ValueError
-    s = 0
-    s += int(match.group("hours")) * 60 * 60
-    s += int(match.group("minutes")) * 60
-    s += int(match.group("seconds"))
-
-    return s
 
 
 def build_parser():

--- a/tests/test_utils_times.py
+++ b/tests/test_utils_times.py
@@ -1,0 +1,37 @@
+import unittest
+
+from streamlink.utils.times import hours_minutes_seconds
+
+
+class TestUtilsTimes(unittest.TestCase):
+
+    def test_hours_minutes_seconds(self):
+        self.assertEqual(hours_minutes_seconds("00:01:30"), 90)
+        self.assertEqual(hours_minutes_seconds("01:20:15"), 4815)
+        self.assertEqual(hours_minutes_seconds("26:00:00"), 93600)
+
+        self.assertEqual(hours_minutes_seconds("07"), 7)
+        self.assertEqual(hours_minutes_seconds("444"), 444)
+        self.assertEqual(hours_minutes_seconds("8888"), 8888)
+
+        self.assertEqual(hours_minutes_seconds("01h"), 3600)
+        self.assertEqual(hours_minutes_seconds("01h22m33s"), 4953)
+        self.assertEqual(hours_minutes_seconds("01H22M37S"), 4957)
+        self.assertEqual(hours_minutes_seconds("01h30s"), 3630)
+        self.assertEqual(hours_minutes_seconds("1m33s"), 93)
+        self.assertEqual(hours_minutes_seconds("55s"), 55)
+
+        self.assertEqual(hours_minutes_seconds("-00:01:40"), 100)
+        self.assertEqual(hours_minutes_seconds("-00h02m30s"), 150)
+
+        with self.assertRaises(ValueError):
+            hours_minutes_seconds("02:04")
+
+        with self.assertRaises(ValueError):
+            hours_minutes_seconds("FOO")
+
+        with self.assertRaises(ValueError):
+            hours_minutes_seconds("BAR")
+
+        with self.assertRaises(ValueError):
+            hours_minutes_seconds("11:ERR:00")


### PR DESCRIPTION
**hours_minutes_seconds**:

allow more timestamps
- hours:minutes:seconds to seconds
- 11h22m33s to seconds
- 11h to seconds
- 20h15m to seconds
- seconds to seconds

**twitch**:
- automate `hls-start-offset` for urls with timestamps
- update for the old vod url's, which I don't think exist anymore

**youtube**:
- tested on youtube, but did not add it because there are to many http streams

---

I put it into `api/utils.py` but could also move it somewhere else.

---

will break https://github.com/streamlink/streamlink/pull/1792 as it uses the same file
