### PR TITLE
Added Canvas plugin

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -36,7 +36,7 @@ brightcove              players.brig... [6]_ Yes   Yes
 btsports                sport.bt.com         Yes   Yes   Requires subscription account
 btv                     btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
 canalplus               mycanal.fr           No    Yes   Streams may be geo-restricted to France.
-canvas                  instructure.com      No    Yes
+canvas                  instructure.com      --    Yes
 cdnbg                   - tv.bnt.bg          Yes   No    Streams may be geo-restricted to Bulgaria.
                         - bgonair.bg
                         - bitelevision.com

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -36,6 +36,7 @@ brightcove              players.brig... [6]_ Yes   Yes
 btsports                sport.bt.com         Yes   Yes   Requires subscription account
 btv                     btv.bg               Yes   No    Requires login, and geo-restricted to Bulgaria.
 canalplus               mycanal.fr           No    Yes   Streams may be geo-restricted to France.
+canvas                  instructure.com      No    Yes
 cdnbg                   - tv.bnt.bg          Yes   No    Streams may be geo-restricted to Bulgaria.
                         - bgonair.bg
                         - bitelevision.com

--- a/src/streamlink/plugins/canvas.py
+++ b/src/streamlink/plugins/canvas.py
@@ -1,0 +1,31 @@
+import re
+
+from json import loads
+from streamlink.plugin import Plugin
+from streamlink.stream import HTTPStream
+
+
+class Canvas(Plugin):
+    url_re = re.compile(r"https?://(.*)\.instructure\.com/media_objects/([^/]+)")
+    api_url = "https://{subdomain}.instructure.com/media_objects/{media_object_id}/info"
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        matches = self.url_re.match(self.url)
+        subdomain = matches.group(1)
+        moid = matches.group(2)
+        self.logger.debug("Media Object ID: {0}", moid)
+        res = self.session.http.get(self.api_url.format(subdomain=subdomain,media_object_id=moid))
+        data = loads(res.text)
+
+        if "media_sources" in data.keys():
+            for stream in data["media_sources"]:
+                yield "{0}p".format(stream["height"]), HTTPStream(self.session, stream["url"])
+        else:
+            self.logger.error("No stream links found. (ID: {0})", moid)
+
+
+__plugin__ = Canvas

--- a/tests/plugins/test_canvas.py
+++ b/tests/plugins/test_canvas.py
@@ -1,0 +1,19 @@
+import unittest
+
+from streamlink.plugins.canvas import Canvas
+
+
+class TestPluginCanvas(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://canvas.instructure.com/media_objects/m-Zeo1NE689yHQMYUXzRX4yIEtoNOIymxP/',
+        ]
+        for url in should_match:
+            self.assertTrue(Canvas.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://example.com/index.html',
+        ]
+        for url in should_not_match:
+            self.assertFalse(Canvas.can_handle_url(url))


### PR DESCRIPTION
Recently, Canvas has grown in popularity as more schools and colleges pick it up. Many teachers and students use it share instructional content and other media. This adds a plugin that supports Canvas media_object URLs. For example:

`https://canvas.instructure.com/media_objects/m-Zeo1NE689yHQMYUXzRX4yIEtoNOIymxP/`