### PR TITLE
plugins.teamliquid: New domain, fix stream_weight

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -198,7 +198,8 @@ svtplay                 - svtplay.se         Yes   Yes   Streams may be geo-rest
 swisstxt                - srf.ch             Yes   No    Streams are geo-restricted to Switzerland.
                         - rsi.ch
 tamago                  player.tamago.live   Yes   --
-teamliquid              teamliquid.net       Yes   Yes
+teamliquid              - teamliquid.net     Yes   --
+                        - tl.net
 teleclubzoom            teleclubzoom.ch      Yes   No    Streams are geo-restricted to Switzerland.
 telefe                  telefe.com           No    Yes   Streams are geo-restricted to Argentina.
 tf1                     - tf1.fr             Yes   No    Streams may be geo-restricted to France.

--- a/src/streamlink/plugins/teamliquid.py
+++ b/src/streamlink/plugins/teamliquid.py
@@ -1,15 +1,20 @@
+import logging
 import re
 
+from streamlink.compat import urlparse
 from streamlink.plugin import Plugin
+from streamlink.plugins.afreeca import AfreecaTV
+from streamlink.plugins.twitch import Twitch
 
-
-_url_re = re.compile(r'''https?://(?:www\.)?teamliquid\.net/video/streams/''')
+log = logging.getLogger(__name__)
 
 
 class Teamliquid(Plugin):
+    _url_re = re.compile(r'''https?://(?:www\.)?(?:tl|teamliquid)\.net/video/streams/''')
+
     @classmethod
     def can_handle_url(cls, url):
-        return _url_re.match(url)
+        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)
@@ -19,7 +24,12 @@ class Teamliquid(Plugin):
         stream_url_match = stream_address_re.search(res.text)
         if stream_url_match:
             stream_url = stream_url_match.group(1)
-            self.logger.info("Attempting to play streams from {0}", stream_url)
+            log.info("Attempting to play streams from {0}".format(stream_url))
+            p = urlparse(stream_url)
+            if p.netloc.endswith("afreecatv.com"):
+                self.stream_weight = AfreecaTV.stream_weight
+            elif p.netloc.endswith("twitch.tv"):
+                self.stream_weight = Twitch.stream_weight
             return self.session.streams(stream_url)
 
 

--- a/tests/plugins/test_teamliquid.py
+++ b/tests/plugins/test_teamliquid.py
@@ -10,6 +10,7 @@ class TestPluginTeamliquid(unittest.TestCase):
         self.assertTrue(Teamliquid.can_handle_url("http://teamliquid.net/video/streams/iwl-fuNny"))
         self.assertTrue(Teamliquid.can_handle_url("http://www.teamliquid.net/video/streams/OGamingTV%20SC2"))
         self.assertTrue(Teamliquid.can_handle_url("http://www.teamliquid.net/video/streams/Check"))
+        self.assertTrue(Teamliquid.can_handle_url("https://tl.net/video/streams/GSL"))
 
         # shouldn't match
         self.assertFalse(Teamliquid.can_handle_url("http://www.teamliquid.net/Classic%20BW%20VODs"))


### PR DESCRIPTION
closes https://github.com/streamlink/streamlink/issues/2407
closes https://github.com/streamlink/streamlink/issues/2416

---

not sure if there is a better way for fixing the `stream_weight`,
but this would work for now.

---

Plugin could also be removed, as the website is just reusing other Streams.