### PR TITLE
Improve terminal progress display for  wide characters

### DIFF
--- a/src/streamlink_cli/utils/progress.py
+++ b/src/streamlink_cli/utils/progress.py
@@ -2,7 +2,6 @@ import sys
 
 from collections import deque
 from time import time
-from unicodedata import east_asian_width
 
 from ..compat import is_win32, get_terminal_size
 

--- a/src/streamlink_cli/utils/progress.py
+++ b/src/streamlink_cli/utils/progress.py
@@ -14,22 +14,38 @@ PROGRESS_FORMATS = (
     "[download] {written}"
 )
 
+# widths generated from
+# http://www.unicode.org/Public/4.0-Update/EastAsianWidth-4.0.0.txt
+
+
+widths = [
+    (13, 1),    (15, 0),    (126, 1),   (159, 0),   (687, 1),   (710, 0),
+    (711, 1),   (727, 0),   (733, 1),   (879, 0),   (1154, 1),  (1161, 0),
+    (4347, 1),  (4447, 2),  (7467, 1),  (7521, 0),  (8369, 1),  (8426, 0),
+    (9000, 1),  (9002, 2),  (11021, 1), (12350, 2), (12351, 1), (12438, 2),
+    (12442, 0), (19893, 2), (19967, 1), (55203, 2), (63743, 1), (64106, 2),
+    (65039, 1), (65059, 0), (65131, 2), (65279, 1), (65376, 2), (65500, 1),
+    (65510, 2), (120831, 1), (262141, 2), (1114109, 1)
+]
+
+
+def get_width(o):
+    """Returns the screen column width for unicode ordinal."""
+    for num, wid in widths:
+        if o <= num:
+            return wid
+    return 1
+
 
 def terminal_width(value):
-    """Returns the length of the string it would be when displayed.
-
-    East Asian Characters take 2 cells in terminal.
-    Other Characters take 1 cell in terminal.
-    """
+    """Returns the width of the string it would be when displayed."""
     if isinstance(value, bytes):
         value = value.decode("utf8", "ignore")
-    # F: FullWidth W: Wide A: Ambiguous
-    return sum([2 if east_asian_width(i) in ('F', 'W', 'A')
-                else 1 for i in value])
+    return sum(map(get_width, map(ord, value)))
 
 
 def get_cut_prefix(value, max_len):
-    """Drop Characters by unicode not by bytes."""
+    """Drops Characters by unicode not by bytes."""
     should_convert = isinstance(value, bytes)
     if should_convert:
         value = value.decode("utf8", "ignore")

--- a/tests/test_cli_util_progress.py
+++ b/tests/test_cli_util_progress.py
@@ -1,0 +1,20 @@
+# coding: utf-8
+from streamlink_cli.utils.progress import terminal_width, get_cut_prefix
+import unittest
+
+
+class TestCliUtilProgess(unittest.TestCase):
+    def test_terminal_width(self):
+        self.assertEqual(10, terminal_width("ABCDEFGHIJ"))
+        self.assertEqual(30, terminal_width("A你好世界こんにちは안녕하세요B"))
+        self.assertEqual(30, terminal_width("·「」『』【】-=！@#￥%……&×（）"))
+        pass
+
+    def test_get_cut_prefix(self):
+        self.assertEqual("녕하세요CD",
+                         get_cut_prefix("你好世界こんにちは안녕하세요CD", 10))
+        self.assertEqual("하세요CD",
+                         get_cut_prefix("你好世界こんにちは안녕하세요CD", 9))
+        self.assertEqual("こんにちは안녕하세요CD",
+                         get_cut_prefix("你好世界こんにちは안녕하세요CD", 23))
+        pass


### PR DESCRIPTION
1. Calculate string width  in terminal  instead of string length for progress output in order to support East asian Characters(CJK) better and avoid terminal display overflow.

Overflow sample:
```
[download][..ちはアロハabcd.mp4] Written 143.1 KB (0s @ 228.7 KB/s)     
     [download][..ちはアロハabcd.mp4] Written 280.5 KB (1s @ 223.9 KB/s)
          [download][..ちはアロハabcd.mp4] Written 280.5 KB (1s @ 223.9 KB/s)
``` 
2. Cut string according to unicode not bytes to avoid malformed character (in python 2)

Malformed sample
```
[download][..�好はロハabcd.mp4] Written 143.1 KB (0s @ 228.7 KB/s) 
```



Some details

|Type|Display|Length
|----|---|--|
|Word| 你好| 2
|Utf-8(Python2 bytes)| \xe4\xbd\xa0\xe5\xa5\xbd| 6|
|Unicode(Python3 str)| \u4f60\u597d| 2|
|Utf-8 [1:]|��好|5|
|Unicode [1:]|好|1|
|Terminal | 你好 |4 cells  

`1 Wide character takes 2 cells in terminal`
