### PR TITLE
plugins.vk: use html_unescape for HLS streams

### DIFF
--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -2,7 +2,7 @@
 import logging
 import re
 
-from streamlink.compat import urlparse, unquote
+from streamlink.compat import html_unescape, urlparse, unquote
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
@@ -82,10 +82,7 @@ class VK(Plugin):
 
         for _i in itertags(res.text, 'source'):
             if _i.attributes.get('type') == 'application/vnd.apple.mpegurl':
-                video_url = _i.attributes['src']
-                # Remove invalid URL
-                if video_url.startswith('https://vk.com/'):
-                    continue
+                video_url = html_unescape(_i.attributes['src'])
                 streams = HLSStream.parse_variant_playlist(self.session,
                                                            video_url)
                 if not streams:


### PR DESCRIPTION
Example Livestreams can be found on https://vk.com/video

```
$ streamlink https://vk.com/video-45085246_456239928 -l info
[cli][info] Found matching plugin vk for URL https://vk.com/video-45085246_456239928
[cli][info] Available streams: 360p (worst), 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
```

closes #2595