### PR TITLE
Trovo Support

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -213,6 +213,7 @@ tga                     - star.plu.cn        Yes   No
 theplatform             player.thepl... [7]_ No    Yes
 tigerdile               tigerdile.com        Yes   --
 tlctr                   tlctv.com.tr         Yes   No
+trovo                   trovo.live           Yes   --
 trt                     trt.net.tr           Yes   No    Some streams may be geo-restricted to Turkey.
 trtspor                 trtspor.com          Yes   No    Some streams are geo-restricted to Turkey.
 turkuvaz                - atv.com.tr         Yes   No

--- a/src/streamlink/plugins/trovo.py
+++ b/src/streamlink/plugins/trovo.py
@@ -1,0 +1,20 @@
+import re
+
+from streamlink.stream import HTTPStream
+from streamlink.plugin import Plugin
+
+class Trovo(Plugin):
+    url_re = re.compile(r"https?://(?:www\.)?trovo\.live/")
+    streams_re = re.compile(r'playUrl:"([^"]+)",desc:"([^"]+)"', re.DOTALL)
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = self.session.http.get(self.url)
+        for m in self.streams_re.finditer(res.text):
+            yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F','/'))
+
+
+__plugin__ = Trovo

--- a/src/streamlink/plugins/trovo.py
+++ b/src/streamlink/plugins/trovo.py
@@ -3,6 +3,7 @@ import re
 from streamlink.stream import HTTPStream
 from streamlink.plugin import Plugin
 
+
 class Trovo(Plugin):
     url_re = re.compile(r"https?://(?:www\.)?trovo\.live/")
     streams_re = re.compile(r'playUrl:"([^"]+)",desc:"([^"]+)"', re.DOTALL)
@@ -14,7 +15,7 @@ class Trovo(Plugin):
     def _get_streams(self):
         res = self.session.http.get(self.url)
         for m in self.streams_re.finditer(res.text):
-            yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F','/'))
+            yield m.group(2), HTTPStream(self.session, m.group(1).replace('\\u002F', '/'))
 
 
 __plugin__ = Trovo

--- a/tests/plugins/test_trovo.py
+++ b/tests/plugins/test_trovo.py
@@ -1,0 +1,21 @@
+import unittest
+
+from streamlink.plugins.trovo import Trovo
+
+
+class TestPluginTrovo(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://trovo.live/Ler_GG',
+            'http://trovo.live/Ler_GG'
+        ]
+        for url in should_match:
+            self.assertTrue(Trovo.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://www.dummywebsite.com/',
+            'http://www.trovo.com/'
+        ]
+        for url in should_not_match:
+            self.assertFalse(Trovo.can_handle_url(url))


### PR DESCRIPTION
This adds support for viewing trovo streams, example:

```
C:\Users\Topologist>streamlink https://trovo.live/Ler_GG
[cli][info] Found matching plugin trovo for URL https://trovo.live/Ler_GG
Available streams: 360p (worst), 480p, 720p, 1080p (best)

C:\Users\Topologist>streamlink https://trovo.live/Ler_GG best
[cli][info] Found matching plugin trovo for URL https://trovo.live/Ler_GG
[cli][info] Available streams: 360p (worst), 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (http)
[cli][info] Starting player: "C:\Program Files (x86)\VideoLAN\VLC\vlc.exe" --file-caching=5000
```