### PR TITLE
docs-CLI: Fix for sort and prog issue

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -30,6 +30,7 @@ _block_re = re.compile(r":\n{2}\s{2}")
 _default_re = re.compile(r"Default is (.+)\.\n")
 _note_re = re.compile(r"Note: (.*)(?:\n\n|\n*$)", re.DOTALL)
 _option_re = re.compile(r"(?m)^((?!\s{2}).*)(--[\w-]+)")
+_prog_re = re.compile(r"%\(prog\)s")
 
 
 class ArgumentParser(object):
@@ -96,6 +97,9 @@ class ArgparseDirective(Directive):
             lambda m: ".. note::\n\n" + indent(m.group(1)) + "\n\n",
             help
         )
+
+        # workaround to replace %(prog)s with streamlink
+        help = _prog_re.sub("streamlink", help)
 
         return indent(help)
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -6,6 +6,8 @@ import traceback
 
 import requests
 
+from collections import OrderedDict
+
 from streamlink.logger import StreamlinkLogger, Logger
 from streamlink.utils import update_scheme, memoize
 from streamlink.utils.l10n import Localization
@@ -79,7 +81,7 @@ class Streamlink(object):
         })
         if options:
             self.options.update(options)
-        self.plugins = {}
+        self.plugins = OrderedDict({})
         self.load_builtin_plugins()
         self._logger = None
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -465,11 +465,12 @@ def build_parser():
             gaming oriented platforms. "Game being played" is a way to categorize
             the stream, so it doesn't need its own separate handling.
 
-       Examples:
-           %(prog)s -p vlc --title '{{title}} -!- {{author}} -!- {{category}} \\$A' <url> [stream]
-           %(prog)s -p mpv --title "{{title}} -- {{author}} -- {{category}} -- (\\${{{{mpv-version}}}})" <url> [stream]
+        Examples:
 
-        """.format(', '.join(SUPPORTED_PLAYERS.keys()),
+            %(prog)s -p vlc --title "{{title}} -!- {{author}} -!- {{category}} \\$A" <url> [stream]
+            %(prog)s -p mpv --title "{{title}} -- {{author}} -- {{category}} -- (\\${{{{mpv-version}}}})" <url> [stream]
+
+        """.format(', '.join(sorted(SUPPORTED_PLAYERS.keys())),
                    DEFAULT_STREAM_METADATA['title'],
                    DEFAULT_STREAM_METADATA['author'],
                    DEFAULT_STREAM_METADATA['category'])


### PR DESCRIPTION
Fix unsorted plugin commands on python <= 3.5
https://github.com/streamlink/streamlink.github.io/commit/afa12b6d1e95c74d5a84a1a1f111725ad4b70b66
also for `streamlink -h`

Fix `%(prog)s`
https://streamlink.github.io/latest/cli.html#player-options

Fix block at the end
https://streamlink.github.io/latest/cli.html#cmdoption-t