### PR TITLE
Use mpv as default player

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![TravisCI build status][travisci-build-status-badge]][travisci-build-status]
 [![codecov.io][codecov-coverage-badge]][codecov-coverage] [![Backers on Open Collective][opencollective-backers-badge]](#backers) [![Sponsors on Open Collective][opencollective-sponsors-badge]](#sponsors)
 
-Streamlink is a CLI utility that pipes flash videos from online streaming services to a variety of video players such as VLC.
+Streamlink is a CLI utility that pipes flash videos from online streaming services to a variety of video players such as mpv.
 
 The main purpose of streamlink is to convert CPU-heavy flash plugins to a less CPU-intensive format.
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -13,7 +13,7 @@ and if you're on Linux or BSD you probably already know the drill.
 
 The way Streamlink works is that it's only a means to extract and transport
 the streams, and the playback is done by an external video player. Streamlink
-works best with `VLC`_ or `mpv`_, which are also cross-platform, but other players
+works best with `mpv`_ or `VLC`_, which are also cross-platform, but other players
 may be compatible too, see the :ref:`Players` page for a complete overview.
 
 Now to get into actually using Streamlink, let's say you want to watch the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@ Overview
 --------
 
 Streamlink is a :ref:`command-line utility <cli>` that pipes video streams
-from various services into a video player, such as `VLC`_.
+from various services into a video player, such as `mpv`_.
 The main purpose of Streamlink is to allow the user to avoid buggy and CPU
 heavy flash plugins but still be able to enjoy various streamed content.
 There is also an :ref:`API <api_guide>` available for developers who want access
@@ -36,7 +36,7 @@ Quickstart
 ----------
 
 The default behaviour of Streamlink is to playback a stream in the default
-player (`VLC <https://www.videolan.org/>`_).
+player (`mpv <https://mpv.io/>`_).
 
 .. sourcecode:: console
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -258,23 +258,23 @@ def build_parser():
         metavar="COMMAND",
         default=find_default_player(),
         help="""
-        Player to feed stream data to. By default, VLC will be used if it can be
+        Player to feed stream data to. By default, MPV will be used if it can be
         found in its default location.
 
         This is a shell-like syntax to support using a specific player:
 
-          %(prog)s --player=vlc <url> [stream]
+          %(prog)s --player=mpv <url> [stream]
 
         Absolute or relative paths can also be passed via this option in the
         event the player's executable can not be resolved:
 
-          %(prog)s --player=/path/to/vlc <url> [stream]
-          %(prog)s --player=./vlc-player/vlc <url> [stream]
+          %(prog)s --player=/path/to/mpv <url> [stream]
+          %(prog)s --player=./mpv <url> [stream]
 
         To use a player that is located in a path with spaces you must quote the
         parameter or its value:
 
-          %(prog)s "--player=/path/with spaces/vlc" <url> [stream]
+          %(prog)s "--player=/path/with spaces/mpv" <url> [stream]
           %(prog)s --player "C:\\path\\with spaces\\mpc-hc64.exe" <url> [stream]
 
         Options may also be passed to the player. For example:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -92,7 +92,7 @@ def create_output(plugin):
         http = namedpipe = None
 
         if not args.player:
-            console.exit("The default player (VLC) does not seem to be "
+            console.exit("The default player (mpv) does not seem to be "
                          "installed. You must specify the path to a player "
                          "executable with --player.")
 

--- a/src/streamlink_cli/utils/player.py
+++ b/src/streamlink_cli/utils/player.py
@@ -15,23 +15,23 @@ def check_paths(exes, paths):
 def find_default_player():
     if "darwin" in sys.platform:
         paths = os.environ.get("PATH", "").split(":")
-        paths += ["/Applications/VLC.app/Contents/MacOS/"]
-        paths += ["~/Applications/VLC.app/Contents/MacOS/"]
-        path = check_paths(("VLC", "vlc"), paths)
+        paths += ["/Applications/MPV.app/Contents/MacOS/"]
+        paths += ["~/Applications/MPV.app/Contents/MacOS/"]
+        path = check_paths(("MPV", "mpv"), paths)
     elif "win32" in sys.platform:
-        exename = "vlc.exe"
+        exename = "mpv.exe"
         paths = os.environ.get("PATH", "").split(";")
         path = check_paths((exename,), paths)
 
         if not path:
-            subpath = "VideoLAN\\VLC\\"
+            subpath = "mpv-x86_64\\mpv\\"
             envvars = ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432")
             paths = filter(None, (os.environ.get(var) for var in envvars))
             paths = (os.path.join(p, subpath) for p in paths)
             path = check_paths((exename,), paths)
     else:
         paths = os.environ.get("PATH", "").split(":")
-        path = check_paths(("vlc",), paths)
+        path = check_paths(("mpv",), paths)
 
     if path:
         # Quote command because it can contain space

--- a/src/streamlink_cli/utils/player.py
+++ b/src/streamlink_cli/utils/player.py
@@ -15,8 +15,8 @@ def check_paths(exes, paths):
 def find_default_player():
     if "darwin" in sys.platform:
         paths = os.environ.get("PATH", "").split(":")
-        paths += ["/Applications/MPV.app/Contents/MacOS/"]
-        paths += ["~/Applications/MPV.app/Contents/MacOS/"]
+        paths += ["/Applications/mpv.app/Contents/MacOS/"]
+        paths += ["~/Applications/mpv.app/Contents/MacOS/"]
         path = check_paths(("MPV", "mpv"), paths)
     elif "win32" in sys.platform:
         exename = "mpv.exe"

--- a/src/streamlink_cli/utils/player.py
+++ b/src/streamlink_cli/utils/player.py
@@ -24,7 +24,7 @@ def find_default_player():
         path = check_paths((exename,), paths)
 
         if not path:
-            subpath = "mpv-x86_64\\mpv\\"
+            subpath = "mpv-x86_64\\"
             envvars = ("PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432")
             paths = filter(None, (os.environ.get(var) for var in envvars))
             paths = (os.path.join(p, subpath) for p in paths)

--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -1,7 +1,7 @@
 # Format is option=value. Lines starting with a # is considered comments
 # and are ignored.
 
-# By default streamlink will attempt to locate MPV on your system
+# By default streamlink will attempt to locate mpv on your system
 # and use that, but you can also specify the location of a player
 # yourself.
 

--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -1,7 +1,7 @@
 # Format is option=value. Lines starting with a # is considered comments
 # and are ignored.
 
-# By default streamlink will attempt to locate VLC on your system
+# By default streamlink will attempt to locate MPV on your system
 # and use that, but you can also specify the location of a player
 # yourself.
 
@@ -9,7 +9,12 @@
 # is because the player command is parsed like a shell command to allow
 # parameters to be passed to the player.
 
-# Here is a few examples of players:
+# Here are a few examples of players:
+
+# mpv
+
+#player="C:\Program Files (x86)\mpv-x86_64\mpv.exe"
+#player="C:\Program Files\mpv-x86_64\mpv.exe"
 
 # VLC
 #player="C:\Program Files (x86)\VideoLAN\VLC\vlc.exe"


### PR DESCRIPTION
VLC has been pretty bad the past few releases for compatibility (generating a lot of issues) as well as functionality wise where as mpv has continued working without issue. I'm proposing that we swap over to mpv for the default player going forward.

Edit: This should not simply be merged without review and significant discussion as it would only be able to go into 1.0 as it's a breaking change. I'm not 100% sure on the mac paths but I believe these should be okay (I don't have a mac currently to test it on a live system).