### PR TITLE
Add force_verify=true to Twitch OAuth URL

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -630,8 +630,11 @@ def authenticate_twitch_oauth():
     client_id = TWITCH_CLIENT_ID
     redirect_uri = "https://streamlink.github.io/twitch_oauth.html"
     url = ("https://api.twitch.tv/kraken/oauth2/authorize"
-           "?response_type=token&client_id={0}&redirect_uri="
-           "{1}&scope=user_read+user_subscriptions").format(client_id, redirect_uri)
+           "?response_type=token"
+           "&client_id={0}"
+           "&redirect_uri={1}"
+           "&scope=user_read+user_subscriptions"
+           "&force_verify=true").format(client_id, redirect_uri)
 
     console.msg("Attempting to open a browser to let you authenticate "
                 "Streamlink with Twitch")


### PR DESCRIPTION
Forces the authentication confirm dialog on Twitch, in case the user is already logged in. This lets them switch to a different account or review the OAuth permissions.