### PR TITLE
plugins.metube: Add support for live streams and  VoDs on www.metube.id

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -108,6 +108,7 @@ livestream              new.livestream.com   Yes   --
 lrt                     lrt.lt               Yes   No
 ltv_lsm_lv              ltv.lsm.lv           Yes   No    Streams may be geo-restricted to Latvia.
 mediaklikk              mediaklikk.hu        Yes   No    Streams may be geo-restricted to Hungary.
+metube                  metube.id            Yes   Yes
 mitele                  mitele.es            Yes   No    Streams may be geo-restricted to Spain.
 mixer                   mixer.com            Yes   Yes
 mjunoon                 mjunoon.tv           Yes   Yes

--- a/src/streamlink/plugins/metube.py
+++ b/src/streamlink/plugins/metube.py
@@ -1,0 +1,58 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import useragents
+from streamlink.stream import HLSStream
+from streamlink import NoStreamsError
+
+
+class MeTube(Plugin):
+
+    _url_re = re.compile(r"""https?://(?:www\.)?metube\.id/
+                         (?P<type>live|videos)/\w+(?:/.*)?""", re.VERBOSE)
+
+    # extracted from webpage source
+    _VOD_STREAM_NAMES = {
+        "3000k": "1080p",
+        "1800k": "720p",
+        "800k": "480p",
+        "300k": "240p"
+    }
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    def _get_streams(self):
+        stream_type = self._url_re.match(self.url).group("type")
+        m3u8_re = re.compile(r"https?://.+\.m3u8")
+
+        headers = {
+            "Origin": "https://www.metube.id",
+            "User-Agent": useragents.FIREFOX
+        }
+
+        res = self.session.http.get(self.url)
+
+        try:
+            stream_url = m3u8_re.search(res.text).group(0)
+        except Exception:
+            raise NoStreamsError(self.url)
+
+        if stream_type == "live":
+            return HLSStream.parse_variant_playlist(self.session, stream_url,
+                                                    headers=headers)
+        else:
+            streams = {}
+
+            for quality, stream in HLSStream.parse_variant_playlist(
+                                   self.session,
+                                   stream_url,
+                                   headers=headers).items():
+                    name = self._VOD_STREAM_NAMES.get(quality, quality)
+                    streams[name] = stream
+
+            return streams
+
+
+__plugin__ = MeTube

--- a/tests/plugins/test_metube.py
+++ b/tests/plugins/test_metube.py
@@ -1,0 +1,24 @@
+import unittest
+
+from streamlink.plugins.metube import MeTube
+
+
+class TestPluginMeTube(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://www.metube.id/live/METROTV',
+            'https://www.metube.id/live/GTV',
+            'https://www.metube.id/videos/16881738/yudi_28_bogor_-amazingakak',
+            'https://www.metube.id/videos/16873428/liverpool-vs-psg-3-2-goals-and-highlights-2018',
+        ]
+        for url in should_match:
+            self.assertTrue(MeTube.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://www.metube.id/me/IMAA2018',
+            'https://www.metube.id/auditions',
+            'https://www.twitch.tv/twitch'
+        ]
+        for url in should_not_match:
+            self.assertFalse(MeTube.can_handle_url(url))


### PR DESCRIPTION
meTube.id is an Indonesian video sharing website owned by MNC Media that has live streams of many Indonesian TV channels.

Plugin works for both live streams and VoDs. Closes #2031 