### PR TITLE
versioneer: always use 7 characters

### DIFF
--- a/src/streamlink/_version.py
+++ b/src/streamlink/_version.py
@@ -235,7 +235,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
+                                          "--always", "--long", "--abbrev=7",
                                           "--match", "%s*" % tag_prefix],
                                    cwd=root)
     # --long was added in git-1.5.5

--- a/versioneer.py
+++ b/versioneer.py
@@ -1047,7 +1047,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
     describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
+                                          "--always", "--long", "--abbrev=7",
                                           "--match", "%s*" % tag_prefix],
                                    cwd=root)
     # --long was added in git-1.5.5


### PR DESCRIPTION
The nightly version won't get build because Streamlink outputs two different versions,
one with 7 and one with 8 characters.

https://bintray.com/streamlink/streamlink-nightly/streamlink

commit `1a5a5fb2e6fccc5a441f987ccd4e53794542dfc9`

> streamlink-0.14.2_133.g1a5a5fb.exe

length 7

https://travis-ci.org/streamlink/streamlink/jobs/440826462#L3090

> streamlink-0.14.2_133.g1a5a5fb2.exe

length 8

https://travis-ci.org/streamlink/streamlink/jobs/440826462#L3198

---

This is a known issue from versioneer, there is also a solution ...

https://github.com/warner/python-versioneer/issues/156

https://github.com/m-labs/artiq/commit/076e4119f744c07afaa6f6cd840a45dfcd13718e#diff-f374b985f7c07f7ff6a8dbaa0b30a10d
https://github.com/m-labs/artiq/commit/d08bd58dffef5c4c13536ecf48d6147f542b7a5b#diff-4af5de46c624a2c4aa3ff1c3e82d5c4a

---

**Before**

Streamlink: 0.14.2+135.gcb587d80

**After**

Streamlink: 0.14.2+135.gcb587d8

---

I did not test it with bintray, just locally where it changed from 8 to 7

closes https://github.com/streamlink/streamlink/issues/2118