### PR TITLE
plugins.afreeca: ignore new preloading urls

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -140,7 +140,7 @@ class AfreecaTV(Plugin):
 
     def _get_streams(self):
         if not self.session.get_option("hls-segment-ignore-names"):
-            ignore_segment = ["_0", "_1", "_2"]
+            ignore_segment = ["preloading"]
             self.session.set_option("hls-segment-ignore-names", ignore_segment)
 
         login_username = self.get_option("username")


### PR DESCRIPTION
new ts url examples

invalid

```
800x480/202020202-flash-original-hls_0_preloading.TS
800x480/202020202-flash-original-hls_1_preloading.TS
800x480/202020202-flash-original-hls_2_preloading.TS
```

valid

```
800x480/202020202-flash-original-hls_3_000000123456789ABCDEF12345678910.TS
800x480/202020202-flash-original-hls_4_000000123456789ABCDEF12345678910.TS
800x480/202020202-flash-original-hls_5_000000123456789ABCDEF12345678910.TS
```

closes https://github.com/streamlink/streamlink/issues/2061