### PR TITLE
plugins.ok_live: Changed URL regex to support VoDs

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -120,7 +120,7 @@ npo                     - npo.nl             Yes   Yes   Streams may be geo-rest
                         - zappelin.nl
 nrk                     - tv.nrk.no          Yes   Yes   Streams may be geo-restricted to Norway.
                         - radio.nrk.no
-ok_live                 ok.ru                Yes   --
+ok_live                 ok.ru                Yes   Yes
 olympicchannel          olympicchannel.com   Yes   Yes   Only non-premium content is available.
 onetv                   - 1tv.ru             Yes   Yes   Streams may be geo-restricted to Russia. VOD only for 1tv.ru
                         - ctc.ru

--- a/src/streamlink/plugins/ok_live.py
+++ b/src/streamlink/plugins/ok_live.py
@@ -5,7 +5,7 @@ from streamlink.plugin.api import validate
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
-_url_re = re.compile(r"https?://(www\.)?ok\.ru/live/\d+")
+_url_re = re.compile(r"https?://(www\.)?ok\.ru/(live|video)/\d+")
 _vod_re = re.compile(r";(?P<hlsurl>[^;]+video\.m3u8.+?)\\&quot;")
 
 _schema = validate.Schema(
@@ -21,7 +21,7 @@ _schema = validate.Schema(
 
 class OK_live(Plugin):
     """
-    Support for ok.ru live stream: http://www.ok.ru/live/
+    Support for ok.ru live stream: http://www.ok.ru/live/ and for ok.ru VoDs: http://www.ok.ru/video/
     """
     @classmethod
     def can_handle_url(cls, url):

--- a/tests/plugins/test_ok_live.py
+++ b/tests/plugins/test_ok_live.py
@@ -9,6 +9,7 @@ class TestPluginOK_live(unittest.TestCase):
         self.assertTrue(OK_live.can_handle_url("https://ok.ru/live/12345"))
         self.assertTrue(OK_live.can_handle_url("http://ok.ru/live/12345"))
         self.assertTrue(OK_live.can_handle_url("http://www.ok.ru/live/12345"))
+        self.assertTrue(OK_live.can_handle_url("https://ok.ru/video/266205792931"))
 
         # shouldn't match
         self.assertFalse(OK_live.can_handle_url("http://www.tvcatchup.com/"))


### PR DESCRIPTION
I noticed that existing ok_live plugin works for VoDs on ok.ru, so I just changed URL regex to support them as well. Closes #2095 