### PR TITLE
plugins.ustreamtv: use Desktop instead of Mobile streams

### DIFF
--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -1,18 +1,19 @@
-import re
+import json
 import logging
+import re
 from random import randint
 from threading import Thread, Event
 
-import time
+import websocket
 
-from streamlink import PluginError
-from streamlink.compat import urljoin
 from streamlink.plugin import Plugin, PluginArguments, PluginArgument
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream import HLSStream, Stream
 from streamlink.stream import HTTPStream
-from streamlink.stream.hls import HLSStreamReader
+from streamlink.utils import parse_json
+
+log = logging.getLogger(__name__)
 
 
 class ModuleInfoNoStreams(Exception):
@@ -24,28 +25,22 @@ class UHSClient(object):
     API Client, reverse engineered by observing the interactions
     between the web browser and the ustream servers.
     """
-    API_URL = "http://r{0}-1-{1}-{2}-{3}.ums.ustream.tv"
-    APP_ID, APP_VERSION = 2, 1
-    api_schama = validate.Schema([{
+    API_URL = "ws://r{0}-1-{1}-{2}-ws-{3}.ums.ustream.tv:1935/1/ustream"
+    APP_ID, APP_VERSION = 11, 2
+    api_schama = validate.Schema({
         "args": [object],
         "cmd": validate.text
-    }])
-    connect_schama = validate.Schema([{
-        "args": validate.all([{"host": validate.text, "connectionId": validate.text}], validate.length(1)),
-        "cmd": "tracking"
-    }], validate.length(1), validate.get(0), validate.get("args"), validate.get(0))
+    })
     module_info_schema = validate.Schema(
         [validate.get("stream")],
         validate.filter(lambda r: r is not None)
     )
 
-    def __init__(self, session, media_id, application, **options):
-        self.session = session
-        self.session.http.headers.update({"User-Agent": useragents.IPHONE_6})
-        self.logger = logging.getLogger("streamlink.plugin.ustream.apiclient")
+    def __init__(self, media_id, application, **options):
+        http.headers.update({"User-Agent": useragents.IPHONE_6})
         self.media_id = media_id
         self.application = application
-        self.referrer = options.pop("referrer", None)
+        self._referrer = options.pop("referrer", None)
         self._host = None
         self.rsid = self.generate_rsid()
         self.rpin = self.generate_rpin()
@@ -54,35 +49,54 @@ class UHSClient(object):
         self._app_version = options.pop("app_version", self.APP_VERSION)
         self._cluster = options.pop("cluster", "live")
         self._password = options.pop("password")
+        self._ws = None
 
-    def connect(self, **options):
-        result = self.send_command(type="viewer", appId=self._app_id,
-                                   appVersion=self._app_version,
-                                   rsid=self.rsid,
-                                   rpin=self.rpin,
-                                   referrer=self.referrer,
-                                   media=str(self.media_id),
-                                   application=self.application,
-                                   schema=self.connect_schama,
-                                   password=self._password)
+    @property
+    def referrer(self):
+        return self._referrer
 
-        self._host = "http://{0}".format(result["host"])
-        self._connection_id = result["connectionId"]
-        self.logger.debug("Got new host={0}, and connectionId={1}", self._host, self._connection_id)
-        return True
+    @referrer.setter
+    def referrer(self, referrer):
+        log.info("Updating referrer to: {0}".format(referrer))
+        self._referrer = referrer
+        self.reconnect()
 
-    def poll(self, schema=None, retries=5, timeout=5.0):
-        stime = time.time()
-        try:
-            r = self.send_command(connectionId=self._connection_id,
-                                  schema=schema,
-                                  retries=retries,
-                                  timeout=timeout)
-        except PluginError as err:
-            self.logger.debug("poll took {0:.2f}s: {1}", time.time() - stime, err)
-        else:
-            self.logger.debug("poll took {0:.2f}s", time.time() - stime)
-            return r
+    @property
+    def cluster(self):
+        return self._cluster
+
+    @cluster.setter
+    def cluster(self, cluster):
+        log.info("Switching cluster to: {0}".format(cluster))
+        self._cluster = cluster
+        self.reconnect()
+
+    def connect(self):
+        log.debug("Connecting to {0}".format(self.host))
+        self._ws = websocket.create_connection(self.host,
+                                               header=["User-Agent: {0}".format(useragents.IPHONE_6)],
+                                               origin="http://www.ustream.tv")
+
+        args = dict(type="viewer",
+                    appId=self._app_id,
+                    appVersion=self._app_version,
+                    rsid=self.rsid,
+                    rpin=self.rpin,
+                    referrer=self._referrer,
+                    clusterHost="r%rnd%-1-%mediaId%-%mediaType%-%protocolPrefix%-%cluster%.ums.ustream.tv",
+                    media=str(self.media_id),
+                    application=self.application)
+        if self._password:
+            args["password"] = self._password
+
+        result = self.send("connect", **args)
+        return result > 0
+
+    def reconnect(self):
+        log.debug("Reconnecting...")
+        if self._ws:
+            self._ws.close()
+        return self.connect()
 
     def generate_rsid(self):
         return "{0:x}:{1:x}".format(randint(0, 1e10), randint(0, 1e10))
@@ -90,24 +104,31 @@ class UHSClient(object):
     def generate_rpin(self):
         return "_rpin.{0}".format(randint(0, 1e15))
 
-    def send_command(self, schema=None, retries=5, timeout=5.0, **args):
-        res = self.session.http.get(self.host,
-                       params=args,
-                       headers={"Referer": self.referrer,
-                                "User-Agent": useragents.IPHONE_6},
-                       retries=retries,
-                       timeout=timeout,
-                       retry_max_backoff=0.5)
-        return self.session.http.json(res, schema=schema or self.api_schama)
+    def send(self, command, **args):
+        log.debug("Sending `{0}` command".format(command))
+        log.trace("{0!r}".format({"cmd": command, "args": [args]}))
+        return self._ws.send(json.dumps({"cmd": command, "args": [args]}))
+
+    def recv(self):
+        data = parse_json(self._ws.recv(), schema=self.api_schama)
+        log.debug("Received `{0}` command".format(data["cmd"]))
+        log.trace("{0!r}".format(data))
+        return data
+
+    def disconnect(self):
+        if self._ws:
+            log.debug("Disconnecting...")
+            self._ws.close()
+            self._ws = None
 
     @property
     def host(self):
-        host = self._host or self.API_URL.format(randint(0, 0xffffff), self.media_id, self.application,
-                                                 "lp-" + self._cluster)
-        return urljoin(host, "/1/ustream")
+        return self._host or self.API_URL.format(randint(0, 0xffffff), self.media_id, self.application, self._cluster)
 
 
-class UStreamHLSStream(HLSStream):
+class UStreamWrapper(Stream):
+    __shortname__ = "ustream"
+
     class APIPoller(Thread):
         """
         Poll the UStream API so that stream URLs stay valid, otherwise they expire after 30 seconds.
@@ -120,30 +141,42 @@ class UStreamHLSStream(HLSStream):
             self.interval = interval
 
         def stop(self):
+            log.debug("Stopping API polling...")
             self.stopped.set()
 
         def run(self):
             while not self.stopped.wait(1.0):
-                res = self.api.poll(retries=30, timeout=self.interval)
-                if not res:
+                cmd_args = self.api.recv()
+                if not cmd_args:
                     continue
-                for cmd_args in res:
-                    self.api.logger.debug("poll response: {0}", cmd_args)
-                    if cmd_args["cmd"] == "warning":
-                        self.api.logger.warning("{code}: {message}", **cmd_args["args"])
+                log.debug("poll response: {0}".format(cmd_args))
+                if cmd_args["cmd"] == "warning":
+                    log.warning("{code}: {message}", **cmd_args["args"])
+            log.debug("Stopped API polling")
 
-    def __init__(self, session_, url, api, force_restart=False, **args):
-        super(UStreamHLSStream, self).__init__(session_, url, force_restart, **args)
-        self.logger = logging.getLogger("streamlink.stream.ustream-hls")
+        def stopper(self, f):
+            def _stopper(*args, **kwargs):
+                self.stop()
+                return f(*args, **kwargs)
+            return _stopper
+
+    def __init__(self, session, stream, api):
+        super(UStreamWrapper, self).__init__(session)
+        self.stream = stream
         self.poller = self.APIPoller(api)
         self.poller.setDaemon(True)
+        log.debug("Wrapping {0} stream".format(stream.shortname()))
 
     def open(self):
-        reader = HLSStreamReader(self)
-        reader.open()
         self.poller.start()
-        self.logger.debug("Starting API polling thread")
-        return reader
+        log.debug("Starting API polling thread")
+        fd = self.stream.open()
+        fd.close = self.poller.stopper(fd.close)
+        return fd
+
+    def __json__(self):
+        return {"type": self.shortname(),
+                "wrapped": self.stream.__json__()}
 
 
 class UStreamTV(Plugin):
@@ -170,76 +203,62 @@ class UStreamTV(Plugin):
     def can_handle_url(cls, url):
         return cls.url_re.match(url) is not None
 
-    def _api_get_streams(self, media_id, application, cluster="live", referrer=None, retries=3):
-        if retries > 0:
-            app_id = 11
-            app_ver = 2
-            referrer = referrer or self.url
-            self.api = UHSClient(self.session, media_id, application, referrer=referrer, cluster=cluster, app_id=app_id,
-                                 app_version=app_ver, password=self.get_option("password"))
-            self.logger.debug("Connecting to UStream API: media_id={0}, application={1}, referrer={2}, cluster={3}, "
-                              "app_id={4}, app_ver={5}",
-                              media_id, application, referrer, cluster, app_id, app_ver)
-            if self.api.connect():
-                for i in range(5):  # make at most five requests to get the moduleInfo
-                    try:
-                        for s in self._do_poll(media_id, application, cluster, referrer, retries):
-                            yield s
-                    except ModuleInfoNoStreams:
-                        self.logger.debug("Retrying moduleInfo request")
-                        time.sleep(1)
-                    else:
-                        break
-
-    def _do_poll(self, media_id, application, cluster="live", referrer=None, retries=3):
-        res = self.api.poll()
-        if res:
-            for result in res:
-                if result["cmd"] == "moduleInfo":
-                    for s in self.handle_module_info(result["args"], media_id, application, cluster,
-                                                     referrer, retries):
-                        yield s
-                elif result["cmd"] == "reject":
-                    for s in self.handle_reject(result["args"], media_id, application, cluster, referrer, retries):
-                        yield s
-                else:
-                    self.logger.debug("Unknown command: {0}({1})", result["cmd"], result["args"])
-
-    def handle_module_info(self, args, media_id, application, cluster="live", referrer=None, retries=3):
-        has_results = False
-        for streams in UHSClient.module_info_schema.validate(args):
-            has_results = True
+    def handle_module_info(self, api, args):
+        res = {}
+        for streams in api.module_info_schema.validate(args):
             if isinstance(streams, list):
                 for stream in streams:
-                    for q, s in HLSStream.parse_variant_playlist(self.session, stream["url"]).items():
-                        yield q, UStreamHLSStream(self.session, s.url, self.api)
+                    if stream['name'] == "uhls":
+                        for q, s in HLSStream.parse_variant_playlist(self.session, stream["url"]).items():
+                            res[q] = UStreamWrapper(self.session, s, api)
+                    if stream['name'] == "ustream":
+                        for substream in stream['streams']:
+                            res["vod"] = HTTPStream(self.session, substream['streamName'])
             elif isinstance(streams, dict):
                 for stream in streams.get("streams", []):
                     name = "{0}k".format(stream["bitrate"])
                     for surl in stream["streamName"]:
-                        yield name, HTTPStream(self.session, surl)
+                        res[name] = HTTPStream(self.session, surl)
             elif streams == "offline":
-                self.logger.warning("This stream is currently offline")
+                log.error("Stream is offline")
+                raise ModuleInfoNoStreams
 
-        if not has_results:
-            raise ModuleInfoNoStreams
+        return res
 
-    def handle_reject(self, args, media_id, application, cluster="live", referrer=None, retries=3):
+    def handle_reject(self, api, args):
         for arg in args:
             if "cluster" in arg:
-                self.logger.debug("Switching cluster to {0}", arg["cluster"]["name"])
-                cluster = arg["cluster"]["name"]
+                api.cluster = arg["cluster"]["name"]
             if "referrerLock" in arg:
-                referrer = arg["referrerLock"]["redirectUrl"]
-
-        return self._api_get_streams(media_id,
-                                     application,
-                                     cluster=cluster,
-                                     referrer=referrer,
-                                     retries=retries - 1)
+                api.referrer = arg["referrerLock"]["redirectUrl"]
+            if "nonexistent" in arg:
+                log.error("This channel does not exist")
+                raise ModuleInfoNoStreams
 
     def _get_streams(self):
         # establish a mobile non-websockets api connection
+        media_id, application = self._get_media_app()
+        if media_id:
+            api = UHSClient(media_id, application, referrer=self.url, cluster="live", password=self.get_option("password"))
+            log.debug("Connecting to UStream API: media_id={0}, application={1}, referrer={2}, cluster={3}",
+                      media_id, application, self.url, "live")
+            api.connect()
+            for _ in range(5):
+                data = api.recv()
+                try:
+                    if data["cmd"] == "moduleInfo":
+                        r = self.handle_module_info(api, data["args"])
+                        if r:
+                            return r
+                    elif data["cmd"] == "reject":
+                        self.handle_reject(api, data["args"])
+                    else:
+                        log.debug("Unexpected `{0}` command".format(data["cmd"]))
+                        log.trace("{0!r}".format(data))
+                except ModuleInfoNoStreams:
+                    return None
+
+    def _get_media_app(self):
         umatch = self.url_re.match(self.url)
         application = "channel"
 
@@ -252,19 +271,10 @@ class UStreamTV(Plugin):
             application = "recorded"
             media_id = video_id
         else:
-            media_id = self._find_media_id()
-
-        if media_id:
-            for s in self._api_get_streams(media_id, application):
-                yield s
-        else:
-            self.logger.error("Cannot find a media_id on this page")
-
-    def _find_media_id(self):
-        self.logger.debug("Searching for media ID on the page")
-        res = self.session.http.get(self.url, headers={"User-Agent": useragents.CHROME})
-        m = self.media_id_re.search(res.text)
-        return m and m.group(1)
+            res = self.session.http.get(self.url, headers={"User-Agent": useragents.CHROME})
+            m = self.media_id_re.search(res.text)
+            media_id = m and m.group(1)
+        return media_id, application
 
 
 __plugin__ = UStreamTV


### PR DESCRIPTION
- use websocket API from https://github.com/streamlink/streamlink/pull/1777
- use **flv/segmented** streams for better stream qualitys

---

Test plugin URL `ustreamtv.py`

https://raw.githubusercontent.com/back-to/streamlink/ustream_desktop/src/streamlink/plugins/ustreamtv.py

---

might need to change some naming of the new used code.

---

@porcomail

closes https://github.com/streamlink/streamlink/issues/1146

@dd00

closes https://github.com/streamlink/streamlink/issues/1653

@sokkycakes

closes https://github.com/streamlink/streamlink/issues/1767

@InstallGentoo11

closes https://github.com/streamlink/streamlink/issues/2050

@xpatryk89

closes https://github.com/streamlink/streamlink/issues/2076

@beardypig

closes https://github.com/streamlink/streamlink/pull/1777