### PR TITLE
Added support for clan tve, children's channel of RTVE

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -176,7 +176,7 @@ rtbf                    - rtbf.be/auvio      Yes   Yes   Streams may be geo-rest
                         - rtbfradioplayer.be
 rtlxl                   rtlxl.nl             No    Yes   Streams may be geo-restricted to The Netherlands. Livestreams not supported.
 rtpplay                 rtp.pt/play          Yes   Yes   Streams may be geo-restricted to Portugal.
-rtve                    rtve.es              Yes   No
+rtve                    rtve.es              Yes   No    Streams may be geo-restricted to Spain.
 rtvs                    rtvs.sk              Yes   No    Streams may be geo-restricted to Slovakia.
 ruv                     ruv.is               Yes   Yes   Streams may be geo-restricted to Iceland.
 sbscokr                 play.sbs.co.kr       Yes   No    Streams may be geo-restricted to South Korea.

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -59,7 +59,7 @@ class ZTNRClient(object):
 class Rtve(Plugin):
     secret_key = base64.b64decode("eWVMJmRhRDM=")
     url_re = re.compile(r"""
-        https?://(?:www\.)?rtve\.es/(?:directo|noticias|television|deportes|alacarta|drmn)/.*?/?
+        https?://(?:www\.)?rtve\.es/(?:directo|infantil|noticias|television|deportes|alacarta|drmn)/.*?/?
     """, re.VERBOSE)
     cdn_schema = validate.Schema(
         validate.transform(partial(parse_xml, invalid_char_entities=True)),

--- a/tests/plugins/test_rtve.py
+++ b/tests/plugins/test_rtve.py
@@ -10,6 +10,7 @@ class TestPluginRtve(unittest.TestCase):
             'http://www.rtve.es/directo/la-2/',
             'http://www.rtve.es/directo/teledeporte/',
             'http://www.rtve.es/directo/canal-24h/',
+            'http://www.rtve.es/infantil/directo/',
         ]
         for url in should_match:
             self.assertTrue(Rtve.can_handle_url(url))


### PR DESCRIPTION
Added support for clan tve, children's channel of RTVE, online available at [https://www.rtve.es/infantil/directo/](https://www.rtve.es/infantil/directo/) since March. 