### PR TITLE
Further cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 128
+trim_trailing_whitespace = true
+
+[*.{cfg,svg,yml}]
+indent_size = 2
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[docs/Makefile]
+indent_size = 8
+indent_style = tab
+
+[docs/_themes/**]
+indent_size = ignore
+indent_style = ignore
+trim_trailing_whitespace = ignore

--- a/src/streamlink/__init__.py
+++ b/src/streamlink/__init__.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# -*- coding: utf-8 -*-
 """Streamlink extracts streams from various services.
 
 The main compontent of Streamlink is a command-line utility that

--- a/src/streamlink/packages/flashmedia/__init__.py
+++ b/src/streamlink/packages/flashmedia/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from .error import *
 from .amf import *
 from .flv import *

--- a/src/streamlink/packages/flashmedia/error.py
+++ b/src/streamlink/packages/flashmedia/error.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-
-
 class FLVError(Exception):
     pass
 

--- a/src/streamlink/packages/flashmedia/f4v.py
+++ b/src/streamlink/packages/flashmedia/f4v.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from .box import Box, RawPayload
 from .compat import is_py2
 

--- a/src/streamlink/packages/flashmedia/flv.py
+++ b/src/streamlink/packages/flashmedia/flv.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from .error import FLVError
 from .compat import is_py2
 from .tag import Header, Tag

--- a/src/streamlink/packages/flashmedia/packet.py
+++ b/src/streamlink/packages/flashmedia/packet.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import struct
 
 

--- a/src/streamlink/packages/flashmedia/tag.py
+++ b/src/streamlink/packages/flashmedia/tag.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from ctypes import BigEndianStructure, Union, c_uint8
 from io import BytesIO
 

--- a/src/streamlink/packages/flashmedia/util.py
+++ b/src/streamlink/packages/flashmedia/util.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from .compat import bytes, is_py2, string_types
 
 import struct

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import logging
 
 import re

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import re

--- a/src/streamlink/plugins/tga.py
+++ b/src/streamlink/plugins/tga.py
@@ -1,5 +1,4 @@
-# coding: utf-8
-
+# -*- coding: utf-8 -*-
 import re
 
 from streamlink.plugin import Plugin

--- a/src/streamlink/plugins/tv3cat.py
+++ b/src/streamlink/plugins/tv3cat.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import logging
 import re
 

--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import re
 
 from streamlink.plugin import Plugin, PluginArguments, PluginArgument

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
 import logging
 import re
 import warnings

--- a/tests/plugins/test_bigo.py
+++ b/tests/plugins/test_bigo.py
@@ -28,7 +28,3 @@ class TestPluginBigo(unittest.TestCase):
         self.assertFalse(Bigo.can_handle_url("http://www.bigo.tv/show/00000000"))
         self.assertFalse(Bigo.can_handle_url("http://bigo.tv/show/00000000"))
         self.assertFalse(Bigo.can_handle_url("https://bigo.tv/show/00000000"))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/plugins/test_deutschewelle.py
+++ b/tests/plugins/test_deutschewelle.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import unittest
 
 from streamlink.plugins.deutschewelle import DeutscheWelle

--- a/tests/plugins/test_huomao.py
+++ b/tests/plugins/test_huomao.py
@@ -86,9 +86,3 @@ class TestPluginHuomao(unittest.TestCase):
         self.assertFalse(Huomao.can_handle_url("https://www.youtube.tv/123456"))
         self.assertFalse(Huomao.can_handle_url("https://youtube.com/123456"))
         self.assertFalse(Huomao.can_handle_url("https://youtube.tv/123456"))
-
-
-# Possibility to run unittest separately as a normal python script.
-if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(TestPluginHuomao)
-    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/tests/plugins/test_stream.py
+++ b/tests/plugins/test_stream.py
@@ -172,7 +172,3 @@ class TestPluginStream(unittest.TestCase):
 
         self.assertGreater(stream_weight("720p+a128k"),
                            stream_weight("360p+a256k"))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/plugins/testplugin.py
+++ b/tests/plugins/testplugin.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 from io import BytesIO
 
 from streamlink import NoStreamsError

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -339,7 +339,3 @@ class TestDASHStreamWorker(unittest.TestCase):
 
         self.assertEqual(representation_vid, DASHStreamWorker.get_representation(mpd, 1, "video/mp4"))
         self.assertEqual(representation_aud, DASHStreamWorker.get_representation(mpd, 1, "audio/aac"))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -225,7 +225,3 @@ class TestHlsExtAudio(unittest.TestCase):
 
         # Check result
         self.assertEqual(result, expected)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/streams/test_hls_playlist.py
+++ b/tests/streams/test_hls_playlist.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from streamlink.stream.hls_playlist import load, StreamInfo, Resolution, Media

--- a/tests/streams/test_stream_wrappers.py
+++ b/tests/streams/test_stream_wrappers.py
@@ -18,7 +18,3 @@ class TestPluginStream(unittest.TestCase):
         self.assertEqual(fd.read(4095), b"2" * 4095)
         self.assertEqual(fd.read(1536), b"3" * 1536)
         self.assertEqual(fd.read(), b"3" * 512)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+# -*- coding: utf-8 -*-
 import requests
 
 import unittest

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -41,7 +41,3 @@ class TestPluginAPIHTTPSession(unittest.TestCase):
             res.encoding = "cp949"
 
             self.assertEqual(HTTPSession.json(res), {u"test": u"\u0391 and \u03a9"})
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1,4 +1,4 @@
-# coding: utf8
+# -*- coding: utf-8 -*-
 import re
 import unittest
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -158,7 +158,3 @@ class TestPluginAPIValidate(unittest.TestCase):
 
     def test_endswith(self):
         assert validate(endswith(u"åäö"), u"xyzåäö")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_cli_util_progress.py
+++ b/tests/test_cli_util_progress.py
@@ -1,4 +1,4 @@
-# coding: utf-8
+# -*- coding: utf-8 -*-
 from streamlink_cli.utils.progress import terminal_width, get_cut_prefix
 import unittest
 

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# -*- coding: utf-8 -*-
 import unittest
 
 from streamlink.compat import is_win32, is_py3

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,4 +1,4 @@
-# encoding=utf8
+# -*- coding: utf-8 -*-
 import logging
 import unittest
 import warnings

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -111,7 +111,3 @@ class TestDeprecatedLogger(unittest.TestCase):
         # regular python loggers shouldn't log here
         logging.getLogger("streamlink.test").critical("should not log")
         self.assertEqual(output.getvalue(), "[test][info] test1\n")
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -129,7 +129,3 @@ class TestSetupOptions(unittest.TestCase):
         self.assertEqual(plugin.options.get("test1"), "default1")
         self.assertEqual(plugin.options.get("test2"), "default2")
         self.assertEqual(plugin.options.get("test3"), None)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -195,7 +195,3 @@ class TestSession(unittest.TestCase):
 
         self.assertFalse("http" in session.http.proxies)
         self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_utils_encoding.py
+++ b/tests/test_utils_encoding.py
@@ -1,4 +1,4 @@
-# encoding=utf8
+# -*- coding: utf-8 -*-
 import unittest
 
 from streamlink.compat import is_py3, is_py2


### PR DESCRIPTION
These are the additional (simple) changes I've mentioned in #2804. 

Regarding the editorconfig, please check if this config is good enough, as there might be a couple of file types/paths which I've left out.

And regarding the removed `unittest.main()` calls from the test modules, people should instead use the [`pytest`](https://docs.pytest.org/en/latest/usage.html) or [`unittest`](https://docs.python.org/3/library/unittest.html) command line interfaces to run test modules or single tests. Or even better, from within their IDEs. For the sake of completeness though, CLI examples here:
```sh
# pytest CLI
python -m pytest
python -m pytest tests/path/to/file.py
python -m pytest tests/path/to/file.py::ClassName
python -m pytest tests/path/to/file.py::ClassName::test_name
# unittest CLI
python -m unittest --verbose
python -m unittest --verbose tests.path.to.file
python -m unittest --verbose tests.path.to.file.ClassName
python -m unittest --verbose tests.path.to.file.ClassName.test_name
```

That should be it for now with my cleanup changes (I think :sweat_smile:).