### PR TITLE
plugins.bbciplayer: do not try to authenticate when not required

### DIFF
--- a/tests/plugins/test_bbciplayer.py
+++ b/tests/plugins/test_bbciplayer.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import unittest
 
 from requests import Response, Request


### PR DESCRIPTION
When using the `--player-external-http` option, some clients will make multiple requests to get the streams. In the case of the BBC iPlayer plugin it was trying to authenticate when it didn't need to, looking for a `nonce` value that would not be there.

This PR adds a check to make sure that double authentication is not attempted. 

Should fix #2278.