### PR TITLE
Add window title to PotPlayer

### DIFF
--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -13,7 +13,8 @@ DEFAULT_STREAM_METADATA = {
 SUPPORTED_PLAYERS = {  # these are the players that streamlink knows how to set the window title for with `--title`. key names are used in help text
     # name: possible binary names (linux/mac and windows)
     "vlc": ["vlc", "vlc.exe"],
-    "mpv": ["mpv", "mpv.exe"]
+    "mpv": ["mpv", "mpv.exe"],
+    "pot": ["potplayer", "potplayermini64.exe", "potplayermini.exe"]
 }
 
 if is_win32:

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -14,7 +14,7 @@ SUPPORTED_PLAYERS = {  # these are the players that streamlink knows how to set 
     # name: possible binary names (linux/mac and windows)
     "vlc": ["vlc", "vlc.exe"],
     "mpv": ["mpv", "mpv.exe"],
-    "potplayer": ["potplayermini64.exe", "potplayermini.exe"]
+    "potplayer": ["potplayer", "potplayermini64.exe", "potplayermini.exe"]
 }
 
 if is_win32:

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -14,7 +14,7 @@ SUPPORTED_PLAYERS = {  # these are the players that streamlink knows how to set 
     # name: possible binary names (linux/mac and windows)
     "vlc": ["vlc", "vlc.exe"],
     "mpv": ["mpv", "mpv.exe"],
-    "pot": ["potplayer", "potplayermini64.exe", "potplayermini.exe"]
+    "potplayer": ["potplayermini64.exe", "potplayermini.exe"]
 }
 
 if is_win32:

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -188,10 +188,8 @@ class PlayerOutput(Output):
                 if filename != "-":
                     # PotPlayer - About - Command Line
                     # You can specify titles for URLs by separating them with a backslash (\) at the end of URLs. ("http://...\title of this url")
-                    title = self.title
-                    if len(self.title) > 1 and self.title.startswith('"') and self.title.endswith('"'):
-                        title = self.title[1:-1]
-                    filename = filename[:-1] + '\\' + title + filename[-1]
+                    self.title = self.title.replace('"', '')
+                    filename = filename[:-1] + '\\' + self.title + filename[-1]
 
         args = self.args.format(filename=filename)
         cmd = self.cmd

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -168,8 +168,6 @@ class PlayerOutput(Output):
             filename = self.http.url
         else:
             filename = "-"
-        args = self.args.format(filename=filename)
-        cmd = self.cmd
         extra_args = []
 
         if self.title is not None:
@@ -185,6 +183,16 @@ class PlayerOutput(Output):
                 self.title = self._mpv_title_escape(self.title)
                 extra_args.extend(["--title", self.title])
 
+            # potplayer
+            if self.player_name == "pot":
+                if filename != "-":
+                    # PotPlayer - About - Command Line
+                    # You can specify titles for URLs by separating them with a backslash (\) at the end of URLs. ("http://...\title of this url")
+                    filename = filename[:-1] + '\\' + self.title + filename[-1]
+
+        args = self.args.format(filename=filename)
+        cmd = self.cmd
+        
         # player command
         if is_win32:
             eargs = maybe_decode(subprocess.list2cmdline(extra_args))

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -184,7 +184,7 @@ class PlayerOutput(Output):
                 extra_args.extend(["--title", self.title])
 
             # potplayer
-            if self.player_name == "pot":
+            if self.player_name == "potplayer":
                 if filename != "-":
                     # PotPlayer - About - Command Line
                     # You can specify titles for URLs by separating them with a backslash (\) at the end of URLs. ("http://...\title of this url")

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -188,7 +188,10 @@ class PlayerOutput(Output):
                 if filename != "-":
                     # PotPlayer - About - Command Line
                     # You can specify titles for URLs by separating them with a backslash (\) at the end of URLs. ("http://...\title of this url")
-                    filename = filename[:-1] + '\\' + self.title + filename[-1]
+                    title = self.title
+                    if len(self.title) > 1 and self.title.startswith('"') and self.title.endswith('"'):
+                        title = self.title[1:-1]
+                    filename = filename[:-1] + '\\' + title + filename[-1]
 
         args = self.args.format(filename=filename)
         cmd = self.cmd

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -52,3 +52,9 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
     def test_open_player_with_default_arg_vlc(self):
         self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe --argh", "http://test.se", "test"],
                         "c:\\Program Files\\VideoLAN\\vlc.exe --argh --input-title-format http://test.se -")
+
+
+    def test_open_player_with_title_pot(self):
+        self._test_args(["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"", 
+                        "--title", "{title}", "http://test.se/stream", "hls", "--player-passthrough", "hls"],
+                        "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \"http://test.se/playlist.m3u8\\Test Title\"", passthrough=True)

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -53,8 +53,29 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
         self._test_args(["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe --argh", "http://test.se", "test"],
                         "c:\\Program Files\\VideoLAN\\vlc.exe --argh --input-title-format http://test.se -")
 
-
+    # PotPlayer
     def test_open_player_with_title_pot(self):
         self._test_args(["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"", 
                         "--title", "{title}", "http://test.se/stream", "hls", "--player-passthrough", "hls"],
-                        "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \"http://test.se/playlist.m3u8\\Test Title\"", passthrough=True)
+                        "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \"http://test.se/playlist.m3u8\\Test Title\"", 
+                        passthrough=True)
+
+    @unittest.skipIf(is_py3, "Encoding is different in Python 2")
+    def test_open_player_with_unicode_author_pot_py2(self):
+        self._test_args(["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"", 
+                        "--title", "{author}", "http://test.se/stream", "hls", "--player-passthrough", "hls"],
+                        "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \"http://test.se/playlist.m3u8\\" + u"Tѥst Āuƭhǿr".encode(get_filesystem_encoding()) + "\"", 
+                        passthrough=True)
+
+    @unittest.skipIf(not is_py3, "Encoding is different in Python 2")
+    def test_open_player_with_unicode_author_pot_py3(self):
+        self._test_args(["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"", 
+                        "--title", "{author}", "http://test.se/stream", "hls", "--player-passthrough", "hls"],
+                        u"\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \"http://test.se/playlist.m3u8\\Tѥst Āuƭhǿr\"", 
+                        passthrough=True)
+
+    def test_open_player_with_default_title_pot(self):
+        self._test_args(["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"", 
+                        "http://test.se/stream", "hls", "--player-passthrough", "hls"],
+                        "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" \"http://test.se/playlist.m3u8\\http://test.se/stream\"", 
+                        passthrough=True)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -14,8 +14,8 @@ class TestPlayerOutput(unittest.TestCase):
         self.assertEqual("mpv",
                          PlayerOutput.supported_player("mpv"))
 
-        self.assertEqual("pot",
-                         PlayerOutput.supported_player("potplayer"))
+        self.assertEqual("potplayer",
+                         PlayerOutput.supported_player("potplayermini.exe"))
 
     @patch("streamlink_cli.output.os.path.basename", new=ntpath.basename)
     def test_supported_player_win32(self):
@@ -23,7 +23,7 @@ class TestPlayerOutput(unittest.TestCase):
                          PlayerOutput.supported_player("C:\\MPV\\mpv.exe"))
         self.assertEqual("vlc",
                          PlayerOutput.supported_player("C:\\VLC\\vlc.exe"))
-        self.assertEqual("pot",
+        self.assertEqual("potplayer",
                          PlayerOutput.supported_player("C:\\PotPlayer\\PotPlayerMini64.exe"))
 
     @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)
@@ -39,7 +39,7 @@ class TestPlayerOutput(unittest.TestCase):
                          PlayerOutput.supported_player("C:\\MPV\\mpv.exe --argh"))
         self.assertEqual("vlc",
                          PlayerOutput.supported_player("C:\\VLC\\vlc.exe --argh"))
-        self.assertEqual("pot",
+        self.assertEqual("potplayer",
                          PlayerOutput.supported_player("C:\\PotPlayer\\PotPlayerMini64.exe --argh"))
 
     @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -63,7 +63,7 @@ class TestPlayerOutput(unittest.TestCase):
         self.assertEqual(None,
                          PlayerOutput.supported_player("C:\\mplayer\\not-vlc.exe"))
         self.assertEqual(None,
-                         PlayerOutput.supported_player("C:\\PotPlayer\\NotPlayerMini64.exe"))
+                         PlayerOutput.supported_player("C:\\NotPlayer\\NotPlayerMini64.exe"))
 
     def test_open_player_with_title_mpv_escape_1(self):
         self.assertEqual(PlayerOutput._mpv_title_escape("no escape $$ codes $"),

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -14,12 +14,17 @@ class TestPlayerOutput(unittest.TestCase):
         self.assertEqual("mpv",
                          PlayerOutput.supported_player("mpv"))
 
+        self.assertEqual("pot",
+                         PlayerOutput.supported_player("potplayer"))
+
     @patch("streamlink_cli.output.os.path.basename", new=ntpath.basename)
     def test_supported_player_win32(self):
         self.assertEqual("mpv",
                          PlayerOutput.supported_player("C:\\MPV\\mpv.exe"))
         self.assertEqual("vlc",
                          PlayerOutput.supported_player("C:\\VLC\\vlc.exe"))
+        self.assertEqual("pot",
+                         PlayerOutput.supported_player("C:\\PotPlayer\\PotPlayerMini64.exe"))
 
     @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)
     def test_supported_player_posix(self):
@@ -34,6 +39,8 @@ class TestPlayerOutput(unittest.TestCase):
                          PlayerOutput.supported_player("C:\\MPV\\mpv.exe --argh"))
         self.assertEqual("vlc",
                          PlayerOutput.supported_player("C:\\VLC\\vlc.exe --argh"))
+        self.assertEqual("pot",
+                         PlayerOutput.supported_player("C:\\PotPlayer\\PotPlayerMini64.exe --argh"))
 
     @patch("streamlink_cli.output.os.path.basename", new=posixpath.basename)
     def test_supported_player_args_posix(self):
@@ -55,6 +62,8 @@ class TestPlayerOutput(unittest.TestCase):
                          PlayerOutput.supported_player("C:\\mpc\\mpc-hd.exe"))
         self.assertEqual(None,
                          PlayerOutput.supported_player("C:\\mplayer\\not-vlc.exe"))
+        self.assertEqual(None,
+                         PlayerOutput.supported_player("C:\\PotPlayer\\NotPlayerMini64.exe"))
 
     def test_open_player_with_title_mpv_escape_1(self):
         self.assertEqual(PlayerOutput._mpv_title_escape("no escape $$ codes $"),


### PR DESCRIPTION
After #1576 we can add window title support to other players.

Due to limitations of PotPlayer, titles can only be added to URL streams and there is no separate title argument.
PotPlayer command line documentation in `PotPlayer - About - Command Line`:
- You can specify titles for URLs by separating them with a backslash (\\) at the end of URLs. ("http://...\title of this url")

Because of this, the title needs to be appended at the end of the filename so args need to be formatted after player check.

Here's an example of it working on Windows 10:
![potplayer-title](https://user-images.githubusercontent.com/5807561/50576629-bdf4e480-0e26-11e9-9f21-2d3def2d9536.png)

