### PR TITLE
ci/travis: install pynsist 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
       pip install doctr;
     fi
   - if [[ $BUILD_INSTALLER == 'yes' ]]; then
-      pip install git+https://github.com/takluyver/pynsist.git@88f56f9e86af9c55522147a67f8b7806ac2ca55b;
+      pip install pynsist==2.4;
     fi
 
 install:


### PR DESCRIPTION
This "bumps" the `pynsist` (Windows installer) dependency to `2.4` and downloads it from pypi instead of cloning the git repo from github and checking out a pre-release commit ID.

The old commit ID was added because pynsist's author didn't publish a new release when we needed the fixes earlier this year, see here:
https://github.com/takluyver/pynsist/commits/master
This has been resolved now since July.

This PR basically doesn't do much other than making the CI config more readable. Since we're going to add Github actions as a secondary CI service soon, I don't want to have mixed or weird dependency definitions, as it's confusing.