### PR TITLE
plugins.ustreamtv: add support for proxying WebSocket connections

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1070,8 +1070,8 @@ def build_parser():
         "--http-proxy",
         metavar="HTTP_PROXY",
         help="""
-        A HTTP proxy to use for all HTTP requests, by default this proxy
-        will be used for all HTTPS requests too.
+        A HTTP proxy to use for all HTTP requests, including WebSocket connections. 
+        By default this proxy will be used for all HTTPS requests too.
 
         Example: "http://hostname:port/"
         """


### PR DESCRIPTION
Supports establishing WebSocket connections using the same proxy as specified by `--http-proxy`. 
Fixes #2531.