### PR TITLE
Add {url} argument to window --title

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -465,6 +465,9 @@ def build_parser():
             gaming oriented platforms. "Game being played" is a way to categorize
             the stream, so it doesn't need its own separate handling.
 
+        {{url}}
+            URL of the stream.
+
         Examples:
 
             %(prog)s -p vlc --title "{{title}} -!- {{author}} -!- {{category}} \\$A" <url> [stream]

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -152,7 +152,8 @@ def create_title(plugin=None):
             title=lambda: plugin.get_title() or DEFAULT_STREAM_METADATA["title"],
             author=lambda: plugin.get_author() or DEFAULT_STREAM_METADATA["author"],
             category=lambda: plugin.get_category() or DEFAULT_STREAM_METADATA["category"],
-            game=lambda: plugin.get_category() or DEFAULT_STREAM_METADATA["game"]
+            game=lambda: plugin.get_category() or DEFAULT_STREAM_METADATA["game"],
+            url=args.url
         )
     else:
         title = args.url

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -153,7 +153,7 @@ def create_title(plugin=None):
             author=lambda: plugin.get_author() or DEFAULT_STREAM_METADATA["author"],
             category=lambda: plugin.get_category() or DEFAULT_STREAM_METADATA["category"],
             game=lambda: plugin.get_category() or DEFAULT_STREAM_METADATA["game"],
-            url=args.url
+            url=plugin.url
         )
     else:
         title = args.url

--- a/tests/test_lazy_formatter.py
+++ b/tests/test_lazy_formatter.py
@@ -5,6 +5,8 @@ from streamlink.utils import LazyFormatter
 
 
 class TestLazyFormat(unittest.TestCase):
+    url = "url"
+
     def _get_fake_plugin(self):
         plugin = MagicMock()
         plugin.get_title.return_value = "title"
@@ -19,7 +21,8 @@ class TestLazyFormat(unittest.TestCase):
         res = LazyFormatter.format("{title}",
                                    title=plugin.get_title,
                                    author=plugin.get_author,
-                                   game=plugin.get_game)
+                                   game=plugin.get_game,
+                                   url=self.url)
 
         self.assertEqual("title", res)
 
@@ -33,7 +36,8 @@ class TestLazyFormat(unittest.TestCase):
         res = LazyFormatter.format("{title} - {author}",
                                    title=plugin.get_title,
                                    author=plugin.get_author,
-                                   game=plugin.get_game)
+                                   game=plugin.get_game,
+                                   url=self.url)
 
         self.assertEqual("title - author", res)
 
@@ -48,9 +52,25 @@ class TestLazyFormat(unittest.TestCase):
         res = LazyFormatter.format("{title} - {author} - {game}",
                                    title=plugin.get_title,
                                    author=plugin.get_author,
-                                   game=plugin.get_game)
+                                   game=plugin.get_game,
+                                   url=self.url)
 
         self.assertEqual("title - author - game", res)
+
+        plugin.get_title.assert_called()
+        plugin.get_author.assert_called()
+        plugin.get_game.assert_called()
+
+    def test_format_lazy_title_author_game_url(self):
+        plugin = self._get_fake_plugin()
+
+        res = LazyFormatter.format("{title} - {author} - {game} - {url}",
+                                   title=plugin.get_title,
+                                   author=plugin.get_author,
+                                   game=plugin.get_game,
+                                   url=self.url)
+
+        self.assertEqual("title - author - game - url", res)
 
         plugin.get_title.assert_called()
         plugin.get_author.assert_called()

--- a/tests/test_lazy_formatter.py
+++ b/tests/test_lazy_formatter.py
@@ -5,13 +5,12 @@ from streamlink.utils import LazyFormatter
 
 
 class TestLazyFormat(unittest.TestCase):
-    url = "url"
-
     def _get_fake_plugin(self):
         plugin = MagicMock()
         plugin.get_title.return_value = "title"
         plugin.get_author.return_value = "author"
         plugin.get_game.return_value = "game"
+        plugin.url = "url"
 
         return plugin
 
@@ -22,7 +21,7 @@ class TestLazyFormat(unittest.TestCase):
                                    title=plugin.get_title,
                                    author=plugin.get_author,
                                    game=plugin.get_game,
-                                   url=self.url)
+                                   url=plugin.url)
 
         self.assertEqual("title", res)
 
@@ -37,7 +36,7 @@ class TestLazyFormat(unittest.TestCase):
                                    title=plugin.get_title,
                                    author=plugin.get_author,
                                    game=plugin.get_game,
-                                   url=self.url)
+                                   url=plugin.url)
 
         self.assertEqual("title - author", res)
 
@@ -53,7 +52,7 @@ class TestLazyFormat(unittest.TestCase):
                                    title=plugin.get_title,
                                    author=plugin.get_author,
                                    game=plugin.get_game,
-                                   url=self.url)
+                                   url=plugin.url)
 
         self.assertEqual("title - author - game", res)
 
@@ -68,7 +67,7 @@ class TestLazyFormat(unittest.TestCase):
                                    title=plugin.get_title,
                                    author=plugin.get_author,
                                    game=plugin.get_game,
-                                   url=self.url)
+                                   url=plugin.url)
 
         self.assertEqual("title - author - game - url", res)
 


### PR DESCRIPTION
For #2225 
Adds `{url}` formatting variable to player window `--title`.

Can there be a situation where `args.url` doesn't exist?
If so, maybe I should add a `DEFAULT_STREAM_METADATA["url"]`?
https://github.com/streamlink/streamlink/blob/07387e22d567994f8fe7eaba79638e22cb2be24b/src/streamlink_cli/constants.py#L7-L12