### PR TITLE
tests: detect unsupported versions for itertags

### DIFF
--- a/tests/test_plugin_utils.py
+++ b/tests/test_plugin_utils.py
@@ -5,6 +5,24 @@ import unittest
 from streamlink.plugin.api.utils import itertags
 
 
+def unsupported_versions_1979():
+    """Unsupported python versions for itertags
+       3.7.0 - 3.7.2 and 3.8.0a1
+       - https://github.com/streamlink/streamlink/issues/1979
+       - https://bugs.python.org/issue34294
+    """
+    v = sys.version_info
+    if (v.major == 3) and (
+        # 3.7.0 - 3.7.2
+        (v.minor == 7 and v.micro <= 2)
+        # 3.8.0a1
+        or (v.minor == 8 and v.micro == 0 and v.releaselevel == 'alpha' and v.serial <= 1)
+    ):
+        return True
+    else:
+        return False
+
+
 class TestPluginUtil(unittest.TestCase):
     test_html = """
 <!doctype html>
@@ -42,7 +60,7 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(script[1].text.strip(), """Tester.ready(function () {\nalert("Hello, world!"); });""")
         self.assertEqual(script[1].attributes, {})
 
-    @unittest.skipIf(sys.version_info >= (3, 7),
+    @unittest.skipIf(unsupported_versions_1979(),
                      "python3.7 issue, see bpo-34294")
     def test_itertags_multi_attrs(self):
         metas = list(itertags(self.test_html, "meta"))
@@ -64,7 +82,7 @@ href="http://test.se/foo">bar</a>
         self.assertEqual(anchor[0].text, "bar")
         self.assertEqual(anchor[0].attributes, {"href": "http://test.se/foo"})
 
-    @unittest.skipIf(sys.version_info >= (3, 7),
+    @unittest.skipIf(unsupported_versions_1979(),
                      "python3.7 issue, see bpo-34294")
     def test_no_end_tag(self):
         links = list(itertags(self.test_html, "link"))


### PR DESCRIPTION
> 3.7.0 - 3.7.2 and 3.8.0a1

skip only unsupported versions,
test it on future supported updates

---

3.7.3 final: 2019-03-25 (expected)
https://www.python.org/dev/peps/pep-0537/#id3

3.8.0 alpha 2: Sunday, 2019-02-24 (expected)
https://www.python.org/dev/peps/pep-0569/#schedule

---

Ref https://bugs.python.org/issue34294
Fixed https://github.com/streamlink/streamlink/issues/1979