### PR TITLE
utils.l10n: use DEFAULT_LANGUAGE_CODE if locale lookup fails

### DIFF
--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -141,7 +141,7 @@ class Localization(object):
                 language_code = None
             if language_code is None or language_code == "C":
                 # cannot be determined
-                language_code = DEFAULT_LANGUAGE
+                language_code = DEFAULT_LANGUAGE_CODE
 
         try:
             self.language, self.country = self._parse_locale_code(language_code)


### PR DESCRIPTION
set `language_code` to `DEFAULT_LANGUAGE_CODE` if `_parse_locale_code()` fails.