### PR TITLE
plugins.bloomberg: fix vods and live streams

### DIFF
--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -32,10 +32,12 @@ class Bloomberg(Plugin):
 ''', re.VERBOSE)
     _live_player_re = re.compile(r'{APP_BUNDLE:"(?P<live_player_url>.+?/app.js)"')
     _js_to_json_re = partial(re.compile(r'(\w+):(["\']|\d?\.?\d+,|true|false|\[|{)').sub, r'"\1":\2')
-    _video_id_re = re.compile(r'data-bmmr-id=\\"(?P<video_id>.+?)\\"')
     _mp4_bitrate_re = re.compile(r'.*_(?P<bitrate>[0-9]+)\.mp4')
-    _preload_state_re = re.compile(r'window.__PRELOADED_STATE__\s*=\s*({.*});', re.DOTALL)
-    _live_stream_info_re = re.compile(r'12:.*t.exports=({.*})},{}],13:', re.DOTALL)
+    _preload_state_re = re.compile(r'<script>\s*window.__PRELOADED_STATE__\s*=\s*({.+});?\s*</script>')
+    _live_stream_info_module_id_re = re.compile(
+        r'{(?:(?:"[^"]+"|\w+):(?:\d+|"[^"]+"),)*"(?:[^"]*/)?config/livestreams":(\d+)(?:,(?:"[^"]+"|\w+):(?:\d+|"[^"]+"))*}'
+    )
+    _live_stream_info_re = r'],{id}:\[function\(.+var n=({{.+}});r.default=n}},{{"[^"]+":\d+}}],{next}:\['
 
     _live_streams_schema = validate.Schema(
         validate.transform(_js_to_json_re),
@@ -75,6 +77,18 @@ class Bloomberg(Plugin):
         validate.get("byChannelId"),
     )
 
+    _vod_list_schema = validate.Schema(
+        validate.transform(parse_json),
+        validate.get("video"),
+        validate.get("videoList"),
+        validate.all([
+            validate.Schema({
+                "slug": validate.text,
+                "video": validate.Schema({"bmmrId": validate.text}, validate.get("bmmrId"))
+            })
+        ])
+    )
+
     _vod_api_schema = validate.Schema(
         {
             'secureStreams': validate.all([
@@ -94,6 +108,18 @@ class Bloomberg(Plugin):
         validate.transform(lambda x: list(set(x['secureStreams'] + x['streams'] + [x['contentLoc']])))
     )
 
+    _headers = {
+        "authority": "www.bloomberg.com",
+        "upgrade-insecure-requests": "1",
+        "dnt": "1",
+        "accept": ";".join([
+            "text/html,application/xhtml+xml,application/xml",
+            "q=0.9,image/webp,image/apng,*/*",
+            "q=0.8,application/signed-exchange",
+            "v=b3"
+        ])
+    }
+
     @classmethod
     def can_handle_url(cls, url):
         return Bloomberg._url_re.match(url)
@@ -103,65 +129,76 @@ class Bloomberg(Plugin):
         match = self._url_re.match(self.url)
         channel = match.group('channel')
 
-        res = self.session.http.get(self.url, headers={
-            "authority": "www.bloomberg.com",
-            "upgrade-insecure-requests": "1",
-            "dnt": "1",
-            "accept": ";".join([
-                "text/html,application/xhtml+xml,application/xml",
-                "q=0.9,image/webp,image/apng,*/*",
-                "q=0.8,application/signed-exchange",
-                "v=b3"
-            ])
-        })
+        res = self.session.http.get(self.url, headers=self._headers)
         if "Are you a robot?" in res.text:
             log.error("Are you a robot?")
+
         match = self._preload_state_re.search(res.text)
-        if match:
-            live_ids = self._channel_list_schema.validate(match.group(1))
-            live_id = live_ids.get(channel)
-            if live_id:
-                log.debug("Found liveId = {0}".format(live_id))
-                # Retrieve live player URL
-                res = self.session.http.get(self.PLAYER_URL)
-                match = self._live_player_re.search(res.text)
-                if match is None:
-                    return []
-                live_player_url = update_scheme(self.url, match.group('live_player_url'))
+        if match is None:
+            return
 
-                # Extract streams from the live player page
-                log.debug("Player URL: {0}".format(live_player_url))
-                res = self.session.http.get(live_player_url)
-                match = self._live_stream_info_re.search(res.text)
-                if match:
-                    stream_info = self._live_streams_schema.validate(match.group(1))
-                    data = stream_info.get(live_id, {})
-                    return data.get('cdns', [])
-            else:
-                log.error("Could not find liveId for channel '{0}'".format(channel))
+        live_ids = self._channel_list_schema.validate(match.group(1))
+        live_id = live_ids.get(channel)
+        if not live_id:
+            log.error("Could not find liveId for channel '{0}'".format(channel))
+            return
 
-        return []
+        log.debug("Found liveId: {0}".format(live_id))
+        # Retrieve live player URL
+        res = self.session.http.get(self.PLAYER_URL)
+        match = self._live_player_re.search(res.text)
+        if match is None:
+            return
+        live_player_url = update_scheme(self.url, match.group('live_player_url'))
+
+        # Extract streams from the live player page
+        log.debug("Player URL: {0}".format(live_player_url))
+        res = self.session.http.get(live_player_url)
+
+        # Get the ID of the webpack module containing the streams config from another module's dependency list
+        match = self._live_stream_info_module_id_re.search(res.text)
+        if match is None:
+            return
+        webpack_module_id = int(match.group(1))
+        log.debug("Webpack module ID: {0}".format(webpack_module_id))
+
+        # Finally get the streams JSON data from the config/livestreams webpack module
+        regex = re.compile(self._live_stream_info_re.format(id=webpack_module_id, next=webpack_module_id + 1))
+        match = regex.search(res.text)
+        if match is None:
+            return
+        stream_info = self._live_streams_schema.validate(match.group(1))
+        data = stream_info.get(live_id, {})
+
+        return data.get('cdns')
 
     def _get_vod_streams(self):
         # Retrieve URL page and search for video ID
-        res = self.session.http.get(self.url)
-        match = self._video_id_re.search(res.text)
-        if match is None:
-            return []
-        video_id = match.group('video_id')
+        res = self.session.http.get(self.url, headers=self._headers)
 
-        res = self.session.http.get(self.VOD_API_URL.format(video_id))
+        match = self._preload_state_re.search(res.text)
+        if match is None:
+            return
+
+        videos = self._vod_list_schema.validate(match.group(1))
+        video_id = next((v["video"] for v in videos if v["slug"] in self.url), None)
+        if video_id is None:
+            return
+
+        log.debug("Found videoId: {0}".format(video_id))
+        res = self.session.http.get(self.VOD_API_URL.format(video_id), headers=self._headers)
         streams = self.session.http.json(res, schema=self._vod_api_schema)
+
         return streams
 
     def _get_streams(self):
         self.session.http.headers.update({"User-Agent": useragents.CHROME})
         if '/news/videos/' in self.url:
             # VOD
-            streams = self._get_vod_streams()
+            streams = self._get_vod_streams() or []
         else:
             # Live
-            streams = self._get_live_streams()
+            streams = self._get_live_streams() or []
 
         for video_url in streams:
             log.debug("Found stream: {0}".format(video_url))


### PR DESCRIPTION
Fixes #2823 

Fixes live streams and vods (tested US+EU live streams and most recent VOD).

Couple of notes:
- The JSON object for the live stream CDN data has to be extracted from a webpack-bundled and minified JS file, just like before. The reason why the extraction failed was a change in the structure of this app file. Extracting this data will always be problematic, because the regex requires anchors for the JS module-IDs of the webpack bundle, and just like it is with all webpack production builds, all useful data (for us) gets stripped off and we're left with IDs. ~~This means that as soon as they'll add another module and rebuild the whole thing, the regex will most likely break again due to an ID shift.~~ Even though I've added a second regex for getting the module ID from another module's dependency list, this will break as soon as the "config/livestreams" module gets renamed or moved on their side.
- I'm a bit unsure about the VOD list schema and the ID extraction afterwards (which depends on the input URL). I think this can be done better, but I don't know the validation API that well.

```
$ streamlink 'https://www.bloomberg.com/live/us' -l debug
[cli][debug] OS:         Linux-5.6.0-rc5-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.2
[cli][debug] Streamlink: 1.3.1+55.g6141075.dirty
[cli][debug] Requests(2.23.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin bloomberg for URL https://www.bloomberg.com/live/us
[plugin.bloomberg][debug] Found liveId: PHOENIX_US
[plugin.bloomberg][debug] Player URL: https://cdn.gotraffic.net/projector/v0.11.182/app.js
[plugin.bloomberg][debug] Webpack module ID: 213
[plugin.bloomberg][debug] Found stream: https://www.bloomberg.com/media-manifest/streams/phoenix-us.m3u8
[utils.l10n][debug] Language code: en_US
[plugin.bloomberg][debug] Found stream: https://www.bloomberg.com/media-manifest/streams/phoenix-us.m3u8?group=backup
[utils.l10n][debug] Language code: en_US
Available streams: 272p_alt (worst), 272p, 360p_alt, 360p, 720p_alt2, 720p_alt, 720p, 1080p_alt, 1080p (best)
```

```
$ streamlink 'https://www.bloomberg.com/live/europe' -l debug
[cli][debug] OS:         Linux-5.6.0-rc5-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.2
[cli][debug] Streamlink: 1.3.1+55.g6141075.dirty
[cli][debug] Requests(2.23.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin bloomberg for URL https://www.bloomberg.com/live/europe
[plugin.bloomberg][debug] Found liveId: EU
[plugin.bloomberg][debug] Player URL: https://cdn.gotraffic.net/projector/v0.11.182/app.js
[plugin.bloomberg][debug] Webpack module ID: 213
[plugin.bloomberg][debug] Found stream: https://www.bloomberg.com/media-manifest/streams/eu.m3u8
[utils.l10n][debug] Language code: en_US
[plugin.bloomberg][debug] Found stream: https://www.bloomberg.com/media-manifest/streams/eu.m3u8?group=backup
[utils.l10n][debug] Language code: en_US
Available streams: 180p_alt (worst), 180p, 270p_alt, 270p, 360p_alt, 360p, 720p_alt, 720p (best)
```

```
$ streamlink 'https://www.bloomberg.com/news/videos/2020-03-11/-bloomberg-daybreak-americas-full-show-03-11-20-video' -l debug
[cli][debug] OS:         Linux-5.6.0-rc5-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.2
[cli][debug] Streamlink: 1.3.1+55.ga5002a1
[cli][debug] Requests(2.23.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin bloomberg for URL https://www.bloomberg.com/news/videos/2020-03-11/-bloomberg-daybreak-americas-full-show-03-11-20-video
[plugin.bloomberg][debug] Found videoId: yzOs1G3_R8q5PKO2bso4zQ
[plugin.bloomberg][debug] Found stream: https://cdn-mobapi.bloomberg.com/wssmobile/v1/video/cc/android/WiFi/vodpkg-Fastly--Azure-US-East1-Zenko/yzOs1G3_R8q5PKO2bso4zQ.m3u8
[utils.l10n][debug] Language code: en_US
[plugin.bloomberg][debug] Found stream: https://bbgvod-azure-us-east1-zenko.global.ssl.fastly.net/vod/vod/m/ODE0NjIxNA/MjcwMDM4MQ/daybreakam031120_150.mp4
Available streams: 100k (worst), 150k, 176p, 272p, 360p, 540p, 720p_alt, 720p, 1080p (best)
```
