### PR TITLE
plugin.schoolism: bug fix for videos with subtitles

### DIFF
--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -17,8 +17,9 @@ class Schoolism(Plugin):
     url_re = re.compile(r"https?://(?:www\.)?schoolism\.com/(viewAssignment|watchLesson).php")
     login_url = "https://www.schoolism.com/index.php"
     key_time_url = "https://www.schoolism.com/video-html/key-time.php"
-    playlist_re = re.compile(r"var allVideos\s*=\s*(\[\{.*\}]);", re.DOTALL)
+    playlist_re = re.compile(r"var allVideos\s*=\s*(\[.*\]);", re.DOTALL)
     js_to_json = partial(re.compile(r'(?!<")(\w+):(?!/)').sub, r'"\1":')
+    fix_brackets = partial(re.compile(r',\s*\}').sub, r'}')
     playlist_schema = validate.Schema(
         validate.transform(playlist_re.search),
         validate.any(
@@ -26,7 +27,7 @@ class Schoolism(Plugin):
             validate.all(
                 validate.get(1),
                 validate.transform(js_to_json),
-                validate.transform(lambda x: x.replace(",}", "}")),  # remove invalid ,
+                validate.transform(fix_brackets),  # remove invalid ,
                 validate.transform(parse_json),
                 [{
                     "sources": validate.all([{

--- a/tests/plugins/test_schoolism.py
+++ b/tests/plugins/test_schoolism.py
@@ -17,3 +17,37 @@ class TestPluginSchoolism(unittest.TestCase):
         ]
         for url in should_not_match:
             self.assertFalse(Schoolism.can_handle_url(url))
+
+    def test_playlist_parse_subs(self):
+        with_subs = """var allVideos=[
+            {sources:[{type:"application/x-mpegurl",src:"https://d8u31iyce9xic.cloudfront.net/44/2/part1.m3u8?Policy=TOKEN&Signature=TOKEN&Key-Pair-Id=TOKEN",title:"Digital Painting - Lesson 2 - Part 1",playlistTitle:"Part 1",}],        subtitles: [{
+                    "default": true,
+                    kind: "subtitles", srclang: "en", label: "English",
+                    src:  "https://s3.amazonaws.com/schoolism-encoded/44/subtitles/2/2-1.vtt",
+                }],
+                },
+            {sources:[{type:"application/x-mpegurl",src:"https://d8u31iyce9xic.cloudfront.net/44/2/part2.m3u8?Policy=TOKEN&Signature=TOKEN&Key-Pair-Id=TOKEN",title:"Digital Painting - Lesson 2 - Part 2",playlistTitle:"Part 2",}],        subtitles: [{
+                    "default": true,
+                    kind: "subtitles", srclang: "en", label: "English",
+                    src:  "https://s3.amazonaws.com/schoolism-encoded/44/subtitles/2/2-2.vtt",
+                }]
+            }];
+            """
+
+        data = Schoolism.playlist_schema.validate(with_subs)
+
+        self.assertIsNotNone(data)
+        self.assertEqual(2, len(data))
+
+
+    def test_playlist_parse(self):
+        without_subs = """var allVideos=[
+            {sources:[{type:"application/x-mpegurl",src:"https://d8u31iyce9xic.cloudfront.net/14/1/part1.m3u8?Policy=TOKEN&Signature=TOKEN&Key-Pair-Id=TOKEN",title:"Gesture Drawing - Lesson 1 - Part 1",playlistTitle:"Part 1",}],},
+            {sources:[{type:"application/x-mpegurl",src:"https://d8u31iyce9xic.cloudfront.net/14/1/part2.m3u8?Policy=TOKEN&Signature=TOKEN&Key-Pair-Id=TOKEN",title:"Gesture Drawing - Lesson 1 - Part 2",playlistTitle:"Part 2",}]}
+            ];
+        """
+
+        data = Schoolism.playlist_schema.validate(without_subs)
+
+        self.assertIsNotNone(data)
+        self.assertEqual(2, len(data))


### PR DESCRIPTION
If videos have subtitles, then the data structure that describes the sources is different and the difference needs to be accounted for. 

Fixes #2491.