### PR TITLE
pin pynist version for GUI

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ codecov
 coverage
 mock
 requests-mock
-pynsist
+pynsist=2.1
 freezegun

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ codecov
 coverage
 mock
 requests-mock
-pynsist=2.1
+pynsist==2.2
 freezegun


### PR DESCRIPTION
@bastimeyer is encountering major issues with the 1.0 release of Streamlink due to some problems with Pynist due to changes they've made with wrapper executables. The last successful build that worked used this version of pynist, so I'm pinning it to that.