### PR TITLE
2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2011-2016, Christopher Rosell
-Copyright (c) 2016-2018, Streamlink Team
+Copyright (c) 2016-2019, Streamlink Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/_themes/sphinx_rtd_theme_violet/LICENSE
+++ b/docs/_themes/sphinx_rtd_theme_violet/LICENSE
@@ -2,7 +2,7 @@ The MIT License (MIT)
 
 Copyright (c) 2013 Dave Snider
 Copyright (c) 2014 Christopher Rosell
-Copyright (c) 2015-2018 Streamlink
+Copyright (c) 2015-2019 Streamlink
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Streamlink'
-copyright = '2018, Streamlink'
+copyright = '2019, Streamlink'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/src/streamlink/__init__.py
+++ b/src/streamlink/__init__.py
@@ -15,7 +15,7 @@ del get_versions
 __title__ = "streamlink"
 __license__ = "Simplified BSD"
 __author__ = "Streamlink"
-__copyright__ = "Copyright 2018 Streamlink"
+__copyright__ = "Copyright 2019 Streamlink"
 __credits__ = [
     "Agustín Carrasco (@asermax)",
     "Andrew Bashore (@bashtech)",


### PR DESCRIPTION
This hasn't been done yet and should be merged before releasing 1.0.0...

Btw, is there a reason why the years in the license strings vary?
For now, I just applied the same changes as the commit of the last bump: 7f8750fa87bbed90e3065b512f0ba97e10a93e72