### PR TITLE
ffmpegmux: use -start_at_zero with -copyts

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -84,7 +84,6 @@ class FFMPEGMuxer(StreamIO):
 
         self.session = session
         self.process = None
-        log = logging.getLogger("streamlink.stream.mp4mux-ffmpeg")
         self.streams = streams
 
         self.pipes = [NamedPipe("ffmpeg-{0}-{1}".format(os.getpid(), random.randint(0, 1000))) for _ in self.streams]
@@ -112,6 +111,7 @@ class FFMPEGMuxer(StreamIO):
 
         if copyts:
             self._cmd.extend(["-copyts"])
+            self._cmd.extend(["-start_at_zero"])
 
         for stream, data in metadata.items():
             for datum in data:


### PR DESCRIPTION
- fixes invalid timestamp on recorded files
- fixes invalid timestamp on live player cache playback
- starts the timestamp always at 0 if -copyts was used
- removed wrong called log, it should have been `self.logger` when it was changed
  it was only used for one line instead of all at the moment.

Fixes https://github.com/streamlink/streamlink/issues/2488