### PR TITLE
Plugin: Zattoo, fix quantum tv streaming

### DIFF
--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import uuid
+import random
 
 from requests.cookies import cookiejar_from_dict
 
@@ -162,7 +163,10 @@ class Zattoo(Plugin):
         res = self.session.http.get(app_token_url)
         match = self._app_token_re.search(res.text)
 
-        app_token = match.group(1)
+        if self.base_url == 'https://www.quantum-tv.com':
+            app_token = '%032x' % random.getrandbits(128)
+        else:
+            app_token = match.group(1)
         hello_url = self.API_HELLO.format(self.base_url)
 
         if self._uuid:


### PR DESCRIPTION
quantum-tv had changed how their website worked. Instead of providing the required token directly, it is hidden behind a ton a javascript.
The javascript will eventuel lead to a url which will return a random token.
Curl call to get token:
```curl 'https://www.quantum-tv.com/token-4d0d61d4ce0bf8d9982171f349d19f34.json' -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:79.0) Gecko/20100101 Firefox/79.0' -H 'Accept: */*' -H 'Accept-Language: de,en-US;q=0.7,en;q=0.3' --compressed -H 'Referer: https://www.quantum-tv.com/login' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Cache-Control: max-age=0'```
Return value:
```{"success": true, "session_token": "0d252274fbae56121a956ef03c516dfb"}```

After toying around for a while I noticed you can provide any 32 digits hex number and it works. So I generate a random 32 digits hex number as an app token.