### PR TITLE
Handle unicode log message in Python 2

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -1,11 +1,13 @@
-import logging
-import warnings
+from __future__ import unicode_literals
 
+import logging
 import sys
+import warnings
+from logging import NOTSET, ERROR, WARN, INFO, DEBUG, CRITICAL
 from threading import Lock
 
 from streamlink.compat import is_py2
-from logging import NOTSET, ERROR, WARN, INFO, DEBUG, CRITICAL
+from streamlink.utils.encoding import maybe_encode
 
 TRACE = 5
 _levelToName = dict([(CRITICAL, "critical"), (ERROR, "error"), (WARN, "warning"), (INFO, "info"), (DEBUG, "debug"),
@@ -40,10 +42,10 @@ class _LogRecord(_CompatLogRecord):
         Return the message for this LogRecord after merging any user-supplied
         arguments with the message.
         """
-        msg = str(self.msg)
+        msg = self.msg
         if self.args:
             msg = msg.format(*self.args)
-        return msg
+        return maybe_encode(msg)
 
 
 class StreamlinkLogger(logging.getLoggerClass(), object):

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import sys
 import warnings

--- a/src/streamlink/utils/encoding.py
+++ b/src/streamlink/utils/encoding.py
@@ -1,0 +1,18 @@
+from streamlink.compat import is_py2
+
+
+def maybe_encode(text, encoding="utf8"):
+    if is_py2:
+        return text.encode(encoding)
+    else:
+        return text
+
+
+def maybe_decode(text, encoding="utf8"):
+    if is_py2 and isinstance(text, str):
+        return text.decode(encoding)
+    else:
+        return text
+
+
+__all__ = ["maybe_decode", "maybe_encode"]

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,3 +1,4 @@
+# encoding=utf8
 import logging
 import unittest
 import warnings

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,13 +4,13 @@ import warnings
 
 from streamlink import logger, Streamlink
 from streamlink.compat import is_py2
+from streamlink.utils.encoding import maybe_decode
+from tests import catch_warnings
 
 if is_py2:
     from io import BytesIO as StringIO
 else:
     from io import StringIO
-
-from tests import catch_warnings
 
 
 
@@ -55,7 +55,11 @@ class TestLogging(unittest.TestCase):
         log.debug("test")
         self.assertEqual(output.getvalue(), "[test][debug] test\n")
 
-
+    def test_log_unicode(self):
+        log, output = self._new_logger()
+        logger.root.setLevel("info")
+        log.info(u"Special Character: Ѩ")
+        self.assertEqual(maybe_decode(output.getvalue()), u"[test][info] Special Character: Ѩ\n")
 
 
 class TestDeprecatedLogger(unittest.TestCase):

--- a/tests/test_utils_encoding.py
+++ b/tests/test_utils_encoding.py
@@ -1,0 +1,24 @@
+# encoding=utf8
+import unittest
+
+from streamlink.compat import is_py3, is_py2
+from streamlink.utils.encoding import maybe_decode, maybe_encode
+
+
+class TestUtilsEncoding(unittest.TestCase):
+
+    @unittest.skipUnless(is_py2, "only applicable in Python 2")
+    def test_maybe_encode_py2(self):
+        self.assertEqual(maybe_encode(u"test \u07f7"), "test \xdf\xb7")
+
+    @unittest.skipUnless(is_py2, "only applicable in Python 2")
+    def test_maybe_decode_py2(self):
+        self.assertEqual(maybe_decode("test \xdf\xb7"), u"test \u07f7")
+
+    @unittest.skipUnless(is_py3, "only applicable in Python 3")
+    def test_maybe_encode_py3(self):
+        self.assertEqual(maybe_encode(u"test \u07f7"), u"test \u07f7")
+
+    @unittest.skipUnless(is_py3, "only applicable in Python 3")
+    def test_maybe_decode_py3(self):
+        self.assertEqual(maybe_decode(u"test \u07f7"), u"test \u07f7")


### PR DESCRIPTION
Using the `maybe_{en,de}code` methods from #1576 to handle log messages that might be unicode in Python 2.7.  