### PR TITLE
plugins.ustreamtv: handle stream names better, allow '_alt' streams

### DIFF
--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -390,7 +390,7 @@ class UStreamTV(Plugin):
                     res["streams"] = []
                     for stream in flv_segmented["streams"]:
                         res["streams"] += [dict(
-                            stream_name=stream["preset"],
+                            stream_name="{0}p".format(stream["videoCodec"]["height"]),
                             path=urljoin(path,
                                          stream["segmentUrl"].replace("%", "%s")),
                             hashes=flv_segmented["hashes"],
@@ -434,7 +434,6 @@ class UStreamTV(Plugin):
             api.connect()
 
             streams_data = {}
-            streams = {}
             for _ in range(5):
                 # do not use to many tries, it might take longer for a timeout
                 # when streamFormats is {} and contentAvailable is True
@@ -454,7 +453,7 @@ class UStreamTV(Plugin):
 
                 if streams_data.get("streams") and streams_data.get("cdn_url"):
                     for s in streams_data["streams"]:
-                        streams[s["stream_name"]] = UHSStream(
+                        yield s["stream_name"], UHSStream(
                             session=self.session,
                             api=api,
                             first_chunk_data=ChunkData(
@@ -465,7 +464,7 @@ class UStreamTV(Plugin):
                             template_url=urljoin(streams_data["cdn_url"],
                                                  s["path"]),
                         )
-                    return streams
+                    break
 
     def _get_media_app(self):
         umatch = self.url_re.match(self.url)

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -449,7 +449,7 @@ class UStreamTV(Plugin):
                         log.debug("Unexpected `{0}` command".format(data["cmd"]))
                         log.trace("{0!r}".format(data))
                 except ModuleInfoNoStreams:
-                    return None
+                    break
 
                 if streams_data.get("streams") and streams_data.get("cdn_url"):
                     for s in streams_data["streams"]:

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -266,11 +266,9 @@ class UHSStream(Stream):
             self.stopped.set()
 
         def run(self):
-            while not self.stopped.wait(0.25):
+            while not self.stopped.wait(0):
                 try:
                     cmd_args = self.api.recv()
-                    if cmd_args and cmd_args["cmd"] == "reject":
-                        sleep(2)
                 except (SocketError,
                         websocket._exceptions.WebSocketConnectionClosedException) as err:
                     cmd_args = None


### PR DESCRIPTION
`preset` might be a duplicate of `original` use `videoCodec height` instead.

```
{'segmentUrl': '2/4/chunk_%_%.flv', 'bitrate': 2561, 'preset': 'original', 'transcoded': False, 'videoCodec': {'height': 720}}
{'segmentUrl': '2/9/chunk_%_%.flv', 'bitrate': 2556, 'preset': 'original', 'transcoded': False, 'videoCodec': {'height': 720}}
{'segmentUrl': '5/4/chunk_%_%.flv', 'bitrate': 312, 'preset': 'original', 'transcoded': False, 'videoCodec': {'height': 486}}
{'segmentUrl': '5/9/chunk_%_%.flv', 'bitrate': 307, 'preset': 'original', 'transcoded': False, 'videoCodec': {'height': 486}}
{'segmentUrl': '8/4/chunk_%_%.flv', 'bitrate': 243, 'preset': '360p', 'transcoded': True, 'videoCodec': {'height': 360}}
{'segmentUrl': '8/9/chunk_%_%.flv', 'bitrate': 238, 'preset': '360p', 'transcoded': True, 'videoCodec': {'height': 360}}
{'segmentUrl': '6/4/chunk_%_%.flv', 'bitrate': 186, 'preset': 'original', 'transcoded': False, 'videoCodec': {'height': 252}}
{'segmentUrl': '6/9/chunk_%_%.flv', 'bitrate': 181, 'preset': 'original', 'transcoded': False, 'videoCodec': {'height': 252}}
```

before

```
$ streamlink https://www.ustream.tv/nasahdtv best -l info
[cli][info] Found matching plugin ustreamtv for URL https://www.ustream.tv/nasahdtv
[cli][info] Available streams: 360p (worst), original (best)
[cli][info] Opening stream: original (uhs)
```

after

```
$ streamlink https://www.ustream.tv/nasahdtv best -l info
[cli][info] Found matching plugin ustreamtv for URL https://www.ustream.tv/nasahdtv
[cli][info] Available streams: 252p_alt (worst), 252p, 360p_alt, 360p, 486p_alt, 486p, 720p_alt, 720p (best)
[cli][info] Opening stream: 720p (uhs)
```