### PR TITLE
tests: use unittest instead of pytest for itertags error

### DIFF
--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -2,8 +2,6 @@ from __future__ import unicode_literals
 import sys
 import unittest
 
-import pytest
-
 from streamlink.plugin.api.utils import itertags
 
 
@@ -44,8 +42,8 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(script[1].text.strip(), """Tester.ready(function () {\nalert("Hello, world!"); });""")
         self.assertEqual(script[1].attributes, {})
 
-    @pytest.mark.xfail(sys.version_info >= (3, 7),
-                       reason="python3.7 issue, see bpo-34294")
+    @unittest.skipIf(sys.version_info >= (3, 7),
+                     "python3.7 issue, see bpo-34294")
     def test_itertags_multi_attrs(self):
         metas = list(itertags(self.test_html, "meta"))
         self.assertTrue(len(metas), 3)
@@ -66,8 +64,8 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(anchor[0].text, "bar")
         self.assertEqual(anchor[0].attributes, {"href": "http://test.se/foo"})
 
-    @pytest.mark.xfail(sys.version_info >= (3, 7),
-                       reason="python3.7 issue, see bpo-34294")
+    @unittest.skipIf(sys.version_info >= (3, 7),
+                     "python3.7 issue, see bpo-34294")
     def test_no_end_tag(self):
         links = list(itertags(self.test_html, "link"))
         self.assertTrue(len(links), 1)


### PR DESCRIPTION
The tests won't pass with `python setup.py test`,
use `unittest` instead of `pytest`.

```
======================================================================
FAIL: test_itertags_multi_attrs (tests.test_plugin_utils.TestPluginUtil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_plugin_utils.py", line 59, in 
test_itertags_multi_attrs
    self.assertEqual(metas[0].text, None)
AssertionError: 'Title' != None

======================================================================
FAIL: test_no_end_tag (tests.test_plugin_utils.TestPluginUtil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_plugin_utils.py", line 80, in test_no_end_tag
    self.assertEqual(links[0].text, None)
AssertionError: '' != None

```

as an example https://aur.archlinux.org/packages/streamlink-git/ uses it.
https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=streamlink-git#n57

---

Ref https://github.com/streamlink/streamlink/pull/1675
Ref https://github.com/streamlink/streamlink/issues/1979
