### PR TITLE
plugins.onetv:  adjust for akamai returned 403 "Forbidden" other way

### DIFF
--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -72,7 +72,7 @@ class OneTV(Plugin):
         if self.is_live:
             self.logger.debug("Loading live stream for {0}...", self.channel)
 
-            self.session.http.headers = {"origin": "http://1tv.ru"}
+            self.session.http.headers.update({"origin": "http://1tv.ru"})
             res = self.session.http.get(self.live_api_url, data={"r": random.randint(1, 100000)})
             live_data = self.session.http.json(res)
 

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -72,6 +72,7 @@ class OneTV(Plugin):
         if self.is_live:
             self.logger.debug("Loading live stream for {0}...", self.channel)
 
+            self.session.http.headers = {"origin": "http://1tv.ru"}
             res = self.session.http.get(self.live_api_url, data={"r": random.randint(1, 100000)})
             live_data = self.session.http.json(res)
 


### PR DESCRIPTION
streamlink 1tv.ru/live
[cli][info] Found matching plugin onetv for URL 1tv.ru/live
error: Unable to open URL: http://live1tvakamai.akamaized.net/dash-live11/streams/1tv/1tvdash.mpd?e=1573218827 (403 Client Error: Forbidden for url: http://live1tvakamai.akamaized.net/dash-live11/streams/1tv/1tvdash.mpd?e=1573218827)
