### PR TITLE
Add dependency for JS parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ deps = [
     'win-inet-pton;python_version<"3.0" and platform_system=="Windows"',
     # shutil.get_terminal_size and which were added in Python 3.3
     'backports.shutil_which;python_version<"3.3"',
-    'backports.shutil_get_terminal_size;python_version<"3.3"'
+    'backports.shutil_get_terminal_size;python_version<"3.3"',
+    'esprima'
 ]
 
 # for encrypted streams


### PR DESCRIPTION
Introducing esprima as JS parser. Inspired by discussions in https://github.com/streamlink/streamlink/pull/2425 and https://github.com/streamlink/streamlink/pull/2505
Source code:
https://github.com/Kronuz/esprima-python
Packages for nodejs  exists in Debian and other distro while python-esprima should be expected as well. 
Here is usage example. The key idea is to iterate list until find type / name pair:
```
import esprima
js = '''
function a(b) {
    b["c"] = "d"
    return b
}

class e {
    constructor() {
        this.f = {g: "h", c: "k"}
    }
    m(n) {
        var p = this.f
        p["g"] = "r"
        return n(p)
    }
}

s = new e
console.log(s.f)
console.log(s.m(a))

'''
data = ""
parse = esprima.parseScript(js, { "tolerant": True })
body = parse.body
for node in body:
    if node.type == "ClassDeclaration" and node.id.name == "e":
        for node in node.body.body:
            if node.type == "MethodDefinition" and node.key.name == "m":
                for node in node.value.body.body:
                    if node.type == "ExpressionStatement" and \
                        node.expression.left.object.name == "p" and \
                        node.expression.left.property.value == "g":
                        data = node.expression.right.value
                        break
                break
        break

print("data = " + data)

```
