### PR TITLE
Fix 404 error on twitch oauth authorize url

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -588,7 +588,7 @@ def authenticate_twitch_oauth():
 
     client_id = TWITCH_CLIENT_ID
     redirect_uri = "https://streamlink.github.io/twitch_oauth.html"
-    url = ("https://api.twitch.tv/kraken/oauth2/authorize/"
+    url = ("https://api.twitch.tv/kraken/oauth2/authorize"
            "?response_type=token&client_id={0}&redirect_uri="
            "{1}&scope=user_read+user_subscriptions").format(client_id, redirect_uri)
 


### PR DESCRIPTION
This PR fixes the 404 error when user request a oauth token for Twitch by removing the trailing slash from the endpoint.

### How to reproduce
1. `streamlink --twitch-oauth-authenticate`
2. Twitch should answer with a HTTP 404 error.