### PR TITLE
plugins.tvplayer: Add missing platform key in the GET for stream_url

### DIFF
--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -78,7 +78,7 @@ class TVPlayer(Plugin):
         if res_schema["response"]["stream"] is None:
             res = self.session.http.get(
                 self.stream_url,
-                params=dict(key=key),
+                params=dict(key=key, platform="chrome"),
                 headers={
                     "Token": token,
                     "Token-Expiry": expiry,


### PR DESCRIPTION
Closes https://github.com/streamlink/streamlink/issues/2983