### PR TITLE
docs: remove deprecated use of script_files

### DIFF
--- a/docs/_themes/sphinx_rtd_theme_violet/layout.html
+++ b/docs/_themes/sphinx_rtd_theme_violet/layout.html
@@ -67,8 +67,10 @@
   {%- endblock %}
   {%- block extrahead %} {% endblock %}
 
+  {%- block scripts %}
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js"></script>
+  {%- endblock %}
 
 </head>
 

--- a/docs/_themes/sphinx_rtd_theme_violet/search.html
+++ b/docs/_themes/sphinx_rtd_theme_violet/search.html
@@ -9,7 +9,10 @@
 #}
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
-{% set script_files = script_files + ['_static/searchtools.js'] %}
+{%- block scripts %}
+    {{ super() }}
+    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+{%- endblock %}
 {% block footer %}
   <script type="text/javascript">
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });


### PR DESCRIPTION
Cherrypicked from sphinx_rtd_theme:
https://github.com/readthedocs/sphinx_rtd_theme/commit/a49a812c8821123091166fae1897d702cdc2d627

Note: don't merge this if https://github.com/streamlink/streamlink/pull/2857 is going to be merged as this change is purely a `sphinx_rtd_theme_violet` theme change.