### PR TITLE
plugins.tf1: use new API to retrieve DASH streams

### DIFF
--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -3,8 +3,7 @@ from __future__ import unicode_literals
 import logging
 import re
 
-from streamlink import PluginError
-from streamlink.compat import urljoin
+from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import DASHStream, HLSStream


### PR DESCRIPTION
This PR fixes DASH stream retrieving by using a new API (the same currently called by the TF1 website):

* before fix:
```
$ streamlink -l debug https://www.tf1.fr/tmc/direct
[cli][debug] OS:         Linux-5.3.16-300.fc31.x86_64-x86_64-with-fedora-31-Thirty_One
[cli][debug] Python:     3.7.5
[cli][debug] Streamlink: 1.3.0
[cli][debug] Requests(2.22.0), Socks(1.7.0), Websocket(0.56.0)
[cli][info] Found matching plugin tf1 for URL https://www.tf1.fr/tmc/direct
[plugin.tf1][debug] Found channel tmc
[plugin.tf1][debug] Got dash stream https://tmc-das-live-ssl.tf1.fr/tmc/1/dash/live_3000000.mpd?e=1578405380&st=aXyXTL7lopcXZt_o8coVYA
[plugin.tf1][error] Could not open dash stream
[plugin.tf1][debug] Failed with error: Unable to open URL: https://tmc-das-live-ssl.tf1.fr/tmc/1/dash/live_3000000.mpd?e=1578405380&st=aXyXTL7lopcXZt_o8coVYA (502 Server Error: Bad Gateway for url: https://tmc-das-live-ssl.tf1.fr/tmc/1/dash/live_3000000.mpd?e=1578405380&st=aXyXTL7lopcXZt_o8coVYA)
[plugin.tf1][debug] Got hls stream https://tmc-hls-live-ssl.tf1.fr/tmc/1/hls/master_4000000.m3u8?e=1578405380&st=E_h7Qdly6-MsmF-gxwswzw
[utils.l10n][debug] Language code: fr_FR
Available streams: 234p (worst), 360p, 576p, 720p (best)
```

* after fix:

```
$ streamlink -l debug https://www.tf1.fr/tmc/direct
[cli][debug] OS:         Linux-5.3.16-300.fc31.x86_64-x86_64-with-fedora-31-Thirty_One
[cli][debug] Python:     3.7.5
[cli][debug] Streamlink: 1.3.0
[cli][debug] Requests(2.22.0), Socks(1.7.0), Websocket(0.56.0)
[cli][info] Found matching plugin tf1 for URL https://www.tf1.fr/tmc/direct
[plugin.tf1][debug] Found channel tmc
[plugin.tf1][debug] Got dash stream https://tmc-das-live-ssl.tf1.fr/out/v1/39e5bad5774f42fd8941edff13ff5072/index.mpd?e=1578405418&st=cUHuv2ja1ke47x6KkpoLBw
[utils.l10n][debug] Language code: fr_FR
[stream.dash][debug] Available languages for DASH audio streams: und (using: und)
[plugin.tf1][debug] Got hls stream https://tmc-hls-live-ssl.tf1.fr/tmc/1/hls/master_4000000.m3u8?e=1578405419&st=JXOwN1xAQInJkX-9nbNVAw
[utils.l10n][debug] Language code: fr_FR
Available streams: 234p (worst), 234p+a96k, 234p+a97k, 234p+a128k, 234p+a129k, 360p, 360p+a96k, 360p+a97k, 360p+a128k, 360p+a129k, 576p, 576p+a96k, 576p+a97k, 576p+a128k, 576p+a129k, 720p, 720p+a96k, 720p+a97k, 720p+a128k, 720p+a129k (best)
```