### PR TITLE
Support bilibili custom API host

### DIFF
--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.compat import urlparse
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginArguments, PluginArgument
 from streamlink.plugin.api import validate, useragents
 from streamlink.stream import HTTPStream
 

--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -52,7 +52,7 @@ class Bilibili(Plugin):
             help="Use custom api host url to bypass bilibili's cloud blocking"
         )
     )
-    
+
     @classmethod
     def can_handle_url(self, url):
         return _url_re.match(url)


### PR DESCRIPTION
Bilibili live stream's API will block requests from cloud services like GCP/AWS. However they don't block the cloud service from downloading the stream from CDN.
So we can replace the API host with custom reverse proxy to bypass that restriction.