### PR TITLE
Feature: Use ConsoleCtrlHandler under Windows

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -292,6 +292,7 @@ Name                                 Notes
 `iso-639`_                           Used for localization settings, provides language information
 `iso3166`_                           Used for localization settings, provides country information
 `isodate`_                           Used for MPEG-DASH streams
+`pywin32`_                           Required to detect console close events on Windows
 `PySocks`_                           Used for SOCKS Proxies
 `websocket-client`_                  Used for some plugins
 `shutil_get_terminal_size`_          Only needed on Python versions older than **3.3**
@@ -329,6 +330,7 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 .. _iso-639: https://pypi.org/project/iso-639/
 .. _iso3166: https://pypi.org/project/iso3166/
 .. _isodate: https://pypi.org/project/isodate/
+.. _pywin32: https://pypi.org/project/pywin32
 .. _PySocks: https://github.com/Anorov/PySocks
 .. _websocket-client: https://pypi.org/project/websocket-client/
 .. _shutil_get_terminal_size: https://pypi.org/project/backports.shutil_get_terminal_size/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -316,6 +316,15 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
     $ export STREAMLINK_USE_PYCRYPTO="true"
     $ export STREAMLINK_USE_PYCOUNTRY="true"
 
+Skipping pywin32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This environment variable can be used to skip `pywin32`_ during installation.
+
+.. code-block:: console
+
+    $ export STREAMLINK_NO_PYWIN32="true"
+
 .. _Python: https://www.python.org/
 .. _python-setuptools: https://pypi.org/project/setuptools/
 .. _python-argparse: https://pypi.org/project/argparse/

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -84,6 +84,7 @@ format=bundled
 ;           - socks / sockshandler
 ;       - websocket-client
 ;       - isodate
+;       - pywin32
 packages=pkg_resources
          six
          iso639
@@ -97,6 +98,7 @@ packages=pkg_resources
          socks
          sockshandler
          isodate
+         pywin32
 pypi_wheels=pycryptodome==3.6.4
 
 files=../win32/LICENSE.txt > \$INSTDIR

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -98,8 +98,8 @@ packages=pkg_resources
          socks
          sockshandler
          isodate
-         pywin32
 pypi_wheels=pycryptodome==3.6.4
+            pywin32
 
 files=../win32/LICENSE.txt > \$INSTDIR
       ../build/lib/streamlink > \$INSTDIR\pkgs

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -99,7 +99,7 @@ packages=pkg_resources
          sockshandler
          isodate
 pypi_wheels=pycryptodome==3.6.4
-            pywin32
+            pywin32==225
 
 files=../win32/LICENSE.txt > \$INSTDIR
       ../build/lib/streamlink > \$INSTDIR\pkgs

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ deps = [
 # support for win32api on Windows (win32 and win-amd64)
 # pypiwin32 is not available for python 3.4 and below
 if get_platform().startswith("win"):
-    deps.append('pypiwin32<=219;platform_system=="Windows" and python_version>"3.4"')
+    deps.append('pypiwin32>=223;platform_system=="Windows" and python_version>"3.4"')
 
 # for encrypted streams
 if environ.get("STREAMLINK_USE_PYCRYPTO"):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ deps = [
     'win-inet-pton;python_version<"3.0" and platform_system=="Windows"',
     # shutil.get_terminal_size and which were added in Python 3.3
     'backports.shutil_which;python_version<"3.3"',
-    'backports.shutil_get_terminal_size;python_version<"3.3"'
+    'backports.shutil_get_terminal_size;python_version<"3.3"',
+    # support for win32api on Windows
+    'pypiwin32<=223;platform_system=="Windows"'
 ]
 
 # for encrypted streams

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 import codecs
 from os import environ, path
 from sys import argv, path as sys_path
+from sysconfig import get_platform
 
 from setuptools import setup, find_packages
 
@@ -23,10 +24,12 @@ deps = [
     'win-inet-pton;python_version<"3.0" and platform_system=="Windows"',
     # shutil.get_terminal_size and which were added in Python 3.3
     'backports.shutil_which;python_version<"3.3"',
-    'backports.shutil_get_terminal_size;python_version<"3.3"',
-    # support for win32api on Windows
-    'pypiwin32<=223;platform_system=="Windows"'
+    'backports.shutil_get_terminal_size;python_version<"3.3"'
 ]
+
+# support for win32api on Windows (win32 and win-amd64)
+if get_platform().startswith("win"):
+    deps.append('pypiwin32<=223;platform_system=="Windows"')
 
 # for encrypted streams
 if environ.get("STREAMLINK_USE_PYCRYPTO"):

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,9 @@ deps = [
 ]
 
 # support for win32api on Windows (win32 and win-amd64)
+# pypiwin32 is not available for python 3.4 and below
 if get_platform().startswith("win"):
-    deps.append('pypiwin32<=223;platform_system=="Windows"')
+    deps.append('pypiwin32<=219;platform_system=="Windows" and python_version>"3.4"')
 
 # for encrypted streams
 if environ.get("STREAMLINK_USE_PYCRYPTO"):

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ deps = [
 ]
 
 # support for win32api on Windows (win32 and win-amd64)
-# pypiwin32 is not available for python 3.4 and below
-if get_platform().startswith("win"):
-    deps.append('pypiwin32>=223;platform_system=="Windows" and python_version>"3.4"')
+# pywin32 is only available for python 2.7, 3.5 and above
+if not environ.get("STREAMLINK_NO_PYWIN32"):
+    deps.append('pywin32>=223;platform_system=="Windows" and (python_version=="2.7" or python_version>"3.4")')
 
 # for encrypted streams
 if environ.get("STREAMLINK_USE_PYCRYPTO"):

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -397,6 +397,13 @@ def read_stream(stream, output, prebuffer, chunk_size=8192):
                     console.exit("Error when writing to output: {0}, exiting", err)
 
                 break
+            except ValueError as err:
+                try:
+                    output.player.wait(10) # Wait a moment before we check the player
+                    if not output.opened:
+                        sys.exit(130)
+                except TimeoutError:
+                    console.exit("Error when writing to output: {0}, exiting", err)
     except IOError as err:
         console.exit("Error when reading from stream: {0}, exiting", err)
     finally:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1006,7 +1006,6 @@ def setup_logging(stream=sys.stdout, level="info"):
 
 
 def main():
-    global use_win32exit
     error_code = 0
     parser = build_parser()
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -38,8 +38,14 @@ from .constants import CONFIG_FILES, PLUGINS_DIR, STREAM_SYNONYMS, DEFAULT_STREA
 from .output import FileOutput, PlayerOutput
 from .utils import NamedPipe, HTTPServer, ignored, progress, stream_to_url
 
+use_win32exit = False
+
 if is_win32:
-    import win32api
+    try:
+        import win32api
+        use_win32exit = True
+    except ImportError:
+        use_win32exit = False
 
 ACCEPTABLE_ERRNO = (errno.EPIPE, errno.EINVAL, errno.ECONNRESET)
 try:
@@ -995,12 +1001,13 @@ def setup_logging(stream=sys.stdout, level="info"):
 
 
 def main():
+    global use_win32exit
     error_code = 0
     parser = build_parser()
 
     setup_args(parser, ignore_unknown=True)
 
-    if is_win32:
+    if use_win32exit:
         win32api.SetConsoleCtrlHandler(win32_exit, True)
 
     # Console output should be on stderr if we are outputting

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -270,13 +270,14 @@ def output_stream_passthrough(plugin, stream):
     title = create_title(plugin)
     filename = '"{0}"'.format(stream_to_url(stream))
     output = PlayerOutput(args.player, args=args.player_args,
-                          filename=filename, call=True,
+                          filename=filename, call=False,
                           quiet=not args.verbose_player,
                           title=title)
 
     try:
         log.info("Starting player: {0}", args.player)
         output.open()
+        output.player.wait()
     except OSError as err:
         console.exit("Failed to start player: {0} ({1})", args.player, err)
         return False

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -62,10 +62,8 @@ def win32_exit(sig, func=None):
     error_code = 130
     if output:
         output.close()
-        console.msg("Interrupted! Exiting...")
     if stream_fd:
         try:
-            log.info("Closing currently open stream...")
             stream_fd.close()
         except KeyboardInterrupt:
             error_code = 130

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -49,7 +49,7 @@ class CommandLineTestCase(unittest.TestCase):
         if not passthrough:
             mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY, bufsize=ANY, stdin=ANY)
         else:
-            mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY)
+            mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY, bufsize=ANY, stdin=ANY)
 
 
 @unittest.skipIf(is_win32, "test only applicable in a POSIX OS")

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -46,10 +46,7 @@ class CommandLineTestCase(unittest.TestCase):
 
         self.assertEqual(exit_code, actual_exit_code)
         mock_setup_streamlink.assert_called_with()
-        if not passthrough:
-            mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY, bufsize=ANY, stdin=ANY)
-        else:
-            mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY, bufsize=ANY, stdin=ANY)
+        mock_popen.assert_called_with(commandline, stderr=ANY, stdout=ANY, bufsize=ANY, stdin=ANY)
 
 
 @unittest.skipIf(is_win32, "test only applicable in a POSIX OS")


### PR DESCRIPTION
This PR is for #2550. @beardypig suggested me making a PR with my changes so we can better discuss them.

---

This attempts to correctly detect the signals received when the Windows command prompt is closed. Additionally I'm using ```subprocess.Popen``` instead of ```subprocess.call``` to correctly close the player when using ```--player-passthrough```.

There are still some issues here:
- I was getting a ```ConsoleCtrlHandler function failed``` message in the command prompt when using ```sys.exit(error_code)``` instead of ```return error_code``` at the end of ```win32_exit``` (L67 in main.py)
- When not using ```--player-passthrough``` and exiting streamlink using CTRL-C will result in the exception below
```
streamlink twitch.tv/lirik best --player-args="--volume=0 {filename}"
[cli][info] Found matching plugin twitch for URL twitch.tv/lirik
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: "H:\Tresors\Dev\mpv\build\mpv.exe"
[cli][info] Stream ended
[cli][info] Closing currently open stream...
Traceback (most recent call last):
  File "F:\python-3.7.3 x64\App\Python\Scripts\streamlink-script.py", line 11, in <module>
    load_entry_point('streamlink==1.1.1+44.g51e7d58.dirty', 'console_scripts', 'streamlink')()
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\main.py", line 1058, in main
    handle_url()
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\main.py", line 612, in handle_url
    handle_stream(plugin, streams, stream_name)
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\main.py", line 465, in handle_stream
    success = output_stream(plugin, stream)
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\main.py", line 349, in output_stream
    read_stream(stream_fd, output, prebuffer)
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\main.py", line 386, in read_stream
    output.write(data)
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\output.py", line 37, in write
    return self._write(data)
  File "F:\python-3.7.3 x64\App\Python\lib\site-packages\streamlink-1.1.1+44.g51e7d58.dirty-py3.7.egg\streamlink_cli\output.py", line 296, in _write
    self.player.stdin.write(data)
ValueError: I/O operation on closed file
```
- With the added dependency the installation via ```python3 setup.py install``` fails under msys2 with python 3.7.3. It works fine with a "normal" installation of python3. I'm not sure if we would be able to use the windows signals in msys2 anyway but I was unable to make the dependency for non-msys2 python only.
```
Searching for pywin32>=223
Reading https://pypi.org/simple/pywin32/
No local packages or working download links found for pywin32>=223
error: Could not find suitable distribution for Requirement.parse('pywin32>=223')
```

The issues above only occur on Windows. Using Debian the issues do not appear and everything looks like it's working as expected. The player closes and only the expected output is generated when closing the player, using CTRL-C or closing the terminal window with and without ```--player-passthrough```.