### PR TITLE
plugin.youtube: bug fix for YouTube live streams check

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -82,6 +82,9 @@ _config_schema = validate.Schema(
             {
                 validate.optional("streamingData"): {
                     validate.optional("hlsManifestUrl"): validate.text,
+                },
+                validate.optional("videoDetails"): {
+                    validate.optional("isLive"): validate.transform(bool),
                 }
             }
         ),
@@ -339,7 +342,8 @@ class YouTube(Plugin):
             log.error("Could not get video info")
             return
 
-        if info.get("livestream") == '1' or info.get("live_playback") == '1':
+        if info.get("livestream") == '1' or info.get("live_playback") == '1' \
+                or info.get("player_response", {}).get("videoDetails", {}).get("isLive") == True:
             log.debug("This video is live.")
             is_live = True
 


### PR DESCRIPTION
close #2539.

Before this patch
```
PS E:\> streamlink -o test.ts -l debug https://www.youtube.com/channel/UCKVlixycWmapnGQ_wht4cHQ/live best
[cli][debug] OS:         Windows 10
[cli][debug] Python:     3.7.3
[cli][debug] Streamlink: 1.1.1
[cli][debug] Requests(2.21.0), Socks(1.7.0), Websocket(0.56.0)
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/channel/UCKVlixycWmapnGQ_wht4cHQ/live
[plugin.youtube][debug] Video ID from currentVideoEndpoint
[plugin.youtube][debug] Using video ID: 4EA6OIYo3gM
[plugin.youtube][debug] get_video_info - 1: Found data
[plugin.youtube][debug] MuxedStream: v 137 a 140 = 1080p
[plugin.youtube][debug] MuxedStream: v 299 a 140 = 1080p60
[utils.l10n][debug] Language code: zh_CN
[cli][info] Available streams: audio_mp4, 144p (worst), 240p, 360p, 480p, 720p, 1080p, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (muxed-stream)
[stream.ffmpegmux][debug] Opening http substream
[stream.mp4mux-ffmpeg][debug] ffmpeg command: ffmpeg -nostats -y -i \\.\pipe\ffmpeg-21932-944 -i \\.\pipe\ffmpeg-21932-651 -c:v copy -c:a copy -map 0 -map 1 -f matroska pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: \\.\pipe\ffmpeg-21932-944
[stream.ffmpegmux][debug] Pipe copy complete: \\.\pipe\ffmpeg-21932-944
[stream.ffmpegmux][debug] Starting copy to pipe: \\.\pipe\ffmpeg-21932-651
[cli][debug] Pre-buffering 8192 bytes
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
[cli][error] Try 1/1: Could not open stream <Stream()> (No data returned from stream)
error: Could not open stream <Stream()>, tried 1 times, exiting
[cli][info] Closing currently open stream...
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
```

After
```
PS \PycharmProjects\streamlink> streamlink -o test.ts -l debug https://www.youtube.com/channel/UCKVlixycWmapnGQ_wht4cHQ/live best
[cli][debug] OS:         Windows 10
[cli][debug] Python:     3.7.3
[cli][debug] Streamlink: 1.1.1+39.g6e926c7.dirty
[cli][debug] Requests(2.22.0), Socks(1.7.0), Websocket(0.56.0)
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/channel/UCKVlixycWmapnGQ_wht4cHQ/live
[plugin.youtube][debug] Video ID from currentVideoEndpoint
[plugin.youtube][debug] Using video ID: 4EA6OIYo3gM
[plugin.youtube][debug] get_video_info - 1: Found data
[plugin.youtube][debug] This video is live.
[utils.l10n][debug] Language code: zh_CN
[cli][info] Available streams: 144p (worst), 240p, 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[stream.hls][debug] Reloading playlist
[stream.hls][debug] First Sequence: 0; Last Sequence: 801
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 799; End Sequence: None
[stream.hls][debug] Adding segment 799 to queue
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] Adding segment 800 to queue
[stream.hls][debug] Adding segment 801 to queue
```