### PR TITLE
Fix bug: Cant get video in Facebook livestream playing game

### DIFF
--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -22,6 +22,18 @@ class Facebook(Plugin):
         streams = {}
         vod_urls = set([])
 
+        if not "sd_src" in res.text and not "hd_src" in res.text:
+            tmp = self.url.split("/")
+            video_id = tmp[-1] if tmp[-1]!="" else tmp[-2]
+            res = self.session.http.post("https://www.facebook.com/video/tahoe/async/%s/?chain=true&isvideo=true&payloadtype=primary"%video_id, 
+                    headers={"User-Agent": useragents.CHROME}, 
+                    data={
+                        "__rev": 4791687,
+                        "fb_dtsg": "",
+                        "__a": 1,
+                        "__pc": "PHASED:DEFAULT"
+                    })
+
         for match in self._src_re.finditer(res.text):
             stream_url = match.group("url")
             if "\\/" in stream_url:


### PR DESCRIPTION
Tested url : https://www.facebook.com/troll3t.live/videos/800841600286701/
Current result :
[cli][info] streamlink is running as root! Be careful!
[cli][info] Found matching plugin facebook for URL https://www.facebook.com/troll3t.live/videos/800841600286701/
error: No playable streams found on this URL: https://www.facebook.com/troll3t.live/videos/800841600286701/

I think it's because of "playing GAME" (screenshot: https://imgur.com/a/L2pmgOf) has different template than other live stream type. So I fix it.