### PR TITLE
cli: make the HH part of HH:MM:SS options optional

### DIFF
--- a/src/streamlink/utils/times.py
+++ b/src/streamlink/utils/times.py
@@ -1,7 +1,7 @@
 import re
 
 _hours_minutes_seconds_re = re.compile(r"""
-    ^-?(?P<hours>\d+):(?P<minutes>\d+):(?P<seconds>\d+)$
+    ^-?(?:(?P<hours>\d+):)?(?P<minutes>\d+):(?P<seconds>\d+)$
 """, re.VERBOSE)
 
 _hours_minutes_seconds_2_re = re.compile(r"""^-?
@@ -21,6 +21,7 @@ def hours_minutes_seconds(value):
     """converts a timestamp to seconds
 
       - hours:minutes:seconds to seconds
+      - minutes:seconds to seconds
       - 11h22m33s to seconds
       - 11h to seconds
       - 20h15m to seconds

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -768,7 +768,7 @@ def build_parser():
     transport.add_argument(
         "--hls-start-offset",
         type=hours_minutes_seconds,
-        metavar="HH:MM:SS",
+        metavar="[HH:]MM:SS",
         default=None,
         help="""
         Amount of time to skip from the beginning of the stream. For live
@@ -779,7 +779,7 @@ def build_parser():
     transport.add_argument(
         "--hls-duration",
         type=hours_minutes_seconds,
-        metavar="HH:MM:SS",
+        metavar="[HH:]MM:SS",
         default=None,
         help="""
         Limit the playback duration, useful for watching segments of a stream.

--- a/tests/test_utils_times.py
+++ b/tests/test_utils_times.py
@@ -24,8 +24,10 @@ class TestUtilsTimes(unittest.TestCase):
         self.assertEqual(hours_minutes_seconds("-00:01:40"), 100)
         self.assertEqual(hours_minutes_seconds("-00h02m30s"), 150)
 
-        with self.assertRaises(ValueError):
-            hours_minutes_seconds("02:04")
+        self.assertEqual(hours_minutes_seconds("02:04"), 124)
+        self.assertEqual(hours_minutes_seconds("1:10"), 70)
+        self.assertEqual(hours_minutes_seconds("10:00"), 600)
+
 
         with self.assertRaises(ValueError):
             hours_minutes_seconds("FOO")


### PR DESCRIPTION
Options `HH` part in the `HH:MM:SS` options, so that you can do `10:00` for 10 minutes. 

Also gives extra utility to the `hours_minutes_seconds` method for parsing time offsets from streaming sites, etc.