### PR TITLE
plugins.twitch: platform=_ in access_token request

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -222,7 +222,7 @@ class TwitchAPI(object):
     # Private API calls
 
     def access_token(self, endpoint, asset, **params):
-        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), **params)
+        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), **dict(platform="_", **params))
 
     def token(self, **params):
         return self.call("/api/viewer/token", **params)


### PR DESCRIPTION
Resolves #2357
Sets the `platform=_` GET parameter in the stream access token request, which results in `server_ads` to be set to `false` in the response (at least for now - might get changed/fixed in the future).

As I've said in #2357, I'm not sure how to feel about actively suppressing ads in Streamlink and its plugins. Yes, this is what probably most - if not all - of the users want, but this violates the ToS of Twitch and may put us at risk of losing our API client ID in the future. Discussion is welcome.