### PR TITLE
stream.dash_manifest: Fixed bug for dynamic playlists when parent.id is None

### DIFF
--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -509,6 +509,10 @@ class SegmentTemplate(MPDNode):
 
     def format_media(self, **kwargs):
         if self.segmentTimeline:
+            if self.parent.id is None:
+                # workaround for invalid `self.root.timelines[self.parent.id]`
+                # creates a timeline for every mimeType instead of one for both
+                self.parent.id = self.parent.mimeType
             log.debug("Generating segment timeline for {0} playlist (id={1}))".format(self.root.type, self.parent.id))
             if self.root.type == "dynamic":
                 # if there is no delay, use a delay of 3 seconds


### PR DESCRIPTION
if `self.parent.id` is None, use `self.parent.mimeType` instead.

This will create two timelines for video and audio,
instead of one for both which won't work.

---

I don't know that much about the MPD class,
maybe it could be solved differently.

---

Test URLs:

https://www.france.tv/france-5/direct.html

http://livesim.dashif.org/livesim/segtimeline_1/testpic_2s/Manifest.mpd
from https://github.com/Dash-Industry-Forum/dash-live-source-simulator/wiki/Test-URLs

---

closes https://github.com/streamlink/streamlink/pull/1934
