### PR TITLE
setup: update requests to latest version and set urllib3 to match

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ deps = [
     'futures;python_version<"3.0"',
     # Require singledispatch on Python <3.4
     'singledispatch;python_version<"3.4"',
-    "requests>=2.2,!=2.12.0,!=2.12.1,!=2.16.0,!=2.16.1,!=2.16.2,!=2.16.3,!=2.16.4,!=2.16.5,!=2.17.1,<3.0",
-    'urllib3[secure]<1.23,>=1.21.1;python_version<"3.0"',
+    "requests>=2.21.0,<3.0",
+    'urllib3[secure]>=1.23;python_version<"3.0"',
     "isodate",
     "websocket-client",
     # Support for SOCKS proxies


### PR DESCRIPTION
Updated the versions due to the following issues

1. urllib3
   > Vulnerable versions: < 1.23
   > Patched version: 1.23
   > urllib3 before version 1.23 does not remove the Authorization HTTP header when following a cross-origin redirect (i.e., a redirect that differs in host, port, or scheme). This can allow for credentials in the Authorization header to be exposed to unintended hosts or transmitted in cleartext.
   https://nvd.nist.gov/vuln/detail/CVE-2018-20060
2. requests
   > Vulnerable versions: <= 2.19.1
   > Patched version: 2.20.0
   > The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.
   https://nvd.nist.gov/vuln/detail/CVE-2018-18074


Fixes #2219.