### PR TITLE
utils: update_qsd to leave blank values unchanged

### DIFF
--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,48 +1,47 @@
-import unittest
+from collections import OrderedDict
 
 from streamlink.utils.url import (
     update_scheme, url_equal, url_concat, update_qsd
 )
 
 
-class TestUtilURL(unittest.TestCase):
-    def test_update_scheme(self):
-        self.assertEqual(
-            "https://example.com/foo",  # becomes https
-            update_scheme("https://other.com/bar", "//example.com/foo")
-        )
-        self.assertEqual(
-            "http://example.com/foo",  # becomes http
-            update_scheme("http://other.com/bar", "//example.com/foo")
-        )
-        self.assertEqual(
-            "http://example.com/foo",  # remains unchanged
-            update_scheme("https://other.com/bar", "http://example.com/foo")
-        )
-        self.assertEqual(
-            "https://example.com/foo",  # becomes https
-            update_scheme("https://other.com/bar", "example.com/foo")
-        )
+def test_update_scheme():
+    assert update_scheme("https://other.com/bar", "//example.com/foo") == "https://example.com/foo", "should become https"
+    assert update_scheme("http://other.com/bar", "//example.com/foo") == "http://example.com/foo", "should become http"
+    assert update_scheme("https://other.com/bar", "http://example.com/foo") == "http://example.com/foo", "should remain http"
+    assert update_scheme("https://other.com/bar", "example.com/foo") == "https://example.com/foo", "should become https"
 
-    def test_url_equal(self):
-        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test"))
-        self.assertFalse(url_equal("http://test.com/test", "http://test.com/test2"))
 
-        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test2", ignore_path=True))
-        self.assertTrue(url_equal("http://test.com/test", "https://test.com/test", ignore_scheme=True))
-        self.assertFalse(url_equal("http://test.com/test", "https://test.com/test"))
+def test_url_equal():
+    assert url_equal("http://test.com/test", "http://test.com/test")
+    assert not url_equal("http://test.com/test", "http://test.com/test2")
 
-        self.assertTrue(url_equal("http://test.com/test", "http://test.com/test#hello", ignore_fragment=True))
-        self.assertTrue(url_equal("http://test.com/test", "http://test2.com/test", ignore_netloc=True))
-        self.assertFalse(url_equal("http://test.com/test", "http://test2.com/test1", ignore_netloc=True))
+    assert url_equal("http://test.com/test", "http://test.com/test2", ignore_path=True)
+    assert url_equal("http://test.com/test", "https://test.com/test", ignore_scheme=True)
+    assert not url_equal("http://test.com/test", "https://test.com/test")
 
-    def test_url_concat(self):
-        self.assertEqual(url_concat("http://test.se", "one", "two", "three"), "http://test.se/one/two/three")
-        self.assertEqual(url_concat("http://test.se", "/one", "/two", "/three"), "http://test.se/one/two/three")
-        self.assertEqual(url_concat("http://test.se/one", "../two", "three"), "http://test.se/two/three")
-        self.assertEqual(url_concat("http://test.se/one", "../two", "../three"), "http://test.se/three")
+    assert url_equal("http://test.com/test", "http://test.com/test#hello", ignore_fragment=True)
+    assert url_equal("http://test.com/test", "http://test2.com/test", ignore_netloc=True)
+    assert not url_equal("http://test.com/test", "http://test2.com/test1", ignore_netloc=True)
 
-    def test_update_qsd(self):
-        self.assertEqual(update_qsd("http://test.se?one=1&two=3", {"two": 2}), "http://test.se?one=1&two=2")
-        self.assertEqual(update_qsd("http://test.se?one=1&two=3", remove=["two"]), "http://test.se?one=1")
-        self.assertEqual(update_qsd("http://test.se?one=1&two=3", {"one": None}, remove="*"), "http://test.se?one=1")
+
+def test_url_concat():
+    assert url_concat("http://test.se", "one", "two", "three") == "http://test.se/one/two/three"
+    assert url_concat("http://test.se", "/one", "/two", "/three") == "http://test.se/one/two/three"
+    assert url_concat("http://test.se/one", "../two", "three") == "http://test.se/two/three"
+    assert url_concat("http://test.se/one", "../two", "../three") == "http://test.se/three"
+
+
+def test_update_qsd():
+    assert update_qsd("http://test.se?one=1&two=3", {"two": 2}) == "http://test.se?one=1&two=2"
+    assert update_qsd("http://test.se?one=1&two=3", remove=["two"]) == "http://test.se?one=1"
+    assert update_qsd("http://test.se?one=1&two=3", {"one": None}, remove="*") == "http://test.se?one=1"
+    assert update_qsd("http://test.se", OrderedDict([("one", ""), ("two", "")])) == "http://test.se?one=&two=", \
+        "should add empty params"
+    assert update_qsd("http://test.se?one=", {"one": None}) == "http://test.se?one=", "should leave empty params unchanged"
+    assert update_qsd("http://test.se?one=", keep_blank_values=False) == "http://test.se", "should strip blank params"
+    assert update_qsd("http://test.se?one=&two=", {"one": None}, keep_blank_values=False) == "http://test.se?one=", \
+        "should leave one"
+    assert update_qsd("http://test.se?&two=", {"one": ''}, keep_blank_values=False) == "http://test.se?one=", \
+        "should set one blank"
+    assert update_qsd("http://test.se?one=", {"two": 2}) == "http://test.se?one=&two=2"


### PR DESCRIPTION
Updates the `update_qsd` to support blank param values.

As pointed out by @calculon-jr in [#2747](https://github.com/streamlink/streamlink/pull/2747/files/b90362964e5c582eb9d960520386f4f12f8e3f54..b0a5f75146b1e0ca0bca6ecd8405878735c01aa7﻿).

I also refactored the tests for the url utils to be more pytesty. 