### PR TITLE
plugins.twitch: low latency

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -244,8 +244,17 @@ class TwitchHLSStreamReader(HLSStreamReader):
 class TwitchHLSStream(HLSStream):
     def __init__(self, *args, **kwargs):
         HLSStream.__init__(self, *args, **kwargs)
-        self.disable_ads = self.session.get_plugin_option("twitch", "disable-ads")
-        self.low_latency = self.session.get_plugin_option("twitch", "low-latency")
+
+        disable_ads = self.session.get_plugin_option("twitch", "disable-ads")
+        low_latency = self.session.get_plugin_option("twitch", "low-latency")
+
+        if low_latency and disable_ads:
+            log.info("Low latency streaming with ad filtering is currently not supported")
+            self.session.set_plugin_option("twitch", "low-latency", False)
+            low_latency = False
+
+        self.disable_ads = disable_ads
+        self.low_latency = low_latency
 
     def open(self):
         if self.disable_ads:

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -152,17 +152,41 @@ _quality_options_schema = validate.Schema(
 
 Segment = namedtuple("Segment", "uri duration title key discontinuity scte35 byterange date map")
 
+LOW_LATENCY_MAX_LIVE_EDGE = 2
+
+
+def parse_condition(attr):
+    def wrapper(func):
+        def method(self, *args, **kwargs):
+            if hasattr(self.stream, attr) and getattr(self.stream, attr, False):
+                func(self, *args, **kwargs)
+        return method
+    return wrapper
+
 
 class TwitchM3U8Parser(M3U8Parser):
+    def __init__(self, base_uri=None, stream=None, **kwargs):
+        M3U8Parser.__init__(self, base_uri, **kwargs)
+        self.stream = stream
+
+    @parse_condition("disable_ads")
     def parse_tag_ext_x_scte35_out(self, value):
         self.state["scte35"] = True
 
     # unsure if this gets used by Twitch
+    @parse_condition("disable_ads")
     def parse_tag_ext_x_scte35_out_cont(self, value):
         self.state["scte35"] = True
 
+    @parse_condition("disable_ads")
     def parse_tag_ext_x_scte35_in(self, value):
         self.state["scte35"] = False
+
+    @parse_condition("low_latency")
+    def parse_tag_ext_x_twitch_prefetch(self, value):
+        segments = self.m3u8.segments
+        if segments:
+            segments.append(segments[-1]._replace(uri=self.uri(value)))
 
     def get_segment(self, uri):
         byterange = self.state.pop("byterange", None)
@@ -188,19 +212,18 @@ class TwitchM3U8Parser(M3U8Parser):
 
 class TwitchHLSStreamWorker(HLSStreamWorker):
     def _reload_playlist(self, text, url):
-        return load_hls_playlist(text, url, parser=TwitchM3U8Parser)
+        return load_hls_playlist(text, url, parser=TwitchM3U8Parser, stream=self.stream)
+
+    def _set_playlist_reload_time(self, playlist, sequences):
+        if not self.stream.low_latency:
+            super(TwitchHLSStreamWorker, self)._set_playlist_reload_time(playlist, sequences)
+        else:
+            self.playlist_reload_time = sequences[-1].segment.duration
 
 
 class TwitchHLSStreamWriter(HLSStreamWriter):
-    def __init__(self, *args, **kwargs):
-        HLSStreamWriter.__init__(self, *args, **kwargs)
-        options = self.session.plugins.get("twitch").options
-        self.disable_ads = options.get("disable-ads")
-        if self.disable_ads:
-            log.info("Will skip ad segments")
-
     def write(self, sequence, *args, **kwargs):
-        if self.disable_ads:
+        if self.stream.disable_ads:
             if sequence.segment.scte35 is not None:
                 self.reader.ads = sequence.segment.scte35
                 if self.reader.ads:
@@ -219,11 +242,28 @@ class TwitchHLSStreamReader(HLSStreamReader):
 
 
 class TwitchHLSStream(HLSStream):
+    def __init__(self, *args, **kwargs):
+        HLSStream.__init__(self, *args, **kwargs)
+        self.disable_ads = self.session.get_plugin_option("twitch", "disable-ads")
+        self.low_latency = self.session.get_plugin_option("twitch", "low-latency")
+
     def open(self):
+        if self.disable_ads:
+            log.info("Will skip ad segments")
+        if self.low_latency:
+            live_edge = max(1, min(LOW_LATENCY_MAX_LIVE_EDGE, self.session.options.get("hls-live-edge")))
+            self.session.options.set("hls-live-edge", live_edge)
+            self.session.options.set("hls-segment-stream-data", True)
+            log.info("Low latency streaming (HLS live edge: {0})".format(live_edge))
+
         reader = TwitchHLSStreamReader(self)
         reader.open()
 
         return reader
+
+    @classmethod
+    def _get_variant_playlist(cls, res):
+        return load_hls_playlist(res.text, base_uri=res.url)
 
 
 class UsherService(object):
@@ -353,47 +393,70 @@ class TwitchAPI(object):
 
 class Twitch(Plugin):
     arguments = PluginArguments(
-        PluginArgument("oauth-token",
-                       sensitive=True,
-                       metavar="TOKEN",
-                       help="""
-        An OAuth token to use for Twitch authentication.
-        Use --twitch-oauth-authenticate to create a token.
-        """),
-        PluginArgument("cookie",
-                       sensitive=True,
-                       metavar="COOKIES",
-                       help="""
-        Twitch cookies to authenticate to allow access to subscription channels.
+        PluginArgument(
+            "oauth-token",
+            sensitive=True,
+            metavar="TOKEN",
+            help="""
+            An OAuth token to use for Twitch authentication.
+            Use --twitch-oauth-authenticate to create a token.
+            """
+        ),
+        PluginArgument(
+            "cookie",
+            sensitive=True,
+            metavar="COOKIES",
+            help="""
+            Twitch cookies to authenticate to allow access to subscription channels.
 
-        Example:
+            Example:
 
-          "_twitch_session_id=xxxxxx; persistent=xxxxx"
+              "_twitch_session_id=xxxxxx; persistent=xxxxx"
 
-        Note: This method is the old and clunky way of authenticating with
-        Twitch, using --twitch-oauth-authenticate is the recommended and
-        simpler way of doing it now.
-        """
-                       ),
-        PluginArgument("disable-hosting",
-                       action="store_true",
-                       help="""
-        Do not open the stream if the target channel is hosting another channel.
-        """
-                       ),
-        PluginArgument("disable-ads",
-                       action="store_true",
-                       help="""
-        Skip embedded advertisement segments at the beginning or during a stream.
-        Will cause these segments to be missing from the stream.
-        """
-                       ),
-        PluginArgument("disable-reruns",
-                       action="store_true",
-                       help="""
-        Do not open the stream if the target channel is currently broadcasting a rerun.
-        """
-                       ))
+            Note: This method is the old and clunky way of authenticating with
+            Twitch, using --twitch-oauth-authenticate is the recommended and
+            simpler way of doing it now.
+            """
+        ),
+        PluginArgument(
+            "disable-hosting",
+            action="store_true",
+            help="""
+            Do not open the stream if the target channel is hosting another channel.
+            """
+        ),
+        PluginArgument(
+            "disable-ads",
+            action="store_true",
+            help="""
+            Skip embedded advertisement segments at the beginning or during a stream.
+            Will cause these segments to be missing from the stream.
+            """
+        ),
+        PluginArgument(
+            "disable-reruns",
+            action="store_true",
+            help="""
+            Do not open the stream if the target channel is currently broadcasting a rerun.
+            """
+        ),
+        PluginArgument(
+            "low-latency",
+            action="store_true",
+            help="""
+            Enables low latency streaming by prefetching HLS segments.
+            Sets --hls-segment-stream-data to true and --hls-live-edge to {live_edge}, if it is higher.
+            Reducing --hls-live-edge to 1 will result in the lowest latency possible.
+
+            Low latency streams have to be enabled by the broadcasters on Twitch themselves.
+            Regular streams can cause buffering issues with this option enabled.
+
+            Note: The caching/buffering settings of the chosen player may need to be adjusted as well.
+            Please refer to the player's own documentation for the required parameters and its configuration.
+            Player parameters can be set via Streamlink's --player or --player-args parameters.
+            """.format(live_edge=LOW_LATENCY_MAX_LIVE_EDGE)
+        )
+    )
 
     @classmethod
     def stream_weight(cls, key):

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -58,6 +58,7 @@ class Streamlink(object):
             "hls-segment-attempts": 3,
             "hls-segment-threads": 1,
             "hls-segment-timeout": 10.0,
+            "hls-segment-stream-data": False,
             "hls-timeout": 60.0,
             "hls-playlist-reload-attempts": 3,
             "hls-start-offset": 0,
@@ -130,6 +131,9 @@ class Streamlink(object):
 
         hls-segment-threads      (int) The size of the thread pool used
                                  to download segments, default: ``1``
+
+        hls-segment-stream-data  (bool) Stream HLS segment downloads,
+                                 default: ``False``
 
         hls-segment-timeout      (float) HLS segment connect and read
                                  timeout, default: ``10.0``

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -222,6 +222,10 @@ class HLSStreamWorker(SegmentedStreamWorker):
         if sequences:
             self.process_sequences(playlist, sequences)
 
+    def _set_playlist_reload_time(self, playlist, sequences):
+        self.playlist_reload_time = (playlist.target_duration
+                                     or sequences[-1].segment.duration)
+
     def process_sequences(self, playlist, sequences):
         first_sequence, last_sequence = sequences[0], sequences[-1]
 
@@ -229,7 +233,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
             log.debug("Segments in this playlist are encrypted")
 
         self.playlist_changed = ([s.num for s in self.playlist_sequences] != [s.num for s in sequences])
-        self.playlist_reload_time = (playlist.target_duration or last_sequence.segment.duration)
+        self._set_playlist_reload_time(playlist, sequences)
         self.playlist_sequences = sequences
 
         if not self.playlist_changed:
@@ -362,6 +366,10 @@ class HLSStream(HTTPStream):
         return reader
 
     @classmethod
+    def _get_variant_playlist(cls, res):
+        return hls_playlist.load(res.text, base_uri=res.url)
+
+    @classmethod
     def parse_variant_playlist(cls, session_, url, name_key="name",
                                name_prefix="", check_streams=False,
                                force_restart=False, name_fmt=None,
@@ -387,7 +395,7 @@ class HLSStream(HTTPStream):
         res = session_.http.get(url, exception=IOError, **request_params)
 
         try:
-            parser = hls_playlist.load(res.text, base_uri=res.url)
+            parser = cls._get_variant_playlist(res)
         except ValueError as err:
             raise IOError("Failed to parse playlist: {0}".format(err))
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -744,6 +744,13 @@ def build_parser():
         """
     )
     transport.add_argument(
+        "--hls-segment-stream-data",
+        action="store_true",
+        help="""
+        Immediately write segment data into output buffer while downloading.
+        """
+    )
+    transport.add_argument(
         "--hls-segment-attempts",
         type=num(int, min=0),
         metavar="ATTEMPTS",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -791,6 +791,9 @@ def setup_options():
     if args.hls_live_edge:
         streamlink.set_option("hls-live-edge", args.hls_live_edge)
 
+    if args.hls_segment_stream_data:
+        streamlink.set_option("hls-segment-stream-data", args.hls_segment_stream_data)
+
     if args.hls_segment_attempts:
         streamlink.set_option("hls-segment-attempts", args.hls_segment_attempts)
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -253,6 +253,22 @@ class TestTwitchHLSStream(unittest.TestCase):
             self.assertFalse(mocked[self.url_segment.format(i)].called, i)
         mock_logging.info.assert_has_calls([])
 
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_no_low_latency_with_disable_ads(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(10)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3], [4, 5]),
+            self.getPlaylist(4, [4, 5, 6, 7], [8, 9]) + "#EXT-X-ENDLIST\n"
+        ]
+        streamlink, result, mocked = self.get_result(streams, playlists, low_latency=True, disable_ads=True)
+
+        self.assertFalse(streamlink.get_plugin_option("twitch", "low-latency"))
+        self.assertTrue(streamlink.get_plugin_option("twitch", "disable-ads"))
+
+        mock_logging.info.assert_has_calls([
+            call("Low latency streaming with ad filtering is currently not supported")
+        ])
+
 
 @patch("streamlink.plugins.twitch.log")
 class TestTwitchReruns(unittest.TestCase):

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -269,6 +269,23 @@ class TestTwitchHLSStream(unittest.TestCase):
             call("Low latency streaming with ad filtering is currently not supported")
         ])
 
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_no_low_latency_no_prefetch(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(10)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3], []),
+            self.getPlaylist(4, [4, 5, 6, 7], []) + "#EXT-X-ENDLIST\n"
+        ]
+        streamlink, result, mocked = self.get_result(streams, playlists, low_latency=True)
+
+        self.assertTrue(streamlink.get_plugin_option("twitch", "low-latency"))
+        self.assertFalse(streamlink.get_plugin_option("twitch", "disable-ads"))
+
+        mock_logging.info.assert_has_calls([
+            call("Low latency streaming (HLS live edge: 2)"),
+            call("This is not a low latency stream")
+        ])
+
 
 @patch("streamlink.plugins.twitch.log")
 class TestTwitchReruns(unittest.TestCase):

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -35,16 +35,21 @@ class TestPluginTwitch(unittest.TestCase):
 
 
 class TestTwitchHLSStream(unittest.TestCase):
+    url_master = "http://mocked/path/master.m3u8"
+    url_playlist = "http://mocked/path/playlist.m3u8"
+    url_segment = "http://mocked/path/stream{0}.ts"
+
     scte35_out = "#EXT-X-DISCONTINUITY\n#EXT-X-SCTE35-OUT\n"
     scte35_out_cont = "#EXT-X-SCTE35-OUT-CONT\n"
     scte35_in = "#EXT-X-DISCONTINUITY\n#EXT-X-SCTE35-IN\n"
     segment = "#EXTINF:1.000,\nstream{0}.ts\n"
+    prefetch = "#EXT-X-TWITCH-PREFETCH:{0}\n"
 
     def getMasterPlaylist(self):
         with text("hls/test_master.m3u8") as pl:
             return pl.read()
 
-    def getPlaylist(self, media_sequence, items):
+    def getPlaylist(self, media_sequence, items, prefetch=None):
         playlist = """
 #EXTM3U
 #EXT-X-VERSION:5
@@ -57,39 +62,39 @@ class TestTwitchHLSStream(unittest.TestCase):
                 playlist += item
             else:
                 playlist += self.segment.format(item)
+        for item in prefetch or []:
+            playlist += self.prefetch.format(self.url_segment.format(item))
 
         return playlist
 
-    def start_streamlink(self, kwargs=None):
+    def start_streamlink(self, disable_ads=False, low_latency=False, kwargs=None):
         kwargs = kwargs or {}
         log.info("Executing streamlink")
         streamlink = Streamlink()
 
         streamlink.set_option("hls-live-edge", 4)
-        streamlink.plugins.get("twitch").options.set("disable-ads", True)
+        streamlink.set_plugin_option("twitch", "disable-ads", disable_ads)
+        streamlink.set_plugin_option("twitch", "low-latency", low_latency)
 
-        masterStream = TwitchHLSStream.parse_variant_playlist(
-            streamlink,
-            "http://mocked/path/master.m3u8",
-            **kwargs
-        )
+        masterStream = TwitchHLSStream.parse_variant_playlist(streamlink, self.url_master, **kwargs)
         stream = masterStream["1080p (source)"].open()
         data = b"".join(iter(partial(stream.read, 8192), b""))
         stream.close()
         log.info("End of streamlink execution")
-        return data
+        return streamlink, data
 
     def mock(self, mocked, method, url, *args, **kwargs):
         mocked[url] = method(url, *args, **kwargs)
 
-    def get_result(self, streams, playlists):
+    def get_result(self, streams, playlists, **kwargs):
         mocked = {}
         with requests_mock.Mocker() as mock:
-            self.mock(mocked, mock.get, "http://mocked/path/master.m3u8", text=self.getMasterPlaylist())
-            self.mock(mocked, mock.get, "http://mocked/path/playlist.m3u8", [{"text": p} for p in playlists])
+            self.mock(mocked, mock.get, self.url_master, text=self.getMasterPlaylist())
+            self.mock(mocked, mock.get, self.url_playlist, [{"text": p} for p in playlists])
             for i, stream in enumerate(streams):
-                self.mock(mocked, mock.get, "http://mocked/path/stream{0}.ts".format(i), content=stream)
-            return self.start_streamlink(), mocked
+                self.mock(mocked, mock.get, self.url_segment.format(i), content=stream)
+            streamlink, data = self.start_streamlink(**kwargs)
+            return streamlink, data, mocked
 
     @patch("streamlink.plugins.twitch.log")
     def test_hls_scte35_start_with_end(self, mock_logging):
@@ -99,12 +104,12 @@ class TestTwitchHLSStream(unittest.TestCase):
             self.getPlaylist(4, [self.scte35_in, 4, 5, 6, 7]),
             self.getPlaylist(8, [8, 9, 10, 11]) + "#EXT-X-ENDLIST\n"
         ]
-        result, mocked = self.get_result(streams, playlists)
+        streamlink, result, mocked = self.get_result(streams, playlists, disable_ads=True)
 
         expected = b''.join(streams[4:12])
         self.assertEqual(expected, result)
-        for i, _ in enumerate(streams):
-            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        for i in range(0, 12):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
         mock_logging.info.assert_has_calls([
             call("Will skip ad segments"),
             call("Will skip ads beginning with segment 0"),
@@ -118,12 +123,12 @@ class TestTwitchHLSStream(unittest.TestCase):
             self.getPlaylist(0, [0, 1, 2, 3]),
             self.getPlaylist(4, [self.scte35_in, 4, 5, 6, 7]) + "#EXT-X-ENDLIST\n"
         ]
-        result, mocked = self.get_result(streams, playlists)
+        streamlink, result, mocked = self.get_result(streams, playlists, disable_ads=True)
 
         expected = b''.join(streams[0:8])
         self.assertEqual(expected, result)
-        for i, _ in enumerate(streams):
-            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        for i in range(0, 8):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
         mock_logging.info.assert_has_calls([
             call("Will skip ad segments")
         ])
@@ -135,12 +140,12 @@ class TestTwitchHLSStream(unittest.TestCase):
             self.getPlaylist(0, [self.scte35_out_cont, 0, 1, 2, 3]),
             self.getPlaylist(4, [self.scte35_in, 4, 5, 6, 7]) + "#EXT-X-ENDLIST\n"
         ]
-        result, mocked = self.get_result(streams, playlists)
+        streamlink, result, mocked = self.get_result(streams, playlists, disable_ads=True)
 
         expected = b''.join(streams[4:8])
         self.assertEqual(expected, result)
-        for i, _ in enumerate(streams):
-            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        for i in range(0, 8):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
         mock_logging.info.assert_has_calls([
             call("Will skip ad segments"),
             call("Will skip ads beginning with segment 0"),
@@ -155,12 +160,12 @@ class TestTwitchHLSStream(unittest.TestCase):
             self.getPlaylist(4, [self.scte35_out, 4, 5, 6, 7]),
             self.getPlaylist(8, [8, 9, 10, 11]) + "#EXT-X-ENDLIST\n"
         ]
-        result, mocked = self.get_result(streams, playlists)
+        streamlink, result, mocked = self.get_result(streams, playlists, disable_ads=True)
 
         expected = b''.join(streams[0:4])
         self.assertEqual(expected, result)
-        for i, _ in enumerate(streams):
-            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        for i in range(0, 12):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
         mock_logging.info.assert_has_calls([
             call("Will skip ad segments"),
             call("Will skip ads beginning with segment 4")
@@ -176,17 +181,77 @@ class TestTwitchHLSStream(unittest.TestCase):
             self.getPlaylist(12, [12, 13, self.scte35_in, 14, 15]),
             self.getPlaylist(16, [16, 17, 18, 19]) + "#EXT-X-ENDLIST\n"
         ]
-        result, mocked = self.get_result(streams, playlists)
+        streamlink, result, mocked = self.get_result(streams, playlists, disable_ads=True)
 
         expected = b''.join(streams[0:6]) + b''.join(streams[14:20])
         self.assertEqual(expected, result)
-        for i, _ in enumerate(streams):
-            self.assertTrue(mocked["http://mocked/path/stream{0}.ts".format(i)].called)
+        for i in range(0, 20):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
         mock_logging.info.assert_has_calls([
             call("Will skip ad segments"),
             call("Will skip ads beginning with segment 6"),
             call("Will stop skipping ads beginning with segment 14")
         ])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_scte35_no_disable_ads(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(20)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3]),
+            self.getPlaylist(4, [4, 5, self.scte35_out, 6, 7]),
+            self.getPlaylist(8, [8, 9, 10, 11]),
+            self.getPlaylist(12, [12, 13, self.scte35_in, 14, 15]),
+            self.getPlaylist(16, [16, 17, 18, 19]) + "#EXT-X-ENDLIST\n"
+        ]
+        streamlink, result, mocked = self.get_result(streams, playlists)
+
+        expected = b''.join(streams[0:20])
+        self.assertEqual(expected, result)
+        for i in range(0, 20):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
+        mock_logging.info.assert_has_calls([])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_prefetch(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(10)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3], [4, 5]),
+            self.getPlaylist(4, [4, 5, 6, 7], [8, 9]) + "#EXT-X-ENDLIST\n"
+        ]
+        streamlink, result, mocked = self.get_result(streams, playlists, low_latency=True)
+
+        self.assertEqual(2, streamlink.options.get("hls-live-edge"))
+        self.assertEqual(True, streamlink.options.get("hls-segment-stream-data"))
+
+        expected = b''.join(streams[4:10])
+        self.assertEqual(expected, result)
+        for i in range(0, 3):
+            self.assertFalse(mocked[self.url_segment.format(i)].called, i)
+        for i in range(4, 9):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
+        mock_logging.info.assert_has_calls([
+            call("Low latency streaming (HLS live edge: 2)")
+        ])
+
+    @patch("streamlink.plugins.twitch.log")
+    def test_hls_prefetch_no_low_latency(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(10)]
+        playlists = [
+            self.getPlaylist(0, [0, 1, 2, 3], [4, 5]),
+            self.getPlaylist(4, [4, 5, 6, 7], [8, 9]) + "#EXT-X-ENDLIST\n"
+        ]
+        streamlink, result, mocked = self.get_result(streams, playlists)
+
+        self.assertEqual(4, streamlink.options.get("hls-live-edge"))
+        self.assertEqual(False, streamlink.options.get("hls-segment-stream-data"))
+
+        expected = b''.join(streams[0:8])
+        self.assertEqual(expected, result)
+        for i in range(0, 7):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
+        for i in range(8, 9):
+            self.assertFalse(mocked[self.url_segment.format(i)].called, i)
+        mock_logging.info.assert_has_calls([])
 
 
 @patch("streamlink.plugins.twitch.log")


### PR DESCRIPTION
Maybe this should be done in two separate pull requests, but here we go.
These changes are mainly based on the work of @back-to and his low latency test plugin for Twitch (see [here](https://github.com/streamlink/streamlink/issues/1676#issuecomment-430304591)).

**Description**
- Adds the `--hls-segment-stream-data` parameter, which makes Streamlink write the HLS segments to the output buffer while they are being downloaded.
- Adds HLS segment prefetching to the custom `TwitchM3U8Parser`.
- Lowers the playlist refresh time to the duration of the HLS segments (2 seconds).
- Adds the `--twitch-low-latency` shorthand plugin-parameter, which automatically sets `--hls-segment-stream-data` to true and limits the value of `--hls-live-edge` to a maximum of 2, as higher values (default is 3) are pointless for low latency streaming.

**Open questions**

- ~~Is reducing the playlist refresh time by this much necessary? It's also what Twitch's web player does nowadays for regular and low latency streams and it basically refreshes the playlist after each segment download. I'm not sure if this defeats the segment prefetching idea. It seems to be right though to ignore the `targetduration`. Maybe a refresh time of `number_of(prefetch_segments) * duration(segment)` would make sense...~~
- Regarding ad filtering and additional segment metadata, is it the right approach while prefetching segments to clone the last segment of the sequence and replace its URL?
- ~~Is introducing a shorthand parameter for setting other parameter values a good idea? I will have to reword the parameter description later, as segment prefetching is always being done.~~
- ~~Tests need to be added...~~

As for the results of the low latency changes, I'm able to beat Twitch's web player by 0-2 seconds while using MPV without additional player cache. Using a HLS live edge value of 1 sometimes results in micro-buffering though, but this can be fixed by pausing the playback for a short moment.

Resolves #2180, #1676, #2402