### PR TITLE
session: use importlib to load plugins in Python 3

### DIFF
--- a/src/streamlink/plugin/api/support_plugin.py
+++ b/src/streamlink/plugin/api/support_plugin.py
@@ -1,5 +1,6 @@
 import os
 import inspect
+
 from streamlink.utils import load_module
 
 __all__ = ["load_support_plugin"]


### PR DESCRIPTION
Using `importlib` to import the plugins in Python 3 speeds up the loading of plugins by 2x over the old `imp` method used in Python 2.

For me, with Python 3, the time to run `load_plugins` goes down from ~550ms to ~220ms (on average). 