### PR TITLE
CI: make sure all the dev dependencies are up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
 before_install:
   - pip install --disable-pip-version-check --upgrade pip setuptools
-  - pip install -r dev-requirements.txt
+  - pip install --upgrade -r dev-requirements.txt
   - pip install pycountry
   - if [[ $BUILD_DOCS == 'yes' ]]; then
       pip install -r docs-requirements.txt;


### PR DESCRIPTION
It seems like some environments ship with an old version of `pytest` that in now incompatible with the latest version of `pytest-cov`. This change should mean that all the packages are at the latest version. 