### PR TITLE
session: default https-proxy option to the same as http-proxy

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -257,6 +257,9 @@ class Streamlink(object):
 
         if key == "http-proxy":
             self.http.proxies["http"] = update_scheme("http://", value)
+            if "https" not in self.http.proxies:
+                self.http.proxies["https"] = update_scheme("http://", value)
+
         elif key == "https-proxy":
             self.http.proxies["https"] = update_scheme("https://", value)
         elif key == "http-cookies":

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1070,7 +1070,8 @@ def build_parser():
         "--http-proxy",
         metavar="HTTP_PROXY",
         help="""
-        A HTTP proxy to use for all HTTP requests.
+        A HTTP proxy to use for all HTTP request, by default this proxy
+        will be used for all HTTPS requests too.
 
         Example: "http://hostname:port/"
         """

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1070,7 +1070,7 @@ def build_parser():
         "--http-proxy",
         metavar="HTTP_PROXY",
         help="""
-        A HTTP proxy to use for all HTTP request, by default this proxy
+        A HTTP proxy to use for all HTTP requests, by default this proxy
         will be used for all HTTPS requests too.
 
         Example: "http://hostname:port/"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -166,6 +166,37 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session.localization.language.alpha2, "en")
         self.assertEqual(session.localization.language_code, "en_US")
 
+    def test_https_proxy_default(self):
+        session = Streamlink()
+        session.set_option("http-proxy", "http://testproxy.com")
+
+        self.assertEqual("http://testproxy.com", session.http.proxies['http'])
+        self.assertEqual("http://testproxy.com", session.http.proxies['https'])
+
+    def test_https_proxy_set_first(self):
+        session = Streamlink()
+        session.set_option("https-proxy", "https://testhttpsproxy.com")
+        session.set_option("http-proxy", "http://testproxy.com")
+
+        self.assertEqual("http://testproxy.com", session.http.proxies['http'])
+        self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
+
+    def test_https_proxy_default_override(self):
+        session = Streamlink()
+        session.set_option("http-proxy", "http://testproxy.com")
+        session.set_option("https-proxy", "https://testhttpsproxy.com")
+
+        self.assertEqual("http://testproxy.com", session.http.proxies['http'])
+        self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
+
+    def test_https_proxy_set_only(self):
+        session = Streamlink()
+        session.set_option("https-proxy", "https://testhttpsproxy.com")
+
+        self.assertFalse("http" in session.http.proxies)
+        self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This sets the default value of `https-proxy` to same as `http-proxy`, it can be overridden still by setting `https-proxy`. 