### PR TITLE
plugins.cdnbg: fix for bstv url

### DIFF
--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -23,6 +23,7 @@ class CDNBG(Plugin):
             mmtvmusic\.com/live|
             mu-vi\.tv/LiveStreams/pages/Live\.aspx|
             videochanel\.bstv\.bg|
+            live\.bstv\.bg|
             bloombergtv.bg/video
         )/?
     """, re.VERBOSE)

--- a/tests/plugins/test_cdnbg.py
+++ b/tests/plugins/test_cdnbg.py
@@ -23,6 +23,7 @@ class TestPluginCDNBG(unittest.TestCase):
         self.assertTrue(CDNBG.can_handle_url("https://mmtvmusic.com/live/"))
         self.assertTrue(CDNBG.can_handle_url("http://mu-vi.tv/LiveStreams/pages/Live.aspx"))
         self.assertTrue(CDNBG.can_handle_url("http://videochanel.bstv.bg/"))
+        self.assertTrue(CDNBG.can_handle_url("http://live.bstv.bg/"))
         self.assertTrue(CDNBG.can_handle_url("https://www.bloombergtv.bg/video"))
 
         # shouldn't match


### PR DESCRIPTION
Fixes #2501 by adding support for the new BSTV url. 