### PR TITLE
plugin: support stream weights returned by DASHStream.parse_manifest

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -56,7 +56,7 @@ def stream_weight(stream):
         if stream in weights:
             return weights[stream], group
 
-    match = re.match(r"^(\d+)(k|p)?(\d+)?(\+)?(?:_(\d+)k)?(?:_(alt)(\d)?)?$", stream)
+    match = re.match(r"^(\d+)(k|p)?(\d+)?(\+)?(?:[a_](\d+)k)?(?:_(alt)(\d)?)?$", stream)
 
     if match:
         weight = 0

--- a/tests/test_plugin_stream.py
+++ b/tests/test_plugin_stream.py
@@ -137,30 +137,44 @@ class TestPluginStream(unittest.TestCase):
             parse_params(""""conn=['B:1', 'S:authMe', 'O:1', 'NN:code:1.23', 'NS:flag:ok', 'O:0']""")
         )
 
+    def test_stream_weight_value(self):
+        self.assertEqual((720, "pixels"),
+                         stream_weight("720p"))
+
+        self.assertEqual((721, "pixels"),
+                         stream_weight("720p+"))
+
+        self.assertEqual((780, "pixels"),
+                         stream_weight("720p60"))
+
     def test_stream_weight(self):
-        self.assertEqual(
-            (720, "pixels"),
-            stream_weight("720p"))
-        self.assertEqual(
-            (721, "pixels"),
-            stream_weight("720p+"))
-        self.assertEqual(
-            (780, "pixels"),
-            stream_weight("720p60"))
+        self.assertGreater(stream_weight("720p+"),
+                           stream_weight("720p"))
 
-        self.assertTrue(
-            stream_weight("720p+") > stream_weight("720p"))
-        self.assertTrue(
-            stream_weight("720p") == stream_weight("720p"))
-        self.assertTrue(
-            stream_weight("720p_3000k") > stream_weight("720p_2500k"))
-        self.assertTrue(
-            stream_weight("720p60_3000k") > stream_weight("720p_3000k"))
-        self.assertTrue(
-            stream_weight("720p_3000k") < stream_weight("720p+_3000k"))
+        self.assertGreater(stream_weight("720p_3000k"),
+                           stream_weight("720p_2500k"))
 
-        self.assertTrue(
-            stream_weight("3000k") > stream_weight("2500k"))
+        self.assertGreater(stream_weight("720p60_3000k"),
+                           stream_weight("720p_3000k"))
+
+        self.assertGreater(stream_weight("3000k"),
+                           stream_weight("2500k"))
+
+        self.assertEqual(stream_weight("720p"),
+                         stream_weight("720p"))
+
+        self.assertLess(stream_weight("720p_3000k"),
+                        stream_weight("720p+_3000k"))
+
+    def test_stream_weight_and_audio(self):
+        self.assertGreater(stream_weight("720p+a256k"),
+                           stream_weight("720p+a128k"))
+
+        self.assertGreater(stream_weight("720p+a256k"),
+                           stream_weight("720p+a128k"))
+
+        self.assertGreater(stream_weight("720p+a128k"),
+                           stream_weight("360p+a256k"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`DASHStream.parse_manifest` returns stream qualities that sometimes include the audio bitrate, eg. `720p+a128k` and `720p+a256k`. This adds support in the stream weight parser for these types of stream names, so they can be properly sorted and the `"best"`/`"worst"` options will work. 

See https://github.com/streamlink/streamlink/pull/1853#issuecomment-400981479
