### PR TITLE
plugins.twitch: rewrite disable ads logic

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -232,21 +232,24 @@ class HLSStreamWorker(SegmentedStreamWorker):
         sequences = [Sequence(media_sequence + i, s)
                      for i, s in enumerate(playlist.segments)]
 
-        if sequences:
-            self.process_sequences(playlist, sequences)
+        self.process_sequences(playlist, sequences)
 
     def _set_playlist_reload_time(self, playlist, sequences):
         self.playlist_reload_time = (playlist.target_duration
-                                     or sequences[-1].segment.duration)
+                                     or len(sequences) > 0 and sequences[-1].segment.duration)
 
     def process_sequences(self, playlist, sequences):
+        self._set_playlist_reload_time(playlist, sequences)
+
+        if not sequences:
+            return
+
         first_sequence, last_sequence = sequences[0], sequences[-1]
 
         if first_sequence.segment.key and first_sequence.segment.key.method != "NONE":
             log.debug("Segments in this playlist are encrypted")
 
         self.playlist_changed = ([s.num for s in self.playlist_sequences] != [s.num for s in sequences])
-        self._set_playlist_reload_time(playlist, sequences)
         self.playlist_sequences = sequences
 
         if not self.playlist_changed:


### PR DESCRIPTION
Resolves #2894

Simply filters out segments that are annotated with `#EXTINF:2.002,Amazon[...]`.
`--twitch-disable-ads` needs to be set, just like before.

edit:
Well, it doesn't "resolve" the issue, just replaces the `--twitch-disable-ads` logic with new one. As I've mentioned in the linked thread, Twitch's webplayer is not showing any ads to me and I haven't figured out yet why. If someone knows how to "trick" Twitch into providing the real stream data, then that would be considered the real "fix" for the issue. Nevertheless, the parameter needs new filtering logic.

----

The stream discontinuities when the "ad" switches to the regular stream data seems to be causing a lot of issues in various players, especially VLC (no idea about the used version though). Maybe we should re-evaluate switching the default player to MPV (#2144), as it's working just fine there.