### PR TITLE
stream.dash: prefer audio streams based on the user's locale

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -196,6 +196,22 @@ class DASHStream(Stream):
         if not audio:
             audio = [None]
 
+        locale_lang = session.localization.language.alpha2
+        # if the locale is explicitly set, prefer that language over others
+        available_languages = set(map(lambda a: a and a.lang, audio))
+
+        if session.localization.explicit and locale_lang in available_languages:
+            lang = locale_lang
+        else:
+            # filter by the first language that appears
+            lang = audio[0] and audio[0].lang
+
+        log.debug("Available languages for DASH audio streams: {0} (using: {1})".format(", ".join(available_languages), lang))
+
+        # if the language is given by the stream, filter out other languages that do not match
+        if len(available_languages) > 1:
+            audio = list(filter(lambda a: a.lang is None or a.lang == lang, audio))
+
         for vid, aud in itertools.product(video, audio):
             stream = DASHStream(session, mpd, vid, aud, **args)
             stream_name = []

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -198,7 +198,7 @@ class DASHStream(Stream):
 
         locale_lang = session.localization.language.alpha2
         # if the locale is explicitly set, prefer that language over others
-        available_languages = set(map(lambda a: a and a.lang, audio))
+        available_languages = set(map(lambda a: a and a.lang or "n/a", audio))
 
         if session.localization.explicit and locale_lang in available_languages:
             lang = locale_lang

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -204,7 +204,7 @@ class DASHStream(Stream):
 
         # if the locale is explicitly set, prefer that language over others
         for aud in audio:
-            if aud:
+            if aud and aud.lang:
                 available_languages.add(aud.lang)
                 try:
                     if locale.explicit and aud.lang and Language.get(aud.lang) == locale_lang:

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -11,6 +11,7 @@ from streamlink.stream.stream import Stream
 from streamlink.stream.dash_manifest import MPD, sleeper, sleep_until, utc, freeze_timeline
 from streamlink.stream.ffmpegmux import FFMPEGMuxer
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
+from streamlink.utils.l10n import Language
 
 log = logging.getLogger(__name__)
 
@@ -196,17 +197,26 @@ class DASHStream(Stream):
         if not audio:
             audio = [None]
 
-        locale_lang = session.localization.language.alpha2
-        # if the locale is explicitly set, prefer that language over others
-        available_languages = set(map(lambda a: a and a.lang or "n/a", audio))
+        locale = session.localization
+        locale_lang = locale.language
+        lang = None
+        available_languages = set()
 
-        if session.localization.explicit and locale_lang in available_languages:
-            lang = locale_lang
-        else:
+        # if the locale is explicitly set, prefer that language over others
+        for aud in audio:
+            if aud:
+                available_languages.add(aud.lang)
+                try:
+                    if locale.explicit and aud.lang and Language.get(aud.lang) == locale_lang:
+                        lang = aud.lang
+                except LookupError:
+                    continue
+
+        if not lang:
             # filter by the first language that appears
             lang = audio[0] and audio[0].lang
 
-        log.debug("Available languages for DASH audio streams: {0} (using: {1})".format(", ".join(available_languages), lang))
+        log.debug("Available languages for DASH audio streams: {0} (using: {1})".format(", ".join(available_languages) or "NONE", lang or "n/a"))
 
         # if the language is given by the stream, filter out other languages that do not match
         if len(available_languages) > 1:

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -1,7 +1,4 @@
 import unittest
-import unittest
-from streamlink.stream.dash import DASHStreamWorker
-from tests.mock import MagicMock, patch, ANY, Mock, call
 
 from streamlink import PluginError
 from streamlink.stream import *
@@ -41,8 +38,8 @@ class TestDASHStream(unittest.TestCase):
             Mock(adaptationSets=[
                 Mock(contentProtection=None,
                      representations=[
-                         Mock(id=1, mimeType="audio/mp4", bandwidth=128.0),
-                         Mock(id=2, mimeType="audio/mp4", bandwidth=256.0)
+                         Mock(id=1, mimeType="audio/mp4", bandwidth=128.0, lang='en'),
+                         Mock(id=2, mimeType="audio/mp4", bandwidth=256.0, lang='en')
                      ])
             ])
         ])
@@ -63,7 +60,7 @@ class TestDASHStream(unittest.TestCase):
                      representations=[
                          Mock(id=1, mimeType="video/mp4", height=720),
                          Mock(id=2, mimeType="video/mp4", height=1080),
-                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0)
+                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0, lang='en')
                      ])
             ])
         ])
@@ -84,8 +81,8 @@ class TestDASHStream(unittest.TestCase):
                      representations=[
                          Mock(id=1, mimeType="video/mp4", height=720),
                          Mock(id=2, mimeType="video/mp4", height=1080),
-                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0),
-                         Mock(id=4, mimeType="audio/aac", bandwidth=256.0)
+                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0, lang='en'),
+                         Mock(id=4, mimeType="audio/aac", bandwidth=256.0, lang='en')
                      ])
             ])
         ])
@@ -97,6 +94,60 @@ class TestDASHStream(unittest.TestCase):
             sorted(list(streams.keys())),
             sorted(["720p+a128k", "1080p+a128k", "720p+a256k", "1080p+a256k"])
         )
+
+
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_audio_multi_lang(self, mpdClass):
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptationSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=720),
+                         Mock(id=2, mimeType="video/mp4", height=1080),
+                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0, lang='en'),
+                         Mock(id=4, mimeType="audio/aac", bandwidth=128.0, lang='es')
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, self.test_url)
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p", "1080p"])
+        )
+
+        self.assertEqual(streams["720p"].audio_representation.lang, "en")
+        self.assertEqual(streams["1080p"].audio_representation.lang, "en")
+
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_audio_multi_lang_locale(self, mpdClass):
+        self.session.localization.language.alpha2 = "es"
+        self.session.localization.explicit = True
+
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptationSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=720),
+                         Mock(id=2, mimeType="video/mp4", height=1080),
+                         Mock(id=3, mimeType="audio/aac", bandwidth=128.0, lang='en'),
+                         Mock(id=4, mimeType="audio/aac", bandwidth=128.0, lang='es')
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, self.test_url)
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p", "1080p"])
+        )
+
+        self.assertEqual(streams["720p"].audio_representation.lang, "es")
+        self.assertEqual(streams["1080p"].audio_representation.lang, "es")
 
     @patch('streamlink.stream.dash.MPD')
     def test_parse_manifest_drm(self, mpdClass):
@@ -122,7 +173,7 @@ class TestDASHStream(unittest.TestCase):
     @patch('streamlink.stream.dash.DASHStreamReader')
     @patch('streamlink.stream.dash.FFMPEGMuxer')
     def test_stream_open_video_audio(self, muxer, reader):
-        stream = DASHStream(self.session, Mock(), Mock(id=1, mimeType="video/mp4"), Mock(id=2, mimeType="audio/mp3"))
+        stream = DASHStream(self.session, Mock(), Mock(id=1, mimeType="video/mp4"), Mock(id=2, mimeType="audio/mp3", lang='en'))
         open_reader = reader.return_value = Mock()
 
         stream.open()
@@ -202,7 +253,7 @@ class TestDASHStreamWorker(unittest.TestCase):
     @patch("streamlink.stream.dash_manifest.time.sleep")
     def test_duplicate_rep_id(self, sleep):
         representation_vid = Mock(id=1, mimeType="video/mp4", height=720)
-        representation_aud = Mock(id=1, mimeType="audio/aac")
+        representation_aud = Mock(id=1, mimeType="audio/aac", lang='en')
 
         mpd = Mock(dynamic=False,
                    publishTime=1,


### PR DESCRIPTION
When selecting the audio streams in a dash stream, if the user has specified a locale, the audio streams that match the language of the user's locale will be preferred. If the user does not set a locale then the first language that appears will be preferred. 

Fixes #1917
