### PR TITLE
TravisCI: Windows + build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,19 @@ script:
   - codecov
 
 
+x-windows-installer: &x-windows-installer
+  python: '3.5'
+  addons:
+    apt:
+      packages:
+        - nsis
+        - imagemagick
+        - inkscape
+  before_script:
+    - python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b
+  script: ./script/makeinstaller.sh
+
+
 jobs:
   allow_failures:
     - stage: test
@@ -82,7 +95,11 @@ jobs:
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - export TRAVIS_PYTHON_VERSION="3.7"
 
-    # test documentation
+    # build Windows installer
+    - name: installer
+      <<: *x-windows-installer
+
+    # build documentation
     - name: documentation
       python: '3.5'
       before_script:
@@ -124,15 +141,7 @@ jobs:
     # tagged release: Windows installer + Github
     - stage: deploy
       if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
-      python: '3.5'
-      addons:
-        apt:
-          packages:
-            - nsis
-            - imagemagick
-            - inkscape
-      before_script: python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b
-      script: ./script/makeinstaller.sh
+      <<: *x-windows-installer
       deploy:
         - provider: releases
           api_key: "${RELEASES_API_KEY}"
@@ -146,15 +155,7 @@ jobs:
     # cron: Windows installer + Bintray
     - stage: deploy
       if: repo = streamlink/streamlink AND branch = master AND type = cron
-      python: '3.5'
-      addons:
-        apt:
-          packages:
-            - nsis
-            - imagemagick
-            - inkscape
-      before_script: python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b
-      script: ./script/makeinstaller.sh
+      <<: *x-windows-installer
       before_deploy: ./script/bintrayconfig.sh
       deploy:
         - provider: bintray

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,7 +109,7 @@ jobs:
     # deploy documentation
     - stage: deploy
       name: documentation
-      if: repo = streamlink/streamlink AND branch = master AND type = push
+      if: repo = streamlink/streamlink AND ( branch = master AND type = push OR tag IS present )
       python: '3.5'
       before_script:
         - python -m pip install -r docs-requirements.txt
@@ -126,7 +126,7 @@ jobs:
     # tagged release
     - stage: deploy
       name: release
-      if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
+      if: repo = streamlink/streamlink AND tag IS present
       python: '3.5'
       before_script: python -m pip install --upgrade wheel twine
       script: ./script/build-and-sign.sh
@@ -145,7 +145,7 @@ jobs:
 
     - stage: deploy
       name: "installer (release)"
-      if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
+      if: repo = streamlink/streamlink AND tag IS present
       <<: *x-windows-installer
       deploy:
         - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   global:
     - STREAMLINK_DIST_DIR=${TRAVIS_BUILD_DIR}/dist
     - STREAMLINK_INSTALLER_DIST_DIR=${STREAMLINK_DIST_DIR}/nsis
-    - SDIST_KEY_FILE="${TRAVIS_BUILD_DIR}/signing.key"
+    - SIGNING_KEY_FILE="${TRAVIS_BUILD_DIR}/signing.key"
 
 
 stages:
@@ -123,23 +123,28 @@ jobs:
           on:
             tags: true
 
-    # tagged release: PyPi + Github
+    # tagged release
     - stage: deploy
+      name: release
       if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
       python: '3.5'
-      script: skip
+      before_script: python -m pip install --upgrade wheel twine
+      script: ./script/build-and-sign.sh
       deploy:
         - provider: script
-          script: ./script/sdistsign.sh
+          script: ./script/deploy-pypi.sh
           skip_cleanup: true
         - provider: releases
           api_key: "${RELEASES_API_KEY}"
           file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}*"
           file_glob: true
           skip_cleanup: true
+        - provider: script
+          script: python script/github_releases.py
+          skip_cleanup: true
 
-    # tagged release: Windows installer + Github
     - stage: deploy
+      name: "installer (release)"
       if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
       <<: *x-windows-installer
       deploy:
@@ -148,12 +153,10 @@ jobs:
           file: "${STREAMLINK_INSTALLER_DIST_DIR}/streamlink-${TRAVIS_TAG}.exe"
           file_glob: true
           skip_cleanup: true
-        - provider: script
-          script: python script/github_releases.py
-          skip_cleanup: true
 
-    # cron: Windows installer + Bintray
+    # cron
     - stage: deploy
+      name: "installer (development)"
       if: repo = streamlink/streamlink AND branch = master AND type = cron
       <<: *x-windows-installer
       before_deploy: ./script/bintrayconfig.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
 
 stages:
   - test
-  - docs
   - deploy
 
 
@@ -83,8 +82,16 @@ jobs:
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         - export TRAVIS_PYTHON_VERSION="3.7"
 
-    # documentation
-    - stage: docs
+    # test documentation
+    - name: documentation
+      python: '3.5'
+      before_script:
+        - python -m pip install -r docs-requirements.txt
+      script: make --directory=docs html
+
+    # deploy documentation
+    - stage: deploy
+      name: documentation
       if: repo = streamlink/streamlink AND branch = master AND type = push
       python: '3.5'
       before_script:
@@ -92,10 +99,8 @@ jobs:
         - python -m pip install doctr
       script: make --directory=docs html
       deploy:
-        # latest version - push docs for master
         - provider: script
           script: doctr deploy latest
-        # stable version - push docs for tags
         - provider: script
           script: doctr deploy .
           on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,30 +53,35 @@ jobs:
       before_install:
         - choco install python2
         - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
+        - export TRAVIS_PYTHON_VERSION="2.7"
     - python: '3.4'
       os: windows
       language: shell
       before_install:
         - choco install python --version 3.4.4.20180111
         - export PATH="/c/Python34:/c/Python34/Scripts:$PATH"
+        - export TRAVIS_PYTHON_VERSION="3.4"
     - python: '3.5'
       os: windows
       language: shell
       before_install:
         - choco install python --version 3.5.4
         - export PATH="/c/Python35:/c/Python35/Scripts:$PATH"
+        - export TRAVIS_PYTHON_VERSION="3.5"
     - python: '3.6'
       os: windows
       language: shell
       before_install:
         - choco install python --version 3.6.8
         - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
+        - export TRAVIS_PYTHON_VERSION="3.6"
     - python: '3.7'
       os: windows
       language: shell
       before_install:
         - choco install python
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - export TRAVIS_PYTHON_VERSION="3.7"
 
     # documentation
     - stage: docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ jobs:
           skip_cleanup: true
         - provider: releases
           api_key: "${RELEASES_API_KEY}"
-          file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}*"
+          file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}.tar.gz{,.asc}"
           file_glob: true
           skip_cleanup: true
         - provider: script
@@ -151,7 +151,6 @@ jobs:
         - provider: releases
           api_key: "${RELEASES_API_KEY}"
           file: "${STREAMLINK_INSTALLER_DIST_DIR}/streamlink-${TRAVIS_TAG}.exe"
-          file_glob: true
           skip_cleanup: true
 
     # cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,58 @@
+git:
+  depth: 999999
+
+os: linux
+dist: trusty
+sudo: true
+
 language: python
+
 env:
   global:
-  - STREAMLINK_DIST_DIR=${TRAVIS_BUILD_DIR}/dist
-  - STREAMLINK_INSTALLER_DIST_DIR=${STREAMLINK_DIST_DIR}/nsis
-  - SDIST_KEY_FILE="${TRAVIS_BUILD_DIR}/signing.key"
+    - STREAMLINK_DIST_DIR=${TRAVIS_BUILD_DIR}/dist
+    - STREAMLINK_INSTALLER_DIST_DIR=${STREAMLINK_DIST_DIR}/nsis
+    - SDIST_KEY_FILE="${TRAVIS_BUILD_DIR}/signing.key"
 
-git:
-  depth: 300
 
-matrix:
+stages:
+  - test
+  - docs
+  - deploy
+
+
+install:
+  - python --version
+  - python -m pip install --disable-pip-version-check --upgrade pip setuptools
+  - python -m pip install --upgrade -r dev-requirements.txt
+  - python -m pip install pycountry
+  - python -m pip install -e .
+
+script:
+  - pytest --cov
+  - codecov
+
+
+jobs:
+  allow_failures:
+    - stage: test
+      python: '3.8-dev'
   include:
-    # Linux
-    - python: '2.7'
+    # tests: Linux + Windows
+    - stage: test
+      python: '2.7'
     - python: '3.4'
     - python: '3.5'
-      env: BUILD_DOCS=yes BUILD_INSTALLER=yes BUILD_SDIST=yes DEPLOY_PYPI=yes
     - python: '3.6'
     - python: '3.7'
       dist: xenial
-      sudo: true
     - python: '3.8-dev'
       dist: xenial
-      sudo: true
-    # Windows
     - python: '2.7'
       os: windows
+      language: shell
       before_install:
         - choco install python2
         - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
-      language: shell
     - python: '3.4'
       os: windows
       language: shell
@@ -53,92 +77,83 @@ matrix:
       before_install:
         - choco install python
         - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-  allow_failures:
-    - python: '3.8-dev'
 
-before_install:
-  - python -m pip install --disable-pip-version-check --upgrade pip setuptools
-  - python -m pip install --upgrade -r dev-requirements.txt
-  - python -m pip install pycountry
-  - if [[ $BUILD_DOCS == 'yes' ]]; then
-      python -m pip install -r docs-requirements.txt;
-      python -m pip install doctr;
-    fi
-  - if [[ $BUILD_INSTALLER == 'yes' ]]; then
-      python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b;
-    fi
+    # documentation
+    - stage: docs
+      if: repo = streamlink/streamlink AND branch = master AND type = push
+      python: '3.5'
+      before_script:
+        - python -m pip install -r docs-requirements.txt
+        - python -m pip install doctr
+      script: make --directory=docs html
+      deploy:
+        # latest version - push docs for master
+        - provider: script
+          script: doctr deploy latest
+        # stable version - push docs for tags
+        - provider: script
+          script: doctr deploy .
+          on:
+            tags: true
 
-install:
-  - python -m pip install -e .
+    # tagged release: PyPi + Github
+    - stage: deploy
+      if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
+      python: '3.5'
+      script: skip
+      deploy:
+        - provider: script
+          script: ./script/sdistsign.sh
+          skip_cleanup: true
+        - provider: releases
+          api_key: "${RELEASES_API_KEY}"
+          file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}*"
+          file_glob: true
+          skip_cleanup: true
 
-script:
-  - pytest --cov
-  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_OS_NAME != 'windows' ]]; then make --directory=docs html; fi
-  - if [[ $BUILD_INSTALLER == 'yes' && $TRAVIS_OS_NAME != 'windows' ]]; then ./script/makeinstaller.sh; fi
+    # tagged release: Windows installer + Github
+    - stage: deploy
+      if: repo = streamlink/streamlink AND branch = master AND type = push AND tag IS present
+      python: '3.5'
+      addons:
+        apt:
+          packages:
+            - nsis
+            - imagemagick
+            - inkscape
+      before_script: python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b
+      script: ./script/makeinstaller.sh
+      deploy:
+        - provider: releases
+          api_key: "${RELEASES_API_KEY}"
+          file: "${STREAMLINK_INSTALLER_DIST_DIR}/streamlink-${TRAVIS_TAG}.exe"
+          file_glob: true
+          skip_cleanup: true
+        - provider: script
+          script: python script/github_releases.py
+          skip_cleanup: true
 
-after_success:
-  - set -e
-  # latest version - push docs for master
-  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_REPO_SLUG == 'streamlink/streamlink' && $TRAVIS_OS_NAME != 'windows' ]]; then doctr deploy latest; fi
-  # stable version - push docs for tags
-  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_REPO_SLUG == 'streamlink/streamlink' && -n "$TRAVIS_TAG" && $TRAVIS_OS_NAME != 'windows' ]]; then doctr deploy .; fi
-  - codecov
+    # cron: Windows installer + Bintray
+    - stage: deploy
+      if: repo = streamlink/streamlink AND branch = master AND type = cron
+      python: '3.5'
+      addons:
+        apt:
+          packages:
+            - nsis
+            - imagemagick
+            - inkscape
+      before_script: python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b
+      script: ./script/makeinstaller.sh
+      before_deploy: ./script/bintrayconfig.sh
+      deploy:
+        - provider: bintray
+          file: build/bintray-nightly.json
+          user: "${BINTRAY_USER}"
+          key: "${BINTRAY_KEY}"
+          skip_cleanup: true
+      after_deploy: ./script/bintrayupdate.sh
 
-addons:
-  apt:
-    packages:
-    - nsis
-    - imagemagick
-    - inkscape
-
-before_deploy:
-  - if [[ $TRAVIS_OS_NAME != 'windows' && $TRAVIS_OS_NAME != 'windows' ]]; then ./script/bintrayconfig.sh; fi
-
-deploy:
-  - provider: releases
-    api_key: "${RELEASES_API_KEY}"
-    file: "${STREAMLINK_INSTALLER_DIST_DIR}/streamlink-${TRAVIS_TAG}.exe"
-    file_glob: true
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: $BUILD_INSTALLER = yes && $TRAVIS_OS_NAME != 'windows'
-      repo: streamlink/streamlink
-  - provider: script
-    script: python script/github_releases.py
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: $BUILD_INSTALLER == yes && $TRAVIS_OS_NAME != 'windows'
-      repo: streamlink/streamlink
-  - provider: bintray
-    file: build/bintray-nightly.json
-    user: "${BINTRAY_USER}"
-    key: "${BINTRAY_KEY}"
-    skip_cleanup: true
-    on:
-      branch: master
-      condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron && $TRAVIS_OS_NAME != 'windows'
-      repo: streamlink/streamlink
-  - provider: script
-    script: ./script/sdistsign.sh
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: $BUILD_SDIST == yes && $TRAVIS_OS_NAME != 'windows'
-      repo: streamlink/streamlink
-  - provider: releases
-    api_key: "${RELEASES_API_KEY}"
-    file: "${STREAMLINK_DIST_DIR}/streamlink-${TRAVIS_TAG}*"
-    file_glob: true
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: $BUILD_SDIST = yes && $TRAVIS_OS_NAME != 'windows'
-      repo: streamlink/streamlink
-
-after_deploy:
-  - if [[ "$BUILD_INSTALLER" == 'yes' && "$TRAVIS_EVENT_TYPE" == 'cron' && $TRAVIS_OS_NAME != 'windows' ]]; then ./script/bintrayupdate.sh; fi
 
 doctr:
   build-tags: True

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,46 +10,78 @@ git:
 
 matrix:
   include:
-  - python: '2.7'
-  - python: '3.4'
-  - python: '3.5'
-    env: BUILD_DOCS=yes BUILD_INSTALLER=yes BUILD_SDIST=yes DEPLOY_PYPI=yes
-  - python: '3.6'
-  - python: '3.7'
-    dist: xenial
-    sudo: true
-  - python: '3.8-dev'
-    dist: xenial
-    sudo: true
+    # Linux
+    - python: '2.7'
+    - python: '3.4'
+    - python: '3.5'
+      env: BUILD_DOCS=yes BUILD_INSTALLER=yes BUILD_SDIST=yes DEPLOY_PYPI=yes
+    - python: '3.6'
+    - python: '3.7'
+      dist: xenial
+      sudo: true
+    - python: '3.8-dev'
+      dist: xenial
+      sudo: true
+    # Windows
+    - python: '2.7'
+      os: windows
+      before_install:
+        - choco install python2
+        - export PATH="/c/Python27:/c/Python27/Scripts:$PATH"
+      language: shell
+    - python: '3.4'
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.4.4.20180111
+        - export PATH="/c/Python34:/c/Python34/Scripts:$PATH"
+    - python: '3.5'
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.5.4
+        - export PATH="/c/Python35:/c/Python35/Scripts:$PATH"
+    - python: '3.6'
+      os: windows
+      language: shell
+      before_install:
+        - choco install python --version 3.6.8
+        - export PATH="/c/Python36:/c/Python36/Scripts:$PATH"
+    - python: '3.7'
+      os: windows
+      language: shell
+      before_install:
+        - choco install python
+        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
   allow_failures:
-  - python: '3.8-dev'
+    - python: '3.8-dev'
 
 before_install:
-  - pip install --disable-pip-version-check --upgrade pip setuptools
-  - pip install --upgrade -r dev-requirements.txt
-  - pip install pycountry
+  - python -m pip install --disable-pip-version-check --upgrade pip setuptools
+  - python -m pip install --upgrade -r dev-requirements.txt
+  - python -m pip install pycountry
   - if [[ $BUILD_DOCS == 'yes' ]]; then
-      pip install -r docs-requirements.txt;
-      pip install doctr;
+      python -m pip install -r docs-requirements.txt;
+      python -m pip install doctr;
     fi
   - if [[ $BUILD_INSTALLER == 'yes' ]]; then
-      pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b;
+      python -m pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b;
     fi
 
 install:
-  - pip install -e .
+  - python -m pip install -e .
 
 script:
   - pytest --cov
-  - if [[ $BUILD_DOCS == 'yes' ]]; then make --directory=docs html; fi
-  - if [[ $BUILD_INSTALLER == 'yes' ]]; then ./script/makeinstaller.sh; fi
+  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_OS_NAME != 'windows' ]]; then make --directory=docs html; fi
+  - if [[ $BUILD_INSTALLER == 'yes' && $TRAVIS_OS_NAME != 'windows' ]]; then ./script/makeinstaller.sh; fi
 
 after_success:
   - set -e
   # latest version - push docs for master
-  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_REPO_SLUG == 'streamlink/streamlink' ]]; then doctr deploy latest; fi
+  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_REPO_SLUG == 'streamlink/streamlink' && $TRAVIS_OS_NAME != 'windows' ]]; then doctr deploy latest; fi
   # stable version - push docs for tags
-  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_REPO_SLUG == 'streamlink/streamlink' && -n "$TRAVIS_TAG" ]]; then doctr deploy .; fi
+  - if [[ $BUILD_DOCS == 'yes' && $TRAVIS_REPO_SLUG == 'streamlink/streamlink' && -n "$TRAVIS_TAG" && $TRAVIS_OS_NAME != 'windows' ]]; then doctr deploy .; fi
   - codecov
 
 addons:
@@ -60,7 +92,7 @@ addons:
     - inkscape
 
 before_deploy:
-  - ./script/bintrayconfig.sh
+  - if [[ $TRAVIS_OS_NAME != 'windows' && $TRAVIS_OS_NAME != 'windows' ]]; then ./script/bintrayconfig.sh; fi
 
 deploy:
   - provider: releases
@@ -70,14 +102,14 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      condition: $BUILD_INSTALLER = yes
+      condition: $BUILD_INSTALLER = yes && $TRAVIS_OS_NAME != 'windows'
       repo: streamlink/streamlink
   - provider: script
     script: python script/github_releases.py
     skip_cleanup: true
     on:
       tags: true
-      condition: $BUILD_INSTALLER == yes
+      condition: $BUILD_INSTALLER == yes && $TRAVIS_OS_NAME != 'windows'
       repo: streamlink/streamlink
   - provider: bintray
     file: build/bintray-nightly.json
@@ -86,14 +118,14 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron
+      condition: $BUILD_INSTALLER == yes && $TRAVIS_EVENT_TYPE == cron && $TRAVIS_OS_NAME != 'windows'
       repo: streamlink/streamlink
   - provider: script
     script: ./script/sdistsign.sh
     skip_cleanup: true
     on:
       tags: true
-      condition: $BUILD_SDIST == yes
+      condition: $BUILD_SDIST == yes && $TRAVIS_OS_NAME != 'windows'
       repo: streamlink/streamlink
   - provider: releases
     api_key: "${RELEASES_API_KEY}"
@@ -102,11 +134,11 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-      condition: $BUILD_SDIST = yes
+      condition: $BUILD_SDIST = yes && $TRAVIS_OS_NAME != 'windows'
       repo: streamlink/streamlink
 
 after_deploy:
-  - if [[ "$BUILD_INSTALLER" == 'yes' && "$TRAVIS_EVENT_TYPE" == 'cron' ]]; then ./script/bintrayupdate.sh; fi
+  - if [[ "$BUILD_INSTALLER" == 'yes' && "$TRAVIS_EVENT_TYPE" == 'cron' && $TRAVIS_OS_NAME != 'windows' ]]; then ./script/bintrayupdate.sh; fi
 
 doctr:
   build-tags: True

--- a/script/build-and-sign.sh
+++ b/script/build-and-sign.sh
@@ -2,21 +2,23 @@
 shopt -s nullglob
 set -e
 
+
+for dep in setuptools wheel; do
+    if ! python -m pip -q show "${dep}"; then
+        echo "build: missing dependency '${dep}'" >&2;
+        exit 1;
+    fi
+done
+
+
 KEY_ID=2E390FA0
-KEY_FILE=${SDIST_KEY_FILE:-signing.key}
+KEY_FILE=${SIGNING_KEY_FILE:-signing.key}
 
 version=$(python setup.py --version)
 dist_dir=${STREAMLINK_DIST_DIR:-dist}
-temp_keyring=$(mktemp -d) && trap "rm -rf ${temp_keyring}" EXIT || exit 255
+
 
 wheel_platforms_windows=("win32" "win-amd64" "cygwin")
-
-if [[ -n "${TRAVIS}" ]]; then
-      openssl aes-256-cbc -K ${encrypted_eeb8b970d3a3_key} -iv ${encrypted_eeb8b970d3a3_iv} -in signing.key.enc -out "${SDIST_KEY_FILE}" -d
-fi
-
-echo "build: Installing twine and wheel" >&2
-pip -q install -U setuptools twine wheel
 
 echo "build: Building Streamlink sdist" >&2
 python setup.py -q sdist --dist-dir "${dist_dir}"
@@ -29,18 +31,19 @@ for platform in "${wheel_platforms_windows[@]}"; do
     python setup.py -q bdist_wheel --plat-name "${platform}" --dist-dir "${dist_dir}"
 done
 
-if [ -f "${KEY_FILE}" ]; then
+
+temp_keyring=$(mktemp -d) && trap "rm -rf ${temp_keyring}" EXIT || exit 255
+
+if [[ -n "${TRAVIS}" ]]; then
+    openssl aes-256-cbc -K ${encrypted_eeb8b970d3a3_key} -iv ${encrypted_eeb8b970d3a3_iv} -in signing.key.enc -out "${KEY_FILE}" -d
+fi
+
+if [[ -f "${KEY_FILE}" ]]; then
     echo "build: Signing sdist and wheel files" >&2
-    gpg --homedir "${temp_keyring}" --import "${KEY_FILE}" 2>&1 > /dev/null
+    gpg --homedir "${temp_keyring}" --import "${KEY_FILE}" 2>&1 >/dev/null
     for file in "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}; do
         gpg --homedir "${temp_keyring}" --trust-model always --default-key "${KEY_ID}" --detach-sign --armor "${file}"
     done
 else
     echo "warning: no signing key, files not signed" >&2
-fi
-
-if [[ "${DEPLOY_PYPI}" == "yes" ]]; then
-    echo "build: Uploading sdist and wheel to PyPI" >&2
-    twine upload --username "${PYPI_USER}" --password "${PYPI_PASSWORD}" \
-        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
 fi

--- a/script/deploy-pypi.sh
+++ b/script/deploy-pypi.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+shopt -s nullglob
+set -e
+
+
+version=$(python setup.py --version)
+dist_dir=${STREAMLINK_DIST_DIR:-dist}
+
+
+if [[ "${1}" = "-n" || "${1}" = "--dry-run" ]]; then
+    echo "deploy: dry-run (${version})" >&2
+    for file in "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}; do
+        echo "${file}" >&2
+    done
+
+else
+    if ! python -m pip -q show twine; then
+        echo "deploy: missing dependency 'twine'" >&2
+        exit 1
+    fi
+
+    if [[ -z "${PYPI_USER}" || -z "${PYPI_PASSWORD}" ]]; then
+        echo "deploy: missing PYPI_USER or PYPI_PASSWORD env var" >&2
+        exit 1
+    fi
+
+    echo "deploy: Uploading files to PyPI (${version})" >&2
+    twine upload \
+        --username "${PYPI_USER}" \
+        --password "${PYPI_PASSWORD}" \
+        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
+fi


### PR DESCRIPTION
AppVeyor is failing once again with random network stuff and is breaking the builds. Let's see if Windows on TravisCI is already good enough for Streamlink (still in beta).

Resolves #2128


## Changes

- Added Windows VMs to the build matrix
  Based on @back-to's config mentioned [here](https://github.com/streamlink/streamlink/issues/2128#issuecomment-462141708).
- Added build stages
  This splits the test, documentation and deploy configs into consecutive and conditional stages instead of using one single python 3.5 VM with special build env vars. It should also improve the readability of the config. The deploy stage will only be run if all previous tests have passed in all environments. This wasn't the case previously.
- Split `sdistsign.sh` into `build-and-sign.sh` and `deploy-pypi.sh`

## To do

- [ ] Remove appveyor.yml once webhook has been removed
- [ ] Test deploy configs in a side-repo
