### PR TITLE
plugins.pluzz: fixes and francetvinfo.fr support

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -141,7 +141,7 @@ playtv                  - playtv.fr          Yes   --    Streams may be geo-rest
 pluzz                   - france.tv          Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
                         - ludo.fr
                         - zouzous.fr
-                        - france3-reg.. [8]_
+                        - francetvinfo.fr
 powerapp                powerapp.com.tr      Yes   No
 qq                      live.qq.com          Yes   No
 radionet                - radio.net          Yes   --
@@ -215,7 +215,7 @@ tv4play                 - tv4play.se         Yes   Yes   Streams may be geo-rest
                         - fotbollskanalen.se
 tv5monde                - tv5monde.com       Yes   Yes   Streams may be geo-restricted to France, Belgium and Switzerland.
                         - tv5mondeplus.com
-                        - tv5mondepl... [9]_
+                        - tv5mondepl... [8]_
 tv8                     tv8.com.tr           Yes   No
 tv360                   tv360.com.tr         Yes   No
 tvcatchup               tvcatchup.com        Yes   No    Streams may be geo-restricted to Great Britain.
@@ -257,10 +257,10 @@ youtube                 - youtube.com        Yes   Yes   Protected videos are no
                         - youtu.be
 yupptv                  yupptv.com           Yes   Yes   Some streams require an account and subscription.
 zattoo                  - zattoo.com         Yes   Yes
-                        - nettv.net... [10]_
+                        - nettv.net... [9]_
                         - tvonline.ewe.de
-                        - iptv.glat... [11]_
-                        - mobiltv.q... [12]_
+                        - iptv.glat... [10]_
+                        - mobiltv.q... [11]_
                         - player.waly.tv
                         - tvplus.m-net.de
                         - www.bbv-tv.net
@@ -280,8 +280,7 @@ zhanqi                  zhanqi.tv            Yes   No
 .. [5] mediathek.daserste.de
 .. [6] players.brightcove.net
 .. [7] player.theplatform.com
-.. [8] france3-regions.francetvinfo.fr
-.. [9] tv5mondeplusafrique.com
-.. [10] nettv.netcologne.de
-.. [11] iptv.glattvision.ch
-.. [12] mobiltv.quickline.com
+.. [8] tv5mondeplusafrique.com
+.. [9] nettv.netcologne.de
+.. [10] iptv.glattvision.ch
+.. [11] mobiltv.quickline.com

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -151,12 +151,8 @@ class Pluzz(Plugin):
                 expired = expired or True
                 continue
 
-            if ('.f4m' in video_url or
-                '.mpd' in video_url or
-                'france.tv' in self.url or
-                'sport.francetvinfo.fr' in self.url):
-                res = self.session.http.get(self.TOKEN_URL.format(video_url))
-                video_url = res.text
+            res = self.session.http.get(self.TOKEN_URL.format(video_url))
+            video_url = res.text
 
             if '.mpd' in video_url:
                 # Get redirect video URL

--- a/tests/plugins/test_pluzz.py
+++ b/tests/plugins/test_pluzz.py
@@ -23,6 +23,7 @@ class TestPluginPluzz(unittest.TestCase):
         self.assertTrue(Pluzz.can_handle_url("http://sport.francetvinfo.fr/roland-garros/direct"))
         self.assertTrue(Pluzz.can_handle_url("http://sport.francetvinfo.fr/roland-garros/live-court-3"))
         self.assertTrue(Pluzz.can_handle_url("http://sport.francetvinfo.fr/roland-garros/andy-murray-gbr-1-andrey-kuznetsov-rus-1er-tour-court-philippe-chatrier"))
+        self.assertTrue(Pluzz.can_handle_url("https://www.francetvinfo.fr/en-direct/tv.html"))
 
         # shouldn't match
         self.assertFalse(Pluzz.can_handle_url("http://www.france.tv/"))
@@ -30,6 +31,5 @@ class TestPluginPluzz(unittest.TestCase):
         self.assertFalse(Pluzz.can_handle_url("http://www.ludo.fr/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.ludo.fr/jeux"))
         self.assertFalse(Pluzz.can_handle_url("http://www.zouzous.fr/"))
-        self.assertFalse(Pluzz.can_handle_url("http://france3-regions.francetvinfo.fr/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(Pluzz.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
This PR:
* speeds up stream resolution for HDS streams (by using a static URL for the SWF player instead of searching it each time the plugin is run)
* makes the plugin use token generator for all kind of streams (since a recent change on France TV)
* enable full support for videos on francetvinfo.fr and its subdomains (fixes https://github.com/streamlink/streamlink/issues/1959)