### PR TITLE
Add support for specifying output file format and audio sync option

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -74,7 +74,7 @@ class Streamlink(object):
             "subprocess-errorlog": False,
             "subprocess-errorlog-path": None,
             "ffmpeg-ffmpeg": None,
-            "ffmpeg-fout": "matroska",
+            "ffmpeg-fout": None,
             "ffmpeg-video-transcode": "copy",
             "ffmpeg-audio-transcode": "copy",
             "ffmpeg-start-at-zero": True,

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -74,8 +74,10 @@ class Streamlink(object):
             "subprocess-errorlog": False,
             "subprocess-errorlog-path": None,
             "ffmpeg-ffmpeg": None,
+            "ffmpeg-fout": "matroska",
             "ffmpeg-video-transcode": "copy",
             "ffmpeg-audio-transcode": "copy",
+            "ffmpeg-start-at-zero": True,
             "locale": None,
             "user-input-requester": None
         })
@@ -205,6 +207,10 @@ class Streamlink(object):
         ffmpeg-verbose-path      (str) Specify the location of the
                                  ffmpeg stderr log file
 
+        ffmpeg-fout              (str) The output file format
+                                 when muxing with ffmpeg
+                                 e.g. ``matroska``
+
         ffmpeg-video-transcode   (str) The codec to use if transcoding
                                  video when muxing with ffmpeg
                                  e.g. ``h264``
@@ -212,6 +218,9 @@ class Streamlink(object):
         ffmpeg-audio-transcode   (str) The codec to use if transcoding
                                  audio when muxing with ffmpeg
                                  e.g. ``aac``
+
+        ffmpeg-start-at-zero     (bool) When used with ffmpeg and copyts,
+                                 shift input timestamps so they start at zero
 
         stream-segment-attempts  (int) How many attempts should be done
                                  to download each segment, default: ``3``.

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -98,7 +98,7 @@ class FFMPEGMuxer(StreamIO):
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
         copyts = options.pop("copyts", False)
-        start_at_zero = session.options.get("start_at_zero", False)
+        start_at_zero = session.options.get("ffmpeg-start-at-zero", True)
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -91,7 +91,7 @@ class FFMPEGMuxer(StreamIO):
                              for stream, np in
                              zip(self.streams, self.pipes)]
 
-        ofmt = session.options.get("ffmpeg-fout")
+        ofmt = session.options.get("ffmpeg-fout") or options.pop("format", "matroska")
         outpath = options.pop("outpath", "pipe:1")
         videocodec = session.options.get("ffmpeg-video-transcode") or options.pop("vcodec", "copy")
         audiocodec = session.options.get("ffmpeg-audio-transcode") or options.pop("acodec", "copy")

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -91,13 +91,14 @@ class FFMPEGMuxer(StreamIO):
                              for stream, np in
                              zip(self.streams, self.pipes)]
 
-        ofmt = options.pop("format", "matroska")
+        ofmt = session.options.get("ffmpeg-fout")
         outpath = options.pop("outpath", "pipe:1")
         videocodec = session.options.get("ffmpeg-video-transcode") or options.pop("vcodec", "copy")
         audiocodec = session.options.get("ffmpeg-audio-transcode") or options.pop("acodec", "copy")
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
         copyts = options.pop("copyts", False)
+        start_at_zero = session.options.get("start_at_zero", False)
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:
@@ -111,7 +112,8 @@ class FFMPEGMuxer(StreamIO):
 
         if copyts:
             self._cmd.extend(["-copyts"])
-            self._cmd.extend(["-start_at_zero"])
+            if start_at_zero:
+                self._cmd.extend(["-start_at_zero"])
 
         for stream, data in metadata.items():
             for datum in data:

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1049,8 +1049,6 @@ def build_parser():
         help="""
         Set output file format.
 
-        Default is "matroska".
-
         Example: "mpegts"
         """
     )

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1077,14 +1077,11 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--ffmpeg-start-at-zero",
-        type=boolean,
-        metavar="STARTATZERO",
+        "--ffmpeg-no-start-at-zero",
+        action="store_true",
         help="""
-        When used with ffmpeg and copyts,
-        shift input timestamps so they start at zero.
-
-        Default is "True".
+        Disables the -start_at_zero ffmpeg option
+        when using copyts. 
         """
     )
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1043,6 +1043,18 @@ def build_parser():
         """
     )
     transport.add_argument(
+        "--ffmpeg-fout",
+        type=str,
+        metavar="OUTFORMAT",
+        help="""
+        Set output file format.
+
+        Default is "matroska".
+
+        Example: "mpegts"
+        """
+    )
+    transport.add_argument(
         "--ffmpeg-video-transcode",
         metavar="CODEC",
         help="""
@@ -1062,6 +1074,17 @@ def build_parser():
         Default is "copy".
 
         Example: "aac"
+        """
+    )
+    transport.add_argument(
+        "--ffmpeg-start-at-zero",
+        type=boolean,
+        metavar="STARTATZERO",
+        help="""
+        When used with ffmpeg and copyts,
+        shift input timestamps so they start at zero.
+
+        Default is "True".
         """
     )
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1079,7 +1079,7 @@ def build_parser():
         action="store_true",
         help="""
         Disables the -start_at_zero ffmpeg option
-        when using copyts. 
+        when using copyts.
         """
     )
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -863,10 +863,14 @@ def setup_options():
         streamlink.set_option("ffmpeg-verbose", args.ffmpeg_verbose)
     if args.ffmpeg_verbose_path:
         streamlink.set_option("ffmpeg-verbose-path", args.ffmpeg_verbose_path)
+    if args.ffmpeg_fout:
+        streamlink.set_option("ffmpeg-fout", args.ffmpeg_fout)
     if args.ffmpeg_video_transcode:
         streamlink.set_option("ffmpeg-video-transcode", args.ffmpeg_video_transcode)
     if args.ffmpeg_audio_transcode:
         streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
+    if args.ffmpeg-start-at-zero:
+        streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg-start-at-zero)
 
     streamlink.set_option("subprocess-errorlog", args.subprocess_errorlog)
     streamlink.set_option("subprocess-errorlog-path", args.subprocess_errorlog_path)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -869,8 +869,8 @@ def setup_options():
         streamlink.set_option("ffmpeg-video-transcode", args.ffmpeg_video_transcode)
     if args.ffmpeg_audio_transcode:
         streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
-    if args.ffmpeg-start-at-zero:
-        streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg-start-at-zero)
+    if args.ffmpeg_no_start_at_zero:
+        streamlink.set_option("ffmpeg-start-at-zero", False)
 
     streamlink.set_option("subprocess-errorlog", args.subprocess_errorlog)
     streamlink.set_option("subprocess-errorlog-path", args.subprocess_errorlog_path)


### PR DESCRIPTION
The change is introducing two new optional cmdline options:

--ffmpeg-fout: The output file format when muxing with ffmpeg
--ffmpeg-start-at-zero: When used with ffmpeg and copyts, shift input timestamps so they start at zero

Both options defaults are keeping the predefined values, hence backwards compatibility is enforced.
