### PR TITLE
plugins.pixiv: removed not working login process via username

### DIFF
--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import argparse
 import logging
 import re
 
@@ -57,22 +58,8 @@ class Pixiv(Plugin):
     login_url_post = "https://accounts.pixiv.net/api/login"
 
     arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            requires=["password"],
-            metavar="USERNAME",
-            help="""
-        The email/username used to register with pixiv.net
-        """
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="""
-        A pixiv.net account password to use with --pixiv-username
-        """
-        ),
+        PluginArgument("username", help=argparse.SUPPRESS),
+        PluginArgument("password", help=argparse.SUPPRESS),
         PluginArgument(
             "sessionid",
             requires=["devicetoken"],
@@ -120,30 +107,6 @@ class Pixiv(Plugin):
     def can_handle_url(cls, url):
         return cls._url_re.match(url) is not None
 
-    def _login(self, username, password):
-        res = self.session.http.get(self.login_url_get)
-        m = self._post_key_re.search(res.text)
-        if not m:
-            raise PluginError("Missing post_key, no login posible.")
-
-        post_key = m.group("data")
-        data = {
-            "lang": "en",
-            "source": "sketch",
-            "post_key": post_key,
-            "pixiv_id": username,
-            "password": password,
-        }
-
-        res = self.session.http.post(self.login_url_post, data=data)
-        res = self.session.http.json(res)
-        log.trace("{0!r}".format(res))
-        if res["body"].get("success"):
-            self.save_cookies()
-            log.info("Successfully logged in")
-        else:
-            log.error("Failed to log in.")
-
     def _login_using_session_id_and_device_token(self, session_id, device_token):
         self.session.http.get(self.login_url_get)
 
@@ -171,9 +134,6 @@ class Pixiv(Plugin):
         raise NoStreamsError(self.url)
 
     def _get_streams(self):
-        login_username = self.get_option("username")
-        login_password = self.get_option("password")
-
         login_session_id = self.get_option("sessionid")
         login_device_token = self.get_option("devicetoken")
 
@@ -184,8 +144,6 @@ class Pixiv(Plugin):
 
         if self._authed:
             log.debug("Attempting to authenticate using cached cookies")
-        elif not self._authed and login_username and login_password:
-            self._login(login_username, login_password)
         elif not self._authed and login_session_id and login_device_token:
             self._login_using_session_id_and_device_token(login_session_id, login_device_token)
 


### PR DESCRIPTION
It doesn't work because they use reCAPTCHA,
removed it so it doesn't confuse people.

---

use cookies instead

`--pixiv-sessionid`

https://streamlink.github.io/cli.html#cmdoption-pixiv-sessionid

`--pixiv-devicetoken`

https://streamlink.github.io/cli.html#cmdoption-pixiv-devicetoken

if it doesn't work, try `--pixiv-purge-credentials`

https://streamlink.github.io/cli.html#cmdoption-pixiv-purge-credentials

---

closes https://github.com/streamlink/streamlink/issues/2515
closes https://github.com/streamlink/streamlink/pull/2521

ref https://github.com/streamlink/streamlink/pull/2529