### PR TITLE
BUG: HDS fragment to segment mapping issue

### DIFF
--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -281,7 +281,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
         table = self.segmentruntable.payload.segment_run_entry_table
 
         for segment, start, end in self.iter_segment_table(table):
-            if start - 1 <= fragment <= end:
+            if start <= fragment <= end:
                 return segment
         else:
             segment = 1


### PR DESCRIPTION
The fragment to segment mapping should be exactly limited to the
fragment boundaries.

If we include start - 1, the last fragment of a segment can be wrongly
assigned to the next segment. This is particularly apparent for stream
with a lot of small segments.