### PR TITLE
stream.hls: if the primary video stream has audio then include it

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -295,7 +295,7 @@ class MuxedHLSStream(MuxedStream):
 
     def __init__(self, session, video, audio, force_restart=False, ffmpeg_options=None, **args):
         tracks = [video]
-        maps = ["0:v"]
+        maps = ["0:v?", "0:a?"]
         if audio:
             if isinstance(audio, list):
                 tracks.extend(audio)


### PR DESCRIPTION
Due to the changes in #1926, if the primary video stream included an audio stream as well it would not be included in the output. This change restores that audio stream. 

Fixes #1938