### PR TITLE
plugins.pixiv: use API for the stream URL and cache login cookies

### DIFF
--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -1,47 +1,62 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
 import re
 
-from streamlink import PluginError
-from streamlink.compat import urljoin
-from streamlink.exceptions import NoStreamsError
-from streamlink.plugin import Plugin
-from streamlink.plugin import PluginArguments, PluginArgument
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
+from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.encoding import maybe_decode
+
+log = logging.getLogger(__name__)
 
 
 class Pixiv(Plugin):
     """Plugin for https://sketch.pixiv.net/lives"""
 
-    _url_re = re.compile(r"https?://sketch\.pixiv\.net/[^/]+(?P<videopage>/lives/\d+)?")
+    _url_re = re.compile(r"https?://sketch\.pixiv\.net/@?(?P<user>[^/]+)")
+    _post_key_re = re.compile(
+        r"""name=["']post_key["']\svalue=["'](?P<data>[^"']+)["']""")
 
-    _videopage_re = re.compile(r"""["']live-button["']><a\shref=["'](?P<path>[^"']+)["']""")
-    _data_re = re.compile(r"""<script\sid=["']state["']>[^><{]+(?P<data>{[^><]+})</script>""")
-    _post_key_re = re.compile(r"""name=["']post_key["']\svalue=["'](?P<data>[^"']+)["']""")
-
-    _data_schema = validate.Schema(
-        validate.all(
-            validate.transform(_data_re.search),
-            validate.any(
-                None,
-                validate.all(
-                    validate.get("data"),
-                    validate.transform(parse_json),
-                    validate.get("context"),
-                    validate.get("dispatcher"),
-                    validate.get("stores"),
-                )
-            )
-        )
+    _user_dict_schema = validate.Schema(
+        {
+            "user": {
+                "unique_name": validate.text,
+                "name": validate.all(validate.text,
+                                     validate.transform(maybe_decode))
+            },
+            validate.optional("hls_movie"): {
+                "url": validate.text
+            }
+        }
     )
 
+    _user_schema = validate.Schema(
+        {
+            "owner": _user_dict_schema,
+            "performers": [
+                validate.any(_user_dict_schema, None)
+            ]
+        }
+    )
+
+    _data_lives_schema = validate.Schema(
+        {
+            "data": {
+                "lives": [_user_schema]
+            }
+        },
+        validate.get("data"),
+        validate.get("lives")
+    )
+
+    api_lives = "https://sketch.pixiv.net/api/lives.json"
     login_url_get = "https://accounts.pixiv.net/login"
     login_url_post = "https://accounts.pixiv.net/api/login"
 
     arguments = PluginArguments(
-
         PluginArgument(
             "username",
             requires=["password"],
@@ -57,25 +72,34 @@ class Pixiv(Plugin):
             help="""
         A pixiv.net account password to use with --pixiv-username
         """
-        )
+        ),
+        PluginArgument(
+            "purge-credentials",
+            action="store_true",
+            help="""
+        Purge cached Pixiv credentials to initiate a new session
+        and reauthenticate.
+        """),
+        PluginArgument(
+            "performer",
+            metavar="USER",
+            help="""
+        Select a co-host stream instead of the owner stream.
+        """)
     )
+
+    def __init__(self, url):
+        super(Pixiv, self).__init__(url)
+        self._authed = (self.session.http.cookies.get("PHPSESSID")
+                        and self.session.http.cookies.get("device_token"))
+        self.session.http.headers.update({
+            "User-Agent": useragents.FIREFOX,
+            "Referer": self.url
+        })
 
     @classmethod
     def can_handle_url(cls, url):
         return cls._url_re.match(url) is not None
-
-    def find_videopage(self):
-        self.logger.debug("Not a videopage")
-        res = self.session.http.get(self.url)
-
-        m = self._videopage_re.search(res.text)
-        if not m:
-            self.logger.debug("No stream path, stream might be offline or invalid url.")
-            raise NoStreamsError(self.url)
-
-        path = m.group("path")
-        self.logger.debug("Found new path: {0}".format(path))
-        return urljoin(self.url, path)
 
     def _login(self, username, password):
         res = self.session.http.get(self.login_url_get)
@@ -94,55 +118,97 @@ class Pixiv(Plugin):
 
         res = self.session.http.post(self.login_url_post, data=data)
         res = self.session.http.json(res)
-
+        log.trace("{0!r}".format(res))
         if res["body"].get("success"):
-            return True
+            self.save_cookies()
+            log.info("Successfully logged in")
         else:
-            return False
+            log.error("Failed to log in.")
+
+    def hls_stream(self, hls_url):
+        log.debug("URL={0}".format(hls_url))
+        for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
+            yield s
+
+    def get_streamer_data(self):
+        res = self.session.http.get(self.api_lives)
+        data = self.session.http.json(res, schema=self._data_lives_schema)
+        log.debug("Found {0} streams".format(len(data)))
+
+        m = self._url_re.match(self.url)
+        for item in data:
+            if item["owner"]["user"]["unique_name"] == m.group("user"):
+                return item
+
+        raise NoStreamsError(self.url)
 
     def _get_streams(self):
-        self.session.http.headers = {"User-Agent": useragents.FIREFOX}
-
         login_username = self.get_option("username")
         login_password = self.get_option("password")
-        if login_username and login_password:
-            self.logger.debug("Attempting login as {0}".format(login_username))
-            if self._login(login_username, login_password):
-                self.logger.info("Successfully logged in as {0}".format(login_username))
-            else:
-                self.logger.info("Failed to login as {0}".format(login_username))
 
-        videopage = self._url_re.match(self.url).group("videopage")
-        if not videopage:
-            self.url = self.find_videopage()
+        if self.options.get("purge_credentials"):
+            self.clear_cookies()
+            self._authed = False
+            log.info("All credentials were successfully removed.")
 
-        data = self.session.http.get(self.url, schema=self._data_schema)
+        if self._authed:
+            log.debug("Attempting to authenticate using cached cookies")
+        elif not self._authed and login_username and login_password:
+            self._login(login_username, login_password)
 
-        if not data.get("LiveStore"):
-            self.logger.debug("No video url found, stream might be offline.")
-            return
-
-        data = data["LiveStore"]["lives"]
-
-        # get the unknown user-id
-        for _key in data.keys():
-            video_data = data.get(_key)
-
-        owner = video_data["owner"]
-        self.logger.info("Owner ID: {0}".format(owner["user_id"]))
-        self.logger.debug("HLS URL: {0}".format(owner["hls_movie"]))
-        for n, s in HLSStream.parse_variant_playlist(self.session, owner["hls_movie"]).items():
-            yield n, s
-
-        performers = video_data.get("performers")
+        streamer_data = self.get_streamer_data()
+        performers = streamer_data.get("performers")
+        log.trace("{0!r}".format(streamer_data))
         if performers:
+            co_hosts = []
+            # create a list of all available performers
             for p in performers:
-                self.logger.info("CO-HOST ID: {0}".format(p["user_id"]))
-                hls_url = p["hls_movie"]
-                self.logger.debug("HLS URL: {0}".format(hls_url))
-                for n, s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                    _n = "{0}_{1}".format(n, p["user_id"])
-                    yield _n, s
+                co_hosts += [(p["user"]["unique_name"], p["user"]["name"])]
+
+            log.info("Available hosts: {0}".format(", ".join(
+                ["{0} ({1})".format(k, v) for k, v in co_hosts])))
+
+            # control if the host from --pixiv-performer is valid,
+            # if not let the User select a different host
+            if (self.get_option("performer")
+                    and not self.get_option("performer") in [v[0] for v in co_hosts]):
+
+                # print the owner as 0
+                log.info("0 - {0} ({1})".format(
+                    streamer_data["owner"]["user"]["unique_name"],
+                    streamer_data["owner"]["user"]["name"]))
+                # print all other performer
+                for i, item in enumerate(co_hosts, start=1):
+                    log.info("{0} - {1} ({2})".format(i, item[0], item[1]))
+
+                try:
+                    number = int(self.input_ask(
+                        "Enter the number you'd like to watch").split(" ")[0])
+                    if number == 0:
+                        # default stream
+                        self.set_option("performer", None)
+                    else:
+                        # other co-hosts
+                        self.set_option("performer", co_hosts[number - 1][0])
+                except FatalPluginError:
+                    raise PluginError("Selected performer is invalid.")
+                except (IndexError, ValueError, TypeError):
+                    raise PluginError("Input is invalid")
+
+        # ignore the owner stream, if a performer is selected
+        # or use it when there are no other performers
+        if not self.get_option("performer") or not performers:
+            return self.hls_stream(streamer_data["owner"]["hls_movie"]["url"])
+
+        # play a co-host stream
+        if performers and self.get_option("performer"):
+            for p in performers:
+                if p["user"]["unique_name"] == self.get_option("performer"):
+                    # if someone goes online at the same time as Streamlink
+                    # was used, the hls URL might not be in the JSON data
+                    hls_movie = p.get("hls_movie")
+                    if hls_movie:
+                        return self.hls_stream(hls_movie["url"])
 
 
 __plugin__ = Pixiv


### PR DESCRIPTION
For the hls URL, use the API call that is used for `https://sketch.pixiv.net/lives`
instead of searching it on the User html source code,
as this might have some caching issues.

---

Save the session cookies after a successfully login,
they can be reseted with `--pixiv-purge-credentials`

---

New command to select the co-hosts `--pixiv-performer`,
rather than adding them as an alternative Stream.

The `unique_name` must be used for this command,
if an invalid user is selected Streamlink will ask the User to select a different User.

---

Normal stream

```
$ streamlink URL worst
[cli][info] Found matching plugin pixiv for URL ...
[cli][info] Available streams: 720p (worst), 1080p (best)
[cli][info] Opening stream: 720p (hls)
```

Stream with other co-hosts

```
$ streamlink URL worst
[cli][info] Found matching plugin pixiv for URL ...
[plugin.pixiv][info] Available hosts: unique_name_1 (display_name_1), unique_name_2 (display_name_2)
[cli][info] Available streams: 720p (worst), 1080p (best)
[cli][info] Opening stream: 720p (hls)
```

Stream with other co-hosts and --pixiv-performer command

```
$ streamlink URL worst --pixiv-performer unique_name_1
[cli][info] Found matching plugin pixiv for URL ...
[plugin.pixiv][info] Available hosts: unique_name_1 (display_name_1), unique_name_2 (display_name_2)
[cli][info] Available streams: 720p (worst), 1080p (best)
[cli][info] Opening stream: 720p (hls)
```

Stream with other co-hosts and invalid --pixiv-performer command

```
$ streamlink URL worst --pixiv-performer invalid_unique_name_2
[cli][info] Found matching plugin pixiv for URL ...
[plugin.pixiv][info] Available hosts: unique_name_1 (display_name_1), unique_name_2 (display_name_2)
[plugin.pixiv][info] 0 - owner_unique_name (owner_display_name)
[plugin.pixiv][info] 1 - unique_name_1 (display_name_1)
[plugin.pixiv][info] 2 - unique_name_2 (display_name_2)
Enter the number you'd like to watch: 2
[cli][info] Available streams: 720p (worst), 1080p (best)
[cli][info] Opening stream: 720p (hls)
```

---

closes https://github.com/streamlink/streamlink/issues/1933
fixed caching issues.

closes https://github.com/streamlink/streamlink/pull/1635
as the plugin changed, the debug messages are gone