### PR TITLE
util: fix some encoding issue when setting unicode/utf8 titles in py2

### DIFF
--- a/src/streamlink/utils/encoding.py
+++ b/src/streamlink/utils/encoding.py
@@ -15,7 +15,10 @@ def get_filesystem_encoding():
 
 def maybe_encode(text, encoding="utf8"):
     if is_py2:
-        return text.encode(encoding)
+        if isinstance(text, unicode):
+            return text.encode(encoding)
+        else:
+            return text
     else:
         return text
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -30,7 +30,7 @@ from streamlink.utils import LazyFormatter
 import streamlink.logger as logger
 from .argparser import build_parser
 from .compat import stdout, is_win32
-from streamlink.utils.encoding import maybe_encode
+from streamlink.utils.encoding import maybe_decode, get_filesystem_encoding
 from .console import ConsoleOutput, ConsoleUserInputRequester
 from .constants import CONFIG_FILES, PLUGINS_DIR, STREAM_SYNONYMS, DEFAULT_STREAM_METADATA
 from .output import FileOutput, PlayerOutput
@@ -146,7 +146,7 @@ def create_http_server(host=None, port=0):
 def create_title(plugin=None):
     if args.title and plugin:
         title = LazyFormatter.format(
-            maybe_encode(args.title),
+            maybe_decode(args.title, get_filesystem_encoding()),
             title=lambda: plugin.get_title() or DEFAULT_STREAM_METADATA["title"],
             author=lambda: plugin.get_author() or DEFAULT_STREAM_METADATA["author"],
             category=lambda: plugin.get_category() or DEFAULT_STREAM_METADATA["category"],

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -185,13 +185,13 @@ class PlayerOutput(Output):
             if self.player_name == "vlc":
                 # see https://wiki.videolan.org/Documentation:Format_String/, allow escaping with \$
                 self.title = self.title.replace("$", "$$").replace(r'\$$', "$")
-                extra_args.extend(["--input-title-format", self.title])
+                extra_args.extend([u"--input-title-format", self.title])
 
             # mpv
             if self.player_name == "mpv":
                 # see https://mpv.io/manual/stable/#property-expansion, allow escaping with \$, respect mpv's $>
                 self.title = self._mpv_title_escape(self.title)
-                extra_args.append("--title={}".format(self.title))
+                extra_args.append(u"--title={}".format(self.title))
 
             # potplayer
             if self.player_name == "potplayer":
@@ -209,8 +209,7 @@ class PlayerOutput(Output):
         if is_win32:
             eargs = maybe_decode(subprocess.list2cmdline(extra_args))
             # do not insert and extra " " when there are no extra_args
-            return maybe_encode(u' '.join([cmd] + ([eargs] if eargs else []) + [args]),
-                                encoding=get_filesystem_encoding())
+            return u' '.join([cmd] + ([eargs] if eargs else []) + [args])
         return shlex.split(cmd) + extra_args + shlex.split(args)
 
     def _open(self):
@@ -233,8 +232,9 @@ class PlayerOutput(Output):
             fargs = args
         else:
             fargs = subprocess.list2cmdline(args)
-        log.debug(u"Calling: {0}".format(maybe_decode(fargs)))
-        subprocess.call(args,
+        log.debug(u"Calling: {0}".format(fargs))
+
+        subprocess.call(maybe_encode(args, get_filesystem_encoding()),
                         stdout=self.stdout,
                         stderr=self.stderr)
 
@@ -246,9 +246,9 @@ class PlayerOutput(Output):
             fargs = args
         else:
             fargs = subprocess.list2cmdline(args)
+        log.debug(u"Opening subprocess: {0}".format(fargs))
 
-        log.debug(u"Opening subprocess: {0}".format(maybe_decode(fargs)))
-        self.player = subprocess.Popen(args,
+        self.player = subprocess.Popen(maybe_encode(args, get_filesystem_encoding()),
                                        stdin=self.stdin, bufsize=0,
                                        stdout=self.stdout,
                                        stderr=self.stderr)

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -233,7 +233,7 @@ class PlayerOutput(Output):
             fargs = args
         else:
             fargs = subprocess.list2cmdline(args)
-        log.debug(u"Calling: {0}".format(fargs))
+        log.debug(u"Calling: {0}".format(maybe_decode(fargs)))
         subprocess.call(args,
                         stdout=self.stdout,
                         stderr=self.stderr)
@@ -246,7 +246,8 @@ class PlayerOutput(Output):
             fargs = args
         else:
             fargs = subprocess.list2cmdline(args)
-        log.debug(u"Opening subprocess: {0}".format(fargs))
+
+        log.debug(u"Opening subprocess: {0}".format(maybe_decode(fargs)))
         self.player = subprocess.Popen(args,
                                        stdin=self.stdin, bufsize=0,
                                        stdout=self.stdout,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,9 @@
+import os
 import warnings
+
+import pytest
+
+from streamlink.compat import is_py2, is_py3
 
 
 def catch_warnings(record=False, module=None):
@@ -6,12 +11,19 @@ def catch_warnings(record=False, module=None):
         def _catch_warnings(*args, **kwargs):
             with warnings.catch_warnings(record=True, module=module) as w:
                 if record:
-                    return f(*(args + (w, )), **kwargs)
+                    return f(*(args + (w,)), **kwargs)
                 else:
                     return f(*args, **kwargs)
+
         return _catch_warnings
 
     return _catch_warnings_wrapper
 
 
-__all__ = ['ignore_warnings']
+windows_only = pytest.mark.skipif(os.name != "nt", reason="test only applicable on Window")
+posix_only = pytest.mark.skipif(os.name != "posix", reason="test only applicable on a POSIX OS")
+py3_only = pytest.mark.skipif(not is_py3, reason="test only applicable for Python 3")
+py2_only = pytest.mark.skipif(not is_py2, reason="test only applicable for Python 2")
+
+
+__all__ = ['catch_warnings', 'windows_only', 'posix_only', 'py2_only', 'py3_only']

--- a/tests/test_cli_playerout.py
+++ b/tests/test_cli_playerout.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from streamlink.utils import get_filesystem_encoding
+from streamlink_cli.output import PlayerOutput
+from tests import posix_only, windows_only, py2_only, py3_only
+from tests.mock import patch, ANY
+
+UNICODE_TITLE = u"기타치는소율 with UL섬 "
+
+
+@posix_only
+@patch('subprocess.Popen')
+def test_output_mpv_unicode_title_posix(popen):
+    po = PlayerOutput("mpv", title=UNICODE_TITLE)
+    popen().poll.side_effect = lambda: None
+    po.open()
+    popen.assert_called_with(['mpv', u"--title=" + UNICODE_TITLE, '-'],
+                             bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
+
+
+@posix_only
+@patch('subprocess.Popen')
+def test_output_vlc_unicode_title_posix(popen):
+    po = PlayerOutput("vlc", title=UNICODE_TITLE)
+    popen().poll.side_effect = lambda: None
+    po.open()
+    popen.assert_called_with(['vlc', u'--input-title-format', UNICODE_TITLE, '-'],
+                             bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
+
+
+@py2_only
+@windows_only
+@patch('subprocess.Popen')
+def test_output_mpv_unicode_title_windows_py2(popen):
+    po = PlayerOutput("mpv.exe", title=UNICODE_TITLE)
+    popen().poll.side_effect = lambda: None
+    po.open()
+    popen.assert_called_with("mpv.exe \"--title=" + UNICODE_TITLE.encode(get_filesystem_encoding()) + "\" -",
+                             bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
+
+
+@py2_only
+@windows_only
+@patch('subprocess.Popen')
+def test_output_vlc_unicode_title_windows_py2(popen):
+    po = PlayerOutput("vlc.exe", title=UNICODE_TITLE)
+    popen().poll.side_effect = lambda: None
+    po.open()
+    popen.assert_called_with("vlc.exe --input-title-format \"" + UNICODE_TITLE.encode(get_filesystem_encoding()) + "\" -",
+                             bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
+
+
+@py3_only
+@windows_only
+@patch('subprocess.Popen')
+def test_output_mpv_unicode_title_windows_py3(popen):
+    po = PlayerOutput("mpv.exe", title=UNICODE_TITLE)
+    popen().poll.side_effect = lambda: None
+    po.open()
+    popen.assert_called_with("mpv.exe \"--title=" + UNICODE_TITLE + "\" -",
+                             bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
+
+
+@py3_only
+@windows_only
+@patch('subprocess.Popen')
+def test_output_vlc_unicode_title_windows_py3(popen):
+    po = PlayerOutput("vlc.exe", title=UNICODE_TITLE)
+    popen().poll.side_effect = lambda: None
+    po.open()
+    popen.assert_called_with("vlc.exe --input-title-format \"" + UNICODE_TITLE + "\" -",
+                             bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -30,7 +30,7 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
 
     def test_unicode_title_2444(self):
         self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
-                        ["mpv", "--title=★", "-"])
+                        ["mpv", u'--title=\u2605', "-"])
 
 
 @unittest.skipIf(not is_win32, "test only applicable on Windows")
@@ -113,7 +113,7 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
 
     @unittest.skipUnless(is_py2, "test only valid for Python 2")
     def test_unicode_title_2444_py2(self):
-        self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
+        self._test_args(["streamlink", "-p", "mpv", "-t", u"★".encode(get_filesystem_encoding()), "http://test.se", "test"],
                         "mpv --title=" + u"★".encode(get_filesystem_encoding()) + " -")
 
     @unittest.skipUnless(is_py3, "test only valid for Python 3")

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import unittest
 
-from streamlink.compat import is_win32, is_py3
+from streamlink.compat import is_win32, is_py3, is_py2
 from streamlink.utils import get_filesystem_encoding
 from tests.test_cmdline import CommandLineTestCase
 
@@ -27,6 +27,10 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
     def test_open_player_with_title_mpv(self):
         self._test_args(["streamlink", "-p", "/usr/bin/mpv", "--title", "{title}", "http://test.se", "test"],
                         ["/usr/bin/mpv", "--title=Test Title", "-"])
+
+    def test_unicode_title_2444(self):
+        self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
+                        ["mpv", "--title=★", "-"])
 
 
 @unittest.skipIf(not is_win32, "test only applicable on Windows")
@@ -77,7 +81,7 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
             passthrough=True
         )
 
-    @unittest.skipIf(is_py3, "Encoding is different in Python 2")
+    @unittest.skipUnless(is_py2, "Encoding is different in Python 2")
     def test_open_player_with_unicode_author_pot_py2(self):
         self._test_args(
             ["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"",
@@ -88,7 +92,7 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
             passthrough=True
         )
 
-    @unittest.skipIf(not is_py3, "Encoding is different in Python 2")
+    @unittest.skipUnless(is_py3, "Encoding is different in Python 3")
     def test_open_player_with_unicode_author_pot_py3(self):
         self._test_args(
             ["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"",
@@ -106,3 +110,13 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
             + "\"http://test.se/playlist.m3u8\\http://test.se/stream\"",
             passthrough=True
         )
+
+    @unittest.skipUnless(is_py2, "test only valid for Python 2")
+    def test_unicode_title_2444_py2(self):
+        self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
+                        "mpv --title=" + u"★".encode(get_filesystem_encoding()) + " -")
+
+    @unittest.skipUnless(is_py3, "test only valid for Python 3")
+    def test_unicode_title_2444_py3(self):
+        self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
+                        "mpv --title=★ -")


### PR DESCRIPTION
This should resolve the encoding issue in log messages for the command line arguments. 

fixes #2444