### PR TITLE
ci: no test/documentation jobs on scheduled run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   test:
     name: Test
+    if: github.event_name != 'schedule'
     strategy:
       fail-fast: false
       # when changing the build matrix, the `after_n_builds` value in codecov.yml may need to be updated
@@ -48,6 +49,7 @@ jobs:
 
   documentation:
     name: Test docs
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
These jobs are unnecessary on scheduled builds, since only commits get merged into master which have passed the tests previously.
Also avoids recurring code coverage uploads if no commits get merged into master between two scheduled builds.

----

Ideally we should cancel the whole workflow run if there were no new commits since the last scheduled build, but that would require adding an additional job that runs before the test, documentation and installer jobs.

----

Duplicate code coverage upload:
- https://github.com/streamlink/streamlink/runs/740545127?check_suite_focus=true#step:7:40
- https://codecov.io/gh/streamlink/streamlink/commit/90e634ec17cd7b90f062f25f2b620e50285dd9c0/build