### PR TITLE
plugins.filmon: fix for live tv URLs that start with channel

### DIFF
--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -164,7 +164,7 @@ class Filmon(Plugin):
             |
             (?:tv/)channel/(?:export\?)?
             |
-            tv/(?!channel)
+            tv/(?!channel/)
             |
             channel/
             |

--- a/tests/plugins/test_filmon.py
+++ b/tests/plugins/test_filmon.py
@@ -10,24 +10,25 @@ class TestPluginFilmon(unittest.TestCase):
             'http://www.filmon.tv/index/popout?channel_id=5510&quality=low',
             'http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1',
             'http://www.filmon.tv/tv/channel/grandstand-show',
+            'http://www.filmon.tv/tv/channel-4',
             'https://www.filmon.com/tv/bbc-news',
             'https://www.filmon.tv/tv/55',
             'http://www.filmon.tv/vod/view/10250-0-crime-boss',
             'http://www.filmon.tv/group/comedy',
         ]
         for url in should_match:
-            self.assertTrue(Filmon.can_handle_url(url))
+            self.assertTrue(Filmon.can_handle_url(url), url)
 
     def test_can_handle_url_negative(self):
         should_not_match = [
             'https://example.com/index.html',
         ]
         for url in should_not_match:
-            self.assertFalse(Filmon.can_handle_url(url))
+            self.assertFalse(Filmon.can_handle_url(url), url)
 
     def _test_regex(self, url, expected):
         m = Filmon.url_re.match(url)
-        self.assertIsNotNone(m)
+        self.assertIsNotNone(m, url)
         # expected must return [is_group, channel, vod_id]
         self.assertEqual(expected, list(m.groups()))
 
@@ -50,6 +51,10 @@ class TestPluginFilmon(unittest.TestCase):
     def test_regex_live_stream_tv(self):
         self._test_regex('https://www.filmon.com/tv/bbc-news',
                          [None, 'bbc-news', None])
+
+    def test_regex_live_stream_tv_with_channel_in_name(self):
+        self._test_regex('https://www.filmon.com/tv/channel-4',
+                         [None, 'channel-4', None])
 
     def test_regex_live_stream_tv_number(self):
         self._test_regex('https://www.filmon.tv/tv/55',


### PR DESCRIPTION
If the live tv channel name started with `channel` (eg. `tv/channel-4`) it would not be matched because of the `tv/(?!channel)` rule in the regex. 

Fixes #2222. 