### PR TITLE
Plugin Request: new plugin for Abema.tv

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -12,6 +12,7 @@ is limited.
 ======================= ==================== ===== ===== ===========================
 Name                    URL(s)               Live  VOD   Notes
 ======================= ==================== ===== ===== ===========================
+abematv                 abema.tv             Yes   Yes   Streams are geo-restricted to Japan.
 abweb                   abweb.com            Yes   No    Requires a login and a subscription.
 adultswim               adultswim.com        Yes   Yes   Streams may be geo-restricted, some VOD streams are protected by DRM.
 afreeca                 - afreecatv.com      Yes   No

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -22,6 +22,11 @@ class AbemaTVLicenseAdapter(BaseAdapter):
     '''
     Handling abematv-license:// protocol to get real video key_data.
     '''
+    SECRETKEY = b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9BRbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$k9cD=3TxwWe86!x#Zyhe"
+    
+    STRTABLE = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    
+    HMACKEY = b"3AF0298C219469522A313570E8583005A642E73EDD58E3EA2FB7339D3DF1597E"
 
     def __init__(self, session):
         self._plugin_session = session
@@ -33,29 +38,27 @@ class AbemaTVLicenseAdapter(BaseAdapter):
         ts_1hour = (int(time.time()) + 60*60) // 3600 * 3600 # for python3 : floor division
         time_struct = time.gmtime(ts_1hour)
 
-        secretkey = b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9BRbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$k9cD=3TxwWe86!x#Zyhe"
-
-        h = hmac.new(secretkey, digestmod=hashlib.sha256)
-        h.update(secretkey)
+        h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
+        h.update(SECRETKEY)
         tmp = h.digest()
         for i in range(time_struct.tm_mon):
-            h = hmac.new(secretkey, digestmod=hashlib.sha256)
+            h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
             h.update(tmp)
             tmp = h.digest()
-        h = hmac.new(secretkey, digestmod=hashlib.sha256)
+        h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
         h.update(urlsafe_b64encode(tmp).rstrip(b"=")+deviceId)
         tmp = h.digest()
         for i in range(time_struct.tm_mday % 5):
-            h = hmac.new(secretkey, digestmod=hashlib.sha256)
+            h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
             h.update(tmp)
             tmp = h.digest()
 
-        h = hmac.new(secretkey, digestmod=hashlib.sha256)
+        h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
         h.update(urlsafe_b64encode(tmp).rstrip(b"=") + str(ts_1hour).encode("utf-8"))
         tmp = h.digest()
 
         for i in range(time_struct.tm_hour % 5):  # utc hour
-            h = hmac.new(secretkey, digestmod=hashlib.sha256)
+            h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
             h.update(tmp)
             tmp = h.digest()
 
@@ -75,12 +78,11 @@ class AbemaTVLicenseAdapter(BaseAdapter):
         cid = res.json()['cid']
         key = res.json()['k']
 
-        str_table = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-        res = sum([str_table.find(key[i]) * (58 ** (len(key) - 1 - i))  for i in range(len(key))])
+        res = sum([STRTABLE.find(key[i]) * (58 ** (len(key) - 1 - i))  for i in range(len(key))])
         encVideoKey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
 
         # Crypto.Cipher.ARC4.new('DB98A8E7CECA3424D975280F90BD03EE'.decode('hex')).decrypt('D4B718BBBA9CFB7D0192A58F9E2D146AFC5DB29E4352DE05FC4CF2C1005804BB'.decode('hex')).encode('hex')
-        h = hmac.new(unhexlify(b"3AF0298C219469522A313570E8583005A642E73EDD58E3EA2FB7339D3DF1597E"), (cid+deviceId).encode("utf-8"), digestmod=hashlib.sha256)
+        h = hmac.new(unhexlify(HMACKEY), (cid+deviceId).encode("utf-8"), digestmod=hashlib.sha256)
         enckey = h.digest()
 
         aes = AES.new(enckey, AES.MODE_ECB)
@@ -96,9 +98,8 @@ class AbemaTVLicenseAdapter(BaseAdapter):
         return resp
 
     def close(self):
-        pass
+        return
 
-    pass
 
 
 class AbemaTV(Plugin):
@@ -107,8 +108,7 @@ class AbemaTV(Plugin):
     Note: Streams are geo-restricted to Japan
 
     '''
-
-    _url_re = re.compile(r"https://abema\.tv/now-on-air/(?P<onair>.+)|https://abema\.tv/video/episode/(?P<episode>.+)|https://abema\.tv/channels/.+?/slots/(?P<slot>.+)")
+    _url_re = re.compile(r"https://abema\.tv/(now-on-air/(?P<onair>.+)|video/episode/(?P<episode>.+)|channels/.+?/slots/(?P<slot>.+))")
 
     @classmethod
     def can_handle_url(cls, url):

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -1,0 +1,147 @@
+from streamlink.exceptions import NoStreamsError
+from streamlink.plugin import Plugin
+from streamlink.plugin.plugin import parse_url_params
+from streamlink.stream import HLSStream
+from streamlink.utils import update_scheme
+
+import hashlib
+import hmac
+import re
+import struct
+import time
+import uuid
+from base64 import urlsafe_b64encode
+from binascii import unhexlify
+
+from Crypto.Cipher import AES
+from requests import Response
+from requests.adapters import BaseAdapter
+
+
+class AbemaTVLicenseAdapter(BaseAdapter):
+    '''
+    Handling abematv-license:// protocol to get real video key_data.
+    '''
+
+    def __init__(self, session):
+        self._plugin_session = session
+        super(AbemaTVLicenseAdapter, self).__init__()
+
+    def _generateApplicationKeySecret(self, deviceId):
+        deviceId = deviceId.encode("utf-8") # for python3
+        # plus 1 hour and drop minute and secs
+        ts_1hour = (int(time.time()) + 60*60) // 3600 * 3600 # for python3 : floor division
+        time_struct = time.gmtime(ts_1hour)
+
+        secretkey = b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9BRbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$k9cD=3TxwWe86!x#Zyhe"
+
+        h = hmac.new(secretkey, digestmod=hashlib.sha256)
+        h.update(secretkey)
+        tmp = h.digest()
+        for i in range(time_struct.tm_mon):
+            h = hmac.new(secretkey, digestmod=hashlib.sha256)
+            h.update(tmp)
+            tmp = h.digest()
+        h = hmac.new(secretkey, digestmod=hashlib.sha256)
+        h.update(urlsafe_b64encode(tmp).rstrip(b"=")+deviceId)
+        tmp = h.digest()
+        for i in range(time_struct.tm_mday % 5):
+            h = hmac.new(secretkey, digestmod=hashlib.sha256)
+            h.update(tmp)
+            tmp = h.digest()
+
+        h = hmac.new(secretkey, digestmod=hashlib.sha256)
+        h.update(urlsafe_b64encode(tmp).rstrip(b"=") + str(ts_1hour).encode("utf-8"))
+        tmp = h.digest()
+
+        for i in range(time_struct.tm_hour % 5):  # utc hour
+            h = hmac.new(secretkey, digestmod=hashlib.sha256)
+            h.update(tmp)
+            tmp = h.digest()
+
+        return urlsafe_b64encode(tmp).rstrip(b"=").decode("utf-8")
+
+    def _getVideoKeyFromTicket(self, ticket):
+        deviceId = str(uuid.uuid4())
+        res = requests.post("https://api.abema.io/v1/users", json={
+                                             "deviceId": deviceId, "applicationKeySecret": self._generateApplicationKeySecret(deviceId)})
+        usertoken = res.json()['token']
+
+        params = {"osName": "android", "osVersion": "6.0.1", "osLang": "ja_JP", "osTimezone": "Asia/Tokyo", "appId": "tv.abema", "appVersion": "3.27.1"}
+        res = self._plugin_session.http.get("https://api.abema.io/v1/media/token", params=params, headers={"Authorization": "Bearer "+usertoken})
+        mediatoken = res.json()['token']
+
+        res = self._plugin_session.http.post("https://license.abema.io/abematv-hls", params={"t": mediatoken}, json={"kv": "a", "lt": ticket})
+        cid = res.json()['cid']
+        key = res.json()['k']
+
+        str_table = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+        res = sum([str_table.find(key[i]) * (58 ** (len(key) - 1 - i))  for i in range(len(key))])
+        encVideoKey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
+
+        # Crypto.Cipher.ARC4.new('DB98A8E7CECA3424D975280F90BD03EE'.decode('hex')).decrypt('D4B718BBBA9CFB7D0192A58F9E2D146AFC5DB29E4352DE05FC4CF2C1005804BB'.decode('hex')).encode('hex')
+        h = hmac.new(unhexlify(b"3AF0298C219469522A313570E8583005A642E73EDD58E3EA2FB7339D3DF1597E"), (cid+deviceId).encode("utf-8"), digestmod=hashlib.sha256)
+        enckey = h.digest()
+
+        aes = AES.new(enckey, AES.MODE_ECB)
+        rawVideoKey = aes.decrypt(encVideoKey)
+
+        return rawVideoKey
+
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+        resp = Response()
+        resp.status_code = 200
+        ticket = re.findall(r"abematv-license://(.*)", request.url)[0]
+        resp._content = self._getVideoKeyFromTicket(ticket)
+        return resp
+
+    def close(self):
+        pass
+
+    pass
+
+
+class AbemaTV(Plugin):
+    '''
+    Abema.tv https://abema.tv/
+    Note: Streams are geo-restricted to Japan
+
+    '''
+
+    _url_re = re.compile(r"https://abema\.tv/now-on-air/(?P<onair>.+)|https://abema\.tv/video/episode/(?P<episode>.+)|https://abema\.tv/channels/.+?/slots/(?P<slot>.+)")
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    def __init__(self, url):
+        super(AbemaTV, self).__init__(url)
+
+    def _get_streams(self):
+        url, params = parse_url_params(self.url)
+        matchResult = self._url_re.match(url)
+        if matchResult.group("onair"):
+            onair = matchResult.group("onair")
+            channels = self.session.http.get("https://api.abema.io/v1/channels").json()["channels"]
+            for channel in channels:
+                if onair == channel["id"]:
+                    break
+            else:
+                raise NoStreamsError 
+            playlisturl = channel["playback"]["hls"]
+        elif matchResult.group("episode"):
+            playlisturl = "https://vod-abematv.akamaized.net/program/%s/playlist.m3u8"%(matchResult.group("episode"))
+        elif matchResult.group("slot"):
+            playlisturl = "https://vod-abematv.akamaized.net/slot/%s/playlist.m3u8"%(matchResult.group("slot"))
+
+        self.logger.debug("AbemaTV playlist URL={0}; ", playlisturl)
+        
+        self.session.http.mount("abematv-license://",AbemaTVLicenseAdapter(self.session)) # hook abematv private protocol
+
+        streams = HLSStream.parse_variant_playlist(self.session, playlisturl)
+        if not streams:
+            return {"live": HLSStream(self.session, playlisturl)}
+        else:
+            return streams
+
+__plugin__ = AbemaTV

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -1,105 +1,139 @@
-from streamlink.exceptions import NoStreamsError
-from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params
-from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
-
 import hashlib
 import hmac
+import logging
 import re
 import struct
 import time
 import uuid
+
 from base64 import urlsafe_b64encode
 from binascii import unhexlify
 
 from Crypto.Cipher import AES
+
 from requests import Response
 from requests.adapters import BaseAdapter
+
+from streamlink.exceptions import NoStreamsError
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import useragents
+from streamlink.plugin.plugin import parse_url_params
+from streamlink.stream import HLSStream
+
+log = logging.getLogger(__name__)
 
 
 class AbemaTVLicenseAdapter(BaseAdapter):
     '''
     Handling abematv-license:// protocol to get real video key_data.
     '''
-    SECRETKEY = b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9BRbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$k9cD=3TxwWe86!x#Zyhe"
-    
+    SECRETKEY = (b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9B"
+                 b"Rbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$"
+                 b"k9cD=3TxwWe86!x#Zyhe")
+
     STRTABLE = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-    
-    HMACKEY = b"3AF0298C219469522A313570E8583005A642E73EDD58E3EA2FB7339D3DF1597E"
+
+    HKEY = b"3AF0298C219469522A313570E8583005A642E73EDD58E3EA2FB7339D3DF1597E"
+
+    _USER_API = "https://api.abema.io/v1/users"
+
+    _TOKEN_API = "https://api.abema.io/v1/media/token"
+
+    _LICENSE_API = "https://license.abema.io/abematv-hls"
 
     def __init__(self, session):
         self._plugin_session = session
+        self._plugin_session.http.headers.update(
+            {'User-Agent': useragents.CHROME})
         super(AbemaTVLicenseAdapter, self).__init__()
 
-    def _generateApplicationKeySecret(self, deviceId):
-        deviceId = deviceId.encode("utf-8") # for python3
+    def _generate_applicationkeysecret(self, deviceid):
+        deviceid = deviceid.encode("utf-8")  # for python3
         # plus 1 hour and drop minute and secs
-        ts_1hour = (int(time.time()) + 60*60) // 3600 * 3600 # for python3 : floor division
+        # for python3 : floor division
+        ts_1hour = (int(time.time()) + 60 * 60) // 3600 * 3600
         time_struct = time.gmtime(ts_1hour)
+        ts_1hour_str = str(ts_1hour).encode("utf-8")
 
-        h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
-        h.update(SECRETKEY)
+        h = hmac.new(self.SECRETKEY, digestmod=hashlib.sha256)
+        h.update(self.SECRETKEY)
         tmp = h.digest()
         for i in range(time_struct.tm_mon):
-            h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
+            h = hmac.new(self.SECRETKEY, digestmod=hashlib.sha256)
             h.update(tmp)
             tmp = h.digest()
-        h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
-        h.update(urlsafe_b64encode(tmp).rstrip(b"=")+deviceId)
+        h = hmac.new(self.SECRETKEY, digestmod=hashlib.sha256)
+        h.update(urlsafe_b64encode(tmp).rstrip(b"=") + deviceid)
         tmp = h.digest()
         for i in range(time_struct.tm_mday % 5):
-            h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
+            h = hmac.new(self.SECRETKEY, digestmod=hashlib.sha256)
             h.update(tmp)
             tmp = h.digest()
 
-        h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
-        h.update(urlsafe_b64encode(tmp).rstrip(b"=") + str(ts_1hour).encode("utf-8"))
+        h = hmac.new(self.SECRETKEY, digestmod=hashlib.sha256)
+        h.update(urlsafe_b64encode(tmp).rstrip(b"=") + ts_1hour_str)
         tmp = h.digest()
 
         for i in range(time_struct.tm_hour % 5):  # utc hour
-            h = hmac.new(SECRETKEY, digestmod=hashlib.sha256)
+            h = hmac.new(self.SECRETKEY, digestmod=hashlib.sha256)
             h.update(tmp)
             tmp = h.digest()
 
         return urlsafe_b64encode(tmp).rstrip(b"=").decode("utf-8")
 
-    def _getVideoKeyFromTicket(self, ticket):
-        deviceId = str(uuid.uuid4())
-        res = requests.post("https://api.abema.io/v1/users", json={
-                                             "deviceId": deviceId, "applicationKeySecret": self._generateApplicationKeySecret(deviceId)})
+    def _get_videokey_from_ticket(self, ticket):
+        deviceid = str(uuid.uuid4())
+        appkeysecret = self._generate_applicationkeysecret(deviceid)
+        json_data = {"deviceId": deviceid,
+                     "applicationKeySecret": appkeysecret}
+        res = self._plugin_session.http.post(self._USER_API, json=json_data)
         usertoken = res.json()['token']
 
-        params = {"osName": "android", "osVersion": "6.0.1", "osLang": "ja_JP", "osTimezone": "Asia/Tokyo", "appId": "tv.abema", "appVersion": "3.27.1"}
-        res = self._plugin_session.http.get("https://api.abema.io/v1/media/token", params=params, headers={"Authorization": "Bearer "+usertoken})
+        params = {
+            "osName": "android",
+            "osVersion": "6.0.1",
+            "osLang": "ja_JP",
+            "osTimezone": "Asia/Tokyo",
+            "appId": "tv.abema",
+            "appVersion": "3.27.1"
+        }
+        auth_header = {"Authorization": "Bearer " + usertoken}
+        res = self._plugin_session.http.get(self._TOKEN_API, params=params,
+                                            headers=auth_header)
         mediatoken = res.json()['token']
 
-        res = self._plugin_session.http.post("https://license.abema.io/abematv-hls", params={"t": mediatoken}, json={"kv": "a", "lt": ticket})
+        res = self._plugin_session.http.post(self._LICENSE_API,
+                                             params={"t": mediatoken},
+                                             json={"kv": "a", "lt": ticket})
         cid = res.json()['cid']
-        key = res.json()['k']
+        k = res.json()['k']
 
-        res = sum([STRTABLE.find(key[i]) * (58 ** (len(key) - 1 - i))  for i in range(len(key))])
-        encVideoKey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
+        res = sum([self.STRTABLE.find(k[i]) * (58 ** (len(k) - 1 - i))
+                  for i in range(len(k))])
+        encvideokey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
 
-        # Crypto.Cipher.ARC4.new('DB98A8E7CECA3424D975280F90BD03EE'.decode('hex')).decrypt('D4B718BBBA9CFB7D0192A58F9E2D146AFC5DB29E4352DE05FC4CF2C1005804BB'.decode('hex')).encode('hex')
-        h = hmac.new(unhexlify(HMACKEY), (cid+deviceId).encode("utf-8"), digestmod=hashlib.sha256)
+        # HMACKEY:
+        # rc4 = ARC4.new('DB98A8E7CECA3424D975280F90BD03EE'.decode('hex'))
+        # rc4.decrypt('D4B718BBBA9CFB7D0192A58F9E2D146AFC5DB29E4352DE05FC4CF2C1005804BB'.decode('hex')).encode('hex')
+        h = hmac.new(unhexlify(self.HKEY), (cid + deviceid).encode("utf-8"),
+                     digestmod=hashlib.sha256)
         enckey = h.digest()
 
         aes = AES.new(enckey, AES.MODE_ECB)
-        rawVideoKey = aes.decrypt(encVideoKey)
+        rawvideokey = aes.decrypt(encvideokey)
 
-        return rawVideoKey
+        return rawvideokey
 
-    def send(self, request, stream=False, timeout=None, verify=True, cert=None, proxies=None):
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None,
+             proxies=None):
         resp = Response()
         resp.status_code = 200
         ticket = re.findall(r"abematv-license://(.*)", request.url)[0]
-        resp._content = self._getVideoKeyFromTicket(ticket)
+        resp._content = self._get_videokey_from_ticket(ticket)
         return resp
 
     def close(self):
         return
-
 
 
 class AbemaTV(Plugin):
@@ -108,7 +142,19 @@ class AbemaTV(Plugin):
     Note: Streams are geo-restricted to Japan
 
     '''
-    _url_re = re.compile(r"https://abema\.tv/(now-on-air/(?P<onair>.+)|video/episode/(?P<episode>.+)|channels/.+?/slots/(?P<slot>.+))")
+    _url_re = re.compile(r"""https://abema\.tv/(
+        now-on-air/(?P<onair>.+)
+        |
+        video/episode/(?P<episode>.+)
+        |
+        channels/.+?/slots/(?P<slot>.+)
+        )""", re.VERBOSE)
+
+    _CHANNEL = "https://api.abema.io/v1/channels"
+
+    _PROGRAMM3U8 = "https://vod-abematv.akamaized.net/program/%s/playlist.m3u8"
+
+    _SLOTM3U8 = "https://vod-abematv.akamaized.net/slot/%s/playlist.m3u8"
 
     @classmethod
     def can_handle_url(cls, url):
@@ -119,29 +165,32 @@ class AbemaTV(Plugin):
 
     def _get_streams(self):
         url, params = parse_url_params(self.url)
-        matchResult = self._url_re.match(url)
-        if matchResult.group("onair"):
-            onair = matchResult.group("onair")
-            channels = self.session.http.get("https://api.abema.io/v1/channels").json()["channels"]
+        matchresult = self._url_re.match(url)
+        if matchresult.group("onair"):
+            onair = matchresult.group("onair")
+            channels = self.session.http.get(self._CHANNEL).json()["channels"]
             for channel in channels:
                 if onair == channel["id"]:
                     break
             else:
-                raise NoStreamsError 
+                raise NoStreamsError
             playlisturl = channel["playback"]["hls"]
-        elif matchResult.group("episode"):
-            playlisturl = "https://vod-abematv.akamaized.net/program/%s/playlist.m3u8"%(matchResult.group("episode"))
-        elif matchResult.group("slot"):
-            playlisturl = "https://vod-abematv.akamaized.net/slot/%s/playlist.m3u8"%(matchResult.group("slot"))
+        elif matchresult.group("episode"):
+            playlisturl = self._PROGRAMM3U8 % (matchresult.group("episode"))
+        elif matchresult.group("slot"):
+            playlisturl = self._SLOTM3U8 % (matchresult.group("slot"))
 
-        self.logger.debug("AbemaTV playlist URL={0}; ", playlisturl)
-        
-        self.session.http.mount("abematv-license://",AbemaTVLicenseAdapter(self.session)) # hook abematv private protocol
+        log.debug("URL={0}".format(playlisturl))
+
+        # hook abematv private protocol
+        self.session.http.mount("abematv-license://",
+                                AbemaTVLicenseAdapter(self.session))
 
         streams = HLSStream.parse_variant_playlist(self.session, playlisturl)
         if not streams:
             return {"live": HLSStream(self.session, playlisturl)}
         else:
             return streams
+
 
 __plugin__ = AbemaTV

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -17,6 +17,7 @@ from requests.adapters import BaseAdapter
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
@@ -26,23 +27,135 @@ class AbemaTVLicenseAdapter(BaseAdapter):
     '''
     Handling abematv-license:// protocol to get real video key_data.
     '''
-    SECRETKEY = (b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9B"
-                 b"Rbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$"
-                 b"k9cD=3TxwWe86!x#Zyhe")
 
     STRTABLE = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 
     HKEY = b"3AF0298C219469522A313570E8583005A642E73EDD58E3EA2FB7339D3DF1597E"
 
-    _USER_API = "https://api.abema.io/v1/users"
-
-    _TOKEN_API = "https://api.abema.io/v1/media/token"
+    _MEDIATOKEN_API = "https://api.abema.io/v1/media/token"
 
     _LICENSE_API = "https://license.abema.io/abematv-hls"
 
-    def __init__(self, session):
-        self._plugin_session = session
+    _MEDIATOKEN_SCHEMA = validate.Schema({u"token": validate.text})
+
+    _LICENSE_SCHEMA = validate.Schema({u"k": validate.text,
+                                       u"cid": validate.text})
+
+    def __init__(self, session, deviceid, usertoken):
+        self._session = session
+        self.deviceid = deviceid
+        self.usertoken = usertoken
         super(AbemaTVLicenseAdapter, self).__init__()
+
+    def _get_videokey_from_ticket(self, ticket):
+        params = {
+            "osName": "android",
+            "osVersion": "6.0.1",
+            "osLang": "ja_JP",
+            "osTimezone": "Asia/Tokyo",
+            "appId": "tv.abema",
+            "appVersion": "3.27.1"
+        }
+        auth_header = {"Authorization": "Bearer " + self.usertoken}
+        res = self._session.http.get(self._MEDIATOKEN_API, params=params,
+                                     headers=auth_header)
+        jsonres = self._session.http.json(res,
+                                          schema=self._MEDIATOKEN_SCHEMA)
+        mediatoken = jsonres['token']
+
+        res = self._session.http.post(self._LICENSE_API,
+                                      params={"t": mediatoken},
+                                      json={"kv": "a", "lt": ticket})
+        jsonres = self._session.http.json(res,
+                                          schema=self._LICENSE_SCHEMA)
+        cid = jsonres['cid']
+        k = jsonres['k']
+
+        res = sum([self.STRTABLE.find(k[i]) * (58 ** (len(k) - 1 - i))
+                  for i in range(len(k))])
+        encvideokey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
+
+        # HKEY:
+        # RC4KEY = unhexlify('DB98A8E7CECA3424D975280F90BD03EE')
+        # RC4DATA = unhexlify(b'D4B718BBBA9CFB7D0192A58F9E2D146A'
+        #                     b'FC5DB29E4352DE05FC4CF2C1005804BB')
+        # rc4 = ARC4.new(RC4KEY)
+        # HKEY = rc4.decrypt(RC4DATA)
+        h = hmac.new(unhexlify(self.HKEY),
+                     (cid + self.deviceid).encode("utf-8"),
+                     digestmod=hashlib.sha256)
+        enckey = h.digest()
+
+        aes = AES.new(enckey, AES.MODE_ECB)
+        rawvideokey = aes.decrypt(encvideokey)
+
+        return rawvideokey
+
+    def send(self, request, stream=False, timeout=None, verify=True, cert=None,
+             proxies=None):
+        resp = Response()
+        resp.status_code = 200
+        ticket = re.findall(r"abematv-license://(.*)", request.url)[0]
+        resp._content = self._get_videokey_from_ticket(ticket)
+        return resp
+
+    def close(self):
+        return
+
+
+class AbemaTV(Plugin):
+    '''
+    Abema.tv https://abema.tv/
+    Note: Streams are geo-restricted to Japan
+
+    '''
+    _url_re = re.compile(r"""https://abema\.tv/(
+        now-on-air/(?P<onair>[^\?]+)
+        |
+        video/episode/(?P<episode>[^\?]+)
+        |
+        channels/.+?/slots/(?P<slots>[^\?]+)
+        )""", re.VERBOSE)
+
+    _CHANNEL = "https://api.abema.io/v1/channels"
+
+    _USER_API = "https://api.abema.io/v1/users"
+
+    _PRGM_API = "https://api.abema.io/v1/video/programs/{0}"
+
+    _SLOTS_API = "https://api.abema.io/v1/media/slots/{0}"
+
+    _PRGM3U8 = "https://vod-abematv.akamaized.net/program/{0}/playlist.m3u8"
+
+    _SLOTM3U8 = "https://vod-abematv.akamaized.net/slot/{0}/playlist.m3u8"
+
+    SECRETKEY = (b"v+Gjs=25Aw5erR!J8ZuvRrCx*rGswhB&qdHd_SYerEWdU&a?3DzN9B"
+                 b"Rbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$"
+                 b"k9cD=3TxwWe86!x#Zyhe")
+
+    _USER_SCHEMA = validate.Schema({u"profile": {u"userId": validate.text},
+                                    u"token": validate.text})
+
+    _CHANNEL_SCHEMA = validate.Schema({u"channels": [{u"id": validate.text,
+                                      "name": validate.text,
+                                       "playback": {validate.optional(u"dash"):
+                                                    validate.text,
+                                                    u"hls": validate.text}}]})
+
+    _PRGM_SCHEMA = validate.Schema({u"label": {validate.optional(u"free"): bool
+                                               }})
+
+    _SLOT_SCHEMA = validate.Schema({u"slot": {u"flags": {
+                                    validate.optional("timeshiftFree"): bool}}}
+                                   )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    def __init__(self, url):
+        super(AbemaTV, self).__init__(url)
+        self.session.http.headers.update({'User-Agent': useragents.CHROME})
 
     def _generate_applicationkeysecret(self, deviceid):
         deviceid = deviceid.encode("utf-8")  # for python3
@@ -78,110 +191,59 @@ class AbemaTVLicenseAdapter(BaseAdapter):
 
         return urlsafe_b64encode(tmp).rstrip(b"=").decode("utf-8")
 
-    def _get_videokey_from_ticket(self, ticket):
+    def _is_playable(self, vtype, vid):
+        auth_header = {"Authorization": "Bearer " + self.usertoken}
+        if vtype == "episode":
+            res = self.session.http.get(self._PRGM_API.format(vid),
+                                        headers=auth_header)
+            jsonres = self.session.http.json(res, schema=self._PRGM_SCHEMA)
+            return jsonres["label"].get("free", False) is True
+        elif vtype == "slots":
+            res = self.session.http.get(self._SLOTS_API.format(vid),
+                                        headers=auth_header)
+            jsonres = self.session.http.json(res, schema=self._SLOT_SCHEMA)
+            return jsonres["slot"]["flags"].get("timeshiftFree", False) is True
+
+    def _get_streams(self):
         deviceid = str(uuid.uuid4())
         appkeysecret = self._generate_applicationkeysecret(deviceid)
         json_data = {"deviceId": deviceid,
                      "applicationKeySecret": appkeysecret}
-        res = self._plugin_session.http.post(self._USER_API, json=json_data)
-        usertoken = res.json()['token']
+        res = self.session.http.post(self._USER_API, json=json_data)
+        jsonres = self.session.http.json(res, schema=self._USER_SCHEMA)
+        self.usertoken = jsonres['token']  # for authorzation
 
-        params = {
-            "osName": "android",
-            "osVersion": "6.0.1",
-            "osLang": "ja_JP",
-            "osTimezone": "Asia/Tokyo",
-            "appId": "tv.abema",
-            "appVersion": "3.27.1"
-        }
-        auth_header = {"Authorization": "Bearer " + usertoken}
-        res = self._plugin_session.http.get(self._TOKEN_API, params=params,
-                                            headers=auth_header)
-        mediatoken = res.json()['token']
-
-        res = self._plugin_session.http.post(self._LICENSE_API,
-                                             params={"t": mediatoken},
-                                             json={"kv": "a", "lt": ticket})
-        cid = res.json()['cid']
-        k = res.json()['k']
-
-        res = sum([self.STRTABLE.find(k[i]) * (58 ** (len(k) - 1 - i))
-                  for i in range(len(k))])
-        encvideokey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
-
-        # HMACKEY:
-        # rc4 = ARC4.new('DB98A8E7CECA3424D975280F90BD03EE'.decode('hex'))
-        # rc4.decrypt('D4B718BBBA9CFB7D0192A58F9E2D146AFC5DB29E4352DE05FC4CF2C1005804BB'.decode('hex')).encode('hex')
-        h = hmac.new(unhexlify(self.HKEY), (cid + deviceid).encode("utf-8"),
-                     digestmod=hashlib.sha256)
-        enckey = h.digest()
-
-        aes = AES.new(enckey, AES.MODE_ECB)
-        rawvideokey = aes.decrypt(encvideokey)
-
-        return rawvideokey
-
-    def send(self, request, stream=False, timeout=None, verify=True, cert=None,
-             proxies=None):
-        resp = Response()
-        resp.status_code = 200
-        ticket = re.findall(r"abematv-license://(.*)", request.url)[0]
-        resp._content = self._get_videokey_from_ticket(ticket)
-        return resp
-
-    def close(self):
-        return
-
-
-class AbemaTV(Plugin):
-    '''
-    Abema.tv https://abema.tv/
-    Note: Streams are geo-restricted to Japan
-
-    '''
-    _url_re = re.compile(r"""https://abema\.tv/(
-        now-on-air/(?P<onair>[^\?]+)
-        |
-        video/episode/(?P<episode>[^\?]+)
-        |
-        channels/.+?/slots/(?P<slot>[^\?]+)
-        )""", re.VERBOSE)
-
-    _CHANNEL = "https://api.abema.io/v1/channels"
-
-    _PROGRAMM3U8 = "https://vod-abematv.akamaized.net/program/%s/playlist.m3u8"
-
-    _SLOTM3U8 = "https://vod-abematv.akamaized.net/slot/%s/playlist.m3u8"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
-    def __init__(self, url):
-        super(AbemaTV, self).__init__(url)
-        self.session.http.headers.update({'User-Agent': useragents.CHROME})
-
-    def _get_streams(self):
         matchresult = self._url_re.match(self.url)
         if matchresult.group("onair"):
             onair = matchresult.group("onair")
-            channels = self.session.http.get(self._CHANNEL).json()["channels"]
+            res = self.session.http.get(self._CHANNEL)
+            jsonres = self.session.http.json(res, schema=self._CHANNEL_SCHEMA)
+            channels = jsonres["channels"]
             for channel in channels:
                 if onair == channel["id"]:
                     break
             else:
-                raise NoStreamsError
+                raise NoStreamsError(self.url)
             playlisturl = channel["playback"]["hls"]
         elif matchresult.group("episode"):
-            playlisturl = self._PROGRAMM3U8 % (matchresult.group("episode"))
-        elif matchresult.group("slot"):
-            playlisturl = self._SLOTM3U8 % (matchresult.group("slot"))
+            episode = matchresult.group("episode")
+            if not self._is_playable("episode", episode):
+                log.error("Premium stream is not playable")
+                return {}
+            playlisturl = self._PRGM3U8.format(episode)
+        elif matchresult.group("slots"):
+            slots = matchresult.group("slots")
+            if not self._is_playable("slots", slots):
+                log.error("Premium stream is not playable")
+                return {}
+            playlisturl = self._SLOTM3U8.format(slots)
 
         log.debug("URL={0}".format(playlisturl))
 
         # hook abematv private protocol
         self.session.http.mount("abematv-license://",
-                                AbemaTVLicenseAdapter(self.session))
+                                AbemaTVLicenseAdapter(self.session, deviceid,
+                                                      self.usertoken))
 
         streams = HLSStream.parse_variant_playlist(self.session, playlisturl)
         if not streams:

--- a/tests/plugins/test_abematv.py
+++ b/tests/plugins/test_abematv.py
@@ -1,0 +1,26 @@
+import unittest
+
+from streamlink.plugins.abematv import AbemaTV
+
+
+class TestPluginABweb(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://abema.tv/now-on-air/abema-news',
+            'https://abema.tv/video/episode/90-1053_s99_p12',
+            'https://abema.tv/channels/everybody-anime/slots/FJcUsdYjTk1rAb'
+        ]
+        for url in should_match:
+            self.assertTrue(AbemaTV.can_handle_url(url))
+
+        should_not_match = [
+            'http://abema.tv/now-on-air/abema-news',
+            'http://www.abema.tv/now-on-air/abema-news',
+            'https://www.abema.tv/now-on-air/abema-news',
+            'https://www.abema.tv/now-on-air/',
+            'https://abema.tv/timetable',
+            'https://abema.tv/video',
+            'https://abema.tv/video/title/13-47'
+        ]
+        for url in should_not_match:
+            self.assertFalse(AbemaTV.can_handle_url(url))

--- a/tests/plugins/test_abematv.py
+++ b/tests/plugins/test_abematv.py
@@ -3,12 +3,15 @@ import unittest
 from streamlink.plugins.abematv import AbemaTV
 
 
-class TestPluginABweb(unittest.TestCase):
+class TestPluginAbemaTV(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
             'https://abema.tv/now-on-air/abema-news',
             'https://abema.tv/video/episode/90-1053_s99_p12',
-            'https://abema.tv/channels/everybody-anime/slots/FJcUsdYjTk1rAb'
+            'https://abema.tv/channels/everybody-anime/slots/FJcUsdYjTk1rAb',
+            'https://abema.tv/now-on-air/abema-news?a=b&c=d',
+            'https://abema.tv/video/episode/90-1053_s99_p12?a=b&c=d',
+            'https://abema.tv/channels/abema-anime/slots/9rTULtcJFiFmM9?a=b'
         ]
         for url in should_match:
             self.assertTrue(AbemaTV.can_handle_url(url))
@@ -20,7 +23,8 @@ class TestPluginABweb(unittest.TestCase):
             'https://www.abema.tv/now-on-air/',
             'https://abema.tv/timetable',
             'https://abema.tv/video',
-            'https://abema.tv/video/title/13-47'
+            'https://abema.tv/video/title/13-47',
+            'https://abema.tv/video/title/13-47?a=b'
         ]
         for url in should_not_match:
             self.assertFalse(AbemaTV.can_handle_url(url))


### PR DESCRIPTION
## Plugin Request

- [x] I have read the contribution and plugin request guidelines. <!-- Replace the space with an x to check the box: [x] -->

### Description
Abema.tv  is a japanese live (news,drama,anime , etc) and vod stream site.


### Example stream URLs
1. Live stream:  https://abema.tv/now-on-air/abema-news
2. VOD stream: https://abema.tv/video/episode/90-1053_s99_p12
3. VOD stream: https://abema.tv/channels/everybody-anime/slots/FJcUsdYjTk1rAb

### Comments, screenshots, etc.
1.Because of `ext-x-discontinuity` issue, players may not handle live stream discontinuity properly.
2.Streams are geo-restricted to Japan , but could be bypassed via `--http-header 'X-Forwarded-For=A_JAPAN_IP' `   (TESTONLY)