### PR TITLE
plugins.camsoda: Fix user status

### DIFF
--- a/src/streamlink/plugins/camsoda.py
+++ b/src/streamlink/plugins/camsoda.py
@@ -1,89 +1,91 @@
+import logging
 import random
 import re
 
+from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate
 from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
-_url_re = re.compile(r"http(s)?://(www\.)?camsoda\.com/(?P<username>[^\"\']+)")
-
-_api_user_schema = validate.Schema(
-    {
-        "status": validate.any(int, validate.text),
-        validate.optional("user"): {
-            "online": validate.any(int, validate.text),
-            "chatstatus": validate.text,
-        }
-    }
-)
-
-_api_video_schema = validate.Schema(
-    {
-        "token": validate.text,
-        "app": validate.text,
-        "edge_servers": [validate.text],
-        "stream_name": validate.text
-    }
-)
+log = logging.getLogger(__name__)
 
 
 class Camsoda(Plugin):
     API_URL_USER = "https://www.camsoda.com/api/v1/user/{0}"
     API_URL_VIDEO = "https://www.camsoda.com/api/v1/video/vtoken/{0}?username=guest_{1}"
     HLS_URL_VIDEO = "https://{server}/{app}/mp4:{stream_name}_aac/playlist.m3u8?token={token}"
-    headers = {
-        "User-Agent": useragents.FIREFOX
-    }
+
+    _url_re = re.compile(r"https?://(?:www\.)?camsoda\.com/(?P<username>[^/]+/?$)")
+
+    _user_schema = validate.Schema(
+        {
+            "status": bool,
+            "user": {
+                "chat": {
+                    "status": validate.text,
+                    "stream_name": validate.text,
+                    "origin_server": validate.text,
+                    "slug": validate.text,
+                }
+            }
+        }
+    )
+
+    _error_schema = validate.Schema(
+        {
+            "status": bool,
+            "error": validate.text
+        }
+    )
+
+    _api_video_schema = validate.Schema(
+        {
+            "token": validate.text,
+            "app": validate.text,
+            "edge_servers": [validate.text],
+            "stream_name": validate.text
+        }
+    )
+
+    _api_schema = validate.Schema(
+        validate.any(_user_schema, _error_schema)
+    )
 
     @classmethod
     def can_handle_url(cls, url):
-        return _url_re.match(url)
+        return cls._url_re.match(url) is not None
 
     def _stream_status(self, data_user):
-        invalid_username = data_user["status"] is False
-        if invalid_username:
-            self.logger.info("No validate username found for {0}".format(self.url))
-            return
+        log.trace("{0!r}".format(data_user))
+        if not data_user["status"]:
+            raise PluginError(data_user["error"])
 
-        is_online = data_user["user"]["online"] is True and data_user["user"]["chatstatus"] == "online"
-        if is_online is False:
-            self.logger.info("Stream is currently offline or private")
-            return
-
-        return True
-
-    def _get_api_user(self, username):
-        res = self.session.http.get(self.API_URL_USER.format(username), headers=self.headers)
-        data_user = self.session.http.json(res, schema=_api_user_schema)
-        return data_user
-
-    def _get_api_video(self, username):
-        res = self.session.http.get(self.API_URL_VIDEO.format(username, str(random.randint(1000, 99999))), headers=self.headers)
-        data_video = self.session.http.json(res, schema=_api_video_schema)
-        return data_video
+        user_status = data_user["user"]["chat"]["status"]
+        is_online = user_status == "online"
+        if not is_online:
+            raise PluginError("status - {0}".format(user_status))
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        username = match.group("username")
-        username = username.replace("/", "")
+        self.session.http.headers.update({"User-Agent": useragents.FIREFOX})
+        username = self._url_re.match(self.url).group("username")
 
-        data_user = self._get_api_user(username)
-        stream_status = self._stream_status(data_user)
+        res = self.session.http.get(self.API_URL_USER.format(username))
+        data_user = self.session.http.json(res, schema=self._api_schema)
+        self._stream_status(data_user)
 
-        if stream_status:
-            data_video = self._get_api_video(username)
-
-            if data_video:
-                hls_url = self.HLS_URL_VIDEO.format(
-                    server=data_video["edge_servers"][0],
-                    app=data_video["app"],
-                    stream_name=data_video["stream_name"],
-                    token=data_video["token"]
-                )
-
-                for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                    yield s
+        res = self.session.http.get(
+            self.API_URL_VIDEO.format(username, random.randint(1000, 99999)))
+        data_video = self.session.http.json(res, schema=self._api_video_schema)
+        log.trace("{0!r}".format(data_video))
+        hls_url = self.HLS_URL_VIDEO.format(
+            server=data_video["edge_servers"][0],
+            app=data_video["app"],
+            stream_name=data_video["stream_name"],
+            token=data_video["token"]
+        )
+        for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
+            yield s
 
 
 __plugin__ = Camsoda

--- a/tests/plugins/test_camsoda.py
+++ b/tests/plugins/test_camsoda.py
@@ -9,7 +9,10 @@ class TestPluginCamsoda(unittest.TestCase):
         self.assertTrue(Camsoda.can_handle_url("https://www.camsoda.com/stream-name"))
         self.assertTrue(Camsoda.can_handle_url("https://www.camsoda.com/streamname"))
         self.assertTrue(Camsoda.can_handle_url("https://www.camsoda.com/username"))
+        self.assertTrue(Camsoda.can_handle_url("https://www.camsoda.com/username/"))
 
+    def test_can_handle_url_negative(self):
         # shouldn't match
+        self.assertFalse(Camsoda.can_handle_url("https://www.camsoda.com/media/user/t/123"))
         self.assertFalse(Camsoda.can_handle_url("http://local.local/"))
         self.assertFalse(Camsoda.can_handle_url("http://localhost.localhost/"))


### PR DESCRIPTION
Stream online

```
$ streamlink https://www.camsoda.com/x
[cli][info] Found matching plugin camsoda for URL https://www.camsoda.com/x
[cli][info] Available streams: 600p (worst, best)
[cli][info] Opening stream: 600p (hls)
[cli][info] Starting player: /usr/bin/mpv
```

Stream offline

```
$ streamlink https://www.camsoda.com/x/
[cli][info] Found matching plugin camsoda for URL https://www.camsoda.com/x/
error: status - offline
```

Stream hidden

```
$ streamlink https://www.camsoda.com/x/
[cli][info] Found matching plugin camsoda for URL https://www.camsoda.com/x/
error: status - connected
```

Stream ticket

```
$ streamlink https://www.camsoda.com/x/
[cli][info] Found matching plugin camsoda for URL https://www.camsoda.com/x/
error: status - limited
```

Stream private

```
$ streamlink https://www.camsoda.com/x
[cli][info] Found matching plugin camsoda for URL https://www.camsoda.com/x
error: status - private
```

Invalid username

```
$ streamlink https://www.camsoda.com/x
[cli][info] Found matching plugin camsoda for URL https://www.camsoda.com/x
error: No username found
```

Fixed https://github.com/streamlink/streamlink/issues/1967