### PR TITLE
plugins.kardelentv: Add support for KARDELEN TV live streams

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -110,7 +110,7 @@ idf1                    idf1.fr              Yes   Yes
 ine                     ine.com              ---   Yes
 itvplayer               itv.com/itvplayer    Yes   Yes   Streams may be geo-restricted to Great Britain.
 invintus                player.invintus.com  Yes   Yes
-kardelentv              kardelentv.com.tr    Yes   No   Streams may be geo-restricted to Erzurum,Turkey.
+kardelentv              kardelentv.com.tr    Yes   No    Streams may be geo-restricted to Erzurum,Turkey.
 kingkong                kingkong.com.tw      Yes   --
 latina                  latina.pe            Yes   No    Streams may be geo-restricted to Peru.
 linelive                live.line.me         Yes   Yes

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -110,6 +110,7 @@ idf1                    idf1.fr              Yes   Yes
 ine                     ine.com              ---   Yes
 itvplayer               itv.com/itvplayer    Yes   Yes   Streams may be geo-restricted to Great Britain.
 invintus                player.invintus.com  Yes   Yes
+kardelentv              kardelentv.com.tr    Yes   No   Streams may be geo-restricted to Erzurum,Turkey.
 kingkong                kingkong.com.tw      Yes   --
 latina                  latina.pe            Yes   No    Streams may be geo-restricted to Peru.
 linelive                live.line.me         Yes   Yes

--- a/src/streamlink/plugins/kardelentv.py
+++ b/src/streamlink/plugins/kardelentv.py
@@ -15,10 +15,8 @@ class KardelenTV(Plugin):
     def can_handle_url(cls, url):
         return cls.url_re.match(url) is not None
 
-
     def get_title(self):
         return "Kardelen TV"
-
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/kardelentv.py
+++ b/src/streamlink/plugins/kardelentv.py
@@ -21,15 +21,14 @@ class KardelenTV(Plugin):
     def _get_streams(self):
         res = self.session.http.get(self.url)
         for iframe in itertags(res.text, "iframe"):
-            self.logger.debug("Found iframe: {0}".format(iframe))
+            log.debug("Found iframe: {0}".format(iframe))
             iframe_res = self.session.http.get(iframe.attributes['src'], headers={"Referer": self.url})
             for source in itertags(iframe_res.text, "source"):
                 if source.attributes.get("src"):
                     stream_url = source.attributes.get("src")
                     url_path = urlparse(stream_url).path
                     if url_path.endswith(".m3u8"):
-                        for s in HLSStream.parse_variant_playlist(self.session,
-                                                                stream_url).items():
+                        for s in HLSStream.parse_variant_playlist(self.session, stream_url).items():
                             yield s
                     else:
                         log.debug("Not used URL path: {0}".format(url_path))

--- a/src/streamlink/plugins/kardelentv.py
+++ b/src/streamlink/plugins/kardelentv.py
@@ -8,6 +8,7 @@ from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
+
 class KardelenTV(Plugin):
     url_re = re.compile(r'http?://(?:www\.)?kardelentv\.com\.tr/kardelen-tv-canli-izle')
 

--- a/src/streamlink/plugins/kardelentv.py
+++ b/src/streamlink/plugins/kardelentv.py
@@ -15,8 +15,10 @@ class KardelenTV(Plugin):
     def can_handle_url(cls, url):
         return cls.url_re.match(url) is not None
 
+
     def get_title(self):
         return "Kardelen TV"
+
 
     def _get_streams(self):
         res = self.session.http.get(self.url)
@@ -32,5 +34,6 @@ class KardelenTV(Plugin):
                             yield s
                     else:
                         log.debug("Not used URL path: {0}".format(url_path))
+
 
 __plugin__ = KardelenTV

--- a/src/streamlink/plugins/kardelentv.py
+++ b/src/streamlink/plugins/kardelentv.py
@@ -1,0 +1,37 @@
+import logging
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api.utils import itertags
+from streamlink.compat import urlparse
+from streamlink.stream import HLSStream
+
+log = logging.getLogger(__name__)
+
+class KardelenTV(Plugin):
+    url_re = re.compile(r'http?://(?:www\.)?kardelentv\.com\.tr/kardelen-tv-canli-izle')
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def get_title(self):
+        return "Kardelen TV"
+
+    def _get_streams(self):
+        res = self.session.http.get(self.url)
+        for iframe in itertags(res.text, "iframe"):
+            self.logger.debug("Found iframe: {0}".format(iframe))
+            iframe_res = self.session.http.get(iframe.attributes['src'], headers={"Referer": self.url})
+            for source in itertags(iframe_res.text, "source"):
+                if source.attributes.get("src"):
+                    stream_url = source.attributes.get("src")
+                    url_path = urlparse(stream_url).path
+                    if url_path.endswith(".m3u8"):
+                        for s in HLSStream.parse_variant_playlist(self.session,
+                                                                stream_url).items():
+                            yield s
+                    else:
+                        log.debug("Not used URL path: {0}".format(url_path))
+
+__plugin__ = KardelenTV

--- a/tests/plugins/test_kardelentv.py
+++ b/tests/plugins/test_kardelentv.py
@@ -1,0 +1,19 @@
+import unittest
+
+from streamlink.plugins.galatasaraytv import KardelenTV
+
+
+class TestPluginKardelenTV(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'http://kardelentv.com.tr/kardelen-tv-canli-izle/',
+        ]
+        for url in should_match:
+            self.assertTrue(KardelenTV.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://example.com/index.html',
+        ]
+        for url in should_not_match:
+            self.assertFalse(KardelenTV.can_handle_url(url))

--- a/tests/plugins/test_kardelentv.py
+++ b/tests/plugins/test_kardelentv.py
@@ -1,6 +1,6 @@
 import unittest
 
-from streamlink.plugins.galatasaraytv import KardelenTV
+from streamlink.plugins.kardelentv import KardelenTV
 
 
 class TestPluginKardelenTV(unittest.TestCase):


### PR DESCRIPTION
Turkey [Erzurum](https://en.wikipedia.org/wiki/Erzurum) province [KARDELEN TV](http://kardelentv.com.tr/) with local TV channels are added free live support.

Added free live stream [KARDELEN TV](http://kardelentv.com.tr/kardelen-tv-canli-izle/) support.
Tested. 480p(best) quality is also broadcast continuously.