### PR TITLE
plugins.streamme: Fixed null error for 'origin'

### DIFF
--- a/src/streamlink/plugins/streamme.py
+++ b/src/streamlink/plugins/streamme.py
@@ -49,9 +49,9 @@ class StreamMe(Plugin):
                         'videoHeight': int,
                         'location': validate.url()
                     }],
-                    validate.optional('origin'): {
+                    validate.optional('origin'): validate.any(None, {
                         validate.optional('location'): validate.url(),
-                    }
+                    })
                 }
             }
         },


### PR DESCRIPTION
Ref https://github.com/streamlink/streamlink/pull/2307#issuecomment-462113332

```
error: Unable to validate response text: Unable to validate key 'formats': Unable to validate key 'mp4-hls':
Unable to validate key 'origin': Type of None should be 'dict' but is 'NoneType'
```