### PR TITLE
plugins.foxtr: Extended support

### DIFF
--- a/src/streamlink/plugins/foxtr.py
+++ b/src/streamlink/plugins/foxtr.py
@@ -10,7 +10,13 @@ class FoxTR(Plugin):
     """
     Support for Turkish Fox live stream: http://www.fox.com.tr/canli-yayin
     """
-    url_re = re.compile(r"https?://www.fox.com.tr/canli-yayin")
+
+    url_re = re.compile(r"""
+        https?://(?:www.)?
+        (?:fox.com.tr/.*|
+           foxplay.com.tr/.*)
+    """, re.VERBOSE)
+
     playervars_re = re.compile(r"source\s*:\s*\[\s*\{\s*videoSrc\s*:\s*'(.*?)'", re.DOTALL)
 
     @classmethod


### PR DESCRIPTION
With a small url regex change, this plugin could play both of the media sites of Fox TR.