### PR TITLE
Add ability to specify custom key URI override for HLS streams

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -45,6 +45,8 @@ class HLSStreamWriter(SegmentedStreamWriter):
         self.byterange_offsets = defaultdict(int)
         self.key_data = None
         self.key_uri = None
+        self.key_uri_override = options.get("hls-segment-key-uri")
+
         if self.ignore_names:
             # creates a regex from a list of segment names,
             # this will be used to ignore segments.
@@ -57,15 +59,17 @@ class HLSStreamWriter(SegmentedStreamWriter):
         if key.method != "AES-128":
             raise StreamError("Unable to decrypt cipher {0}", key.method)
 
-        if not key.uri:
+        if not self.key_uri_override and not key.uri:
             raise StreamError("Missing URI to decryption key")
 
-        if self.key_uri != key.uri:
-            res = self.session.http.get(key.uri, exception=StreamError,
+        key_uri = self.key_uri_override if self.key_uri_override else key.uri
+
+        if self.key_uri != key_uri:
+            res = self.session.http.get(key_uri, exception=StreamError,
                                         retries=self.retries,
                                         **self.reader.request_params)
             self.key_data = res.content
-            self.key_uri = key.uri
+            self.key_uri = key_uri
 
         iv = key.iv or num_to_iv(sequence)
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -68,6 +68,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
             res = self.session.http.get(key_uri, exception=StreamError,
                                         retries=self.retries,
                                         **self.reader.request_params)
+            res.encoding = "binary/octet-stream"
             self.key_data = res.content
             self.key_uri = key_uri
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -738,6 +738,18 @@ def build_parser():
         """
     )
     transport.add_argument(
+        "--hls-segment-key-uri",
+        metavar=str,
+        help="""
+        URI to segment encryption key. If none is specified, the URI contained
+        in the segments will be used.
+
+        Example: --hls-segment-key-uri "https://example.com/hls/encryption_key"
+
+        Default is None.
+        """
+    )
+    transport.add_argument(
         "--hls-audio-select",
         type=comma_list,
         metavar="CODE",

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -739,9 +739,10 @@ def build_parser():
     )
     transport.add_argument(
         "--hls-segment-key-uri",
-        metavar=str,
+        metavar="URI",
+        type=str,
         help="""
-        URI to segment encryption key. If none is specified, the URI contained
+        URI to segment encryption key. If no URI is specified, the URI contained
         in the segments will be used.
 
         Example: --hls-segment-key-uri "https://example.com/hls/encryption_key"

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -777,6 +777,9 @@ def setup_options():
     if args.hls_segment_ignore_names:
         streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
 
+    if args.hls_segment_key_uri:
+        streamlink.set_option("hls-segment-key-uri", args.hls_segment_key_uri)
+
     if args.hls_timeout:
         streamlink.set_option("hls-timeout", args.hls_timeout)
 


### PR DESCRIPTION
This pull request adds the "--hls-segment-key-uri \<URI\>" CLI flag which allows you to override the URI used to retrieve HLS segment keys.

I also force requests to parse the key response body as `binary/octet-stream` as per the HLS spec. Not having this was actually giving me issues.