### PR TITLE
plugins.tvrplus: fix for new website layout

### DIFF
--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -7,7 +7,7 @@ from streamlink.stream import HLSStream
 
 
 class TVRPlus(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?tvrplus\.ro/live-")
+    url_re = re.compile(r"https?://(?:www\.)?tvrplus\.ro/live/")
     hls_file_re = re.compile(r"""["'](?P<url>[^"']+\.m3u8(?:[^"']+)?)["']""")
 
     stream_schema = validate.Schema(

--- a/tests/plugins/test_tvrplus.py
+++ b/tests/plugins/test_tvrplus.py
@@ -6,10 +6,10 @@ from streamlink.plugins.tvrplus import TVRPlus
 class TestPluginTVRPlus(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
-            "http://tvrplus.ro/live-tvr-1",
-            "http://www.tvrplus.ro/live-tvr-1",
-            "http://www.tvrplus.ro/live-tvr-3",
-            "http://www.tvrplus.ro/live-tvr-international",
+            "http://tvrplus.ro/live/tvr-1",
+            "http://www.tvrplus.ro/live/tvr-1",
+            "http://www.tvrplus.ro/live/tvr-3",
+            "http://www.tvrplus.ro/live/tvr-international",
         ]
         for url in should_match:
             self.assertTrue(TVRPlus.can_handle_url(url))


### PR DESCRIPTION
Fixes the plugin after website layout change:
```
$ streamlink https://www.tvrplus.ro/live/tvr-international
error: No plugin can handle URL: https://www.tvrplus.ro/live/tvr-international
```
