### PR TITLE
plugins.bbciplayer: Fixed login params

### DIFF
--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -1,13 +1,13 @@
-from __future__ import print_function
 
 import base64
 import logging
 import re
+
 from collections import defaultdict
 from hashlib import sha1
 
-from streamlink import PluginError
-from streamlink.compat import parse_qsl, urlparse
+from streamlink.compat import urlparse
+from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin, PluginArguments, PluginArgument
 from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream
@@ -85,28 +85,11 @@ class BBCiPlayer(Plugin):
 
     @classmethod
     def can_handle_url(cls, url):
-        """ Confirm plugin can handle URL """
         return cls.url_re.match(url) is not None
 
     @classmethod
     def _hash_vpid(cls, vpid):
         return sha1(cls.hash + str(vpid).encode("utf8")).hexdigest()
-
-    @classmethod
-    def _extract_nonce(cls, http_result):
-        """
-        Given an HTTP response from the session endpoint, extract the nonce, so we can "sign" requests with it.
-        We don't really sign the requests in the traditional sense of a nonce, we just include them in the auth requests.
-
-        :param http_result: HTTP response from the bbc session endpoint.
-        :type http_result: requests.Response
-        :return: nonce to "sign" url requests with
-        :rtype: string
-        """
-
-        p = urlparse(http_result.url)
-        d = dict(parse_qsl(p.query))
-        return d.get("nonce")
 
     def find_vpid(self, url, res=None):
         """
@@ -165,7 +148,7 @@ class BBCiPlayer(Plugin):
                                                            url).items():
                             yield s
                     log.debug("  OK:   {0}", url)
-                except:
+                except Exception:
                     log.debug("  FAIL: {0}", url)
 
     def login(self, ptrt_url):
@@ -191,13 +174,9 @@ class BBCiPlayer(Plugin):
             log.debug("Already authenticated, skipping authentication")
             return True
 
-        http_nonce = self._extract_nonce(session_res)
         res = self.session.http.post(
             self.auth_url,
-            params=dict(
-                ptrt=ptrt_url,
-                nonce=http_nonce
-            ),
+            params=urlparse(session_res.url).query,
             data=dict(
                 jsEnabled=True,
                 username=self.get_option("username"),

--- a/tests/plugins/test_bbciplayer.py
+++ b/tests/plugins/test_bbciplayer.py
@@ -1,9 +1,5 @@
-import json
 import unittest
 
-from requests import Response, Request
-
-from streamlink.compat import urlencode
 from streamlink.plugins.bbciplayer import BBCiPlayer
 
 
@@ -24,12 +20,3 @@ class TestPluginBBCiPlayer(unittest.TestCase):
             "71c345435589c6ddeea70d6f252e2a52281ecbf3",
             BBCiPlayer._hash_vpid("1234567890")
         )
-
-    def test_extract_nonce(self):
-        mock_nonce = "mock-nonce-nse"
-        mock_response = Response()
-        mock_response.url = "http://example.com/?" + urlencode(dict(nonce=mock_nonce))
-
-        self.assertEqual(BBCiPlayer._extract_nonce(mock_response), mock_nonce)
-
-


### PR DESCRIPTION
solution from https://github.com/streamlink/streamlink/issues/2716#issuecomment-565192550

closes https://github.com/streamlink/streamlink/issues/2716

```
$ streamlink http://www.bbc.co.uk/iplayer/live/bbcone best --bbciplayer-username XXX --bbciplayer-password XXX
[cli][debug] OS:         Linux
[cli][debug] Python:     2.7.15+
[cli][debug] Streamlink: 1.3.0
[cli][debug] Requests(2.22.0), Socks(1.6.7), Websocket(0.54.0)
[cli][info] Found matching plugin bbciplayer for URL http://www.bbc.co.uk/iplayer/live/bbcone
[cli][debug] Plugin specific arguments:
[cli][debug]  --bbciplayer-username=XXX (username)
[cli][debug]  --bbciplayer-password=******** (password)
[plugin.bbciplayer][debug] Loading stream for live channel: bbcone
[plugin.bbciplayer][debug] Looking for  tvip on http://www.bbc.co.uk/iplayer/live/bbcone
[plugin.bbciplayer][debug] Found TVIP: bbc_one_london
...
```