### PR TITLE
plugins.idf1: HTTPS support

### DIFF
--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -11,7 +11,7 @@ class IDF1(Plugin):
     DACAST_API_URL = 'https://json.dacast.com/b/{}/{}/{}'
     DACAST_TOKEN_URL = 'https://services.dacast.com/token/i/b/{}/{}/{}'
 
-    _url_re = re.compile(r'http://www\.idf1\.fr/(videos/[^/]+/[^/]+\.html|live\b)')
+    _url_re = re.compile(r'https?://www\.idf1\.fr/(videos/[^/]+/[^/]+\.html|live\b)')
     _video_id_re = re.compile(r"dacast\('(?P<broadcaster_id>\d+)_(?P<video_type>[a-z]+)_(?P<video_id>\d+)', 'replay_content', data\);")
     _video_id_alt_re = re.compile(r'<script src="https://player.dacast.com/js/player.js" id="(?P<broadcaster_id>\d+)_(?P<video_type>[cf])_(?P<video_id>\d+)"')
     _player_url = 'http://ssl.p.jwpcdn.com/player/v/7.12.6/jwplayer.flash.swf'

--- a/tests/plugins/test_idf1.py
+++ b/tests/plugins/test_idf1.py
@@ -6,13 +6,13 @@ from streamlink.plugins.idf1 import IDF1
 class TestPluginIDF1(unittest.TestCase):
     def test_can_handle_url(self):
         # should match
-        self.assertTrue(IDF1.can_handle_url("http://www.idf1.fr/live"))
-        self.assertTrue(IDF1.can_handle_url("http://www.idf1.fr/videos/jlpp/best-of-2018-02-24-partie-2.html"))
+        self.assertTrue(IDF1.can_handle_url("https://www.idf1.fr/live"))
+        self.assertTrue(IDF1.can_handle_url("https://www.idf1.fr/videos/jlpp/best-of-2018-02-24-partie-2.html"))
         self.assertTrue(IDF1.can_handle_url("http://www.idf1.fr/videos/buzz-de-noel/partie-2.html"))
 
         # shouldn't match
-        self.assertFalse(IDF1.can_handle_url("http://www.idf1.fr/"))
-        self.assertFalse(IDF1.can_handle_url("http://www.idf1.fr/videos"))
-        self.assertFalse(IDF1.can_handle_url("http://www.idf1.fr/programmes/emissions/idf1-chez-vous.html"))
+        self.assertFalse(IDF1.can_handle_url("https://www.idf1.fr/"))
+        self.assertFalse(IDF1.can_handle_url("https://www.idf1.fr/videos"))
+        self.assertFalse(IDF1.can_handle_url("https://www.idf1.fr/programmes/emissions/idf1-chez-vous.html"))
         self.assertFalse(IDF1.can_handle_url("http://www.tvcatchup.com/"))
         self.assertFalse(IDF1.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
This PR enables HTTPS support for the IDF1 plugin.