### PR TITLE
Fix subprocess argument debug log on Windows

### DIFF
--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -207,7 +207,7 @@ class PlayerOutput(Output):
 
     def _open_call(self):
         args = self._create_arguments()
-        log.debug(u"Calling: {0}".format(subprocess.list2cmdline(args)))
+        log.debug(u"Calling: {0}".format(args))
         subprocess.call(args,
                         stdout=self.stdout,
                         stderr=self.stderr)
@@ -216,7 +216,7 @@ class PlayerOutput(Output):
         # Force bufsize=0 on all Python versions to avoid writing the
         # unflushed buffer when closing a broken input pipe
         args = self._create_arguments()
-        log.debug(u"Opening subprocess: {0}".format(subprocess.list2cmdline(args)))
+        log.debug(u"Opening subprocess: {0}".format(args))
         self.player = subprocess.Popen(args,
                                        stdin=self.stdin, bufsize=0,
                                        stdout=self.stdout,

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -208,9 +208,10 @@ class PlayerOutput(Output):
     def _open_call(self):
         args = self._create_arguments()
         if is_win32:
-            log.debug(u"Calling: {0}".format(args))
+            fargs = args
         else:
-            log.debug(u"Calling: {0}".format(subprocess.list2cmdline(args)))
+            fargs = subprocess.list2cmdline(args)
+        log.debug(u"Calling: {0}".format(fargs))
         subprocess.call(args,
                         stdout=self.stdout,
                         stderr=self.stderr)
@@ -220,9 +221,10 @@ class PlayerOutput(Output):
         # unflushed buffer when closing a broken input pipe
         args = self._create_arguments()
         if is_win32:
-            log.debug(u"Opening subprocess: {0}".format(args))
+            fargs = args
         else:
-            log.debug(u"Opening subprocess: {0}".format(subprocess.list2cmdline(args)))
+            fargs = subprocess.list2cmdline(args)
+        log.debug(u"Opening subprocess: {0}".format(fargs))
         self.player = subprocess.Popen(args,
                                        stdin=self.stdin, bufsize=0,
                                        stdout=self.stdout,

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -207,7 +207,10 @@ class PlayerOutput(Output):
 
     def _open_call(self):
         args = self._create_arguments()
-        log.debug(u"Calling: {0}".format(args))
+        if is_win32:
+            log.debug(u"Calling: {0}".format(args))
+        else:
+            log.debug(u"Calling: {0}".format(subprocess.list2cmdline(args)))
         subprocess.call(args,
                         stdout=self.stdout,
                         stderr=self.stderr)
@@ -216,7 +219,10 @@ class PlayerOutput(Output):
         # Force bufsize=0 on all Python versions to avoid writing the
         # unflushed buffer when closing a broken input pipe
         args = self._create_arguments()
-        log.debug(u"Opening subprocess: {0}".format(args))
+        if is_win32:
+            log.debug(u"Opening subprocess: {0}".format(args))
+        else:
+            log.debug(u"Opening subprocess: {0}".format(subprocess.list2cmdline(args)))
         self.player = subprocess.Popen(args,
                                        stdin=self.stdin, bufsize=0,
                                        stdout=self.stdout,


### PR DESCRIPTION
Due to #1576, `args` are `string` on Windows but `list` on other OS.

https://github.com/streamlink/streamlink/blob/94a8a7301c45dfdee89dd7d4d14043438dda4b38/src/streamlink_cli/output.py#L188-L194

A later debug call then converts `string` into space-separated characters.
https://github.com/streamlink/streamlink/blob/94a8a7301c45dfdee89dd7d4d14043438dda4b38/src/streamlink_cli/output.py#L209-L210