### PR TITLE
 plugins.twitch: implement disable-ads parameter

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -181,6 +181,9 @@ class HLSStreamWorker(SegmentedStreamWorker):
                       self.duration_offset_start, self.duration_limit,
                       self.playlist_sequence, self.playlist_end)
 
+    def _reload_playlist(self, text, url):
+        return hls_playlist.load(text, url)
+
     def reload_playlist(self):
         if self.closed:
             return
@@ -192,7 +195,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
                                     retries=self.playlist_reload_retries,
                                     **self.reader.request_params)
         try:
-            playlist = hls_playlist.load(res.text, res.url)
+            playlist = self._reload_playlist(res.text, res.url)
         except ValueError as err:
             raise StreamError(err)
 
@@ -472,8 +475,12 @@ class HLSStream(HTTPStream):
                                         duration=duration,
                                         **request_params)
             else:
-                stream = HLSStream(session_, playlist.uri, force_restart=force_restart,
-                                   start_offset=start_offset, duration=duration, **request_params)
+                stream = cls(session_,
+                             playlist.uri,
+                             force_restart=force_restart,
+                             start_offset=start_offset,
+                             duration=duration,
+                             **request_params)
             streams[name_prefix + stream_name] = stream
 
         return streams

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -19,24 +19,20 @@ Key = namedtuple("Key", "method uri iv key_format key_format_versions")
 Map = namedtuple("Map", "uri byterange")
 
 # EXT-X-MEDIA
-Media = namedtuple("Media", "uri type group_id language name default "
-                            "autoselect forced characteristics")
+Media = namedtuple("Media", "uri type group_id language name default autoselect forced characteristics")
 
 # EXT-X-START
 Start = namedtuple("Start", "time_offset precise")
 
 # EXT-X-STREAM-INF
-StreamInfo = namedtuple("StreamInfo", "bandwidth program_id codecs resolution "
-                                      "audio video subtitles")
+StreamInfo = namedtuple("StreamInfo", "bandwidth program_id codecs resolution audio video subtitles")
 
 # EXT-X-I-FRAME-STREAM-INF
-IFrameStreamInfo = namedtuple("IFrameStreamInfo", "bandwidth program_id "
-                                                  "codecs resolution video")
+IFrameStreamInfo = namedtuple("IFrameStreamInfo", "bandwidth program_id codecs resolution video")
 
 Playlist = namedtuple("Playlist", "uri stream_info media is_iframe")
 Resolution = namedtuple("Resolution", "width height")
-Segment = namedtuple("Segment", "uri duration title key discontinuity "
-                                "byterange date map")
+Segment = namedtuple("Segment", "uri duration title key discontinuity byterange date map")
 
 
 class M3U8(object):
@@ -65,7 +61,7 @@ class M3U8Parser(object):
     _tag_re = re.compile(r"#(?P<tag>[\w-]+)(:(?P<value>.+))?")
     _res_re = re.compile(r"(\d+)x(\d+)")
 
-    def __init__(self, base_uri=None):
+    def __init__(self, base_uri=None, **kwargs):
         self.base_uri = base_uri
 
     def create_stream_info(self, streaminf, cls=None):
@@ -142,97 +138,107 @@ class M3U8Parser(object):
 
         return Resolution(width, height)
 
-    def parse_tag(self, line, transform=None):
-        tag, value = self.split_tag(line)
+    def parse_tag_extinf(self, value):
+        self.state["expect_segment"] = True
+        self.state["extinf"] = self.parse_extinf(value)
 
-        if transform:
-            value = transform(value)
+    def parse_tag_ext_x_byterange(self, value):
+        self.state["expect_segment"] = True
+        self.state["byterange"] = self.parse_byterange(value)
 
-        return value
+    def parse_tag_ext_x_targetduration(self, value):
+        self.m3u8.target_duration = int(value)
+
+    def parse_tag_ext_x_media_sequence(self, value):
+        self.m3u8.media_sequence = int(value)
+
+    def parse_tag_ext_x_key(self, value):
+        attr = self.parse_attributes(value)
+        iv = attr.get("IV")
+        if iv:
+            iv = self.parse_hex(iv)
+        self.state["key"] = Key(attr.get("METHOD"),
+                                self.uri(attr.get("URI")),
+                                iv, attr.get("KEYFORMAT"),
+                                attr.get("KEYFORMATVERSIONS"))
+
+    def parse_tag_ext_x_program_date_time(self, value):
+        self.state["date"] = value
+
+    def parse_tag_ext_x_allow_cache(self, value):
+        self.m3u8.allow_cache = self.parse_bool(value)
+
+    def parse_tag_ext_x_stream_inf(self, value):
+        self.state["streaminf"] = self.parse_attributes(value)
+        self.state["expect_playlist"] = True
+
+    def parse_tag_ext_x_playlist_type(self, value):
+        self.m3u8.playlist_type = value
+
+    def parse_tag_ext_x_endlist(self, value):
+        self.m3u8.is_endlist = True
+
+    def parse_tag_ext_x_media(self, value):
+        attr = self.parse_attributes(value)
+        media = Media(
+            self.uri(attr.get("URI")),
+            attr.get("TYPE"),
+            attr.get("GROUP-ID"),
+            attr.get("LANGUAGE"),
+            attr.get("NAME"),
+            self.parse_bool(attr.get("DEFAULT")),
+            self.parse_bool(attr.get("AUTOSELECT")),
+            self.parse_bool(attr.get("FORCED")),
+            attr.get("CHARACTERISTICS")
+        )
+        self.m3u8.media.append(media)
+
+    def parse_tag_ext_x_discontinuity(self, value):
+        self.state["discontinuity"] = True
+        self.state["map"] = None
+
+    def parse_tag_ext_x_discontinuity_sequence(self, value):
+        self.m3u8.discontinuity_sequence = int(value)
+
+    def parse_tag_ext_x_i_frames_only(self, value):
+        self.m3u8.iframes_only = True
+
+    def parse_tag_ext_x_map(self, value):
+        attr = self.parse_attributes(value)
+        byterange = self.parse_byterange(attr.get("BYTERANGE", ""))
+        self.state["map"] = Map(attr.get("URI"), byterange)
+
+    def parse_tag_ext_x_i_frame_stream_inf(self, value):
+        attr = self.parse_attributes(value)
+        streaminf = self.state.pop("streaminf", attr)
+        stream_info = self.create_stream_info(streaminf, IFrameStreamInfo)
+        playlist = Playlist(self.uri(attr.get("URI")), stream_info, [], True)
+        self.m3u8.playlists.append(playlist)
+
+    def parse_tag_ext_x_version(self, value):
+        self.m3u8.version = int(value)
+
+    def parse_tag_ext_x_start(self, value):
+        attr = self.parse_attributes(value)
+        start = Start(attr.get("TIME-OFFSET"),
+                      self.parse_bool(attr.get("PRECISE", "NO")))
+        self.m3u8.start = start
 
     def parse_line(self, line):
-        if not line.startswith("#"):
-            if self.state.pop("expect_segment", None):
-                byterange = self.state.pop("byterange", None)
-                extinf = self.state.pop("extinf", (0, None))
-                date = self.state.pop("date", None)
-                map_ = self.state.get("map")
-                key = self.state.get("key")
-
-                segment = Segment(self.uri(line), extinf[0],
-                                  extinf[1], key,
-                                  self.state.pop("discontinuity", False),
-                                  byterange, date, map_)
-                self.m3u8.segments.append(segment)
-            elif self.state.pop("expect_playlist", None):
-                streaminf = self.state.pop("streaminf", {})
-                stream_info = self.create_stream_info(streaminf)
-                playlist = Playlist(self.uri(line), stream_info, [], False)
-                self.m3u8.playlists.append(playlist)
-        elif line.startswith("#EXTINF"):
-            self.state["expect_segment"] = True
-            self.state["extinf"] = self.parse_tag(line, self.parse_extinf)
-        elif line.startswith("#EXT-X-BYTERANGE"):
-            self.state["expect_segment"] = True
-            self.state["byterange"] = self.parse_tag(line, self.parse_byterange)
-        elif line.startswith("#EXT-X-TARGETDURATION"):
-            self.m3u8.target_duration = self.parse_tag(line, int)
-        elif line.startswith("#EXT-X-MEDIA-SEQUENCE"):
-            self.m3u8.media_sequence = self.parse_tag(line, int)
-        elif line.startswith("#EXT-X-KEY"):
-            attr = self.parse_tag(line, self.parse_attributes)
-            iv = attr.get("IV")
-            if iv:
-                iv = self.parse_hex(iv)
-            self.state["key"] = Key(attr.get("METHOD"),
-                                    self.uri(attr.get("URI")),
-                                    iv, attr.get("KEYFORMAT"),
-                                    attr.get("KEYFORMATVERSIONS"))
-        elif line.startswith("#EXT-X-PROGRAM-DATE-TIME"):
-            self.state["date"] = self.parse_tag(line)
-        elif line.startswith("#EXT-X-ALLOW-CACHE"):
-            self.m3u8.allow_cache = self.parse_tag(line, self.parse_bool)
-        elif line.startswith("#EXT-X-STREAM-INF"):
-            self.state["streaminf"] = self.parse_tag(line, self.parse_attributes)
-            self.state["expect_playlist"] = True
-        elif line.startswith("#EXT-X-PLAYLIST-TYPE"):
-            self.m3u8.playlist_type = self.parse_tag(line)
-        elif line.startswith("#EXT-X-ENDLIST"):
-            self.m3u8.is_endlist = True
-        elif line.startswith("#EXT-X-MEDIA"):
-            attr = self.parse_tag(line, self.parse_attributes)
-            media = Media(self.uri(attr.get("URI")), attr.get("TYPE"),
-                          attr.get("GROUP-ID"), attr.get("LANGUAGE"),
-                          attr.get("NAME"),
-                          self.parse_bool(attr.get("DEFAULT")),
-                          self.parse_bool(attr.get("AUTOSELECT")),
-                          self.parse_bool(attr.get("FORCED")),
-                          attr.get("CHARACTERISTICS"))
-            self.m3u8.media.append(media)
-        elif line.startswith("#EXT-X-DISCONTINUITY"):
-            self.state["discontinuity"] = True
-            self.state["map"] = None
-        elif line.startswith("#EXT-X-DISCONTINUITY-SEQUENCE"):
-            self.m3u8.discontinuity_sequence = self.parse_tag(line, int)
-        elif line.startswith("#EXT-X-I-FRAMES-ONLY"):
-            self.m3u8.iframes_only = True
-        elif line.startswith("#EXT-X-MAP"):
-            attr = self.parse_tag(line, self.parse_attributes)
-            byterange = self.parse_byterange(attr.get("BYTERANGE", ""))
-            self.state["map"] = Map(attr.get("URI"), byterange)
-        elif line.startswith("#EXT-X-I-FRAME-STREAM-INF"):
-            attr = self.parse_tag(line, self.parse_attributes)
-            streaminf = self.state.pop("streaminf", attr)
-            stream_info = self.create_stream_info(streaminf, IFrameStreamInfo)
-            playlist = Playlist(self.uri(attr.get("URI")), stream_info, [], True)
+        if line.startswith("#"):
+            tag, value = self.split_tag(line)
+            if not tag:
+                return
+            method = "parse_tag_" + tag.lower().replace("-", "_")
+            if not hasattr(self, method):
+                return
+            getattr(self, method)(value)
+        elif self.state.pop("expect_segment", None):
+            segment = self.get_segment(self.uri(line))
+            self.m3u8.segments.append(segment)
+        elif self.state.pop("expect_playlist", None):
+            playlist = self.get_playlist(self.uri(line))
             self.m3u8.playlists.append(playlist)
-        elif line.startswith("#EXT-X-VERSION"):
-            self.m3u8.version = self.parse_tag(line, int)
-        elif line.startswith("#EXT-X-START"):
-            attr = self.parse_tag(line, self.parse_attributes)
-            start = Start(attr.get("TIME-OFFSET"),
-                          self.parse_bool(attr.get("PRECISE", "NO")))
-            self.m3u8.start = start
 
     def parse(self, data):
         self.state = {}
@@ -272,8 +278,32 @@ class M3U8Parser(object):
         else:
             return uri
 
+    def get_segment(self, uri):
+        byterange = self.state.pop("byterange", None)
+        extinf = self.state.pop("extinf", (0, None))
+        date = self.state.pop("date", None)
+        map_ = self.state.get("map")
+        key = self.state.get("key")
+        discontinuity = self.state.pop("discontinuity", False)
 
-def load(data, base_uri=None, parser=M3U8Parser):
+        return Segment(
+            uri,
+            extinf[0],
+            extinf[1],
+            key,
+            discontinuity,
+            byterange,
+            date,
+            map_
+        )
+
+    def get_playlist(self, uri):
+        streaminf = self.state.pop("streaminf", {})
+        stream_info = self.create_stream_info(streaminf)
+        return Playlist(uri, stream_info, [], False)
+
+
+def load(data, base_uri=None, parser=M3U8Parser, **kwargs):
     """Attempts to parse a M3U8 playlist from a string of data.
 
     If specified, *base_uri* is the base URI that relative URIs will
@@ -283,4 +313,4 @@ def load(data, base_uri=None, parser=M3U8Parser):
     to parse the data.
 
     """
-    return parser(base_uri).parse(data)
+    return parser(base_uri, **kwargs).parse(data)

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -1,6 +1,17 @@
+import logging
 import unittest
+from functools import partial
 
-from streamlink.plugins.twitch import Twitch
+from streamlink.plugins.twitch import Twitch, TwitchHLSStream
+
+import requests_mock
+from tests.mock import call, patch
+
+from streamlink.session import Streamlink
+from tests.resources import text
+
+
+log = logging.getLogger(__name__)
 
 
 class TestPluginTwitch(unittest.TestCase):
@@ -21,3 +32,158 @@ class TestPluginTwitch(unittest.TestCase):
         ]
         for url in should_not_match:
             self.assertFalse(Twitch.can_handle_url(url))
+
+
+class TestTwitchHLSStream(unittest.TestCase):
+    scte35_out = "#EXT-X-DISCONTINUITY\n#EXT-X-SCTE35-OUT\n"
+    scte35_out_cont = "#EXT-X-SCTE35-OUT-CONT\n"
+    scte35_in = "#EXT-X-DISCONTINUITY\n#EXT-X-SCTE35-IN\n"
+    segment = "#EXTINF:1.000,\nstream{0}.ts\n"
+
+    def getMasterPlaylist(self):
+        with text("hls/test_master.m3u8") as pl:
+            return pl.read()
+
+    def getPlaylist(self, media_sequence, items):
+        playlist = """
+#EXTM3U
+#EXT-X-VERSION:5
+#EXT-X-TARGETDURATION:1
+#EXT-X-MEDIA-SEQUENCE:{0}
+""".format(media_sequence)
+
+        for item in items:
+            if type(item) != int:
+                playlist += item
+            else:
+                playlist += self.segment.format(item)
+
+        return playlist
+
+    def start_streamlink(self, kwargs=None):
+        kwargs = kwargs or {}
+        log.info("Executing streamlink")
+        streamlink = Streamlink()
+
+        streamlink.set_option("hls-live-edge", 4)
+        streamlink.plugins.get("twitch").options.set("disable-ads", True)
+
+        masterStream = TwitchHLSStream.parse_variant_playlist(
+            streamlink,
+            "http://mocked/path/master.m3u8",
+            **kwargs
+        )
+        stream = masterStream["1080p (source)"].open()
+        data = b"".join(iter(partial(stream.read, 8192), b""))
+        stream.close()
+        log.info("End of streamlink execution")
+        return data
+
+    def mock(self, mocked, method, url, *args, **kwargs):
+        mocked[url] = method(url, *args, **kwargs)
+
+    def get_result(self, streams, playlists):
+        mocked = {}
+        with requests_mock.Mocker() as mock:
+            self.mock(mocked, mock.get, "http://mocked/path/master.m3u8", text=self.getMasterPlaylist())
+            self.mock(mocked, mock.get, "http://mocked/path/playlist.m3u8", [{"text": p} for p in playlists])
+            for i, stream in enumerate(streams):
+                self.mock(mocked, mock.get, "http://mocked/path/stream{0}.ts".format(i), content=stream)
+            return self.start_streamlink(), mocked
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_scte35_start_with_end(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(12)]
+        playlists = [
+            self.getPlaylist(0, [self.scte35_out, 0, 1, 2, 3]),
+            self.getPlaylist(4, [self.scte35_in, 4, 5, 6, 7]),
+            self.getPlaylist(8, [8, 9, 10, 11]) + "#EXT-X-ENDLIST\n"
+        ]
+        result, mocked = self.get_result(streams, playlists)
+
+        expected = b''.join(streams[4:12])
+        self.assertEqual(expected, result)
+        for i, _ in enumerate(streams):
+            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        mock_logging.info.assert_has_calls([
+            call("Will skip ad segments"),
+            call("Will skip ads beginning with segment 0"),
+            call("Will stop skipping ads beginning with segment 4")
+        ])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_scte35_no_start(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(8)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3]),
+            self.getPlaylist(4, [self.scte35_in, 4, 5, 6, 7]) + "#EXT-X-ENDLIST\n"
+        ]
+        result, mocked = self.get_result(streams, playlists)
+
+        expected = b''.join(streams[0:8])
+        self.assertEqual(expected, result)
+        for i, _ in enumerate(streams):
+            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        mock_logging.info.assert_has_calls([
+            call("Will skip ad segments")
+        ])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_scte35_no_start_with_cont(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(8)]
+        playlists = [
+            self.getPlaylist(0, [self.scte35_out_cont, 0, 1, 2, 3]),
+            self.getPlaylist(4, [self.scte35_in, 4, 5, 6, 7]) + "#EXT-X-ENDLIST\n"
+        ]
+        result, mocked = self.get_result(streams, playlists)
+
+        expected = b''.join(streams[4:8])
+        self.assertEqual(expected, result)
+        for i, _ in enumerate(streams):
+            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        mock_logging.info.assert_has_calls([
+            call("Will skip ad segments"),
+            call("Will skip ads beginning with segment 0"),
+            call("Will stop skipping ads beginning with segment 4")
+        ])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_scte35_no_end(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(12)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3]),
+            self.getPlaylist(4, [self.scte35_out, 4, 5, 6, 7]),
+            self.getPlaylist(8, [8, 9, 10, 11]) + "#EXT-X-ENDLIST\n"
+        ]
+        result, mocked = self.get_result(streams, playlists)
+
+        expected = b''.join(streams[0:4])
+        self.assertEqual(expected, result)
+        for i, _ in enumerate(streams):
+            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        mock_logging.info.assert_has_calls([
+            call("Will skip ad segments"),
+            call("Will skip ads beginning with segment 4")
+        ])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_scte35_in_between(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(20)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3]),
+            self.getPlaylist(4, [4, 5, self.scte35_out, 6, 7]),
+            self.getPlaylist(8, [8, 9, 10, 11]),
+            self.getPlaylist(12, [12, 13, self.scte35_in, 14, 15]),
+            self.getPlaylist(16, [16, 17, 18, 19]) + "#EXT-X-ENDLIST\n"
+        ]
+        result, mocked = self.get_result(streams, playlists)
+
+        expected = b''.join(streams[0:6]) + b''.join(streams[14:20])
+        self.assertEqual(expected, result)
+        for i, _ in enumerate(streams):
+            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        mock_logging.info.assert_has_calls([
+            call("Will skip ad segments"),
+            call("Will skip ads beginning with segment 6"),
+            call("Will stop skipping ads beginning with segment 14")
+        ])


### PR DESCRIPTION
Resolves #2368, #2357 (deleted, for whatever reason, which is really sad - I've opened a support ticket to get it hopefully restored) 

Please see #2369 and my comment here first:
https://github.com/streamlink/streamlink/pull/2369#issuecomment-475528275

Adds a custom `TwitchHLSStream` implementation and the `--twitch-disable-ads` CLI parameter, which will skip HLS segments between `#EXT-X-SCTE35-OUT` and `#EXT-X-SCTE35-IN` tags.

If this PR gets merged, **please don't squash the commits**.