### PR TITLE
plugins.cwtv: Add support for videos on cwtv.com

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -51,6 +51,7 @@ cinergroup              - showtv.com.tr      Yes   No
 cnews                   cnews.fr             Yes   Yes
 crunchyroll             crunchyroll.com      --    Yes
 cubetv                  cubetv.sg            Yes   --
+cwtv                    cwtv.com             --    Yes   Streams may be geo-restricted to USA.
 cybergame               cybergame.tv         Yes   Yes
 dailymotion             dailymotion.com      Yes   Yes
 delfi                   - delfi.lt           --    Yes

--- a/src/streamlink/plugins/cwtv.py
+++ b/src/streamlink/plugins/cwtv.py
@@ -1,0 +1,32 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.utils import update_scheme
+from streamlink.plugins.theplatform import ThePlatform
+from streamlink import NoStreamsError
+
+
+class CWTV(Plugin):
+
+    _url_re = re.compile(r"https?://(?:www\.)?cwtv\.com/shows/[\w-]+")
+    _embed_re = re.compile(r"""iframe.+src="(?P<url>[^"]+theplatform[^"]+)""")
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = self.session.http.get(self.url)
+
+        try:
+            theplatform_url = self._embed_re.search(res.text).group("url")
+        except Exception:
+            raise NoStreamsError(self.url)
+
+        url = update_scheme(self.url, theplatform_url)
+        p = ThePlatform(url)
+        p.bind(self.session, "plugin.cwtv")
+        return p.streams()
+
+
+__plugin__ = CWTV

--- a/tests/plugins/test_cwtv.py
+++ b/tests/plugins/test_cwtv.py
@@ -1,0 +1,24 @@
+import unittest
+
+from streamlink.plugins.cwtv import CWTV
+
+
+class TestPluginCWTV(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'http://www.cwtv.com/shows/the-100/the-warriors-will/?play=d7857786-f312-45d3-a63b-c36ba8401138',
+            'http://www.cwtv.com/shows/the-outpost/',
+            'http://www.cwtv.com/shows/the-flash/',
+            'http://www.cwtv.com/shows/dcs-legends-of-tomorrow/',
+        ]
+        for url in should_match:
+            self.assertTrue(CWTV.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'http://www.cwtv.com/',
+            'http://www.cwtv.com/thecw/privacy-policy/',
+            'https://www.twitch.tv/twitch'
+        ]
+        for url in should_not_match:
+            self.assertFalse(CWTV.can_handle_url(url))


### PR DESCRIPTION
The CW is an American TV network. Their original TV programs are available on their website for streaming (may be restricted to USA).

The website uses thePlatform player, so this plugin just extracts thePlatform url and passes it to thePlatform plugin. Closes #2016