### PR TITLE
API for plugins to request input from the user

### DIFF
--- a/src/streamlink/exceptions.py
+++ b/src/streamlink/exceptions.py
@@ -7,6 +7,16 @@ class PluginError(StreamlinkError):
     """Plugin related error."""
 
 
+class FatalPluginError(PluginError):
+    """
+    Plugin related error that cannot be recovered from
+
+    Plugin's should use this Exception when errors that can
+    never be recovered from are encountered. For example, when
+    a user's input is required an none can be given.
+    """
+
+
 class NoStreamsError(StreamlinkError):
     def __init__(self, url):
         self.url = url

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -38,6 +38,10 @@ class Options(object):
         if key in self.options:
             return self.options[key]
 
+    def update(self, options):
+        for key, value in options.items():
+            self.set(key, value)
+
 
 class Argument(object):
     """

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -12,6 +12,8 @@ from streamlink.cache import Cache
 from streamlink.exceptions import PluginError, NoStreamsError
 from streamlink.options import Options, Arguments
 
+log = logging.getLogger(__name__)
+
 # FIXME: This is a crude attempt at making a bitrate's
 # weight end up similar to the weight of a resolution.
 # Someone who knows math, please fix.
@@ -155,6 +157,33 @@ def parse_params(params):
     return rval
 
 
+class UserInputRequester(object):
+    """
+    Base Class / Interface for requesting user input
+
+    eg. From the console
+    """
+    def ask(self, prompt):
+        """
+        Ask the user for a text input, the input is not sensitive
+        and can be echoed to the user
+
+        :param prompt: message to display when asking for the input
+        :return: the value the user input
+        """
+        raise NotImplementedError
+
+    def ask_password(self, prompt):
+        """
+        Ask the user for a text input, the input _is_ sensitive
+        and should be masked as the user gives the input
+
+        :param prompt: message to display when asking for the input
+        :return: the value the user input
+        """
+        raise NotImplementedError
+
+
 class Plugin(object):
     """A plugin can retrieve stream information from the URL specified.
 
@@ -167,14 +196,20 @@ class Plugin(object):
     options = Options()
     arguments = Arguments()
     session = None
+    _user_input_requester = None
 
     @classmethod
-    def bind(cls, session, module):
+    def bind(cls, session, module, user_input_requester=None):
         cls.cache = Cache(filename="plugin-cache.json",
                           key_prefix=module)
         cls.logger = logging.getLogger("streamlink.plugin." + module)
         cls.module = module
         cls.session = session
+        if user_input_requester is not None:
+            if isinstance(user_input_requester, UserInputRequester):
+                cls._user_input_requester = user_input_requester
+            else:
+                raise RuntimeError("user-input-requester must be an instance of UserInputRequester")
 
     def __init__(self, url):
         self.url = url
@@ -482,6 +517,23 @@ class Plugin(object):
                     removed.append(key)
 
         return removed
+
+    def input_ask(self, prompt):
+        if self._user_input_requester:
+            try:
+                return self._user_input_requester.ask(prompt)
+            except NotImplementedError:  # ignore this and raise a PluginError
+                pass
+        raise PluginError("This plugin requires user interaction, however it is not supported on this platform")
+
+    def input_ask_password(self, prompt):
+        if self._user_input_requester:
+            try:
+                return self._user_input_requester.ask_password(prompt)
+            except NotImplementedError:  # ignore this and raise a PluginError
+                pass
+        raise PluginError("This plugin requires user interaction, however it is not supported on this platform")
+
 
 
 __all__ = ["Plugin"]

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -9,7 +9,7 @@ from functools import partial
 from collections import OrderedDict
 
 from streamlink.cache import Cache
-from streamlink.exceptions import PluginError, NoStreamsError
+from streamlink.exceptions import PluginError, NoStreamsError, FatalPluginError
 from streamlink.options import Options, Arguments
 
 log = logging.getLogger(__name__)
@@ -523,20 +523,20 @@ class Plugin(object):
             try:
                 return self._user_input_requester.ask(prompt)
             except IOError as e:
-                raise PluginError("User input error: {0}".format(e))
-            except NotImplementedError:  # ignore this and raise a PluginError
+                raise FatalPluginError("User input error: {0}".format(e))
+            except NotImplementedError:  # ignore this and raise a FatalPluginError
                 pass
-        raise PluginError("This plugin requires user input, however it is not supported on this platform")
+        raise FatalPluginError("This plugin requires user input, however it is not supported on this platform")
 
     def input_ask_password(self, prompt):
         if self._user_input_requester:
             try:
                 return self._user_input_requester.ask_password(prompt)
             except IOError as e:
-                raise PluginError("User input error: {0}".format(e))
-            except NotImplementedError:  # ignore this and raise a PluginError
+                raise FatalPluginError("User input error: {0}".format(e))
+            except NotImplementedError:  # ignore this and raise a FatalPluginError
                 pass
-        raise PluginError("This plugin requires user input, however it is not supported on this platform")
+        raise FatalPluginError("This plugin requires user input, however it is not supported on this platform")
 
 
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -522,17 +522,21 @@ class Plugin(object):
         if self._user_input_requester:
             try:
                 return self._user_input_requester.ask(prompt)
+            except IOError as e:
+                raise PluginError("User input error: {0}".format(e))
             except NotImplementedError:  # ignore this and raise a PluginError
                 pass
-        raise PluginError("This plugin requires user interaction, however it is not supported on this platform")
+        raise PluginError("This plugin requires user input, however it is not supported on this platform")
 
     def input_ask_password(self, prompt):
         if self._user_input_requester:
             try:
                 return self._user_input_requester.ask_password(prompt)
+            except IOError as e:
+                raise PluginError("User input error: {0}".format(e))
             except NotImplementedError:  # ignore this and raise a PluginError
                 pass
-        raise PluginError("This plugin requires user interaction, however it is not supported on this platform")
+        raise PluginError("This plugin requires user input, however it is not supported on this platform")
 
 
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -44,7 +44,7 @@ class Streamlink(object):
     """A Streamlink session is used to keep track of plugins,
        options and log settings."""
 
-    def __init__(self):
+    def __init__(self, options=None):
         self.http = api.HTTPSession()
         self.options = Options({
             "hds-live-edge": 10.0,
@@ -74,12 +74,14 @@ class Streamlink(object):
             "ffmpeg-ffmpeg": None,
             "ffmpeg-video-transcode": "copy",
             "ffmpeg-audio-transcode": "copy",
-            "locale": None
+            "locale": None,
+            "user-input-requester": None
         })
+        if options:
+            self.options.update(options)
         self.plugins = {}
         self.load_builtin_plugins()
         self._logger = None
-
 
     @property
     def logger(self):
@@ -232,6 +234,11 @@ class Streamlink(object):
         locale                   (str) Locale setting, in the RFC 1766 format
                                  eg. en_US or es_ES
                                  default: ``system locale``.
+
+        user-input-requester     (UserInputRequester) instance of UserInputRequester
+                                 to collect input from the user at runtime. Must be
+                                 set before the plugins are loaded.
+                                 default: ``UserInputRequester``.
         ======================== =========================================
 
         """
@@ -458,6 +465,7 @@ class Streamlink(object):
 
     def load_plugin(self, name, file, pathname, desc):
         # Set the global http session for this plugin
+        user_input_requester = self.get_option("user-input-requester")
         api.http = self.http
 
         module = imp.load_module(name, file, pathname, desc)
@@ -467,7 +475,7 @@ class Streamlink(object):
             plugin_name = module_name.split(".")[-1]  # get the plugin part of the module name
 
             plugin = getattr(module, "__plugin__")
-            plugin.bind(self, plugin_name)
+            plugin.bind(self, plugin_name, user_input_requester)
 
             if plugin.module in self.plugins:
                 log.debug("Plugin {0} is being overridden by {1}".format(plugin.module, pathname))

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -3,10 +3,25 @@ import sys
 import logging
 from getpass import getpass
 
+from streamlink.plugin.plugin import UserInputRequester
 from .compat import input
 from .utils import JSONEncoder
 
 log = logging.getLogger("streamlink.cli")
+
+
+class ConsoleUserInputRequester(UserInputRequester):
+    """
+    Request input from the user on the console using the standard ask/askpass methods
+    """
+    def __init__(self, console):
+        self.console = console
+
+    def ask(self, prompt):
+        return self.console.ask(prompt.strip() + ": ")
+
+    def ask_password(self, prompt):
+        return self.console.askpass(prompt.strip() + ": ")
 
 
 class ConsoleOutput(object):

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -1,9 +1,8 @@
 import json
-import sys
 import logging
+import sys
 from getpass import getpass
 
-from streamlink import PluginError
 from streamlink.plugin.plugin import UserInputRequester
 from .compat import input
 from .utils import JSONEncoder

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -29,7 +29,7 @@ from streamlink.plugin import PluginOptions
 import streamlink.logger as logger
 from .argparser import build_parser
 from .compat import stdout, is_win32
-from .console import ConsoleOutput
+from .console import ConsoleOutput, ConsoleUserInputRequester
 from .constants import CONFIG_FILES, PLUGINS_DIR, STREAM_SYNONYMS
 from .output import FileOutput, PlayerOutput
 from .utils import NamedPipe, HTTPServer, ignored, progress, stream_to_url
@@ -737,7 +737,7 @@ def setup_streamlink():
     """Creates the Streamlink session."""
     global streamlink
 
-    streamlink = Streamlink()
+    streamlink = Streamlink({"user-input-requester": ConsoleUserInputRequester(console)})
 
 
 def setup_options():
@@ -959,6 +959,7 @@ def main():
     silent_log = any(getattr(args, attr) for attr in QUIET_OPTIONS)
     log_level = args.loglevel if not silent_log else "none"
     setup_logging(console_out, log_level)
+    setup_console(console_out)
 
     setup_streamlink()
     # load additional plugins
@@ -972,7 +973,6 @@ def main():
     log_level = args.loglevel if not silent_log else "none"
     logger.root.setLevel(log_level)
 
-    setup_console(console_out)
     setup_http_session()
     check_root()
     log_current_versions()

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -22,6 +22,7 @@ from streamlink import __version__ as streamlink_version
 from streamlink import (Streamlink, StreamError, PluginError,
                         NoPluginError)
 from streamlink.cache import Cache
+from streamlink.exceptions import FatalPluginError
 from streamlink.stream import StreamProcess
 from streamlink.plugins.twitch import TWITCH_CLIENT_ID
 from streamlink.plugin import PluginOptions
@@ -432,6 +433,8 @@ def fetch_streams_with_retry(plugin, interval, count):
 
         try:
             streams = fetch_streams(plugin)
+        except FatalPluginError as err:
+            raise
         except PluginError as err:
             log.error(u"{0}", err)
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -29,6 +29,13 @@ class TestOptions(unittest.TestCase):
         self.options.set("a_option", "option")
         self.assertEqual(self.options.get("a_option"), "option")
 
+    def test_options_update(self):
+        self.assertEqual(self.options.get("a_default"), "default")
+        self.assertEqual(self.options.get("non_existing"), None)
+
+        self.options.update({"a_option": "option"})
+        self.assertEqual(self.options.get("a_option"), "option")
+
     def test_options_name_normalised(self):
         self.assertEqual(self.options.get("a_default"), "default")
         self.assertEqual(self.options.get("a-default"), "default")

--- a/tests/test_plugins_input.py
+++ b/tests/test_plugins_input.py
@@ -37,8 +37,8 @@ class TestPluginUserInput(unittest.TestCase):
         p = _TestPlugin("http://example.com/stream")
         with self._mock_console_input() as console_input:
             p.bind(self.session, 'test_plugin', console_input)
-            self.assertEquals("username", p.input_ask("username"))
-            self.assertEquals("password", p.input_ask_password("password"))
+            self.assertEqual("username", p.input_ask("username"))
+            self.assertEqual("password", p.input_ask_password("password"))
             console_input.console.ask.assert_called_with("username: ")
             console_input.console.askpass.assert_called_with("password: ")
 
@@ -55,5 +55,5 @@ class TestPluginUserInput(unittest.TestCase):
             session.load_plugins(os.path.join(os.path.dirname(__file__), "plugins"))
 
             p = session.resolve_url("http://test.se/channel")
-            self.assertEquals("username", p.input_ask("username"))
-            self.assertEquals("password", p.input_ask_password("password"))
+            self.assertEqual("username", p.input_ask("username"))
+            self.assertEqual("password", p.input_ask_password("password"))

--- a/tests/test_plugins_input.py
+++ b/tests/test_plugins_input.py
@@ -1,0 +1,47 @@
+import unittest
+import os.path
+
+from streamlink.plugin.plugin import UserInputRequester
+from tests.mock import MagicMock
+
+from streamlink import Streamlink, PluginError
+from streamlink_cli.console import ConsoleUserInputRequester
+from tests.plugins.testplugin import TestPlugin as _TestPlugin
+
+
+class TestPluginUserInput(unittest.TestCase):
+    def setUp(self):
+        self.session = Streamlink()
+
+    def _mock_console_input(self):
+        mock_console = MagicMock()
+        mock_console.ask.return_value = "username"
+        mock_console.askpass.return_value = "password"
+        return ConsoleUserInputRequester(mock_console)
+
+    def test_user_input_bad_class(self):
+        p = _TestPlugin("http://example.com/stream")
+        self.assertRaises(RuntimeError, p.bind, self.session, 'test_plugin', object())
+
+    def test_user_input_not_implemented(self):
+        p = _TestPlugin("http://example.com/stream")
+        p.bind(self.session, 'test_plugin', UserInputRequester())
+        self.assertRaises(PluginError, p.input_ask, 'test')
+        self.assertRaises(PluginError, p.input_ask_password, 'test')
+
+    def test_user_input_console(self):
+        p = _TestPlugin("http://example.com/stream")
+        console_input = self._mock_console_input()
+        p.bind(self.session, 'test_plugin', console_input)
+        self.assertEquals("username", p.input_ask("username"))
+        self.assertEquals("password", p.input_ask_password("password"))
+        console_input.console.ask.assert_called_with("username: ")
+        console_input.console.askpass.assert_called_with("password: ")
+
+    def test_set_via_session(self):
+        session = Streamlink({"user-input-requester": self._mock_console_input()})
+        session.load_plugins(os.path.join(os.path.dirname(__file__), "plugins"))
+
+        p = session.resolve_url("http://test.se/channel")
+        self.assertEquals("username", p.input_ask("username"))
+        self.assertEquals("password", p.input_ask_password("password"))

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,17 +1,7 @@
 import os
-import sys
-if sys.version_info[0:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY
-
-try:
-    from unittest.mock import MagicMock
-except ImportError:
-    from mock import MagicMock
-
 from streamlink import Streamlink, NoPluginError
 from streamlink.plugins import Plugin
 from streamlink.stream import *


### PR DESCRIPTION
I have taken a bash at creating an API for plugins to request input from a user. I have only implemented in solution for the standard `streamlink_cli`, but I have tried to design it in a way that other front-ends can use. 

During the `Plugin.bind` call and additional (optional) parameter is passed - an instance of `UserInputRequester`, the job of which is to provide a way for the user to give an input. Implementations of `UserInputRequester` must implement two methods, `ask` and `ask_password`. `ask` is for users to input non-sensitive data, eg. username. `ask_password` is for users to input sensitive data, eg. password. For example, in the `ConsoleUserInputRequester` the two methods (`ask`, and `ask_password`) are handled by `Console.ask` and `Console.askpass`. 

For a `Plugin` to request input from the user, there are two new methods `Plugin.input_ask` and `Plugin.input_ask_password` that call `UserInputRequester.ask` and `UserInputRequester.ask_password` respectively. If no `UserInputRequester` is given and a `Plugin` tries to request user input, it will raise a `PluginError`. 

As a user of the `Streamlink` API, the `UserInputRequester` instance can set by setting the option `user-input-requester`, using `Sreamlink` options constructor parameter. It must be set when instance of `Streamlink` is created to affect built-in plugins.

I mainly created this as some way is needed for the `SteamBroadcast` plugin (#1717) to request input from the user for 2FA, and we need to maintain the disconnect between `streamlink` and `streamlink_cli`. 