### PR TITLE
add python 2.7 deprecation warning

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -3,6 +3,7 @@ import logging
 import pkgutil
 import sys
 import traceback
+import warnings
 
 import requests
 
@@ -42,11 +43,21 @@ def print_small_exception(start_after):
     sys.stderr.write("\n")
 
 
+class PythonDeprecatedWarning(UserWarning):
+    pass
+
+
 class Streamlink(object):
     """A Streamlink session is used to keep track of plugins,
        options and log settings."""
 
     def __init__(self, options=None):
+        if sys.version_info[0] == 2:
+            warnings.warn("Python 2.7 has reached the end of its life.  A future version of streamlink will drop "
+                          "support for Python 2.7. Please upgrade your Python to at least 3.5.",
+                          category=PythonDeprecatedWarning,
+                          stacklevel=2)
+
         self.http = api.HTTPSession()
         self.options = Options({
             "hds-live-edge": 10.0,


### PR DESCRIPTION
In a future version of streamlink only Python 3.5 and above will be supported.

As suggested in #2921 