### PR TITLE
travis-ci: Fixed Python 3.8 error's

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -96,7 +96,10 @@ root.setLevel(logging.WARNING)
 
 class StringFormatter(logging.Formatter):
     def __init__(self, fmt, datefmt=None, style='%', remove_base=None):
-        super(StringFormatter, self).__init__(fmt, datefmt=datefmt)
+        if is_py2:
+            super(StringFormatter, self).__init__(fmt, datefmt=datefmt)
+        else:
+            super(StringFormatter, self).__init__(fmt, datefmt=datefmt, style=style)
         if style not in ("{", "%"):
             raise ValueError("Only {} and % formatting styles are supported")
         self.style = style

--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -7,9 +7,9 @@ from ...utils import parse_qsd as parse_query, parse_json, parse_xml
 __all__ = ["parse_json", "parse_xml", "parse_query"]
 
 
-tag_re = re.compile('''(?=<(?P<tag>[a-zA-Z]+)(?P<attr>.*?)(?P<end>/)?>(?:(?P<inner>.*?)</\s*(?P=tag)\s*>)?)''',
+tag_re = re.compile(r'''(?=<(?P<tag>[a-zA-Z]+)(?P<attr>.*?)(?P<end>/)?>(?:(?P<inner>.*?)</\s*(?P=tag)\s*>)?)''',
                     re.MULTILINE | re.DOTALL)
-attr_re = re.compile('''\s*(?P<key>[\w-]+)\s*(?:=\s*(?P<quote>["']?)(?P<value>.*?)(?P=quote)\s*)?''')
+attr_re = re.compile(r'''\s*(?P<key>[\w-]+)\s*(?:=\s*(?P<quote>["']?)(?P<value>.*?)(?P=quote)\s*)?''')
 Tag = namedtuple("Tag", "tag attributes text")
 
 
@@ -26,4 +26,3 @@ def itertags(html, tag):
         if match.group("tag") == tag:
             attrs = dict((a.group("key").lower(), a.group("value")) for a in attr_re.finditer(match.group("attr")))
             yield Tag(match.group("tag"), attrs, match.group("inner"))
-

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -82,7 +82,7 @@ class HDSStreamWriter(SegmentedStreamWriter):
                                          **request_params)
         except StreamError as err:
             log.error("Failed to open fragment {0}-{1}: {2}",
-                              fragment.segment, fragment.fragment, err)
+                      fragment.segment, fragment.fragment, err)
             return self.fetch(fragment, retries - 1)
 
     def write(self, fragment, res, chunk_size=8192):
@@ -100,12 +100,12 @@ class HDSStreamWriter(SegmentedStreamWriter):
                     break
         except F4VError as err:
             log.error("Failed to parse fragment {0}-{1}: {2}",
-                              fragment.segment, fragment.fragment, err)
+                      fragment.segment, fragment.fragment, err)
             return
 
         if not mdat:
             log.error("No MDAT box found in fragment {0}-{1}",
-                              fragment.segment, fragment.fragment)
+                      fragment.segment, fragment.fragment)
             return
 
         try:
@@ -116,16 +116,16 @@ class HDSStreamWriter(SegmentedStreamWriter):
                     break
             else:
                 log.debug("Download of fragment {0}-{1} complete",
-                                  fragment.segment, fragment.fragment)
+                          fragment.segment, fragment.fragment)
         except IOError as err:
             if "Unknown tag type" in str(err):
                 log.error("Unknown tag type found, this stream is "
-                                  "probably encrypted")
+                          "probably encrypted")
                 self.close()
                 return
 
             log.error("Error reading fragment {0}-{1}: {2}",
-                              fragment.segment, fragment.fragment, err)
+                      fragment.segment, fragment.fragment, err)
 
 
 class HDSStreamWorker(SegmentedStreamWorker):
@@ -182,7 +182,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
                                        current_fragment - (fragment_buffer - 1))
 
                 log.debug("Live edge buffer {0} sec is {1} fragments",
-                                  self.live_edge, fragment_buffer)
+                          self.live_edge, fragment_buffer)
 
                 # Make sure we don't have a duration set when it's a
                 # live stream since it will just confuse players anyway.
@@ -327,7 +327,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
                                     fragment_duration, fragment_url)
 
                 log.debug("Adding fragment {0}-{1} to queue",
-                                  fragment.segment, fragment.fragment)
+                          fragment.segment, fragment.fragment)
                 yield fragment
 
                 # End of stream
@@ -556,7 +556,7 @@ class HDSStream(Stream):
                     # manifest but not the child one.
                     bitrate = media.attrib.get("bitrate")
 
-                    if bitrate and not re.match("^(\d+)k$", name):
+                    if bitrate and not re.match(r"^(\d+)k$", name):
                         name = bitrate + "k"
 
                     streams[name] = stream

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -89,7 +89,7 @@ class TestPluginAPIValidate(unittest.TestCase):
         assert validate(get("invalidkey", "default"), {"key": "value"}) == "default"
 
     def test_get_re(self):
-        m = re.match("(\d+)p", "720p")
+        m = re.match(r"(\d+)p", "720p")
         assert validate(get(1), m) == "720"
 
     def test_getattr(self):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,6 +7,7 @@ import unittest
 
 import streamlink.plugins
 from streamlink import Streamlink
+from streamlink.utils import load_module
 
 
 class PluginTestMeta(type):
@@ -14,8 +15,7 @@ class PluginTestMeta(type):
         plugin_path = os.path.dirname(streamlink.plugins.__file__)
         plugins = []
         for loader, pname, ispkg in pkgutil.iter_modules([plugin_path]):
-            file, pathname, desc = imp.find_module(pname, [plugin_path])
-            module = imp.load_module(pname, file, pathname, desc)
+            module = load_module(pname, plugin_path)
             if hasattr(module, "__plugin__"):
                 plugins.append((pname))
 


### PR DESCRIPTION
- **logger**: `ValueError: Invalid format '[{name}][{levelname}] {message}'  for '%' style`
- **api/utils**: `SyntaxWarning: invalid escape sequence`
- **hds**: `SyntaxWarning: invalid escape sequence` and `Flake8 E127`
- **test_api_validate**: `SyntaxWarning: invalid escape sequence`
- **test_plugins**: `ResourceWarning: unclosed file`