### PR TITLE
plugin args: if args are suppressed, ignore them

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1,3 +1,4 @@
+import argparse
 import errno
 import logging
 import os
@@ -860,19 +861,20 @@ def setup_plugin_options(session, plugin):
     pname = plugin.module
     required = OrderedDict({})
     for parg in plugin.arguments:
-        if parg.required:
-            required[parg.name] = parg
-        value = getattr(args, parg.namespace_dest(pname))
-        session.set_plugin_option(pname, parg.dest, value)
-        # if the value is set, check to see if any of the required arguments are not set
-        if parg.required or value:
-            try:
-                for rparg in plugin.arguments.requires(parg.name):
-                    required[rparg.name] = rparg
-            except RuntimeError:
-                console.logger.error("{0} plugin has a configuration error and the arguments "
-                                     "cannot be parsed".format(pname))
-                break
+        if parg.options.get("help") != argparse.SUPPRESS:
+            if parg.required:
+                required[parg.name] = parg
+            value = getattr(args, parg.namespace_dest(pname))
+            session.set_plugin_option(pname, parg.dest, value)
+            # if the value is set, check to see if any of the required arguments are not set
+            if parg.required or value:
+                try:
+                    for rparg in plugin.arguments.requires(parg.name):
+                        required[rparg.name] = rparg
+                except RuntimeError:
+                    console.logger.error("{0} plugin has a configuration error and the arguments "
+                                         "cannot be parsed".format(pname))
+                    break
     if required:
         for req in required.values():
             if not session.get_plugin_option(pname, req.dest):


### PR DESCRIPTION
If a `PluginArgument` has been suppress (deprecated) then it should be ignored when collecting the options. 