### PR TITLE
stream.hls: customizable playlist reload times

### DIFF
--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -80,8 +80,8 @@ _info_pages = set((
 
 
 class ShowroomHLSStreamWorker(HLSStreamWorker):
-    def _set_playlist_reload_time(self, playlist, sequences):
-        self.playlist_reload_time = 1.5
+    def _playlist_reload_time(self, playlist, sequences):
+        return 1.5
 
 
 class ShowroomHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -197,11 +197,11 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
 
         return playlist
 
-    def _set_playlist_reload_time(self, playlist, sequences):
-        if self.stream.low_latency and len(sequences) > 0:
-            self.playlist_reload_time = sequences[-1].segment.duration
-        else:
-            super(TwitchHLSStreamWorker, self)._set_playlist_reload_time(playlist, sequences)
+    def _playlist_reload_time(self, playlist, sequences):
+        if self.stream.low_latency and sequences:
+            return sequences[-1].segment.duration
+
+        return super(TwitchHLSStreamWorker, self)._playlist_reload_time(playlist, sequences)
 
     def process_sequences(self, playlist, sequences):
         if self.stream.low_latency and self.playlist_reloads == 1 and not playlist.has_prefetch_segments:

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -61,6 +61,7 @@ class Streamlink(object):
             "hls-segment-stream-data": False,
             "hls-timeout": 60.0,
             "hls-playlist-reload-attempts": 3,
+            "hls-playlist-reload-time": "default",
             "hls-start-offset": 0,
             "hls-duration": None,
             "http-stream-timeout": 60.0,

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -769,6 +769,20 @@ def build_parser():
         """
     )
     transport.add_argument(
+        "--hls-playlist-reload-time",
+        metavar="TIME",
+        help="""
+        Set a custom HLS playlist reload time value, either in seconds
+        or by using one of the following keywords:
+
+            segment: The duration of the last segment in the current playlist
+            live-edge: The sum of segment durations of the live edge value minus one
+            default: The playlist's target duration metadata
+
+        Default is default.
+        """
+    )
+    transport.add_argument(
         "--hls-segment-threads",
         type=num(int, max=10),
         metavar="THREADS",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -774,6 +774,9 @@ def setup_options():
     if args.hls_playlist_reload_attempts:
         streamlink.set_option("hls-playlist-reload-attempts", args.hls_playlist_reload_attempts)
 
+    if args.hls_playlist_reload_time:
+        streamlink.set_option("hls-playlist-reload-time", args.hls_playlist_reload_time)
+
     if args.hls_segment_threads:
         streamlink.set_option("hls-segment-threads", args.hls_segment_threads)
 


### PR DESCRIPTION
Adds support for customizable HLS playlist reload times via `--hls-playlist-reload-time`.

Values can be
- numbers (float) greater than 2 - self-explanatory
- `"segment"` - sets refresh time to the duration of the last segment
- `"live-edge"` - sets refresh time to the sum of durations of the `live-edge - 1`  last segments

For all other values, falls back to the playlist's `target_duration` if it is set, otherwise does the same as `live-edge` (this logic got changed, was `segment` before), and if no target duration and no segments are present, then the default value of 15 is used.

Also renames `HLSStreamWorker._set_playlist_reload_time` to `HLSStreamWorker._playlist_reload_time` and sets the reload time from its return value instead.

----

The changes are rather trivial, but I'd like to improve the integration tests a bit. It currently only tests one playlist refresh. Ideally, multiple playlists should be tested, but I couldn't set up a simple method spy with unittest.mock. Help and feedback is appreciated.