### PR TITLE
plugins.tamago: support for live streams on player.tamago.live

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -187,6 +187,7 @@ svtplay                 - svtplay.se         Yes   Yes   Streams may be geo-rest
                         - oppetarkiv.se
 swisstxt                - srf.ch             Yes   No    Streams are geo-restricted to Switzerland.
                         - rsi.ch
+tamago                  player.tamago.live   Yes   --
 teamliquid              teamliquid.net       Yes   Yes
 teleclubzoom            teleclubzoom.ch      Yes   No    Streams are geo-restricted to Switzerland.
 telefe                  telefe.com           No    Yes   Streams are geo-restricted to Argentina.

--- a/src/streamlink/plugins/tamago.py
+++ b/src/streamlink/plugins/tamago.py
@@ -1,0 +1,51 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import validate
+from streamlink.stream import HTTPStream, FLVPlaylist
+from streamlink import NoStreamsError
+
+class Tamago(Plugin):
+
+    _url_re = re.compile(r"https?://(player\.)?tamago\.live/w/(?P<id>\d+)")
+
+    _api_url_base = "https://player.tamago.live/api/rooms/{id}"
+
+    _api_response_schema = validate.Schema({
+        u"status" : 200,
+        u"message": u"Success",
+        u"data": {
+            u"room_number": validate.text,
+            u"stream": { validate.text: validate.url() }
+        }
+    })
+
+    _stream_qualities = {
+        u"150": "144p",
+        u"350": "360p",
+        u"550": "540p",
+        u"900": "720p",
+    }
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    def _get_streams(self):
+        user_id = self._url_re.match(self.url).group(2)
+        
+        try:
+            api_response = self.session.http.get(self._api_url_base.format(id=user_id))
+            streams = self.session.http.json(api_response, schema=self._api_response_schema)['data']['stream']
+        except Exception as e:
+            raise NoStreamsError(self.url)
+        
+        unique_stream_urls = []
+        for stream in streams.keys():
+            if streams[stream] not in unique_stream_urls:
+                unique_stream_urls.append(streams[stream])
+                quality = self._stream_qualities[stream] if stream in self._stream_qualities.keys() else "720p+"
+                yield quality, HTTPStream(self.session, streams[stream])
+            
+
+__plugin__ = Tamago

--- a/src/streamlink/plugins/tamago.py
+++ b/src/streamlink/plugins/tamago.py
@@ -2,21 +2,22 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream, FLVPlaylist
+from streamlink.stream import HTTPStream
 from streamlink import NoStreamsError
+
 
 class Tamago(Plugin):
 
-    _url_re = re.compile(r"https?://(player\.)?tamago\.live/w/(?P<id>\d+)")
+    _url_re = re.compile(r"https?://(?:player\.)?tamago\.live/w/(?P<id>\d+)")
 
     _api_url_base = "https://player.tamago.live/api/rooms/{id}"
 
     _api_response_schema = validate.Schema({
-        u"status" : 200,
+        u"status": 200,
         u"message": u"Success",
         u"data": {
             u"room_number": validate.text,
-            u"stream": { validate.text: validate.url() }
+            u"stream": {validate.text: validate.url()}
         }
     })
 
@@ -32,20 +33,20 @@ class Tamago(Plugin):
         return cls._url_re.match(url) is not None
 
     def _get_streams(self):
-        user_id = self._url_re.match(self.url).group(2)
-        
+        user_id = self._url_re.match(self.url).group('id')
+
         try:
             api_response = self.session.http.get(self._api_url_base.format(id=user_id))
             streams = self.session.http.json(api_response, schema=self._api_response_schema)['data']['stream']
-        except Exception as e:
+        except Exception:
             raise NoStreamsError(self.url)
-        
+
         unique_stream_urls = []
         for stream in streams.keys():
             if streams[stream] not in unique_stream_urls:
                 unique_stream_urls.append(streams[stream])
                 quality = self._stream_qualities[stream] if stream in self._stream_qualities.keys() else "720p+"
                 yield quality, HTTPStream(self.session, streams[stream])
-            
+
 
 __plugin__ = Tamago

--- a/tests/plugins/test_tamago.py
+++ b/tests/plugins/test_tamago.py
@@ -1,0 +1,24 @@
+import unittest
+
+from streamlink.plugins.tamago import Tamago
+
+
+class TestPluginTamago(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://player.tamago.live/w/2009642',
+            'https://player.tamago.live/w/1882066',
+            'https://player.tamago.live/w/1870142',
+            'https://player.tamago.live/w/1729968',
+        ]
+        for url in should_match:
+            self.assertTrue(Tamago.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://download.tamago.live/faq',
+            'https://player.tamago.live/gaming/pubg',
+            'https://www.twitch.tv/twitch'
+        ]
+        for url in should_not_match:
+            self.assertFalse(Tamago.can_handle_url(url))


### PR DESCRIPTION
Add support for Tamago Live, a streaming website. Closes #2071 