### PR TITLE
travis: increase git clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ env:
   - STREAMLINK_INSTALLER_DIST_DIR=${STREAMLINK_DIST_DIR}/nsis
   - SDIST_KEY_FILE="${TRAVIS_BUILD_DIR}/signing.key"
 
+git:
+  depth: 300
+
 matrix:
   include:
   - python: '2.7'


### PR DESCRIPTION
There are not enough commits for Versioneer `streamlink-0+untagged`,
with more commits the Streamlink version should be fixed for travis.

Fixes Windows build.

Error Example:
https://travis-ci.org/streamlink/streamlink/jobs/436299646#L1165
https://github.com/streamlink/streamlink.github.io/commit/42e74cce133a0dfcc6c40a9a71ebbaa336b3285f#diff-1438650dd2508a32fb38f7b8aa3c8e19

Ref:
https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth