### PR TITLE
ci.github: fix continue on error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,16 +32,16 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        continue-on-error: ${{ matrix.continue }}
+        continue-on-error: ${{ matrix.continue || false }}
         run: bash ./script/install-dependencies.sh
       - name: Test
-        continue-on-error: ${{ matrix.continue }}
+        continue-on-error: ${{ matrix.continue || false }}
         run: pytest -r a --cov --cov-report=xml
       - name: Lint
-        continue-on-error: ${{ matrix.continue }}
+        continue-on-error: ${{ matrix.continue || false }}
         run: flake8
       - name: Upload coverage data
-        continue-on-error: ${{ matrix.continue }}
+        continue-on-error: ${{ matrix.continue || false }}
         uses: codecov/codecov-action@v1
 
   documentation:


### PR DESCRIPTION
This fixes the irrelevant but potentially confusing error message if a test has failed on one of the required test jobs. Github expects a boolean value on the `continue-on-error` config, but `matrix.continue` is only set on additional allowed-to-fail jobs, which we currently don't have, so the value is an empty string instead, which it doesn't like.

Example:
https://github.com/streamlink/streamlink/runs/567342748?check_suite_focus=true#step:6:15

Fixed:
https://github.com/bastimeyer-test/streamlink-test/runs/567542014?check_suite_focus=true#step:5:271