### PR TITLE
actions: no need to use a secret for the PyPI username

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,6 @@ jobs:
         run: ./script/github_releases.py "${STREAMLINK_DIST_DIR}/"*{.exe,.tar.gz{,.asc}}
       - name: PyPI release
         env:
-          PYPI_USER: ${{ secrets.PYPI_USER }}
+          PYPI_USER: streamlink
           PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: ./script/deploy-pypi.sh


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/pull/2656#discussion_r411630309.

I took the liberty of doing it, in case @back-to didn't get round to it :)

We'll need to remove the `PYPI_USER` secret after this is merged too.