### PR TITLE
Plugin.nicolive:resolve API format change

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -108,6 +108,8 @@ class NicoLive(Plugin):
         try:
             self.wss_api_url = extract_text(
                 resp.text, "&quot;webSocketUrl&quot;:&quot;", "&quot;")
+            if not self.wss_api_url:
+                return False
         except Exception as e:
             _log.debug(e)
             _log.debug("Failed to extract wss api url")

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -114,13 +114,6 @@ class NicoLive(Plugin):
             return False
 
         try:
-            self.broadcast_id = extract_text(
-                resp.text, "&quot;broadcastId&quot;:&quot;", "&quot;")
-        except Exception as e:
-            _log.debug(e)
-            _log.warning("Failed to extract broadcast id")
-
-        try:
             self.frontend_id = extract_text(
                 resp.text, "&quot;frontendId&quot;:", ",&quot;")
         except Exception as e:
@@ -132,7 +125,6 @@ class NicoLive(Plugin):
         _log.debug("Video page response code: {0}".format(resp.status_code))
         _log.trace(u"Video page response body: {0}".format(resp.text))
         _log.debug("Got wss_api_url: {0}".format(self.wss_api_url))
-        _log.debug("Got broadcast_id: {0}".format(self.broadcast_id))
         _log.debug("Got frontend_id: {0}".format(self.frontend_id))
 
         return self.wss_api_url.startswith("wss://")


### PR DESCRIPTION
Currently, “broadcast_id” field of Nicolive api is not needed.
fix #3028 