### PR TITLE
plugins.facebook: Support manifest strings and tahoe player urls

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -81,7 +81,7 @@ eltrecetv               eltrecetv.com.ar     Yes   Yes   Streams may be geo-rest
 eurocom                 eurocom.bg           Yes   No
 euronews                euronews.com         Yes   No
 europaplus              europaplus.ru        Yes   --
-facebook                facebook.com         Yes   No    Only 360p HLS streams.
+facebook                facebook.com         Yes   Yes
 filmon                  filmon.com           Yes   Yes   Only SD quality streams.
 foxtr                   fox.com.tr           Yes   No
 funimationnow           - funimation.com     --    Yes   :ref:`Requires session cookies <cli-funimationnow>`

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -34,12 +34,12 @@ elif is_py3:
 
 try:
     from urllib.parse import (
-        urlparse, urlunparse, urljoin, quote, unquote, parse_qsl, urlencode, urlsplit, urlunsplit
+        urlparse, urlunparse, urljoin, quote, unquote, unquote_plus, parse_qsl, urlencode, urlsplit, urlunsplit
     )
     import queue
 except ImportError:
     from urlparse import urlparse, urlunparse, urljoin, parse_qsl, urlsplit, urlunsplit
-    from urllib import quote, unquote, urlencode
+    from urllib import quote, unquote, unquote_plus, urlencode
     import Queue as queue
 
 try:
@@ -60,5 +60,5 @@ getargspec = getattr(inspect, "getfullargspec", inspect.getargspec)
 
 __all__ = ["is_py2", "is_py3", "is_py33", "is_win32", "str", "bytes",
            "urlparse", "urlunparse", "urljoin", "parse_qsl", "quote",
-           "unquote", "queue", "range", "urlencode", "devnull", "which",
+           "unquote", "unquote_plus", "queue", "range", "urlencode", "devnull", "which",
            "izip", "urlsplit", "urlunsplit", "getargspec", "html_unescape"]

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -40,10 +40,8 @@ class Facebook(Plugin):
 
         match = self._dash_manifest_re.search(res.text)
         if match:
-            manifest = match.group("manifest")
-            if "\\/" in manifest:
-                manifest = manifest.replace("\\/", "/")
             # facebook replaces "<" characters with the substring "\\x3C"
+            manifest = match.group("manifest").replace("\\/", "/")
             if is_py3:
                 manifest = bytes(unquote_plus(manifest), "utf-8").decode("unicode_escape")
             else:

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -1,5 +1,6 @@
 import re
 
+from streamlink.compat import bytes, is_py3, unquote_plus, urlencode
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import DASHStream, HTTPStream
@@ -7,47 +8,94 @@ from streamlink.utils import parse_json
 
 
 class Facebook(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?facebook\.com/[^/]+/(posts|videos)")
+    _url_re = re.compile(r"https?://(?:www\.)?facebook\.com/[^/]+/(posts|videos)(/(?P<video_id>[0-9]+))?")
     _src_re = re.compile(r'''(sd|hd)_src["']?\s*:\s*(?P<quote>["'])(?P<url>.+?)(?P=quote)''')
+    _dash_manifest_re = re.compile(r'''dash_manifest["']?\s*:\s*["'](?P<manifest>.+?)["'],''')
     _playlist_re = re.compile(r'''video:\[({url:".+?}\])''')
     _plurl_re = re.compile(r'''url:"(.*?)"''')
+    _pc_re = re.compile(r'''pkg_cohort["']\s*:\s*["'](.+?)["']''')
+    _rev_re = re.compile(r'''client_revision["']\s*:\s*(\d+),''')
+    _dtsg_re = re.compile(r'''DTSGInitialData["'],\s*\[\],\s*{\s*["']token["']\s*:\s*["'](.+?)["']''')
+    _DEFAULT_PC = "PHASED:DEFAULT"
+    _DEFAULT_REV = 4681796
+    _TAHOE_URL = "https://www.facebook.com/video/tahoe/async/{0}/?chain=true&isvideo=true&payloadtype=primary"
 
     @classmethod
     def can_handle_url(cls, url):
         return cls._url_re.match(url)
 
-    def _get_streams(self):
-        res = self.session.http.get(self.url, headers={"User-Agent": useragents.CHROME})
-
-        streams = {}
-        vod_urls = set([])
-
+    def _parse_streams(self, res):
         for match in self._src_re.finditer(res.text):
             stream_url = match.group("url")
             if "\\/" in stream_url:
                 # if the URL is json encoded, decode it
                 stream_url = parse_json("\"{}\"".format(stream_url))
             if ".mpd" in stream_url:
-                streams.update(DASHStream.parse_manifest(self.session, stream_url))
+                for s in DASHStream.parse_manifest(self.session, stream_url).items():
+                    yield s
             elif ".mp4" in stream_url:
-                streams[match.group(1)] = HTTPStream(self.session, stream_url)
-                vod_urls.add(stream_url)
+                yield match.group(1), HTTPStream(self.session, stream_url)
             else:
                 self.logger.debug("Non-dash/mp4 stream: {0}".format(stream_url))
 
-        if streams:
-            return streams
+        match = self._dash_manifest_re.search(res.text)
+        if match:
+            manifest = match.group("manifest")
+            if "\\/" in manifest:
+                manifest = manifest.replace("\\/", "/")
+            # facebook replaces "<" characters with the substring "\\x3C"
+            if is_py3:
+                manifest = bytes(unquote_plus(manifest), "utf-8").decode("unicode_escape")
+            else:
+                manifest = unquote_plus(manifest).decode("string_escape")
+            for s in DASHStream.parse_manifest(self.session, manifest).items():
+                yield s
+
+    def _get_streams(self):
+        done = False
+        res = self.session.http.get(self.url, headers={"User-Agent": useragents.CHROME})
+        for s in self._parse_streams(res):
+            done = True
+            yield s
+        if done:
+            return
 
         # fallback on to playlist
         self.logger.debug("Falling back to playlist regex")
         match = self._playlist_re.search(res.text)
         playlist = match and match.group(1)
         if playlist:
-            for url in dict(url.group(1) for url in self._plurl_re.finditer(playlist)):
-                if url not in vod_urls:
-                    streams["sd"] = HTTPStream(self.session, url)
+            match = self._plurl_re.search(playlist)
+            if match:
+                url = match.group(1)
+                yield "sd", HTTPStream(self.session, url)
+                return
 
-        return streams
+        # fallback to tahoe player url
+        match = self._url_re.match(self.url)
+        if match.group("video_id"):
+            self.logger.debug("Falling back to tahoe player")
+            url = self._TAHOE_URL.format(match.group("video_id"))
+            data = {"__a": 1}
+            match = self._pc_re.search(res.text)
+            if match:
+                data["__pc"] = match.group(1)
+            else:
+                data["__pc"] = self._DEFAULT_PC
+            match = self._rev_re.search(res.text)
+            if match:
+                data["__rev"] = match.group(1)
+            else:
+                data["__rev"] = self._DEFAULT_REV
+            match = self._dtsg_re.search(res.text)
+            if match:
+                data["fb_dtsg"] = match.group(1)
+            else:
+                data["fb_dtsg"] = ""
+            res = self.session.http.post(url, headers={"User-Agent": useragents.CHROME, "Content-Type": "application/x-www-form-urlencoded"},
+                                         data=urlencode(data).encode("ascii"))
+            for s in self._parse_streams(res):
+                yield s
 
 
 __plugin__ = Facebook

--- a/tests/plugins/test_facebook.py
+++ b/tests/plugins/test_facebook.py
@@ -10,6 +10,7 @@ class TestPluginFacebook(unittest.TestCase):
         self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/nytfood/videos/1485091228202006/"))
         self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/SporTurkTR/videos/798553173631138/"))
         self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/119555411802156/posts/500665313691162/"))
+        self.assertTrue(Facebook.can_handle_url("https://www.facebookcorewwwi.onion/SporTurkTR/videos/798553173631138/"))
 
         # shouldn't match
         self.assertFalse(Facebook.can_handle_url("https://www.facebook.com"))


### PR DESCRIPTION
Addresses #2168, #2133.
Immediate playback for DASH streams with separate audio and video
streams will not be supported until proper SegmentBase handling is
implemented.

Depends on the `url_or_manifest` changes from #2285.

See also: #2239 

Immediate playback for DASH streams with separate audio and video streams is still not supported, this will require implementing support for DASH SegmentBase.