### PR TITLE
docs: Add reuters.com for reuters plugin entry in plugin matrix

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -164,7 +164,8 @@ radionet                - radio.net          Yes   --
                         - radio.pt
                         - radio.se
 raiplay                 raiplay.it           Yes   No    Most streams are geo-restricted to Italy.
-reuters                 reuters.tv           Yes   Yes
+reuters                 -- reuters.com       Yes   Yes
+                        -- reuters.tv
 rotana                  rotana.net           Yes   --    Streams are geo-restricted to Saudi Arabia.
 rtbf                    - rtbf.be/auvio      Yes   Yes   Streams may be geo-restricted to Belgium or Europe.
                         - rtbfradioplayer.be


### PR DESCRIPTION
My bad, as I didn't update this with the last plugin fix...