### PR TITLE
Upgrade Python syntax with pyupgrade

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -10,7 +10,7 @@ from streamlink.utils.encoding import maybe_encode
 TRACE = 5
 _levelToName = dict([(CRITICAL, "critical"), (ERROR, "error"), (WARN, "warning"), (INFO, "info"), (DEBUG, "debug"),
                      (TRACE, "trace"), (NOTSET, "none")])
-_nameToLevel = dict([(name, level) for level, name in _levelToName.items()])
+_nameToLevel = {name: level for level, name in _levelToName.items()}
 
 for level, name in _levelToName.items():
     logging.addLevelName(level, name)

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -131,7 +131,7 @@ class Arguments(object):
 
         :return: list of dependant arguments
         """
-        results = set([name])
+        results = {name}
         argument = self.get(name)
         for reqname in argument.requires:
             required = self.get(reqname)

--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -24,5 +24,5 @@ def itertags(html, tag):
     """
     for match in tag_re.finditer(html):
         if match.group("tag") == tag:
-            attrs = dict((a.group("key").lower(), a.group("value")) for a in attr_re.finditer(match.group("attr")))
+            attrs = {a.group("key").lower(): a.group("value") for a in attr_re.finditer(match.group("attr"))}
             yield Tag(match.group("tag"), attrs, match.group("inner"))

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -1,4 +1,3 @@
-
 import base64
 import logging
 import re

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -1,4 +1,3 @@
-
 import re
 
 from streamlink.plugin import Plugin

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -48,7 +48,7 @@ class OneTV(Plugin):
         res = self.session.http.get(update_scheme(self.url, self._session_api))
         data = self.session.http.json(res)
         # the values are already quoted, we don't want them quoted
-        return dict((k, unquote(v)) for k, v in data.items())
+        return {k: unquote(v) for k, v in data.items()}
 
     @property
     def is_live(self):

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -59,7 +59,7 @@ _quality_weights = {
     "low": 160
 }
 # pages that definitely aren't rooms
-_info_pages = set((
+_info_pages = {
     "onlive",
     "campaign",
     "timetable",
@@ -76,7 +76,7 @@ _info_pages = set((
     "s",
     "organizer_registration",
     "lottery"
-))
+}
 
 
 class ShowroomHLSStreamWorker(HLSStreamWorker):

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -58,7 +58,7 @@ class Streann(Plugin):
 
     def get_token(self, **config):
         self.logger.debug("get_token ...")
-        pdata = dict(arg1=base64.b64encode("www.ellobo106.com".encode("utf8")),
+        pdata = dict(arg1=base64.b64encode(b"www.ellobo106.com"),
                      arg2=base64.b64encode(self.time.encode("utf8")))
 
         headers = {

--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -90,7 +90,7 @@ class TVPlayer(Plugin):
         return res_schema
 
     def _get_stream_attrs(self, page):
-        stream_attrs = dict((k.replace("-", "_"), v.strip('"')) for k, v in self.stream_attrs_re.findall(page.text))
+        stream_attrs = {k.replace("-", "_"): v.strip('"') for k, v in self.stream_attrs_re.findall(page.text)}
 
         log.debug("Got stream attributes: {0}", str(stream_attrs))
         valid = True

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -143,7 +143,7 @@ class USTVNow(Plugin):
                    "tenant-code": self.TENANT_CODE,
                    "content-type": "application/json"}
         res = self.session.http.post(self._api_url + path, data=json.dumps(post_data), headers=headers).json()
-        data = dict((k, v and json.loads(self.decrypt_data(v, key, iv)))for k, v in res.items())
+        data = {k: v and json.loads(self.decrypt_data(v, key, iv)) for k, v in res.items()}
         return data
 
     def login(self, username, password):

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -36,7 +36,7 @@ class VK(Plugin):
         # with an video ID in the GET request, get that instead
         parsed_url = urlparse(url)
         if parsed_url.path.startswith('/videos'):
-            query = dict((v[0], v[1]) for v in [q.split('=') for q in parsed_url.query.split('&')] if v[0] == 'z')
+            query = {v[0]: v[1] for v in [q.split('=') for q in parsed_url.query.split('&')] if v[0] == 'z'}
             try:
                 true_path = unquote(query['z']).split('/')[0]
                 return parsed_url.scheme + '://' + parsed_url.netloc + '/' + true_path

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -84,7 +84,7 @@ class MPDParsers(object):
 
     @staticmethod
     def type(type_):
-        if type_ not in (u"static", u"dynamic"):
+        if type_ not in ("static", "dynamic"):
             raise MPDParsingError("@type must be static or dynamic")
         return type_
 
@@ -143,8 +143,8 @@ class MPDNode(object):
         self.node = node
         self.root = root
         self.parent = parent
-        self._base_url = kwargs.get(u"base_url")
-        self.attributes = set([])
+        self._base_url = kwargs.get("base_url")
+        self.attributes = set()
         if self.__tag__ and self.node.tag.lower() != self.__tag__.lower():
             raise MPDParsingError("root tag did not match the expected tag: {}".format(self.__tag__))
 
@@ -220,7 +220,7 @@ class MPD(MPDNode):
     Representation.
 
     """
-    __tag__ = u"MPD"
+    __tag__ = "MPD"
 
     def __init__(self, node, root=None, parent=None, url=None, *args, **kwargs):
         # top level has no parent
@@ -229,19 +229,19 @@ class MPD(MPDNode):
         self.url = url
         self.timelines = defaultdict(lambda: -1)
         self.timelines.update(kwargs.pop("timelines", {}))
-        self.id = self.attr(u"id")
-        self.profiles = self.attr(u"profiles", required=True)
-        self.type = self.attr(u"type", default=u"static", parser=MPDParsers.type)
-        self.minimumUpdatePeriod = self.attr(u"minimumUpdatePeriod", parser=MPDParsers.duration, default=Duration())
-        self.minBufferTime = self.attr(u"minBufferTime", parser=MPDParsers.duration, required=True)
-        self.timeShiftBufferDepth = self.attr(u"timeShiftBufferDepth", parser=MPDParsers.duration)
-        self.availabilityStartTime = self.attr(u"availabilityStartTime", parser=MPDParsers.datetime,
+        self.id = self.attr("id")
+        self.profiles = self.attr("profiles", required=True)
+        self.type = self.attr("type", default="static", parser=MPDParsers.type)
+        self.minimumUpdatePeriod = self.attr("minimumUpdatePeriod", parser=MPDParsers.duration, default=Duration())
+        self.minBufferTime = self.attr("minBufferTime", parser=MPDParsers.duration, required=True)
+        self.timeShiftBufferDepth = self.attr("timeShiftBufferDepth", parser=MPDParsers.duration)
+        self.availabilityStartTime = self.attr("availabilityStartTime", parser=MPDParsers.datetime,
                                                default=datetime.datetime.fromtimestamp(0, utc),  # earliest date
                                                required=self.type == "dynamic")
-        self.publishTime = self.attr(u"publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
-        self.availabilityEndTime = self.attr(u"availabilityEndTime", parser=MPDParsers.datetime)
-        self.mediaPresentationDuration = self.attr(u"mediaPresentationDuration", parser=MPDParsers.duration)
-        self.suggestedPresentationDelay = self.attr(u"suggestedPresentationDelay", parser=MPDParsers.duration)
+        self.publishTime = self.attr("publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
+        self.availabilityEndTime = self.attr("availabilityEndTime", parser=MPDParsers.datetime)
+        self.mediaPresentationDuration = self.attr("mediaPresentationDuration", parser=MPDParsers.duration)
+        self.suggestedPresentationDelay = self.attr("suggestedPresentationDelay", parser=MPDParsers.duration)
 
         # parse children
         location = self.children(Location)
@@ -293,15 +293,15 @@ class Location(MPDNode):
 
 
 class Period(MPDNode):
-    __tag__ = u"Period"
+    __tag__ = "Period"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super(Period, self).__init__(node, root, parent, *args, **kwargs)
-        self.i = kwargs.get(u"i", 0)
-        self.id = self.attr(u"id")
-        self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.bool_str)
-        self.duration = self.attr(u"duration", default=Duration(), parser=MPDParsers.duration)
-        self.start = self.attr(u"start", default=Duration(), parser=MPDParsers.duration)
+        self.i = kwargs.get("i", 0)
+        self.id = self.attr("id")
+        self.bitstreamSwitching = self.attr("bitstreamSwitching", parser=MPDParsers.bool_str)
+        self.duration = self.attr("duration", default=Duration(), parser=MPDParsers.duration)
+        self.start = self.attr("start", default=Duration(), parser=MPDParsers.duration)
 
         if self.start is None and self.i == 0 and self.root.type == "static":
             self.start = 0
@@ -382,29 +382,29 @@ class SegmentList(MPDNode):
 
 
 class AdaptationSet(MPDNode):
-    __tag__ = u"AdaptationSet"
+    __tag__ = "AdaptationSet"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super(AdaptationSet, self).__init__(node, root, parent, *args, **kwargs)
 
-        self.id = self.attr(u"id")
-        self.group = self.attr(u"group")
-        self.mimeType = self.attr(u"mimeType")
-        self.lang = self.attr(u"lang")
-        self.contentType = self.attr(u"contentType")
-        self.par = self.attr(u"par")
-        self.minBandwidth = self.attr(u"minBandwidth")
-        self.maxBandwidth = self.attr(u"maxBandwidth")
-        self.minWidth = self.attr(u"minWidth", parser=int)
-        self.maxWidth = self.attr(u"maxWidth", parser=int)
-        self.minHeight = self.attr(u"minHeight", parser=int)
-        self.maxHeight = self.attr(u"maxHeight", parser=int)
-        self.minFrameRate = self.attr(u"minFrameRate", parser=MPDParsers.frame_rate)
-        self.maxFrameRate = self.attr(u"maxFrameRate", parser=MPDParsers.frame_rate)
-        self.segmentAlignment = self.attr(u"segmentAlignment", default=False, parser=MPDParsers.bool_str)
-        self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.bool_str)
-        self.subsegmentAlignment = self.attr(u"subsegmentAlignment", default=False, parser=MPDParsers.bool_str)
-        self.subsegmentStartsWithSAP = self.attr(u"subsegmentStartsWithSAP", default=0, parser=int)
+        self.id = self.attr("id")
+        self.group = self.attr("group")
+        self.mimeType = self.attr("mimeType")
+        self.lang = self.attr("lang")
+        self.contentType = self.attr("contentType")
+        self.par = self.attr("par")
+        self.minBandwidth = self.attr("minBandwidth")
+        self.maxBandwidth = self.attr("maxBandwidth")
+        self.minWidth = self.attr("minWidth", parser=int)
+        self.maxWidth = self.attr("maxWidth", parser=int)
+        self.minHeight = self.attr("minHeight", parser=int)
+        self.maxHeight = self.attr("maxHeight", parser=int)
+        self.minFrameRate = self.attr("minFrameRate", parser=MPDParsers.frame_rate)
+        self.maxFrameRate = self.attr("maxFrameRate", parser=MPDParsers.frame_rate)
+        self.segmentAlignment = self.attr("segmentAlignment", default=False, parser=MPDParsers.bool_str)
+        self.bitstreamSwitching = self.attr("bitstreamSwitching", parser=MPDParsers.bool_str)
+        self.subsegmentAlignment = self.attr("subsegmentAlignment", default=False, parser=MPDParsers.bool_str)
+        self.subsegmentStartsWithSAP = self.attr("subsegmentStartsWithSAP", default=0, parser=int)
 
         self.baseURLs = self.children(BaseURL)
         self.segmentTemplate = self.only_child(SegmentTemplate)
@@ -419,15 +419,15 @@ class SegmentTemplate(MPDNode):
         super(SegmentTemplate, self).__init__(node, root, parent, *args, **kwargs)
         self.defaultSegmentTemplate = self.walk_back_get_attr('segmentTemplate')
 
-        self.initialization = self.attr(u"initialization", parser=MPDParsers.segment_template)
-        self.media = self.attr(u"media", parser=MPDParsers.segment_template)
-        self.duration = self.attr(u"duration", parser=int,
+        self.initialization = self.attr("initialization", parser=MPDParsers.segment_template)
+        self.media = self.attr("media", parser=MPDParsers.segment_template)
+        self.duration = self.attr("duration", parser=int,
                                   default=self.defaultSegmentTemplate.duration if self.defaultSegmentTemplate else None)
-        self.timescale = self.attr(u"timescale", parser=int,
+        self.timescale = self.attr("timescale", parser=int,
                                    default=self.defaultSegmentTemplate.timescale if self.defaultSegmentTemplate else 1)
-        self.startNumber = self.attr(u"startNumber", parser=int,
+        self.startNumber = self.attr("startNumber", parser=int,
                                      default=self.defaultSegmentTemplate.startNumber if self.defaultSegmentTemplate else 1)
-        self.presentationTimeOffset = self.attr(u"presentationTimeOffset", parser=MPDParsers.timedelta(self.timescale))
+        self.presentationTimeOffset = self.attr("presentationTimeOffset", parser=MPDParsers.timedelta(self.timescale))
 
         if self.duration:
             self.duration_seconds = self.duration / float(self.timescale)
@@ -472,7 +472,7 @@ class SegmentTemplate(MPDNode):
         :return:
         """
         log.debug("Generating segment numbers for {0} playlist (id={1})".format(self.root.type, self.parent.id))
-        if self.root.type == u"static":
+        if self.root.type == "static":
             available_iter = repeat(epoch_start)
             duration = self.period.duration.seconds or self.root.mediaPresentationDuration.seconds
             if duration:
@@ -560,28 +560,28 @@ class SegmentTemplate(MPDNode):
 
 
 class Representation(MPDNode):
-    __tag__ = u"Representation"
+    __tag__ = "Representation"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super(Representation, self).__init__(node, root, parent, *args, **kwargs)
-        self.id = self.attr(u"id", required=True)
-        self.bandwidth = self.attr(u"bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
-        self.mimeType = self.attr(u"mimeType", required=True, inherited=True)
+        self.id = self.attr("id", required=True)
+        self.bandwidth = self.attr("bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
+        self.mimeType = self.attr("mimeType", required=True, inherited=True)
 
-        self.codecs = self.attr(u"codecs")
-        self.startWithSAP = self.attr(u"startWithSAP")
+        self.codecs = self.attr("codecs")
+        self.startWithSAP = self.attr("startWithSAP")
 
         # video
-        self.width = self.attr(u"width", parser=int)
-        self.height = self.attr(u"height", parser=int)
-        self.frameRate = self.attr(u"frameRate", parser=MPDParsers.frame_rate)
+        self.width = self.attr("width", parser=int)
+        self.height = self.attr("height", parser=int)
+        self.frameRate = self.attr("frameRate", parser=MPDParsers.frame_rate)
 
         # audio
-        self.audioSamplingRate = self.attr(u"audioSamplingRate", parser=int)
-        self.numChannels = self.attr(u"numChannels", parser=int)
+        self.audioSamplingRate = self.attr("audioSamplingRate", parser=int)
+        self.numChannels = self.attr("numChannels", parser=int)
 
         # subtitle
-        self.lang = self.attr(u"lang", inherited=True)
+        self.lang = self.attr("lang", inherited=True)
 
         self.baseURLs = self.children(BaseURL)
         self.subRepresentation = self.children(SubRepresentation)
@@ -668,6 +668,6 @@ class ContentProtection(MPDNode):
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super(ContentProtection, self).__init__(node, root, parent, *args, **kwargs)
 
-        self.schemeIdUri = self.attr(u"schemeIdUri")
-        self.value = self.attr(u"value")
-        self.default_KID = self.attr(u"default_KID")
+        self.schemeIdUri = self.attr("schemeIdUri")
+        self.value = self.attr("value")
+        self.default_KID = self.attr("default_KID")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -50,7 +50,7 @@ class TestPluginAPIValidate(unittest.TestCase):
 
     def test_list_tuple_set_frozenset(self):
         assert validate([int], [1, 2])
-        assert validate(set([int]), set([1, 2])) == set([1, 2])
+        assert validate({int}, {1, 2}) == {1, 2}
         assert validate(tuple([int]), tuple([1, 2])) == tuple([1, 2])
 
     def test_dict(self):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -17,7 +17,7 @@ class PluginTestMeta(type):
         for loader, pname, ispkg in pkgutil.iter_modules([plugin_path]):
             module = load_module(pname, plugin_path)
             if hasattr(module, "__plugin__"):
-                plugins.append((pname))
+                plugins.append(pname)
 
         session = Streamlink()
 


### PR DESCRIPTION
Split out from https://github.com/streamlink/streamlink/pull/2919.

https://github.com/asottile/pyupgrade has few options:

```console
$ pyupgrade --help
usage: pyupgrade [-h] [--exit-zero-even-if-changed] [--keep-percent-format] [--py3-plus] [--py36-plus] [--py37-plus]
                 [filenames [filenames ...]]

positional arguments:
  filenames

optional arguments:
  -h, --help            show this help message and exit
  --exit-zero-even-if-changed
  --keep-percent-format
  --py3-plus, --py3-only
  --py36-plus
  --py37-plus
```

This runs it with the minimal changes, and retains Python 2.7 support.

A follow-up can run with `--py3-plus`.

---


From https://github.com/streamlink/streamlink/pull/2919:

> * It would probably be better to split this up into more commits, for reviewing reasons. One commit for each operation `pyupgrade` supports, for example, if it's possible, similar to #2804. This would also be better for the commit history, git blame, etc...
>
> * The string format related changes are probably unneeded or rather too much, as they only make explicit string templates implicit. Also, there's the 3.5 support drop in September, which enables the usage of f-strings once we go >=3.6, making these changes therefore a bit redundant.

Unfortunately there's no option to skip explicit string template things. If you prefer, I can `git add -p` to skip those from the PR. But if they were be acceptable, it would make future `--py3-plus`, `--py36-plus` etc. runs easier.

