### PR TITLE
docs: fix duplicate object description of streamlink in api docs

### DIFF
--- a/docs/api_guide.rst
+++ b/docs/api_guide.rst
@@ -3,8 +3,6 @@
 API Guide
 =========
 
-.. module:: streamlink
-
 This API is what powers the :ref:`cli` but is also available to developers that wish
 to make use of the data Streamlink can retrieve in their own application.
 


### PR DESCRIPTION
A module directive for the streamlink module is duplicated in
both `api_guide.rst` and `api.rst`.
Remove the one in `api_guide.rst`.

This was triggering warning with sphinx:
```
WARNING: duplicate object description of streamlink, other instance in
api, use :noindex: for one of them.
```