### PR TITLE
docs: removed some notes, updated some urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![TravisCI build status][travisci-build-status-badge]][travisci-build-status]
 [![codecov.io][codecov-coverage-badge]][codecov-coverage] [![Backers on Open Collective][opencollective-backers-badge]](#backers) [![Sponsors on Open Collective][opencollective-sponsors-badge]](#sponsors)
 
-Streamlink is a CLI utility that pipes flash videos from online streaming services to a variety of video players such as VLC, or alternatively, a browser.
+Streamlink is a CLI utility that pipes flash videos from online streaming services to a variety of video players such as VLC.
 
 The main purpose of streamlink is to convert CPU-heavy flash plugins to a less CPU-intensive format.
 
@@ -47,8 +47,8 @@ Supported streaming services, among many others, are:
 - [Dailymotion](https://www.dailymotion.com)
 - [Livestream](https://livestream.com)
 - [Twitch](https://www.twitch.tv)
-- [UStream](http://www.ustream.tv)
-- [YouTube Live](https://www.youtube.com)
+- [UStream](http://www.ustream.tv/explore/all)
+- [YouTube](https://www.youtube.com)
 
 A list of all supported plugins can be found on the [plugin page][streamlink-plugins].
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -44,8 +44,8 @@ even on Windows.
 
 .. code-block:: console
 
-    $ streamlink hlsvariant://file://C:/hls/playlist.m3u8
-    [cli][info] Found matching plugin stream for URL hlsvariant://file://C:/hls/playlist.m3u8
+    $ streamlink hls://file://C:/hls/playlist.m3u8
+    [cli][info] Found matching plugin stream for URL hls://file://C:/hls/playlist.m3u8
     Available streams: 180p (worst), 272p, 408p, 554p, 818p, 1744p (best)
 
 
@@ -100,13 +100,6 @@ Unix-like (POSIX) - $XDG_CONFIG_HOME/streamlink/config
                   - ~/.streamlinkrc
 Windows           %APPDATA%\\streamlink\\streamlinkrc
 ================= ====================================================
-
-.. note::
-  Currently the Windows installer does not create the streamlinkrc file. This
-  is a known issue being tracked
-  `here <https://github.com/streamlink/streamlink/issues/81>`_. An example
-  configuration file is available in the
-  `repo <https://github.com/streamlink/streamlink/blob/master/win32/streamlinkrc>`_.
 
 You can also specify the location yourself using the :option:`--config` option.
 
@@ -321,12 +314,14 @@ Name                           Prefix
 ============================== =================================================
 Adobe HTTP Dynamic Streaming   hds://
 Akamai HD Adaptive Streaming   akamaihd://
-Apple HTTP Live Streaming      hls:// hlsvariant:// [1]_
+Apple HTTP Live Streaming      hls:// [1]_
+MPEG-DASH [2]_                 dash://
 Real Time Messaging Protocol   rtmp:// rtmpe:// rtmps:// rtmpt:// rtmpte://
 Progressive HTTP, HTTPS, etc   httpstream:// [1]_
 ============================== =================================================
 
 .. [1] supports local files using the file:// protocol
+.. [2] Dynamic Adaptive Streaming over HTTP
 .. _cli-options:
 
 Proxy Support
@@ -362,4 +357,3 @@ Command-line usage
 .. argparse::
     :module: streamlink_cli.main
     :attr: parser_helper
-

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Overview
 --------
 
 Streamlink is a :ref:`command-line utility <cli>` that pipes video streams
-from various services into a video player, such as `VLC <http://videolan.org/>`_.
+from various services into a video player, such as `VLC`_.
 The main purpose of Streamlink is to allow the user to avoid buggy and CPU
 heavy flash plugins but still be able to enjoy various streamed content.
 There is also an :ref:`API <api_guide>` available for developers who want access
@@ -12,7 +12,7 @@ no longer maintained.
 - Latest release: |version| (https://github.com/streamlink/streamlink/releases/latest)
 - GitHub: https://github.com/streamlink/streamlink
 - Issue tracker: https://github.com/streamlink/streamlink/issues
-- PyPI: https://pypi.python.org/pypi/streamlink
+- PyPI: https://pypi.org/project/streamlink/
 - Free software: Simplified BSD license
 - Icon: https://www.flickr.com/photos/phploveme/27078045626 (cc-by-sa 2.0)
 
@@ -23,11 +23,11 @@ Streamlink is built upon a plugin system which allows support for new services
 to be easily added. Currently most of the big streaming services are supported,
 such as:
 
-- `Dailymotion <http://dailymotion.com/live>`_
-- `Livestream <http://livestream.com>`_
-- `Twitch <http://twitch.tv>`_
-- `UStream <http://ustream.tv>`_
-- `YouTube Live <http://youtube.com>`_
+- `Dailymotion <https://www.dailymotion.com/live>`_
+- `Livestream <https://livestream.com/>`_
+- `Twitch <https://www.twitch.tv/>`_
+- `UStream <http://www.ustream.tv/explore/all>`_
+- `YouTube <https://www.youtube.com/>`_
 
 ... and many more. A full list of plugins currently included can be found
 on the :ref:`plugin_matrix` page.
@@ -36,7 +36,7 @@ Quickstart
 ----------
 
 The default behaviour of Streamlink is to playback a stream in the default
-player (`VLC <http://videolan.org/>`_).
+player (`VLC <https://www.videolan.org/>`_).
 
 .. sourcecode:: console
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -44,7 +44,11 @@ Distribution                         Installing
 
                                         $ cd /usr/pkgsrc/multimedia/streamlink
                                         # make install clean
-`NixOS`_                             `Installing NixOS packages`_
+`NixOS`_                             .. code-block:: console
+
+                                        $ nix-env -iA nixos.streamlink
+
+                                     `NixOS channel`_
 `Solus`_                             .. code-block:: console
 
                                         $ sudo eopkg install streamlink
@@ -66,12 +70,12 @@ Distribution                         Installing
 .. _Gentoo Linux: https://packages.gentoo.org/package/net-misc/streamlink
 .. _NetBSD (pkgsrc): http://pkgsrc.se/multimedia/streamlink
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
-.. _Solus: https://git.solus-project.com/packages/streamlink/
+.. _Solus: https://dev.solus-project.com/source/streamlink/
 .. _Ubuntu: http://ppa.launchpad.net/nilarimogard/webupd8/ubuntu/pool/main/s/streamlink/
-.. _Void: https://github.com/voidlinux/void-packages/tree/master/srcpkgs/streamlink
+.. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
 
 .. _Installing AUR packages: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages
-.. _Installing NixOS packages: https://nixos.org/wiki/Install/remove_software#How_to_install_software
+.. _NixOS channel: https://nixos.org/nixos/packages.html#streamlink
 
 
 Other platforms
@@ -201,6 +205,11 @@ Name                                 Notes
 `pycryptodome`_                      Required to play some encrypted streams
 `iso-639`_                           Used for localization settings, provides language information
 `iso3166`_                           Used for localization settings, provides country information
+`isodate`_                           Used for MPEG-DASH streams
+`PySocks`_                           Used for SOCKS Proxies
+`websocket-client`_                  Used for some plugins
+`shutil_get_terminal_size`_          Only needed on Python versions older than **3.3**
+`shutil_which`_                      Only needed on Python versions older than **3.3**
 
 **Optional**
 --------------------------------------------------------------------------------
@@ -220,19 +229,24 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
     $ export STREAMLINK_USE_PYCRYPTO="true"
     $ export STREAMLINK_USE_PYCOUNTRY="true"
 
-.. _Python: http://python.org/
-.. _python-setuptools: http://pypi.python.org/pypi/setuptools
-.. _python-argparse: http://pypi.python.org/pypi/argparse
-.. _python-futures: http://pypi.python.org/pypi/futures
+.. _Python: https://www.python.org/
+.. _python-setuptools: https://pypi.org/project/setuptools/
+.. _python-argparse: https://pypi.org/project/argparse/
+.. _python-futures: https://pypi.org/project/futures/
 .. _python-requests: http://python-requests.org/
-.. _python-singledispatch: http://pypi.python.org/pypi/singledispatch
+.. _python-singledispatch: https://pypi.org/project/singledispatch/
 .. _RTMPDump: http://rtmpdump.mplayerhq.hu/
-.. _pycountry: https://pypi.python.org/pypi/pycountry
+.. _pycountry: https://pypi.org/project/pycountry/
 .. _pycrypto: https://www.dlitz.net/software/pycrypto/
 .. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
 .. _ffmpeg: https://www.ffmpeg.org/
-.. _iso-639: https://pypi.python.org/pypi/iso-639
-.. _iso3166: https://pypi.python.org/pypi/iso3166
+.. _iso-639: https://pypi.org/project/iso-639/
+.. _iso3166: https://pypi.org/project/iso3166/
+.. _isodate: https://pypi.org/project/isodate/
+.. _PySocks: https://github.com/Anorov/PySocks
+.. _websocket-client: https://pypi.org/project/websocket-client/
+.. _shutil_get_terminal_size: https://pypi.org/project/backports.shutil_get_terminal_size/
+.. _shutil_which: https://pypi.org/project/backports.shutil_which/
 
 
 Installing without root permissions
@@ -265,10 +279,10 @@ instead.
 .. note::
 
     This may also be required on some OS X versions that seems to have weird
-    permission issues (see issue #401).
+    permission issues.
 
 
-.. _virtualenv: http://virtualenv.readthedocs.org/en/latest/
+.. _virtualenv: https://virtualenv.readthedocs.io/en/latest/
 
 
 Windows binaries
@@ -295,7 +309,7 @@ Release                              Notes
 .. _GitHub releases page: https://github.com/streamlink/streamlink/releases/latest
 .. _Development build:
 .. _Bintray: https://bintray.com/streamlink/streamlink-nightly/streamlink/_latestVersion/#files
-.. _list of recent changes: https://bintray.com/streamlink/streamlink-nightly/streamlink/latest#release
+.. _list of recent changes: https://bintray.com/streamlink/streamlink-nightly/streamlink/_latestVersion/#release
 
 These installers contain:
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -193,7 +193,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
 
         if playlist.is_master:
             raise StreamError("Attempted to play a variant playlist, use "
-                              "'hlsvariant://{0}' instead".format(self.stream.url))
+                              "'hls://{0}' instead".format(self.stream.url))
 
         if playlist.iframes_only:
             raise StreamError("Streams containing I-frames only is not playable")


### PR DESCRIPTION
removed `hlsvariant://` documentation,
`hls://` is enough

**README.md**
- removed invalid note
- update some URLs

**cli.rst**
- removed old note
- added `dash://`

**index.rst**
- update for https URLs

**install.rst**
- update for new **Solus** / **Void** URL
- update for **NixOS**, found only this URL
- update for Dependencies
- PyPI URL update
- removed old livestreamer issue ref 401
- use correct URL for Bintray changelog

---

closes https://github.com/streamlink/streamlink/issues/1807