### PR TITLE
plugins.facebook: Randomize user_agent

### DIFF
--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import random
 
 from streamlink.compat import bytes, is_py3, unquote_plus, urlencode
 from streamlink.plugin import Plugin
@@ -58,7 +59,8 @@ class Facebook(Plugin):
                     yield s
 
     def _get_streams(self):
-        self.session.http.headers.update({'User-Agent': useragents.CHROME})
+        i = random.randint(1000, 10000)
+        self.session.http.headers.update({'User-Agent': f'streamlink/{i}'})
         done = False
         res = self.session.http.get(self.url)
         for s in self._parse_streams(res):


### PR DESCRIPTION
- fixes #2992

Problem: using the CLI `streamlink` command on facebook live streams yielded an error response. Upon investigation, the response seemed to be sent by FB in an attempt to prevent the tool from working on their urls ([see comment](https://github.com/streamlink/streamlink/issues/2992#issuecomment-639840641)). After playing around a ton with various headers in Postman and changing the source/rebuilding, I isolated the problem to be the `User-Agent` header. Running in Postman with `User-Agent` header as their default "`PostmanRuntime/7.25.0`", the result got a 200, but when using the `useragents.CHROME` var from the repo, I got an error. 

Not sure if this is the _best_ solution for this, but I am happy to change this to whatever solution you all deem best 😄 