### PR TITLE
plugins.crunchyroll: Allow CR's multilingual URLs to be handled

### DIFF
--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -38,6 +38,9 @@ _url_re = re.compile(r"""
     (?:
         com|de|es|fr|co.jp
     )
+    (?:
+        /(en-gb|es|es-es|pt-pt|pt-br|fr|de|ar|it|ru)
+    )?
     (?:/[^/&?]+)?
     /[^/&?]+-(?P<media_id>\d+)
 """, re.VERBOSE)

--- a/tests/plugins/test_crunchyroll.py
+++ b/tests/plugins/test_crunchyroll.py
@@ -7,9 +7,13 @@ class TestPluginCrunchyroll(unittest.TestCase):
     def test_can_handle_url(self):
         # should match
         self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/idol-incidents/episode-1-why-become-a-dietwoman-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/ru/idol-incidents/episode-1-why-become-a-dietwoman-728233"))
         self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/idol-incidents/media-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/fr/idol-incidents/media-728233"))
         self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/media-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.com/de/media-728233"))
         self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.fr/media-728233"))
+        self.assertTrue(Crunchyroll.can_handle_url("http://www.crunchyroll.fr/es/media-728233"))
 
         # shouldn't match
         self.assertFalse(Crunchyroll.can_handle_url("http://www.crunchyroll.com/gintama"))


### PR DESCRIPTION
Multilingual URLs shoud be allowed to be handled by the crunchyroll plugin.

Using [crunchyroll's rss](https://www.crunchyroll.com/rss), I've seen that the `<link></link>` given is formatted depending your localization, probably IP based. Since I am currently living in France I always get the /fr language path

```python
import feedparser
url = 'https://www.crunchyroll.com/rss'
f = feedparser.parse(url)
print(f['entries'][0]['link'])
```
```
# gives:
http://www.crunchyroll.com/fr/shonen-ashibe-go-go-goma-chan/episode-94-graduating-from-goma-chan-780795
```