### PR TITLE
plugins.bilibili: ignore unavailable URLs

### DIFF
--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
+from streamlink.compat import urlparse
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate, useragents
 from streamlink.stream import HTTPStream
+
+log = logging.getLogger(__name__)
 
 API_URL = "https://api.live.bilibili.com/room/v1/Room/playUrl"
 ROOM_API = "https://api.live.bilibili.com/room/v1/Room/room_init?id={}"
@@ -75,6 +79,19 @@ class Bilibili(Plugin):
         for stream_list in room["durl"]:
             name = "source"
             url = stream_list["url"]
+            # check if the URL is available
+            log.trace('URL={0}'.format(url))
+            r = self.session.http.get(url,
+                                      retries=0,
+                                      timeout=3,
+                                      stream=True,
+                                      acceptable_status=(200, 403, 404, 405))
+            p = urlparse(url)
+            if r.status_code != 200:
+                log.error('Netloc: {0} with error {1}'.format(p.netloc, r.status_code))
+                continue
+
+            log.debug('Netloc: {0}'.format(p.netloc))
             stream = HTTPStream(self.session, url)
             yield name, stream
 


### PR DESCRIPTION
closes https://github.com/streamlink/streamlink/issues/2816

```
[plugin.bilibili][debug] Netloc: d1--cn-gotcha05.bilivideo.com
[plugin.bilibili][error] Netloc: txy.live-play.acgvideo.com with error 403
[plugin.bilibili][error] Netloc: d1--cn-gotcha01.bilivideo.com with error 404
[plugin.bilibili][error] Netloc: txy.live-play.acgvideo.com with error 403
[cli][info] Available streams: source (worst, best)
[cli][info] Opening stream: source (http)
```