### PR TITLE
utils.l10n: fix pycountry language lookup

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -6,5 +6,6 @@ set -ex
 
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
-python -m pip install pycountry==19.8.18
+python -m pip install 'pycountry==19.8.18;python_version<"3.0"'
+python -m pip install 'pycountry;python_version>="3.0"'
 python -m pip install -e .

--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -1,5 +1,6 @@
 import locale
 import logging
+import re
 
 from streamlink.compat import is_py2
 
@@ -72,7 +73,8 @@ class Language(object):
     def get(cls, language):
         try:
             if PYCOUNTRY:
-                lang = languages.lookup(language)
+                # lookup workaround for alpha_2 language codes
+                lang = languages.get(alpha_2=language) if re.match(r"^[a-z]{2}$", language) else languages.lookup(language)
                 return Language(lang.alpha_2, lang.alpha_3, lang.name, getattr(lang, "bibliographic", None))
             else:
                 lang = None


### PR DESCRIPTION
See #3054 and the comments in #3055

~~This will require py2 to be dropped first (tests will fail - will rebase once done), as pycountry's recent release has removed it.~~ The added lookup workaround can be removed as soon as pycountry fixes the issue itself (see flyingcircusio/pycountry#41).

The reason why pycountry had to be downgraded with a fixed version in #3054 was an upgrade of their database with the addition of the En language, causing generic "en" language lookups to return this instead of English. Since the returned language record doesn't have an `alpha_2` code, trying to access this attribute resulted in a raised AttributeError, causing the tests to fail.

Pycountry is being used by the packages on Arch (community repo and AUR), Debian/Ubuntu/etc and Gentoo and thus needs to be fixed at some point.