### PR TITLE
tests.localization: use en_CA instead of en_US for test_equivalent

### DIFF
--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -32,11 +32,12 @@ class LocalizationTestsMixin(object):
         self.assertRaises(LookupError, l10n.Localization, "enUS")
 
     def test_equivalent(self):
-        l = l10n.Localization("en_US")
+        l = l10n.Localization("en_CA")
         self.assertTrue(l.equivalent(language="eng"))
         self.assertTrue(l.equivalent(language="en"))
-        self.assertTrue(l.equivalent(language="en", country="US"))
-        self.assertTrue(l.equivalent(language="en", country="United States"))
+        self.assertTrue(l.equivalent(language="en", country="CA"))
+        self.assertTrue(l.equivalent(language="en", country="CAN"))
+        self.assertTrue(l.equivalent(language="en", country="Canada"))
 
     def test_equivalent_remap(self):
         l = l10n.Localization("fr_FR")
@@ -48,7 +49,7 @@ class LocalizationTestsMixin(object):
         self.assertFalse(l.equivalent(language="eng"))
         self.assertFalse(l.equivalent(language="en"))
         self.assertFalse(l.equivalent(language="en", country="US"))
-        self.assertFalse(l.equivalent(language="en", country="United States"))
+        self.assertFalse(l.equivalent(language="en", country="Canada"))
         self.assertFalse(l.equivalent(language="en", country="ES"))
         self.assertFalse(l.equivalent(language="en", country="Spain"))
 
@@ -71,8 +72,8 @@ class LocalizationTestsMixin(object):
                          l10n.Localization.get_country("USA").alpha2)
         self.assertEqual("GB",
                          l10n.Localization.get_country("GB").alpha2)
-        self.assertEqual("United States",
-                         l10n.Localization.get_country("United States").name)
+        self.assertEqual("Canada",
+                         l10n.Localization.get_country("Canada").name)
 
     def test_get_country_miss(self):
         self.assertRaises(LookupError, l10n.Localization.get_country, "XE")


### PR DESCRIPTION
**python-iso3166** got an update which breaks the Streamlink tests.
https://pypi.org/project/iso3166/#history

**python-iso3166** and **pycountry** have now a different `name` for _the United States of America_

> python-iso3166: United States of America
https://github.com/deactivated/python-iso3166/commit/e5f8b37f18b01fcb5fa0e8130d8296fc7a7b5a9f

> pycountry: United States
https://bitbucket.org/flyingcircus/pycountry/src/5aa4bb47e33798cb631a81521b7b5b18f7d6c919/src/pycountry/databases/iso3166-1.json?at=default&fileviewer=file-view-default#iso3166-1.json-1572:1578

https://www.iso.org/obp/ui/#iso:code:3166:US

---

use **en_CA** instead of **en_US** for backwards compatibility,
as changing the **US** name would fail with older versions of **python-iso3166** / **pycountry**