### PR TITLE
[plugins.bfmtv] Fix player regex

### DIFF
--- a/src/streamlink/plugins/bfmtv.py
+++ b/src/streamlink/plugins/bfmtv.py
@@ -8,7 +8,7 @@ from streamlink.stream import HLSStream
 class BFMTV(Plugin):
     _url_re = re.compile(r'https://.+\.(?:bfmtv|01net)\.com')
     _brightcove_video_re = re.compile(r'data-holder="video(?P<video_id>[0-9]+)" data-account="(?P<account_id>[0-9]+)"')
-    _brightcove_video_alt_re = re.compile(r'data-account="(?P<account_id>[0-9]+).*?data-video-id="(?P<video_id>[0-9]+)"')
+    _brightcove_video_alt_re = re.compile(r'data-account="(?P<account_id>[0-9]+).*?data-video-id="(?P<video_id>[0-9]+)"', re.DOTALL)
     _embed_video_url_re = re.compile(r"\$YOPLAYER\('liveStitching', {.+?file: '(?P<video_url>[^\"]+?)'.+?}\);", re.DOTALL)
 
     @classmethod


### PR DESCRIPTION
This PR fixes this issue:
```
$ /usr/bin/streamlink https://bfmbusiness.bfmtv.com/mediaplayer/live-video/
[cli][info] Found matching plugin bfmtv for URL https://bfmbusiness.bfmtv.com/mediaplayer/live-video/
error: No playable streams found on this URL: https://bfmbusiness.bfmtv.com/mediaplayer/live-video/
```