### PR TITLE
release: set the date of the release for UTC time

### DIFF
--- a/script/release.sh
+++ b/script/release.sh
@@ -62,7 +62,7 @@ success() {
 
 changelog() {
   temp_changes=$(mktemp) && trap "rm -rf ${temp_changes}" EXIT || exit 255
-  date=$(date +"%Y-%m-%d")
+  date=$(date -u +"%Y-%m-%d")
   shortlog=$(git shortlog --email --no-merges --pretty=%s ${1}..)
 
   echo -e "\n## streamlink $2 ($date)\n\n!! WRITE RELEASE NOTES HERE !!\n\n\`\`\`text\n${shortlog}\n\`\`\`\n" > "${temp_changes}"


### PR DESCRIPTION
This changes the release date that is automatically added to the release notes from your local timezone to UTC. If different people are deploying two releases in different timezones, it is possible that a newer version could be released "before" the previous version. For example, if someone in Italy deployed a release at 01:00 2018-06-02 (UTC+2) and later someone in California deployed a release at 22:00 2018-04-01 (UTC-7)- we have a time travelling release. If all releases are labeled using UTC then they will be consistent, however it is possible to have a "future" release if you live west of the prime meridian.
