### PR TITLE
plugins.linelive: update to support VOD/archived streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -107,7 +107,7 @@ itvplayer               itv.com/itvplayer    Yes   Yes   Streams may be geo-rest
 kanal7                  - kanal7.com         Yes   No
                         - tvt.tv.tr
 kingkong                kingkong.com.tw      Yes   --
-linelive                live.line.me         Yes   --
+linelive                live.line.me         Yes   Yes
 live_russia_tv          live.russia.tv       Yes   --
 liveedu                 - liveedu.tv         Yes   --    Some streams require a login.
                         - livecoding.tv


### PR DESCRIPTION
Support archived broadcasts for `linelive`

Example URL: https://live.line.me/channels/1805733/broadcast/10625625

Also had a couple of issues reported by flake8 in the previous version that are now fixed.