### PR TITLE
plugins.cdnbg: Update for extra channels

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -39,8 +39,12 @@ btv                     btv.bg               Yes   No    Requires login, and geo
 canalplus               mycanal.fr           No    Yes   Streams may be geo-restricted to France.
 cdnbg                   - tv.bnt.bg          Yes   No    Streams may be geo-restricted to Bulgaria.
                         - bgonair.bg
-                        - kanal3.bg
                         - bitelevision.com
+                        - bloombergtv.bg
+                        - inlife.bg
+                        - kanal3.bg
+                        - mmtvmusic.com
+                        - mu-vi.tv
                         - nova.bg
 ceskatelevize           ceskatelevize.cz     Yes   Yes   Streams may be geo-restricted to Czechia.
 cinergroup              - showtv.com.tr      Yes   No

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -1,5 +1,4 @@
-from __future__ import print_function
-
+import logging
 import re
 
 from streamlink.compat import urlparse
@@ -8,6 +7,8 @@ from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
+
+log = logging.getLogger(__name__)
 
 
 class CDNBG(Plugin):
@@ -19,10 +20,13 @@ class CDNBG(Plugin):
             kanal3\.bg/live|
             bgonair\.bg/tvonline|
             tvevropa\.com/na-zhivo|
+            inlife\.bg|
+            mmtvmusic\.com/live|
+            mu-vi\.tv/LiveStreams/pages/Live\.aspx|
             bloombergtv.bg/video
         )/?
     """, re.VERBOSE)
-    iframe_re = re.compile(r"iframe .*?src=\"((?:https?:)?//(?:\w+\.)?cdn.bg/live[^\"]+)\"", re.DOTALL)
+    iframe_re = re.compile(r"iframe .*?src=\"((?:https?(?::|&#58;))?//(?:\w+\.)?cdn.bg/live[^\"]+)\"", re.DOTALL)
     sdata_re = re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>http.*?)(?P=q)")
     hls_file_re = re.compile(r"(src|file): (?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)")
     hls_src_re = re.compile(r"video src=(?P<url>http[^ ]+m3u8[^ ]*)")
@@ -43,23 +47,25 @@ class CDNBG(Plugin):
         p = urlparse(self.url)
         for url in self.iframe_re.findall(res.text):
             if "googletagmanager" not in url:
+                url = url.replace("&#58;", ":")
                 if url.startswith("//"):
                     return "{0}:{1}".format(p.scheme, url)
                 else:
                     return url
 
     def _get_streams(self):
-        self.session.http.headers = {"User-Agent": useragents.CHROME}
+        self.session.http.headers.update({"User-Agent": useragents.CHROME})
         res = self.session.http.get(self.url)
         iframe_url = self.find_iframe(res)
 
         if iframe_url:
-            self.logger.debug("Found iframe: {0}", iframe_url)
+            log.debug("Found iframe: {0}", iframe_url)
             res = self.session.http.get(iframe_url, headers={"Referer": self.url})
             stream_url = update_scheme(self.url, self.stream_schema.validate(res.text))
+            log.warning("SSL Verification disabled.")
             return HLSStream.parse_variant_playlist(self.session,
                                                     stream_url,
-                                                    headers={"User-Agent": useragents.CHROME})
+                                                    verify=False)
 
 
 __plugin__ = CDNBG

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -19,7 +19,6 @@ class CDNBG(Plugin):
             nova\.bg/live|
             kanal3\.bg/live|
             bgonair\.bg/tvonline|
-            tvevropa\.com/na-zhivo|
             inlife\.bg|
             mmtvmusic\.com/live|
             mu-vi\.tv/LiveStreams/pages/Live\.aspx|

--- a/tests/plugins/test_cdnbg.py
+++ b/tests/plugins/test_cdnbg.py
@@ -22,7 +22,9 @@ class TestPluginCDNBG(unittest.TestCase):
         self.assertTrue(CDNBG.can_handle_url("http://inlife.bg/"))
         self.assertTrue(CDNBG.can_handle_url("https://mmtvmusic.com/live/"))
         self.assertTrue(CDNBG.can_handle_url("http://mu-vi.tv/LiveStreams/pages/Live.aspx"))
+        self.assertTrue(CDNBG.can_handle_url("https://www.bloombergtv.bg/video"))
 
         # shouldn't match
         self.assertFalse(CDNBG.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(CDNBG.can_handle_url("http://www.youtube.com/"))
+        self.assertFalse(CDNBG.can_handle_url("https://www.tvevropa.com"))

--- a/tests/plugins/test_cdnbg.py
+++ b/tests/plugins/test_cdnbg.py
@@ -19,6 +19,9 @@ class TestPluginCDNBG(unittest.TestCase):
         self.assertTrue(CDNBG.can_handle_url("http://tv.bnt.bg/bnt1/16x9"))
         self.assertTrue(CDNBG.can_handle_url("http://tv.bnt.bg/bnt2/16x9/"))
         self.assertTrue(CDNBG.can_handle_url("http://tv.bnt.bg/bnt2/16x9"))
+        self.assertTrue(CDNBG.can_handle_url("http://inlife.bg/"))
+        self.assertTrue(CDNBG.can_handle_url("https://mmtvmusic.com/live/"))
+        self.assertTrue(CDNBG.can_handle_url("http://mu-vi.tv/LiveStreams/pages/Live.aspx"))
 
         # shouldn't match
         self.assertFalse(CDNBG.can_handle_url("http://www.tvcatchup.com/"))


### PR DESCRIPTION
- http://inlife.bg/
- https://mmtvmusic.com/live/
- http://mu-vi.tv/LiveStreams/pages/Live.aspx

---

- use python logging
- removed SSL Verification for Stream URLs
- find iframes with `&#58;` instead of `:`

closes https://github.com/streamlink/streamlink/issues/1392