### PR TITLE
docs: add appropriate funimation docs

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -245,7 +245,7 @@ Authenticating with FunimationNow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Like Crunchyroll, the FunimationNow plugin requires authenticating with a premium account to access some
 content: :option:`--funimation-email`, :option:`--funimation-password`. In addition, this plugin requires a ``incap_ses`` cookie to be
-sent with each HTTP request (`see issue #2088 <https://github.com/streamlink/streamlink/issues/2088#issue-366192126>`_); this unique session cookie can be found in your browser and sent via the :option:`--http-cookie` option.
+sent with each HTTP request (see issue #2088); this unique session cookie can be found in your browser and sent via the :option:`--http-cookie` option.
 
 For example:
 
@@ -259,7 +259,7 @@ For example:
     information on browser cookies, please consult the following:
 
     - `What are cookies? <http://www.whatarecookies.com/view.asp>`_
-      
+
 Sideloading plugins
 -------------------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -239,6 +239,24 @@ For this, the plugin provides the :option:`--crunchyroll-purge-credentials`
 option, which removes your saved session and credentials and tries to log
 in again using your username and password.
 
+Authenticating with FunimationNow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Like Crunchyroll, the Funimation plugin requires authenticating with a premium account to access some
+content: :option:`--funimation-email`, :option:`--funimation-password`. In addition, this plugin requires an ``incap_ses`` cookie to be
+sent with each HTTP request; this unique session cookie can be found in your browser
+and sent via the :option:`--http-cookie` option.  For example:
+
+.. sourcecode:: console
+
+    $ streamlink --funimation-email=xxxx --funimation-password=xxx --http-cookie "incap_ses_123_98765=SGVsbG8\bZb==" https://funimation.com/shows/show/an-episode-link
+
+.. note::
+
+    There are multiple ways to retrieve the required cookie.  For more
+    information on browser cookies, please consult the following:
+
+    - `What are cookies? <http://www.whatarecookies.com/view.asp>`_
+      
 Sideloading plugins
 -------------------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -242,9 +242,9 @@ in again using your username and password.
 Authenticating with FunimationNow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Like Crunchyroll, the Funimation plugin requires authenticating with a premium account to access some
-content: :option:`--funimation-email`, :option:`--funimation-password`. In addition, this plugin requires an ``incap_ses`` cookie to be
-sent with each HTTP request; this unique session cookie can be found in your browser
-and sent via the :option:`--http-cookie` option.  For example:
+content: :option:`--funimation-email`, :option:`--funimation-password`. In addition, this plugin requires a ``incap_ses`` cookie to be
+sent with each HTTP request; this unique session cookie can be found in your browser and sent via the :option:`--http-cookie` option.
+For example:
 
 .. sourcecode:: console
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -239,16 +239,19 @@ For this, the plugin provides the :option:`--crunchyroll-purge-credentials`
 option, which removes your saved session and credentials and tries to log
 in again using your username and password.
 
+.. _cli-funimationnow:
+
 Authenticating with FunimationNow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Like Crunchyroll, the Funimation plugin requires authenticating with a premium account to access some
+Like Crunchyroll, the FunimationNow plugin requires authenticating with a premium account to access some
 content: :option:`--funimation-email`, :option:`--funimation-password`. In addition, this plugin requires a ``incap_ses`` cookie to be
-sent with each HTTP request; this unique session cookie can be found in your browser and sent via the :option:`--http-cookie` option.
+sent with each HTTP request (`see issue #2088 <https://github.com/streamlink/streamlink/issues/2088#issue-366192126>`_); this unique session cookie can be found in your browser and sent via the :option:`--http-cookie` option.
+
 For example:
 
 .. sourcecode:: console
 
-    $ streamlink --funimation-email=xxxx --funimation-password=xxx --http-cookie "incap_ses_123_98765=SGVsbG8\bZb==" https://funimation.com/shows/show/an-episode-link
+    $ streamlink --funimation-email='xxx' --funimation-password='xxx' --http-cookie 'incap_ses_xxx=xxxx=' https://funimation.com/shows/show/an-episode-link
 
 .. note::
 

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -81,7 +81,7 @@ europaplus              europaplus.ru        Yes   --
 facebook                facebook.com         Yes   No    Only 360p HLS streams.
 filmon                  filmon.com           Yes   Yes   Only SD quality streams.
 foxtr                   fox.com.tr           Yes   No
-funimationnow           - funimation.com     --    Yes   Both premium and non-premium content require a session cookie to be sent with each request (:ref:`docs <cli-funimationnow>`).
+funimationnow           - funimation.com     --    Yes   :ref:`Requires session cookies <cli-funimationnow>`
                         - funimationnow.uk
 gardenersworld          gardenersworld.com   --    Yes
 garena                  garena.live          Yes   --

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -81,7 +81,7 @@ europaplus              europaplus.ru        Yes   --
 facebook                facebook.com         Yes   No    Only 360p HLS streams.
 filmon                  filmon.com           Yes   Yes   Only SD quality streams.
 foxtr                   fox.com.tr           Yes   No
-funimationnow           - funimation.com     --    Yes   Both premium and non-premium content require a session cookie to be sent with each request 
+funimationnow           - funimation.com     --    Yes   Both premium and non-premium content require a session cookie to be sent with each request (:ref:`docs <cli-funimationnow>`).
                         - funimationnow.uk
 gardenersworld          gardenersworld.com   --    Yes
 garena                  garena.live          Yes   --

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -81,7 +81,7 @@ europaplus              europaplus.ru        Yes   --
 facebook                facebook.com         Yes   No    Only 360p HLS streams.
 filmon                  filmon.com           Yes   Yes   Only SD quality streams.
 foxtr                   fox.com.tr           Yes   No
-funimationnow           - funimation.com     --    Yes
+funimationnow           - funimation.com     --    Yes   Both premium and non-premium content require a session cookie to be sent with each request 
                         - funimationnow.uk
 gardenersworld          gardenersworld.com   --    Yes
 garena                  garena.live          Yes   --


### PR DESCRIPTION
I added documentation and notes for the Funimation plugin

**cli.rst**:
  - added authentication and `incap_ses` cookie information

**plugin_matrix.rst**:
  - added note about the required cookie