### PR TITLE
fix quantum tv streaming

### DIFF
--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -216,12 +216,9 @@ class Zattoo(Plugin):
             raise e
 
         data = self.session.http.json(res)
-
         self._authed = data['success']
         log.debug('New Session Data')
         self.save_cookies(default_expires=self.TIME_SESSION)
-
-
         self._session_attributes.set('power_guide_hash',
                                      data['session']['power_guide_hash'],
                                      expires=self.TIME_SESSION)

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import uuid
+import json
 
 from requests.cookies import cookiejar_from_dict
 
@@ -19,7 +20,9 @@ log = logging.getLogger(__name__)
 class Zattoo(Plugin):
     API_CHANNELS = '{0}/zapi/v2/cached/channels/{1}?details=False'
     API_HELLO = '{0}/zapi/session/hello'
+    API_HELLO_V3 = '{0}/zapi/v3/session/hello'
     API_LOGIN = '{0}/zapi/v2/account/login'
+    API_LOGIN_V3 = '{0}/zapi/v3/account/login'
     API_SESSION = '{0}/zapi/v2/session'
     API_WATCH = '{0}/zapi/watch'
     API_WATCH_REC = '{0}/zapi/watch/recording/{1}'
@@ -157,13 +160,19 @@ class Zattoo(Plugin):
         self.session.http.cookies = cookiejar_from_dict({})
         if self.base_url == 'https://zattoo.com':
             app_token_url = 'https://zattoo.com/int/'
+        elif self.base_url == 'https://www.quantum-tv.com':
+            app_token_url = 'https://www.quantum-tv.com/token-4d0d61d4ce0bf8d9982171f349d19f34.json'
         else:
             app_token_url = self.base_url
         res = self.session.http.get(app_token_url)
         match = self._app_token_re.search(res.text)
 
-        app_token = match.group(1)
-        hello_url = self.API_HELLO.format(self.base_url)
+        if self.base_url == 'https://www.quantum-tv.com':
+            app_token = json.loads(res.text)["session_token"]
+            hello_url = self.API_HELLO_V3.format(self.base_url)
+        else:
+            app_token = match.group(1)
+            hello_url = self.API_HELLO.format(self.base_url)
 
         if self._uuid:
             __uuid = self._uuid
@@ -175,20 +184,30 @@ class Zattoo(Plugin):
         params = {
             'client_app_token': app_token,
             'uuid': __uuid,
-            'lang': 'en',
-            'format': 'json'
         }
-        res = self.session.http.post(hello_url, headers=self.headers, data=params)
+
+        if self.base_url == 'https://www.quantum-tv.com':
+            params['app_version'] = '3.2028.3'
+        else:
+            params['lang'] = 'en'
+            params['format'] = 'json'
+
+        res = self.session.http.post(hello_url, headers=self.headers, data=params, cookies=self.session.http.cookies)
 
     def _login(self, email, password):
         log.debug('_login ... Attempting login as {0}'.format(email))
 
-        login_url = self.API_LOGIN.format(self.base_url)
         params = {
             'login': email,
             'password': password,
             'remember': 'true'
         }
+
+        if self.base_url == 'https://quantum-tv.com':
+            login_url = self.API_LOGIN_V3.format(self.base_url)
+            params['remember'] = 'True'
+        else:
+            login_url = self.API_LOGIN.format(self.base_url)
 
         try:
             res = self.session.http.post(login_url, headers=self.headers, data=params)


### PR DESCRIPTION
quantum-tv had changed how their login worked:
- client token is hidden behind a obscure url
- they use zapi/v3
- session hello must only consist of token, uuid, app_version