### PR TITLE
Handle keyboard interrupts in can_handle_url checks

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1020,7 +1020,6 @@ def main():
         except NoPluginError:
             error_code = 1
         except KeyboardInterrupt:
-            console.msg("Interrupted! Exiting...")
             error_code = 130
     elif args.can_handle_url_no_redirect:
         try:
@@ -1028,7 +1027,6 @@ def main():
         except NoPluginError:
             error_code = 1
         except KeyboardInterrupt:
-            console.msg("Interrupted! Exiting...")
             error_code = 130
     elif args.url:
         try:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1019,11 +1019,17 @@ def main():
             streamlink.resolve_url(args.can_handle_url)
         except NoPluginError:
             error_code = 1
+        except KeyboardInterrupt:
+            console.msg("Interrupted! Exiting...")
+            error_code = 130
     elif args.can_handle_url_no_redirect:
         try:
             streamlink.resolve_url_no_redirect(args.can_handle_url_no_redirect)
         except NoPluginError:
             error_code = 1
+        except KeyboardInterrupt:
+            console.msg("Interrupted! Exiting...")
+            error_code = 130
     elif args.url:
         try:
             setup_options()


### PR DESCRIPTION
These checks can take a long time in the case of a typo in the url, for example.
This sets the return code to 130 so that external scripts can handle it
correctly.