### PR TITLE
plugins.youtube: Remove itag 303

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -148,7 +148,6 @@ class YouTube(Plugin):
 
     adp_video = {
         137: "1080p",
-        303: "1080p60",  # HFR
         299: "1080p60",  # HFR
         264: "1440p",
         308: "1440p60",  # HFR


### PR DESCRIPTION
1080p60 video/webm format that doesn't work

example video: https://www.youtube.com/watch?v=9lb0gZRO2Go

closes https://github.com/streamlink/streamlink/issues/2694