### PR TITLE
cli: disable progress output for -o when no tty is available

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -57,10 +57,14 @@ def check_file_output(filename, force):
     log.debug("Checking file output")
 
     if os.path.isfile(filename) and not force:
-        answer = console.ask("File {0} already exists! Overwrite it? [y/N] ",
-                             filename)
+        if sys.stdin.isatty():
+            answer = console.ask("File {0} already exists! Overwrite it? [y/N] ",
+                                 filename)
 
-        if answer.lower() != "y":
+            if answer.lower() != "y":
+                sys.exit()
+        else:
+            log.error("File {0} already exists, use --force to overwrite it.".format(filename))
             sys.exit()
 
     return FileOutput(filename)
@@ -322,7 +326,7 @@ def read_stream(stream, output, prebuffer, chunk_size=8192):
     is_player = isinstance(output, PlayerOutput)
     is_http = isinstance(output, HTTPServer)
     is_fifo = is_player and output.namedpipe
-    show_progress = isinstance(output, FileOutput) and output.fd is not stdout
+    show_progress = isinstance(output, FileOutput) and output.fd is not stdout and sys.stdout.isatty()
 
     stream_iterator = chain(
         [prebuffer],

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -18,9 +18,22 @@ class TestCLIMain(unittest.TestCase):
         tmpfile = tempfile.NamedTemporaryFile()
         try:
             streamlink_cli.main.console = console = Mock()
+            streamlink_cli.main.sys.stdin = stdin = Mock()
+            stdin.isatty.return_value = True
             console.ask.return_value = "y"
             self.assertTrue(os.path.exists(tmpfile.name))
             self.assertIsInstance(check_file_output(tmpfile.name, False), FileOutput)
+        finally:
+            tmpfile.close()
+
+    def test_check_file_output_exists_notty(self):
+        tmpfile = tempfile.NamedTemporaryFile()
+        try:
+            streamlink_cli.main.console = console = Mock()
+            streamlink_cli.main.sys.stdin = stdin = Mock()
+            stdin.isatty.return_value = False
+            self.assertTrue(os.path.exists(tmpfile.name))
+            self.assertRaises(SystemExit, check_file_output, tmpfile.name, False)
         finally:
             tmpfile.close()
 


### PR DESCRIPTION
Changes to the behaviour of the progress bar when using -o.

If there is no tty available for output (eg. when piping, or running a subprocess), then no progress bar is output. This is because the progress bar rewrites the console, which is only possible on interactive terminals not for a pipe.

If there is no tty available for input and the file already exists an error is given instead of a prompt to the user.

Should fix #1770. 