### PR TITLE
plugins.tf1: update to support new DASH streams

### DIFF
--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -1,74 +1,43 @@
 from __future__ import print_function
+
+import logging
 import re
 
-from streamlink.compat import urlparse, parse_qsl
+from streamlink.compat import urljoin
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.stream import HDSStream
-from streamlink.stream import HLSStream
-from streamlink.utils.url import update_qsd
+from streamlink.stream import DASHStream
+
+log = logging.getLogger(__name__)
 
 
 class TF1(Plugin):
     url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/([\w-]+)/direct|(lci).fr/direct)/?")
-    embed_url = "http://www.wat.tv/embedframe/live{0}"
-    embed_re = re.compile(r"urlLive.*?:.*?\"(http.*?)\"", re.MULTILINE)
-    api_url = "http://www.wat.tv/get/{0}/591997"
-    swf_url = "http://www.wat.tv/images/v70/PlayerLite.swf"
-    hds_channel_remap = {"tf1": "androidliveconnect",
-                         "lci": "androidlivelci",
-                         "tfx": "nt1live",
-                         "hd1": "hd1live",  # renamed to tfx
-                         "tf1-series-films": "hd1live"}
-    hls_channel_remap = {"lci": "LCI",
-                         "tf1": "V4",
-                         "tfx": "nt1",
-                         "tf1-series-films": "hd1"}
+    api_url_base = "https://delivery.tf1.fr/mytf1-wrd/"
+    token = "07e45841-a17a-47cf-af64-a42311bdcc3d"
+
+    def api_call(self, channel):
+        url = urljoin(self.api_url_base, "L_"+channel.upper())
+        req = self.session.http.get(url, params=dict(token=self.token))
+        return self.session.http.json(req)
 
     @classmethod
     def can_handle_url(cls, url):
         return cls.url_re.match(url) is not None
-
-    def _get_hds_streams(self, channel):
-        channel = self.hds_channel_remap.get(channel, "{0}live".format(channel))
-        self.logger.debug("Using HDS channel name: {0}".format(channel))
-        manifest_url = self.session.http.get(self.api_url.format(channel),
-                                params={"getURL": 1},
-                                headers={"User-Agent": useragents.FIREFOX}).text
-
-        for s in HDSStream.parse_manifest(self.session,
-                                          manifest_url,
-                                          pvswf=self.swf_url,
-                                          headers={"User-Agent": useragents.FIREFOX}).items():
-            yield s
-
-    def _get_hls_streams(self, channel):
-        channel = self.hls_channel_remap.get(channel, channel)
-        embed_url = self.embed_url.format(channel)
-        self.logger.debug("Found embed URL: {0}", embed_url)
-        # page needs to have a mobile user agent
-        embed_page = self.session.http.get(embed_url, headers={"User-Agent": useragents.ANDROID})
-
-        m = self.embed_re.search(embed_page.text)
-        if m:
-            # remove all query string arguments except hdnea
-            hls_stream_url = update_qsd(m.group(1), {"hdnea": None}, remove="*")
-            try:
-                for s in HLSStream.parse_variant_playlist(self.session, hls_stream_url).items():
-                    yield s
-            except Exception:
-                self.logger.error("Failed to load the HLS playlist for {0}", channel)
 
     def _get_streams(self):
         m = self.url_re.match(self.url)
         if m:
             channel = m.group(1) or m.group(2)
             self.logger.debug("Found channel {0}", channel)
-            for s in self._get_hds_streams(channel):
-                yield s
+            data = self.api_call(channel)
 
-            for s in self._get_hls_streams(channel):
-                yield s
+            if data.get("error"):
+                log.error("Failed to get stream for {0}: {error} ({code})".format(channel, **data))
+            else:
+                log.debug("Got {format} stream {url}".format(**data))
+                if data["format"] == "dash":
+                    for s in DASHStream.parse_manifest(self.session, data["url"]).items():
+                        yield s
 
 
 __plugin__ = TF1


### PR DESCRIPTION
It appears that the HDS and HLS streams have been removed and DASH is the only supported streaming format.

I might be wrong but I couldn't find the HLS nor HDS streams any more. 

Fixes #2268 