### PR TITLE
streams.dash: Support manifest strings in addition to manifest urls

### DIFF
--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -5,7 +5,7 @@ from streamlink.stream import *
 from streamlink.stream.dash import DASHStreamWorker
 from streamlink.stream.dash_manifest import MPD
 from tests.mock import MagicMock, patch, ANY, Mock, call
-from tests.resources import xml
+from tests.resources import text, xml
 
 
 class TestDASHStream(unittest.TestCase):
@@ -208,25 +208,12 @@ class TestDASHStream(unittest.TestCase):
                           self.session, self.test_url)
         mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
 
-    @patch('streamlink.stream.dash.MPD')
-    def test_parse_manifest_string(self, mpdClass):
-        test_manifest = """<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:DASH:schema:MPD:2011"></MPD>"""
-        mpd = mpdClass.return_value = Mock(periods=[
-            Mock(adaptationSets=[
-                Mock(contentProtection=None,
-                     representations=[
-                         Mock(id=1, mimeType="video/mp4", height=720),
-                     ])
-            ])
-        ])
+    def test_parse_manifest_string(self):
+        with text("dash/test_9.mpd") as mpd_txt:
+            test_manifest = mpd_txt.read()
 
         streams = DASHStream.parse_manifest(self.session, test_manifest)
-        mpdClass.assert_called_with(ANY)
-
-        self.assertSequenceEqual(
-            sorted(list(streams.keys())),
-            sorted(["720p"])
-        )
+        self.assertSequenceEqual(list(streams.keys()), ['2500k'])
 
     @patch('streamlink.stream.dash.DASHStreamReader')
     @patch('streamlink.stream.dash.FFMPEGMuxer')

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -208,6 +208,26 @@ class TestDASHStream(unittest.TestCase):
                           self.session, self.test_url)
         mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
 
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_string(self, mpdClass):
+        test_manifest = """<?xml version="1.0" encoding="UTF-8"?><MPD xmlns="urn:mpeg:DASH:schema:MPD:2011"></MPD>"""
+        mpd = mpdClass.return_value = Mock(periods=[
+            Mock(adaptationSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=720),
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, test_manifest)
+        mpdClass.assert_called_with(ANY)
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p"])
+        )
+
     @patch('streamlink.stream.dash.DASHStreamReader')
     @patch('streamlink.stream.dash.FFMPEGMuxer')
     def test_stream_open_video_only(self, muxer, reader):


### PR DESCRIPTION
Modifies `parse_manifest()` to accept a `url_or_manifest` parameter.

See also: #2239 

This does not include any of the changes for supporting DASH SegmentBase.