### PR TITLE
tests: run Python 3.7 tests on AppVeyor and Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ matrix:
   - python: '3.7'
     dist: xenial
     sudo: true
+  - python: '3.8-dev'
+    dist: xenial
+    sudo: true
+  allow_failures:
+  - python: '3.8-dev'
 
 before_install:
   - pip install --disable-pip-version-check --upgrade pip setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ matrix:
   - python: '3.5'
     env: BUILD_DOCS=yes BUILD_INSTALLER=yes BUILD_SDIST=yes DEPLOY_PYPI=yes
   - python: '3.6'
-  - python: '3.7-dev'
-  allow_failures:
-  - python: '3.7-dev'
+  - python: '3.7'
+    dist: xenial
+    sudo: true
 
 before_install:
   - pip install --disable-pip-version-check --upgrade pip setuptools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,10 +5,12 @@ environment:
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python36"
+    - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
+    - PYTHON: "C:\\Python37-x64"
 
 install:
   # If there is a newer build queued for the same PR, cancel this one.


### PR DESCRIPTION
**Travis-ci**

- `dist: xenial` for 3.7 because `openssl` is to old on `trusty`
https://github.com/travis-ci/travis-ci/issues/9069
https://github.com/travis-ci/travis-ci/issues/9815

**AppVeyor**

- https://github.com/appveyor/ci/issues/2475