### PR TITLE
stream.hls: add option to skip discontinuous segments (eg. ads)

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -763,6 +763,21 @@ def build_parser():
         """
     )
     transport.add_argument(
+        "--hls-segment-skip-discontinuity",
+        action="store_true",
+        help="""
+        Ignore segments in the playlist that occur during a discontinuity. This
+        option can be used to skip ads that are inserted in to a stream and marked
+        as a discontinuity.
+
+        Default is False.
+
+        Note: This option should be used with care, if the stream is running an ad
+        when Streamlink connects the ad will play and the actual stream will be
+        considered as an ad, and only ads will play.
+        """
+    )
+    transport.add_argument(
         "--hls-segment-key-uri",
         metavar="URI",
         type=str,

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -796,6 +796,9 @@ def setup_options():
     if args.hls_segment_ignore_names:
         streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
 
+    if args.hls_segment_skip_discontinuity:
+        streamlink.set_option("hls-segment-skip-discontinuity", args.hls_segment_skip_discontinuity)
+
     if args.hls_segment_key_uri:
         streamlink.set_option("hls-segment-key-uri", args.hls_segment_key_uri)
 


### PR DESCRIPTION
Adds a new option `--hls-segment-skip-discontinuity`, that will cause Streamlink to skip any part of the stream that is between two `#EXT-X-DISCONTINUITY` markers. 

This can be used to skip ads that are injected in to the stream. 

Can be used to skip the pre-roll and in-stream ads add by Twitch, as noted in #2368. 

For example 

```
streamlink --hls-segment-skip-discontinuity https://www.twitch.tv/esl_csgo best
```