### PR TITLE
fix radionet plugin so it works with new radio.net page format

### DIFF
--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
+from streamlink.compat import urlparse, urlunparse
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream
+from streamlink.stream import HTTPStream, HLSStream
 from streamlink.utils import parse_json
+
+log = logging.getLogger(__name__)
 
 
 class RadioNet(Plugin):
@@ -20,7 +24,8 @@ class RadioNet(Plugin):
                 {
                     'type': validate.text,
                     'streams': validate.all([{
-                        'url': validate.url()
+                        'url': validate.url(),
+                        'contentFormat': validate.text,
                     }])
                 },
             )
@@ -29,23 +34,35 @@ class RadioNet(Plugin):
 
     @classmethod
     def can_handle_url(cls, url):
-        return cls._url_re.match(url)
+        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         streams = self.session.http.get(self.url, schema=self._stream_schema)
         if streams is None:
             return
 
-        # Ignore non-radio streams (podcasts...)
         if streams['type'] != 'STATION':
             return
 
         stream_urls = set()
         for stream in streams['streams']:
-            stream_urls.add(stream['url'])
+            log.trace('{0!r}'.format(stream))
+            url = stream['url']
 
-        for url in stream_urls:
-            yield 'live', HTTPStream(self.session, url)
+            url_no_scheme = urlunparse(urlparse(url)._replace(scheme=''))
+            if url_no_scheme in stream_urls:
+                continue
+            stream_urls.add(url_no_scheme)
+
+            if stream['contentFormat'] in ('audio/mpeg', 'audio/aac'):
+                yield 'live', HTTPStream(self.session, url, allow_redirects=True)
+            elif stream['contentFormat'] == 'video/MP2T':
+                streams = HLSStream.parse_variant_playlist(self.session, stream["url"])
+                if not streams:
+                    yield stream["quality"], HLSStream(self.session, stream["url"])
+                else:
+                    for s in streams.items():
+                        yield s
 
 
 __plugin__ = RadioNet

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -40,17 +40,12 @@ class RadioNet(Plugin):
         if streams['type'] != 'STATION':
             return
 
-        stream_urls = []
+        stream_urls = set()
         for stream in streams['streams']:
-            url = stream['url']
-            if url in stream_urls:
-                continue
+            stream_urls.add(stream['url'])
 
-            # NOTE there doesn't appear to be any bit rate information any
-            # more so I hard code it to 'live':
-            bitrate = 'live'
-            yield bitrate, HTTPStream(self.session, url)
-            stream_urls.append(url)
+        for url in stream_urls:
+            yield 'live', HTTPStream(self.session, url)
 
 
 __plugin__ = RadioNet

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -18,10 +18,9 @@ class RadioNet(Plugin):
                 validate.get(1),
                 validate.transform(parse_json),
                 {
-                    'stationType': validate.text,
-                    'streamUrls': validate.all([{
-                        'bitRate': int,
-                        'streamUrl': validate.url()
+                    'type': validate.text,
+                    'streams': validate.all([{
+                        'url': validate.url()
                     }])
                 },
             )
@@ -38,20 +37,20 @@ class RadioNet(Plugin):
             return
 
         # Ignore non-radio streams (podcasts...)
-        if streams['stationType'] != 'radio_station':
+        if streams['type'] != 'STATION':
             return
 
         stream_urls = []
-        for stream in streams['streamUrls']:
-            if stream['streamUrl'] in stream_urls:
+        for stream in streams['streams']:
+            url = stream['url']
+            if url in stream_urls:
                 continue
 
-            if stream['bitRate'] > 0:
-                bitrate = '{}k'.format(stream['bitRate'])
-            else:
-                bitrate = 'live'
-            yield bitrate, HTTPStream(self.session, stream['streamUrl'])
-            stream_urls.append(stream['streamUrl'])
+            # NOTE there doesn't appear to be any bit rate information any
+            # more so I hard code it to 'live':
+            bitrate = 'live'
+            yield bitrate, HTTPStream(self.session, url)
+            stream_urls.append(url)
 
 
 __plugin__ = RadioNet


### PR DESCRIPTION
I think the page layout for radio.net changed about a month ago, at least that's when the radionet plugin stopped working for me.

I hacked the code so it works for me.

Note - the plugin is hardcoded to return `live` for bitrate as I don't think this is available any more.

Here's a trimmed example of the JSON we scrape from the page:
```
{
  'id': 'bbcradio4lw',
  'name': 'BBC Radio 4 Long Wave',
  'streams': [
    {
      'url': 'http://bbcmedia.ic.llnwd.net/stream/bbcmedia_radio4lw_mf_q',
      'contentFormat': 'audio/mpeg'
    }
  ],
  'type': 'STATION'
}
```