### PR TITLE
Plugin Request: new Plugin for Latvian live TV channels on ltv.lsm.lv

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -118,6 +118,7 @@ liveedu                 - liveedu.tv         Yes   --    Some streams require a 
 liveme                  liveme.com           Yes   --
 livestream              new.livestream.com   Yes   --
 lrt                     lrt.lt               Yes   No
+ltv_lsm_lv              ltv.lsm.lv           Yes   No    Streams may be geo-restricted to Latvia.
 mediaklikk              mediaklikk.hu        Yes   No    Streams may be geo-restricted to Hungary.
 mips                    mips.tv              Yes   --    Requires rtmpdump with K-S-V patches.
 mitele                  mitele.es            Yes   No    Streams may be geo-restricted to Spain.

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -1,7 +1,7 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import http, useragents
+from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
 

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -1,0 +1,51 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import http, useragents
+from streamlink.stream import HLSStream
+
+
+class LtvLsmLv(Plugin):
+    '''
+    Support for Latvian live channels streams on ltv.lsm.lv
+    '''
+    url_re = re.compile(r"https?://ltv.lsm.lv/lv/tieshraide")
+    iframe_re = re.compile(r'iframe .*?src="((?:http(s)?:)?//[^"]*?)"')
+    stream_re = re.compile(r'source .*?src="((?:http(s)?:)?//[^"]*?)"') 
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        HEADERS = {
+           "Referer": self.url,
+           "User-Agent": useragents.FIREFOX
+        }
+        # get URL content
+        res = self.session.http.get(self.url, headers=HEADERS)
+        # find iframe url
+        iframe = self.iframe_re.search(res.text)
+        iframe_url = iframe and iframe.group(1)
+        if iframe_url:
+            self.logger.debug("Found iframe: {}", iframe_url)
+            ires = self.session.http.get(iframe_url, headers=HEADERS)
+            streams_m = self.stream_re.search(ires.text)
+            streams_url = streams_m and streams_m.group(1)
+            if streams_url:
+                self.logger.debug("Found streams URL: {}", streams_url)
+                streams = HLSStream.parse_variant_playlist(self.session, streams_url)
+                if not streams:
+                    self.logger.debug("Play whole m3u8 file")
+                    yield 'live', HLSStream(self.session, video_url)
+                else:
+                    self.logger.debug("Play single stream (but broadcaster currently set all the listed resolutions point to the same 480p stream)")
+                    for s in streams.items():
+                        yield s
+            else:
+                self.logger.error("Could not find the stream URL")
+        else:
+            self.logger.error("Could not find player iframe")
+
+
+__plugin__ = LtvLsmLv

--- a/tests/plugins/test_ltv_lsm_lv.py
+++ b/tests/plugins/test_ltv_lsm_lv.py
@@ -1,0 +1,21 @@
+import unittest
+
+from streamlink.plugins.ltv_lsm_lv import LtvLsmLv
+
+
+class TestPluginLtvLsmLv(unittest.TestCase):
+    def test_can_handle_url(self):
+        self.assertTrue(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv/tieshraide/example/"))
+        self.assertTrue(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv/tieshraide/example/"))
+        self.assertTrue(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv/tieshraide/example/live.123/"))
+        self.assertTrue(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv/tieshraide/example/live.123/"))
+
+    def test_can_handle_url_negative(self):
+        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv"))
+        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv"))
+        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv"))
+        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv"))
+        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/other-site/"))
+        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/other-site/"))
+        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv/other-site/"))
+        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv/other-site/"))


### PR DESCRIPTION
# Plugin request
- [x] I have read the contribution and plugin request guidelines. 
## Description
LTV.LSM.LV is the official website of the Latvian state-owned television. It contains the live streams of 3 TV channels.
## Example stream URLs
1. Live stream: https://ltv.lsm.lv/lv/tieshraide/ltv1
2. Live stream: https://ltv.lsm.lv/lv/tieshraide/ltv7/live.782/
3. Live stream: https://ltv.lsm.lv/lv/tieshraide/visiemltv.lv/live.1480/
## Comments, screenshots, etc.
Some of the auditions are geo-resticted to Latvia.
Only handling the live TV channels streams has been implemented.
Although a single stream contains the links to 3 different resolutions (and handling setting them has been implemented) at the moment the broadcaster set all of them seem point to the same stream.
For testers - the 3-rd stream seems to be the least frequently geo-restricted.