### PR TITLE
cli.output: fix mpv player parameter format

### DIFF
--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -190,7 +190,7 @@ class PlayerOutput(Output):
             if self.player_name == "mpv":
                 # see https://mpv.io/manual/stable/#property-expansion, allow escaping with \$, respect mpv's $>
                 self.title = self._mpv_title_escape(self.title)
-                extra_args.extend(["--title", self.title])
+                extra_args.append("--title={}".format(self.title))
 
             # potplayer
             if self.player_name == "potplayer":
@@ -202,7 +202,7 @@ class PlayerOutput(Output):
 
         args = self.args.format(filename=filename)
         cmd = self.cmd
-        
+
         # player command
         if is_win32:
             eargs = maybe_decode(subprocess.list2cmdline(extra_args))

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -26,7 +26,7 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
 
     def test_open_player_with_title_mpv(self):
         self._test_args(["streamlink", "-p", "/usr/bin/mpv", "--title", "{title}", "http://test.se", "test"],
-                        ["/usr/bin/mpv", "--title", 'Test Title', "-"])
+                        ["/usr/bin/mpv", "--title=Test Title", "-"])
 
 
 @unittest.skipIf(not is_win32, "test only applicable on Windows")


### PR DESCRIPTION
Fixes #2764

See https://github.com/mpv-player/mpv/commit/d3cef97ad38fb027262a905bd82e1d3d2549aec7

The MPV change is supposed to print out a deprecation warning, but if it causes the player to immediately terminate as described in #2764, this would mean that we should publish a patch release soon. As I've said on Gitter, such a breaking change with the parameter parsing should actually require a major version bump on the side of MPV. Weird.