### PR TITLE
plugins.gulli: HTTPS support + fix live stream fetching

### DIFF
--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -17,7 +17,8 @@ class Gulli(Plugin):
 
     _video_schema = validate.Schema(
         validate.all(
-            validate.transform(lambda x: re.sub(r'"?file"?:\s*[\'"](.+?)[\'"]', r'"file": "\1"', x, flags=re.DOTALL)),
+            validate.transform(lambda x: re.sub(r'"?file"?:\s*[\'"](.+?)[\'"],?', r'"file": "\1"', x, flags=re.DOTALL)),
+            validate.transform(lambda x: re.sub(r'"?\w+?"?:\s*function\b.*?(?<={).*(?=})', "", x, flags=re.DOTALL)),
             validate.transform(parse_json),
             [
                 validate.Schema({

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -7,10 +7,10 @@ from streamlink.utils import parse_json
 
 
 class Gulli(Plugin):
-    LIVE_PLAYER_URL = 'http://replay.gulli.fr/jwplayer/embedstreamtv'
-    VOD_PLAYER_URL = 'http://replay.gulli.fr/jwplayer/embed/{0}'
+    LIVE_PLAYER_URL = 'https://replay.gulli.fr/jwplayer/embedstreamtv'
+    VOD_PLAYER_URL = 'https://replay.gulli.fr/jwplayer/embed/{0}'
 
-    _url_re = re.compile(r'http://replay\.gulli\.fr/(?:Direct|.+/(?P<video_id>VOD[0-9]+))')
+    _url_re = re.compile(r'https?://replay\.gulli\.fr/(?:Direct|.+/(?P<video_id>VOD[0-9]+))')
     _playlist_re = re.compile(r'sources: (\[.+?\])', re.DOTALL)
     _vod_video_index_re = re.compile(r'jwplayer\(idplayer\).playlistItem\((?P<video_index>[0-9]+)\)')
     _mp4_bitrate_re = re.compile(r'.*_(?P<bitrate>[0-9]+)\.mp4')

--- a/tests/plugins/test_gulli.py
+++ b/tests/plugins/test_gulli.py
@@ -8,8 +8,8 @@ class TestPluginGulli(unittest.TestCase):
         # should match
         self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/Direct"))
         self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/dessins-animes/My-Little-Pony-les-amies-c-est-magique/VOD68328764799000"))
-        self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/emissions/In-Ze-Boite2/VOD68639028668000"))
-        self.assertTrue(Gulli.can_handle_url("http://replay.gulli.fr/series/Power-Rangers-Dino-Super-Charge/VOD68612908435000"))
+        self.assertTrue(Gulli.can_handle_url("https://replay.gulli.fr/emissions/In-Ze-Boite2/VOD68639028668000"))
+        self.assertTrue(Gulli.can_handle_url("https://replay.gulli.fr/series/Power-Rangers-Dino-Super-Charge/VOD68612908435000"))
 
         # shouldn't match
         self.assertFalse(Gulli.can_handle_url("http://replay.gulli.fr/"))


### PR DESCRIPTION
This PR enables HTTPS support for the Gulli plugin. It also fixes live stream fetching:

```
$ streamlink http://replay.gulli.fr/Direct
[cli][info] Found matching plugin gulli for URL http://replay.gulli.fr/Direct
error: Unable to parse JSON: Expecting property name enclosed in double quotes: line 4 column 21 (char 242) ('[\n                {\n             ...)
```