### PR TITLE
Build additional "streamlinkw" launcher on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_install:
       pip install -r docs-requirements.txt;
       pip install doctr;
     fi
+  - if [[ $BUILD_INSTALLER == 'yes' ]]; then
+      pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b;
+    fi
 
 install:
   - pip install -e .

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,4 @@ codecov
 coverage
 mock
 requests-mock
-pynsist
 freezegun

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -106,6 +106,10 @@ files=../win32/LICENSE.txt > \$INSTDIR
 [Command streamlink]
 entry_point=streamlink_cli.main:main
 
+[Command streamlinkw]
+entry_point=streamlink_cli.main:main
+console=false
+
 [Build]
 directory=nsis
 nsi_template=installer_tmpl.nsi

--- a/script/sdistsign.sh
+++ b/script/sdistsign.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+shopt -s nullglob
 set -e
 
 KEY_ID=2E390FA0
@@ -8,6 +9,8 @@ version=$(python setup.py --version)
 dist_dir=${STREAMLINK_DIST_DIR:-dist}
 temp_keyring=$(mktemp -d) && trap "rm -rf ${temp_keyring}" EXIT || exit 255
 
+wheel_platforms_windows=("win32" "win-amd64" "cygwin")
+
 if [[ -n "${TRAVIS}" ]]; then
       openssl aes-256-cbc -K ${encrypted_eeb8b970d3a3_key} -iv ${encrypted_eeb8b970d3a3_iv} -in signing.key.enc -out "${SDIST_KEY_FILE}" -d
 fi
@@ -15,14 +18,23 @@ fi
 echo "build: Installing twine and wheel" >&2
 pip -q install -U setuptools twine wheel
 
-echo "build: Building streamlink sdist and wheel" >&2
-python setup.py -q sdist bdist_wheel --dist-dir "${dist_dir}"
+echo "build: Building Streamlink sdist" >&2
+python setup.py -q sdist --dist-dir "${dist_dir}"
+
+echo "build: Building Streamlink wheel (universal)" >&2
+python setup.py -q bdist_wheel --dist-dir "${dist_dir}"
+
+for platform in "${wheel_platforms_windows[@]}"; do
+    echo "build: Building Streamlink wheel (${platform})" >&2
+    python setup.py -q bdist_wheel --plat-name "${platform}" --dist-dir "${dist_dir}"
+done
 
 if [ -f "${KEY_FILE}" ]; then
     echo "build: Signing sdist and wheel files" >&2
     gpg --homedir "${temp_keyring}" --import "${KEY_FILE}" 2>&1 > /dev/null
-    gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${dist_dir}/streamlink-${version}.tar.gz"
-    gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl"
+    for file in "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}; do
+        gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${file}"
+    done
 else
     echo "warning: no signing key, files not signed" >&2
 fi
@@ -30,9 +42,5 @@ fi
 if [[ "${DEPLOY_PYPI}" == "yes" ]]; then
     echo "build: Uploading sdist and wheel to PyPI" >&2
     twine upload --username "${PYPI_USER}" --password "${PYPI_PASSWORD}" \
-        "${dist_dir}/streamlink-${version}.tar.gz" \
-        "${dist_dir}/streamlink-${version}.tar.gz.asc"
-    twine upload --username "${PYPI_USER}" --password "${PYPI_PASSWORD}" \
-        "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl" \
-        "${dist_dir}/streamlink-${version}-py2.py3-none-any.whl.asc"
+        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
 fi

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 import codecs
-from os import environ
-from os import path
-from sys import path as sys_path
+from os import environ, path
+from sys import argv, path as sys_path
 
 from setuptools import setup, find_packages
 
@@ -53,6 +52,27 @@ sys_path.insert(0, srcdir)
 with codecs.open(path.join(this_directory, "README.md"), 'r', "utf8") as f:
     long_description = f.read()
 
+
+def is_wheel_for_windows():
+    if "bdist_wheel" in argv:
+        names = ["win32", "win-amd64", "cygwin"]
+        length = len(argv)
+        for pos in range(argv.index("bdist_wheel") + 1, length):
+            if argv[pos] == "--plat-name" and pos + 1 < length:
+                return argv[pos + 1] in names
+            elif argv[pos][:12] == "--plat-name=":
+                return argv[pos][12:] in names
+    return False
+
+
+entry_points = {
+    "console_scripts": ["streamlink=streamlink_cli.main:main"]
+}
+
+if is_wheel_for_windows():
+    entry_points["gui_scripts"] = ["streamlinkw=streamlink_cli.main:main"]
+
+
 setup(name="streamlink",
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
@@ -74,9 +94,7 @@ setup(name="streamlink",
       license="Simplified BSD",
       packages=find_packages("src"),
       package_dir={"": "src"},
-      entry_points={
-          "console_scripts": ["streamlink=streamlink_cli.main:main"]
-      },
+      entry_points=entry_points,
       install_requires=deps,
       test_suite="tests",
       python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, <4",


### PR DESCRIPTION
This adds an additional `streamlink-noconsole.exe` "GUI" launcher to the Windows installer and the Streamlink python wheel. This launcher uses `pythonw.exe` under the hood, so that a new terminal window doesn't get opened if executed from a non-terminal context on Windows.

Resolves #2287, #2308 

----

**Motivation of this PR and why this change is needed**

A couple of months ago, both `pip` and `pynsist` changed their entry point launchers on Windows from [`setuptools`](https://github.com/pypa/setuptools/blob/v40.8.0/launcher.c) to [`simple_launcher`](https://bitbucket.org/vinay.sajip/simple_launcher). This change broke the Streamlink resolver in Streamlink Twitch GUI, as these new launchers are lacking the additional `streamlink-script.py` file, which is used for parsing its shebang and getting the path to `pythonw.exe`, which is needed to suppress the terminal window from being opened. Unfortunately, it is impossible to work around the new launchers without parsing them or asking the user to manually set custom paths. That is however not a real solution.

Fortunately though, `simple_launcher` does provide two different versions of the launchers, a "console" one and a "GUI" one. Setuptools does this as well, but their GUI launcher is useless, as its process terminates immediately and therefore can't be used. The new `simple_launcher`-based launchers however work exactly as they should and the GUI launcher can be used by GUI applications like Streamlink Twitch GUI without any issues.

That's why I'm submitting this pull request, which adds `streamlink-noconsole` as a new additional GUI launcher.

I've already submitted a PR to pynist (takluyver/pynsist#179) a couple of days ago which adds a new `console=false` option to the installer's "command" section, so that a GUI launcher can be built. My PR was merged a couple of hours ago, but since a new release hasn't been published yet, it will be installed from the master branch for now (see the TravisCI config changes).

Regarding the Streamlink python wheel, an additional [`gui_scripts` entry point](https://packaging.python.org/specifications/entry-points/#use-for-scripts) can be added to `setup.py`, so that pip will also build a GUI launcher.

----

**Issues / Open questions**

- Since I don't know much about python wheels and python packaging in general, I guess that this change will also add a `streamlink-noconsole` on Linux and macOS. Is it possible to change that?
- Is the name `streamlink-noconsole` okay? Or does anybody have a better idea?
- Regular installs via `python setup.py install` will still build the useless GUI launcher.
- ~~I've noticed some issues with certain plugins while using the GUI launcher, but I don't know if it was because of the build env in my Windows VM or something else. This has to be resolved before this PR can get merged. (I will check this tomorrow)~~