### PR TITLE
plugins.reuters fix

### DIFF
--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 class Reuters(Plugin):
-    _url_re = re.compile(r'https?://(?:www\.)?reuters\.tv')
+    _url_re = re.compile(r'https?://(.*?\.)?reuters\.(com|tv)')
     _hls_re = re.compile(r'''(?<!')https://[^"';!<>]+\.m3u8''')
     _json_re = re.compile(r'''(?P<data>{.*});''')
     _data_schema = validate.Schema(

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -12,6 +12,8 @@ log = logging.getLogger(__name__)
 
 class Reuters(Plugin):
     _url_re = re.compile(r'https?://(.*?\.)?reuters\.(com|tv)')
+    _id_re = re.compile(r'(/l/|id=)(?P<id>.*?)(/|\?|$)')
+    _iframe_url = 'https://www.reuters.tv/l/{0}/?nonav=true'
     _hls_re = re.compile(r'''(?<!')https://[^"';!<>]+\.m3u8''')
     _json_re = re.compile(r'''(?P<data>{.*});''')
     _data_schema = validate.Schema(
@@ -58,6 +60,13 @@ class Reuters(Plugin):
 
     def _get_data(self):
         res = self.session.http.get(self.url)
+        for script in itertags(res.text, 'script'):
+            if script.attributes.get('type') == 'text/javascript' and '#rtvIframe' in script.text:
+                m = self._id_re.search(self.url)
+                if m and m.group('id'):
+                    log.debug('ID: {0}'.format(m.group('id')))
+                    res = self.session.http.get(self._iframe_url.format(m.group('id')))
+
         for script in itertags(res.text, 'script'):
             if script.attributes.get('type') == 'text/javascript' and 'RTVJson' in script.text:
                 data = self._data_schema.validate(script.text)

--- a/tests/plugins/test_reuters.py
+++ b/tests/plugins/test_reuters.py
@@ -6,6 +6,9 @@ from streamlink.plugins.reuters import Reuters
 class TestPluginReuters(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
+            'https://uk.reuters.com/video/watch/east-africa-battles-locust-invasion-idOVC2J9BHJ?chan=92jv7sln',
+            'https://www.reuters.com/livevideo?id=Pdeb',
+            'https://www.reuters.com/video/watch/baby-yoda-toy-makes-its-big-debut-idOVC1KAO9Z?chan=8adtq7aq',
             'https://www.reuters.tv/l/PFJx/2019/04/19/way-of-the-cross-ritual-around-notre-dame-cathedral',
             'https://www.reuters.tv/l/PFcO/2019/04/10/first-ever-black-hole-image-released-astrophysics-milestone',
             'https://www.reuters.tv/p/WoRwM1a00y8',


### PR DESCRIPTION
Update to fix: https://github.com/streamlink/streamlink/issues/2803

- Add support for .com TLD and country specific sub-domains 
- Find IFRAME and then GET its source HTML as necessary
- Update tests to include reuters.com and uk.reuters.com URLs

I've tested this pretty thoroughly, as per: https://github.com/streamlink/streamlink/issues/2803#issuecomment-593011020

closes https://github.com/streamlink/streamlink/issues/2803