### PR TITLE
plugin.powerapp: support for "tvs" URLs

### DIFF
--- a/src/streamlink/plugins/powerapp.py
+++ b/src/streamlink/plugins/powerapp.py
@@ -7,7 +7,7 @@ from streamlink.stream import HLSStream
 
 
 class PowerApp(Plugin):
-    url_re = re.compile(r"https?://(?:www.)?powerapp.com.tr/tv/(\w+)")
+    url_re = re.compile(r"https?://(?:www.)?powerapp.com.tr/tvs?/(\w+)")
     api_url = "http://api.powergroup.com.tr/Channels/{0}/?appRef=iPowerWeb&apiVersion=11"
     api_schema = validate.Schema(validate.all({
         "errorCode": 0,

--- a/tests/plugins/test_powerapp.py
+++ b/tests/plugins/test_powerapp.py
@@ -9,9 +9,10 @@ class TestPluginPowerApp(unittest.TestCase):
             'http://powerapp.com.tr/tv/powertv4k',
             'http://powerapp.com.tr/tv/powerturktv4k',
             'http://powerapp.com.tr/tv/powerEarthTV',
+            'http://www.powerapp.com.tr/tvs/powertv'
         ]
         for url in should_match:
-            self.assertTrue(PowerApp.can_handle_url(url))
+            self.assertTrue(PowerApp.can_handle_url(url), url)
 
     def test_can_handle_url_negative(self):
         should_not_match = [


### PR DESCRIPTION
Updated the url regex to support `tvs` URLs.

Fixes #2221.