### PR TITLE
Add MRTmk plugin

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -119,6 +119,7 @@ mediaklikk              mediaklikk.hu        Yes   No    Streams may be geo-rest
 metube                  metube.id            Yes   Yes
 mitele                  mitele.es            Yes   No    Streams may be geo-restricted to Spain.
 mjunoon                 mjunoon.tv           Yes   Yes
+mrtmk                   play.mrt.com.mk      Yes   Yes
 n13tv                   13tv.co.il           Yes   Yes   Streams may be geo-restricted to Israel.
 nbc                     nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
 nbcnews                 nbcnews.com          Yes   No

--- a/src/streamlink/plugins/mrtmk.py
+++ b/src/streamlink/plugins/mrtmk.py
@@ -1,0 +1,41 @@
+import re
+
+from streamlink.plugin import Plugin
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+
+
+class MRTmk(Plugin):
+    url_re = re.compile(r"""https?://play.mrt.com.mk/(live|play)/""")
+    file_re = re.compile(r"""(?P<url>https?://vod-[\d\w]+\.interspace\.com[^"',]+\.m3u8[^"',]*)""")
+
+    stream_schema = validate.Schema(
+        validate.all(
+            validate.transform(file_re.finditer),
+            validate.transform(list),
+            [validate.get("url")],
+            # remove duplicates
+            validate.transform(set),
+            validate.transform(list),
+        ),
+    )
+
+    def __init__(self, url):
+        super(MRTmk, self).__init__(url)
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def _get_streams(self):
+        res = self.session.http.get(self.url)
+        stream_urls = self.stream_schema.validate(res.text)
+        self.logger.debug("Found {0} stream URL{1}", len(stream_urls),
+                          "" if len(stream_urls) == 1 else "s")
+
+        for stream_url in stream_urls:
+            for s in HLSStream.parse_variant_playlist(self.session, stream_url).items():
+                yield s
+
+
+__plugin__ = MRTmk

--- a/tests/plugins/test_mrtmk.py
+++ b/tests/plugins/test_mrtmk.py
@@ -1,0 +1,16 @@
+import unittest
+
+from streamlink.plugins.mrtmk import MRTmk
+
+class TestPluginBigo(unittest.TestCase):
+  def test_can_handle_url(self)
+    # should match
+    self.assertTrue(MRTmk.can_handle_url("http://play.mrt.com.mk/live/658323455489957"))
+    self.assertTrue(MRTmk.can_handle_url("http://play.mrt.com.mk/live/47"))
+    self.assertTrue(MRTmk.can_handle_url("http://play.mrt.com.mk/play/1581"))
+
+    #shouldn't match
+    self.assertFalse(IDF1.can_handle_url("http://play.mrt.com.mk/"))
+    self.assertFalse(IDF1.can_handle_url("http://play.mrt.com.mk/c/2"))
+    self.assertFalse(IDF1.can_handle_url("http://www.tvcatchup.com/"))
+    self.assertFalse(IDF1.can_handle_url("http://www.youtube.com/"))


### PR DESCRIPTION
Add plugin to support MRT live stream and VOD.

Website with content: http://play.mrt.com.mk/

Working sample:

```
tr4sk@bluebox ...gbf1460c-py3.8.egg/streamlink/plugins % streamlink -l trace http://play.mrt.com.mk/live/47 best
[01:50:54,097][cli][debug] OS:         Linux-5.7.10-zen1-1-zen-x86_64-with-glibc2.2.5
[01:50:54,097][cli][debug] Python:     3.8.3
[01:50:54,097][cli][debug] Streamlink: 1.5.0+9.gbf1460c
[01:50:54,098][cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.57.0)
[01:50:54,098][cli][info] Found matching plugin mrtmk for URL http://play.mrt.com.mk/live/47
[01:50:54,196][plugin.mrtmk][debug] Found 1 stream URL
[01:50:54,249][utils.l10n][debug] Language code: fr_FR
[01:50:54,527][cli][info] Available streams: 128k (worst, best)
[01:50:54,527][cli][info] Opening stream: 128k (hls)
[01:50:54,527][stream.hls][debug] Reloading playlist
[01:50:54,684][stream.hls][debug] First Sequence: 7213; Last Sequence: 7216
[01:50:54,684][stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 7214; End Sequence: None
[01:50:54,685][stream.hls][debug] Adding segment 7214 to queue
[01:50:54,685][cli][debug] Pre-buffering 8192 bytes
[01:50:54,685][stream.hls][debug] Adding segment 7215 to queue
[01:50:54,685][stream.hls][debug] Adding segment 7216 to queue
[01:50:55,007][stream.hls][debug] Download of segment 7214 complete
[01:50:55,007][cli][info] Starting player: /usr/bin/vlc
[01:50:55,008][cli.output][debug] Opening subprocess: /usr/bin/vlc --input-title-format http://play.mrt.com.mk/live/47 -
[01:50:55,333][stream.hls][debug] Download of segment 7215 complete
[01:50:55,511][cli][debug] Writing stream to output
[01:50:55,628][stream.hls][debug] Download of segment 7216 complete
[01:51:00,687][stream.hls][debug] Reloading playlist
[01:51:00,880][stream.hls][debug] Adding segment 7217 to queue
[01:51:01,205][stream.hls][debug] Download of segment 7217 complete
```

For some reason, MRT1, MRT2  and another one that I can't read ask for Flash plugin. This plugin still manage to grab the stream but get rejected.

Here is the failing one
```
tr4sk@bluebox ...gbf1460c-py3.8.egg/streamlink/plugins % streamlink -l trace http://play.mrt.com.mk/live/42 best
[01:52:34,768][cli][debug] OS:         Linux-5.7.10-zen1-1-zen-x86_64-with-glibc2.2.5
[01:52:34,769][cli][debug] Python:     3.8.3
[01:52:34,769][cli][debug] Streamlink: 1.5.0+9.gbf1460c
[01:52:34,769][cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.57.0)
[01:52:34,769][cli][info] Found matching plugin mrtmk for URL http://play.mrt.com.mk/live/42
[01:52:34,847][plugin.mrtmk][debug] Found 1 stream URL
[01:52:34,913][utils.l10n][debug] Language code: fr_FR
error: Unable to open URL: http://vod-c57.interspace.com:80/channel_abr/42/playlist.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9OC81LzIwMjAgMTE6NTI6MzQgUE0maGFzaF92YWx1ZT0zTG83MEI0QVRCSHo1cTNnaHh1TS93PT0mdmFsaWRtaW51dGVzPTMwJmlkPTVmMmI0NjQyYzZhNzg= (403 Client Error: Forbidden for url: http://vod-c57.interspace.com:80/channel_abr/42/playlist.m3u8?wmsAuthSign=c2VydmVyX3RpbWU9OC81LzIwMjAgMTE6NTI6MzQgUE0maGFzaF92YWx1ZT0zTG83MEI0QVRCSHo1cTNnaHh1TS93PT0mdmFsaWRtaW51dGVzPTMwJmlkPTVmMmI0NjQyYzZhNzg=)
```