### PR TITLE
Removed old Livestreamer deprecations and API references

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,4 +7,3 @@ mock
 requests-mock
 pynsist
 freezegun
-unittest2; python_version < '2.7'

--- a/src/streamlink/__init__.py
+++ b/src/streamlink/__init__.py
@@ -9,19 +9,6 @@ An API is also provided that allows direct access to stream data.
 Full documentation is available at https://streamlink.github.io.
 
 """
-import warnings
-from sys import version_info
-
-
-if version_info[:2] == (2, 6):
-    warnings.warn(
-        "Python 2.6 is no longer supported by the Python core team, please "
-        "upgrade your Python. A future version of streamlink will drop "
-        "support for Python 2.6",
-        DeprecationWarning
-    )
-
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
@@ -87,4 +74,3 @@ from .api import streams
 from .exceptions import (StreamlinkError, PluginError, NoStreamsError,
                          NoPluginError, StreamError)
 from .session import Streamlink
-

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -311,22 +311,6 @@ class Plugin(object):
         :param sorting_excludes: Specify which streams to exclude from
                                  the best/worst synonyms.
 
-
-        .. versionchanged:: 1.4.2
-           Added *priority* parameter.
-
-        .. versionchanged:: 1.5.0
-           Renamed *priority* to *stream_types* and changed behaviour
-           slightly.
-
-        .. versionchanged:: 1.5.0
-           Added *sorting_excludes* parameter.
-
-        .. versionchanged:: 1.6.0
-           *sorting_excludes* can now be a list of filter expressions
-           or a function that is passed to filter().
-
-
         """
 
         try:
@@ -420,15 +404,6 @@ class Plugin(object):
             final_sorted_streams["best"] = streams[best]
 
         return final_sorted_streams
-
-    def get_streams(self, *args, **kwargs):
-        """Deprecated since version 1.9.0.
-
-        Has been renamed to :func:`Plugin.streams`, this is an alias
-        for backwards compatibility.
-        """
-
-        return self.streams(*args, **kwargs)
 
     def _get_streams(self):
         raise NotImplementedError

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -318,9 +318,6 @@ class HLSStream(HTTPStream):
     - :attr:`args` A :class:`dict` containing keyword arguments passed
       to :meth:`requests.request`, such as headers and cookies.
 
-    .. versionchanged:: 1.7.0
-       Added *args* attribute.
-
     """
 
     __shortname__ = "hls"

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -8,7 +8,7 @@ try:
 except ImportError:  # pragma: no cover
     import xml.etree.ElementTree as ET
 
-from streamlink.compat import urljoin, urlparse, parse_qsl, is_py2, urlunparse, is_py3
+from streamlink.compat import urljoin, urlparse, parse_qsl, is_py2, is_py3
 from streamlink.exceptions import PluginError
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.lazy_formatter import LazyFormatter
@@ -202,91 +202,6 @@ def load_module(name, path=None):
             if fd:
                 fd.close()
 
-#####################################
-# Deprecated functions, do not use. #
-#####################################
-
-import requests
-
-
-def urlget(url, *args, **kwargs):  # pragma: no cover
-    """This function is deprecated."""
-    data = kwargs.pop("data", None)
-    exception = kwargs.pop("exception", PluginError)
-    method = kwargs.pop("method", "GET")
-    session = kwargs.pop("session", None)
-    timeout = kwargs.pop("timeout", 20)
-
-    if data is not None:
-        method = "POST"
-
-    try:
-        if session:
-            res = session.request(method, url, timeout=timeout, data=data,
-                                  *args, **kwargs)
-        else:
-            res = requests.request(method, url, timeout=timeout, data=data,
-                                   *args, **kwargs)
-
-        res.raise_for_status()
-    except (requests.exceptions.RequestException, IOError) as rerr:
-        err = exception("Unable to open URL: {url} ({err})".format(url=url,
-                                                                   err=rerr))
-        err.err = rerr
-        raise err
-
-    return res
-
-
-urlopen = urlget
-
-
-def urlresolve(url):  # pragma: no cover
-    """This function is deprecated."""
-    res = urlget(url, stream=True, allow_redirects=False)
-
-    if res.status_code == 302 and "location" in res.headers:
-        return res.headers["location"]
-    else:
-        return url
-
-
-def res_xml(res, *args, **kw):  # pragma: no cover
-    """This function is deprecated."""
-    return parse_xml(res.text, *args, **kw)
-
-
-def res_json(res, jsontype="JSON", exception=PluginError):  # pragma: no cover
-    """This function is deprecated."""
-    try:
-        jsondata = res.json()
-    except ValueError as err:
-        if len(res.text) > 35:
-            snippet = res.text[:35] + "..."
-        else:
-            snippet = res.text
-
-        raise exception("Unable to parse {0}: {1} ({2})".format(jsontype, err,
-                                                                snippet))
-
-    return jsondata
-
-
-import hmac
-import hashlib
-
-SWF_KEY = b"Genuine Adobe Flash Player 001"
-
-
-def swfverify(url):  # pragma: no cover
-    """This function is deprecated."""
-    res = urlopen(url)
-    swf = swfdecompress(res.content)
-
-    h = hmac.new(SWF_KEY, swf, hashlib.sha256)
-
-    return h.hexdigest(), len(swf)
-
 
 def escape_librtmp(value):  # pragma: no cover
     if isinstance(value, bool):
@@ -301,8 +216,8 @@ def escape_librtmp(value):  # pragma: no cover
     return value
 
 
-__all__ = ["urlopen", "urlget", "urlresolve", "swfdecompress", "swfverify",
-           "verifyjson", "absolute_url", "parse_qsd", "parse_json", "res_json",
-           "parse_xml", "res_xml", "rtmpparse", "prepend_www", "NamedPipe",
+__all__ = ["swfdecompress", "update_scheme", "url_equal",
+           "verifyjson", "absolute_url", "parse_qsd", "parse_json",
+           "parse_xml", "rtmpparse", "prepend_www", "NamedPipe",
            "escape_librtmp", "LazyFormatter", "get_filesystem_encoding",
            "maybe_decode", "maybe_encode"]

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1105,22 +1105,6 @@ def build_parser():
     )
 
     # Deprecated options
-    stream.add_argument(
-        "--best-stream-default",
-        action="store_true",
-        help=argparse.SUPPRESS
-    )
-    player.add_argument(
-        "-q", "--quiet-player",
-        action="store_true",
-        help=argparse.SUPPRESS
-    )
-    transport.add_argument(
-        "--hds-fragment-buffer",
-        type=int,
-        metavar="fragments",
-        help=argparse.SUPPRESS
-    )
     http.add_argument(
         "--http-cookies",
         metavar="COOKIES",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -433,8 +433,8 @@ def handle_stream(plugin, streams, stream_name):
 def fetch_streams(plugin):
     """Fetches streams using correct parameters."""
 
-    return plugin.get_streams(stream_types=args.stream_types,
-                              sorting_excludes=args.stream_sorting_excludes)
+    return plugin.streams(stream_types=args.stream_types,
+                          sorting_excludes=args.stream_sorting_excludes)
 
 
 def fetch_streams_with_retry(plugin, interval, count):
@@ -563,9 +563,6 @@ def handle_url():
     if not streams:
         console.exit("No playable streams found on this URL: {0}", args.url)
 
-    if args.best_stream_default:
-        args.default_stream = ["best"]
-
     if args.default_stream and not args.stream and not args.json:
         args.stream = args.default_stream
 
@@ -689,17 +686,6 @@ def setup_console(output):
 
     # All console related operations is handled via the ConsoleOutput class
     console = ConsoleOutput(output, streamlink)
-
-    if args.quiet_player:
-        log.warning("The option --quiet-player is deprecated since "
-                    "version 1.4.3 as hiding player output is now "
-                    "the default.")
-
-    if args.best_stream_default:
-        log.warning("The option --best-stream-default is deprecated "
-                    "since version 1.9.0, use '--default-stream best' "
-                    "instead.")
-
     console.json = args.json
 
     # Handle SIGTERM just like SIGINT
@@ -858,12 +844,6 @@ def setup_options():
     streamlink.set_option("subprocess-errorlog", args.subprocess_errorlog)
     streamlink.set_option("subprocess-errorlog-path", args.subprocess_errorlog_path)
     streamlink.set_option("locale", args.locale)
-
-    # Deprecated options
-    if args.hds_fragment_buffer:
-        log.warning("The option --hds-fragment-buffer is deprecated "
-                    "and will be removed in the future. Use "
-                    "--ringbuffer-size instead")
 
 
 def setup_plugin_args(session, parser):

--- a/tests/plugins/test_stream.py
+++ b/tests/plugins/test_stream.py
@@ -1,7 +1,8 @@
+import unittest
+
 from streamlink import Streamlink
 from streamlink.plugin.plugin import stream_weight, parse_params
-from streamlink.stream import *
-import unittest
+from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream
 from tests.mock import patch
 
 
@@ -15,7 +16,7 @@ class TestPluginStream(unittest.TestCase):
 
     def _test_akamaihd(self, surl, url):
         channel = self.session.resolve_url(surl)
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         self.assertTrue("live" in streams)
 
@@ -28,7 +29,7 @@ class TestPluginStream(unittest.TestCase):
         mock_parse.return_value = {}
 
         channel = self.session.resolve_url(surl)
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         self.assertTrue("live" in streams)
         mock_parse.assert_called_with(self.session, url)
@@ -42,7 +43,7 @@ class TestPluginStream(unittest.TestCase):
         mock_parse.return_value = {"best": HLSStream(self.session, url)}
 
         channel = self.session.resolve_url(surl)
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         mock_parse.assert_called_with(self.session, url)
 
@@ -55,7 +56,7 @@ class TestPluginStream(unittest.TestCase):
 
     def _test_rtmp(self, surl, url, params):
         channel = self.session.resolve_url(surl)
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         self.assertTrue("live" in streams)
 
@@ -66,7 +67,7 @@ class TestPluginStream(unittest.TestCase):
 
     def _test_http(self, surl, url, params):
         channel = self.session.resolve_url(surl)
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         self.assertTrue("live" in streams)
 

--- a/tests/plugins/test_tvplayer.py
+++ b/tests/plugins/test_tvplayer.py
@@ -55,7 +55,7 @@ class TestPluginTVPlayer(unittest.TestCase):
         TVPlayer.bind(self.session, "test.tvplayer")
         plugin = TVPlayer("http://tvplayer.com/watch/dave")
 
-        streams = plugin.get_streams()
+        streams = plugin.streams()
 
         self.assertTrue("test" in streams)
 
@@ -77,7 +77,7 @@ class TestPluginTVPlayer(unittest.TestCase):
         TVPlayer.bind(self.session, "test.tvplayer")
         plugin = TVPlayer("http://tvplayer.com/watch/dave")
 
-        streams = plugin.get_streams()
+        streams = plugin.streams()
 
         self.assertEqual({}, streams)
 

--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -1,14 +1,10 @@
 from __future__ import unicode_literals
 import sys
+import unittest
 
 import pytest
 
 from streamlink.plugin.api.utils import itertags
-
-if sys.version_info[0:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
 
 
 class TestPluginUtil(unittest.TestCase):
@@ -47,7 +43,6 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(script[1].tag, "script")
         self.assertEqual(script[1].text.strip(), """Tester.ready(function () {\nalert("Hello, world!"); });""")
         self.assertEqual(script[1].attributes, {})
-
 
     @pytest.mark.xfail(sys.version_info >= (3, 7),
                        reason="python3.7 issue, see bpo-34294")
@@ -88,5 +83,3 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(links[0].tag, "p")
         self.assertEqual(links[0].text.strip(), '<a \nhref="http://test.se/foo">bar</a>')
         self.assertEqual(links[0].attributes, {})
-
-

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,7 +5,7 @@ from streamlink import Streamlink, NoPluginError
 from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY
 from streamlink.plugins import Plugin
 from streamlink.session import print_small_exception
-from streamlink.stream import *
+from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream
 from tests.mock import patch, call
 
 
@@ -76,7 +76,7 @@ class TestSession(unittest.TestCase):
 
     def test_plugin(self):
         channel = self.session.resolve_url("http://test.se/channel")
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         self.assertTrue("best" in streams)
         self.assertTrue("worst" in streams)
@@ -89,33 +89,33 @@ class TestSession(unittest.TestCase):
 
     def test_plugin_stream_types(self):
         channel = self.session.resolve_url("http://test.se/channel")
-        streams = channel.get_streams(stream_types=["http", "rtmp"])
+        streams = channel.streams(stream_types=["http", "rtmp"])
 
         self.assertTrue(isinstance(streams["480p"], HTTPStream))
         self.assertTrue(isinstance(streams["480p_rtmp"], RTMPStream))
 
-        streams = channel.get_streams(stream_types=["rtmp", "http"])
+        streams = channel.streams(stream_types=["rtmp", "http"])
 
         self.assertTrue(isinstance(streams["480p"], RTMPStream))
         self.assertTrue(isinstance(streams["480p_http"], HTTPStream))
 
     def test_plugin_stream_sorted_excludes(self):
         channel = self.session.resolve_url("http://test.se/channel")
-        streams = channel.get_streams(sorting_excludes=["1080p", "3000k"])
+        streams = channel.streams(sorting_excludes=["1080p", "3000k"])
 
         self.assertTrue("best" in streams)
         self.assertTrue("worst" in streams)
         self.assertTrue(streams["best"] is streams["1500k"])
 
-        streams = channel.get_streams(sorting_excludes=[">=1080p", ">1500k"])
+        streams = channel.streams(sorting_excludes=[">=1080p", ">1500k"])
         self.assertTrue(streams["best"] is streams["1500k"])
 
-        streams = channel.get_streams(sorting_excludes=lambda q: not q.endswith("p"))
+        streams = channel.streams(sorting_excludes=lambda q: not q.endswith("p"))
         self.assertTrue(streams["best"] is streams["3000k"])
 
     def test_plugin_support(self):
         channel = self.session.resolve_url("http://test.se/channel")
-        streams = channel.get_streams()
+        streams = channel.streams()
 
         self.assertTrue("support" in streams)
         self.assertTrue(isinstance(streams["support"], HTTPStream))

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,10 +1,8 @@
-import sys
-from streamlink.utils.url import *
+import unittest
 
-if sys.version_info[0:2] == (2, 6):
-    import unittest2 as unittest
-else:
-    import unittest
+from streamlink.utils.url import (
+    update_scheme, url_equal, url_concat, update_qsd
+)
 
 
 class TestUtilURL(unittest.TestCase):


### PR DESCRIPTION
- removed **versionchange references** as Streamlink does not use it.
- removed **old code** that was deprecated in Livestreamer
- removed DeprecatedWarning for **2.6** as it is already mentioned in 
`setup.py`
  
https://github.com/streamlink/streamlink/blob/a14f170a04252d4275de417c13dcc2a19bf269c9/setup.py#L82
- removed **unittest2**
- **Flake8** for some lines/files that I changed.

---

Fixed https://github.com/streamlink/streamlink/issues/1141