### PR TITLE
plugins.showroom: Fix HLS missing segments

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -181,7 +181,7 @@ ruv                     ruv.is               Yes   Yes   Streams may be geo-rest
 sbscokr                 play.sbs.co.kr       Yes   No    Streams may be geo-restricted to South Korea.
 schoolism               schoolism.com        --    Yes   Requires a login and a subscription.
 senategov               senate.gov           --    Yes   Supports hearing streams.
-showroom                showroom-live.com    Yes   No    Only RTMP streams are available.
+showroom                showroom-live.com    Yes   No
 skai                    skai.gr              Yes   No    Only embedded youtube live streams are supported
 sportal                 sportal.bg           Yes   No
 sportschau              sportschau.de        Yes   No

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -4,6 +4,7 @@ import re
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate, useragents
 from streamlink.stream import HLSStream, RTMPStream
+from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker
 
 _url_re = re.compile(r'''^https?://
     (?:\w*.)?
@@ -78,6 +79,23 @@ _info_pages = set((
 ))
 
 
+class ShowroomHLSStreamWorker(HLSStreamWorker):
+    def _set_playlist_reload_time(self, playlist, sequences):
+        self.playlist_reload_time = 1.5
+
+
+class ShowroomHLSStreamReader(HLSStreamReader):
+    __worker__ = ShowroomHLSStreamWorker
+
+
+class ShowroomHLSStream(HLSStream):
+    def open(self):
+        reader = ShowroomHLSStreamReader(self)
+        reader.open()
+
+        return reader
+
+
 class Showroom(Plugin):
     @classmethod
     def can_handle_url(cls, url):
@@ -150,7 +168,7 @@ class Showroom(Plugin):
             if stream_info["type"] == "rtmp":
                 yield self._get_rtmp_stream(stream_info)
             elif stream_info["type"] == "hls":
-                for s in HLSStream.parse_variant_playlist(self.session, stream_info["url"]).items():
+                for s in ShowroomHLSStream.parse_variant_playlist(self.session, stream_info["url"]).items():
                     yield s
 
 


### PR DESCRIPTION
use a custom playlist_reload_time of 1.5 sec

closes https://github.com/streamlink/streamlink/pull/2735
closes https://github.com/streamlink/streamlink/issues/2726