### PR TITLE
debug: Added Session Language code as a debug message

### DIFF
--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -1,4 +1,5 @@
 import locale
+import logging
 
 from streamlink.compat import is_py2
 
@@ -15,6 +16,8 @@ except ImportError:  # pragma: no cover
 DEFAULT_LANGUAGE = "en"
 DEFAULT_COUNTRY = "US"
 DEFAULT_LANGUAGE_CODE = "{0}_{1}".format(DEFAULT_LANGUAGE, DEFAULT_COUNTRY)
+
+log = logging.getLogger(__name__)
 
 
 class Country(object):
@@ -147,6 +150,7 @@ class Localization(object):
                 self._language_code = DEFAULT_LANGUAGE_CODE
             else:
                 raise
+        log.debug("Language code: {0}".format(self._language_code))
 
     def equivalent(self, language=None, country=None):
         equivalent = True


### PR DESCRIPTION
It will show this message when Localization is called by muxed hls or 
dash streams.

```
$ streamlink ... --locale ru_RU
...
[plugin.dash][debug] Parsing MPD URL: ...
[utils.l10n][debug] Language code: ru_RU
```

or your local system code

```
$ streamlink ...
...
[plugin.dash][debug] Parsing MPD URL: ...
[utils.l10n][debug] Language code: xx_XX
```