### PR TITLE
plugins.huomao: fix/rewrite

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -98,7 +98,8 @@ gulli                   replay.gulli.fr      Yes   Yes   Streams may be geo-rest
 hitbox                  - hitbox.tv          Yes   Yes
                         - smashcast.tv
 huajiao                 huajiao.com          Yes   No
-huomao                  huomao.com           Yes   No
+huomao                  - huomao.com         Yes   Yes
+                        - huomao.tv
 huya                    huya.com             Yes   No    Temporarily only HLS streams available.
 idf1                    idf1.fr              Yes   Yes
 ine                     ine.com              ---   Yes

--- a/src/streamlink/plugins/huomao.py
+++ b/src/streamlink/plugins/huomao.py
@@ -1,101 +1,225 @@
-"""
-NOTE: Since a documented API is nowhere to be found for Huomao; this plugin
-simply extracts the videos stream_id, stream_url and stream_quality by
-scraping the HTML and JS of one of Huomaos mobile webpages.
-
-When viewing a stream on huomao.com, the base URL references a room_id. This
-room_id is mapped one-to-one to a stream_id which references the actual .m3u8
-file. Both stream_id, stream_url and stream_quality can be found in the
-HTML and JS source of the mobile_page. Since one stream can occur in many
-different qualities, we scrape all stream_url and stream_quality occurrences
-and return each option to the user.
-"""
-
+import logging
 import re
 
+from hashlib import md5
+from time import time
+
+from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
+from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
 
-# URL pattern for recognizing inputed Huomao.tv / Huomao.com URL.
-url_re = re.compile(r"""
-    (http(s)?://)?
-    (www\.)?
-    huomao
-    (\.tv|\.com)
-    /(?P<room_id>\d+)
-""", re.VERBOSE)
-
-# URL used to retrive the stream_id, stream_url and stream_quality based of
-# a room_id.
-mobile_url = "http://www.huomao.com/mobile/mob_live/{0}"
-
-# Pattern for extracting the stream_id from the mobile_url HTML.
-#
-# Example from HTML:
-#   <input id="html_stream" value="efmrCH" type="hidden">
-stream_id_pattern = re.compile(r'id=\"html_stream\" value=\"(?P<stream_id>\w+)\"')
-
-# Pattern for extracting each stream_url and
-# stream_quality_name used for quality naming.
-#
-# Example from HTML:
-#   src="http://live-ws-hls.huomaotv.cn/live/<stream_id>_720/playlist.m3u8"
-stream_info_pattern = re.compile(r"""
-    (?P<stream_url>(?:[\w\/\.\-:]+)
-    \/[^_\"]+(?:_(?P<stream_quality_name>\d+))
-    ?/playlist.m3u8)
-""", re.VERBOSE)
+log = logging.getLogger(__name__)
 
 
 class Huomao(Plugin):
+    '''
+    magic_val:
+
+    This value is returned by the function that is an argument to md5() in
+    https://m.huomao.com/static/web/js/sea.js?v=202004029 on L287 in the
+    prettifyed JS source.  At the time of writing, this function returned a
+    static value.  This value could change at some point in the future if
+    sea.js is updated.  As it is, if a change to sea.js means this value is no
+    longer static, this plugin will break and some rewriting will be required.
+    The arguments to the JS md5 function are as defined by the arguments for
+    'token = md5(...)' in the _get_streams_data() method within this plugin.
+
+    With due credit to @bastimeyer:
+    https://github.com/streamlink/streamlink/pull/3104#issuecomment-671095610
+    '''
+    magic_val = '6FE26D855E1AEAE090E243EB1AF73685'
+    mobile_url = 'https://m.huomao.com/mobile/mob_live/{0}'
+    live_data_url = 'https://m.huomao.com/swf/live_data'
+    vod_url = 'https://www.huomao.com/video/vreplay/{0}'
+
+    url_re = re.compile(r'''
+        (?:https?://)?(?:www\.)?huomao(?:\.tv|\.com)
+        (?P<path>/|/video/v/)
+        (?P<room_id>\d+)
+    ''', re.VERBOSE)
+
+    author_re = re.compile(
+        r'<p class="nickname_live">\s*<span>\s*(.*?)\s*</span>',
+        re.DOTALL,
+    )
+
+    title_re = re.compile(
+        r'<p class="title-name">\s*(.*?)\s*</p>',
+        re.DOTALL,
+    )
+
+    video_id_re = re.compile(r'var stream = "([^"]+)"')
+    video_res_re = re.compile(r'_([\d]+p?)\.m3u8')
+    vod_data_re = re.compile(r'var video = ({.*});')
+
+    _live_data_schema = validate.Schema({
+        'roomStatus': validate.transform(lambda x: int(x)),
+        'streamList': [{'list_hls': [{
+            'url': validate.url(),
+        }]}],
+    })
+
+    _vod_data_schema = validate.Schema({
+        'title': validate.text,
+        'username': validate.text,
+        'vaddress': [{
+            'url': validate.url(),
+            'vheight': int,
+        }],
+    })
+
     @classmethod
-    def can_handle_url(self, url):
-        return url_re.match(url)
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
 
-    def get_stream_id(self, html):
-        """Returns the stream_id contained in the HTML."""
-        stream_id = stream_id_pattern.search(html)
+    def _get_live_streams_data(self, video_id):
+        client_type = 'huomaomobileh5'
+        time_now = int(time())
 
-        if not stream_id:
-            self.logger.error("Failed to extract stream_id.")
+        token = md5(
+            "{0}{1}{2}{3}".format(
+                str(video_id),
+                str(client_type),
+                str(time_now),
+                str(self.magic_val),
+            )
+        ).hexdigest()
+        log.debug("Token={0}".format(token))
 
-        return stream_id.group("stream_id")
+        post_data = {
+            'cdns': 1,
+            'streamtype': 'live',
+            'VideoIDS': video_id,
+            'from': client_type,
+            'time': time_now,
+            'token': token,
+        }
+        video_data = self.session.http.post(self.live_data_url, data=post_data)
 
-    def get_stream_info(self, html):
-        """
-        Returns a nested list of different stream options.
+        return self.session.http.json(
+            video_data,
+            schema=self._live_data_schema,
+        )
 
-        Each entry in the list will contain a stream_url and stream_quality_name
-        for each stream occurrence that was found in the JS.
-        """
-        stream_info = stream_info_pattern.findall(html)
+    def _get_vod_streams(self, vod_id):
+        res = self.session.http.get(self.vod_url.format(vod_id))
+        m = self.vod_data_re.search(res.text)
+        vod_json = m and m.group(1)
 
-        if not stream_info:
-            self.logger.error("Failed to extract stream_info.")
+        if vod_json is None:
+            raise PluginError("Failed to get VOD data")
 
-        # Rename the "" quality to "source" by transforming the tuples to a
-        # list and reassigning.
-        stream_info_list = []
-        for info in stream_info:
-            if not info[1]:
-                stream_info_list.append([info[0], "source"])
-            else:
-                stream_info_list.append(list(info))
+        vod_json = vod_json.decode('unicode-escape')
+        vod_json = vod_json.replace('"[', '[')
+        vod_json = vod_json.replace(']"', ']')
+        vod_json = vod_json.replace('\\', '')
+        vod_data = parse_json(vod_json, schema=self._vod_data_schema)
 
-        return stream_info_list
+        self.title = vod_data['title'].encode(res.encoding)
+        self.author = vod_data['username'].encode(res.encoding)
+        self.category = 'VOD'
 
-    def _get_streams(self):
-        room_id = url_re.search(self.url).group("room_id")
-        html = self.session.http.get(mobile_url.format(room_id))
-        stream_id = self.get_stream_id(html.text)
-        stream_info = self.get_stream_info(html.text)
+        log.debug("Title={0}".format(self.title))
+        log.debug("Author={0}".format(self.author))
+        log.debug("Category={0}".format(self.category))
+
+        vod_data = vod_data['vaddress']
 
         streams = {}
-        for info in stream_info:
-            if stream_id in info[0]:
-                streams[info[1]] = HLSStream(self.session, info[0])
+        for stream in vod_data:
+            video_res = stream['vheight']
+
+            if 'p' not in str(video_res):
+                video_res = "{0}p".format(video_res)
+
+            if video_res in streams:
+                video_res = "{0}_alt".format(video_res)
+
+            streams[video_res] = HLSStream(self.session, stream['url'])
 
         return streams
+
+    def _get_live_streams(self, room_id):
+        res = self.session.http.get(self.mobile_url.format(room_id))
+
+        m = self.title_re.search(res.text)
+        if m:
+            self.title = m.group(1).encode(res.encoding)
+        else:
+            raise PluginError("Failed to get title")
+
+        m = self.author_re.search(res.text)
+        if m:
+            self.author = m.group(1).encode(res.encoding)
+        else:
+            raise PluginError("Failed to get author")
+
+        self.category = 'Live'
+
+        log.debug("Title={0}".format(self.title))
+        log.debug("Author={0}".format(self.author))
+        log.debug("Category={0}".format(self.category))
+
+        m = self.video_id_re.search(res.text)
+        video_id = m and m.group(1)
+
+        if video_id is None:
+            raise PluginError("Failed to get video ID")
+        else:
+            log.debug("Video ID={0}".format(video_id))
+
+        streams_data = self._get_live_streams_data(video_id)
+
+        if streams_data['roomStatus'] == 0:
+            log.info("This room is currently inactive: {0}".format(room_id))
+            return
+
+        streams_data = streams_data['streamList'][0]['list_hls']
+
+        streams = {}
+        for stream in streams_data:
+            m = self.video_res_re.search(stream['url'])
+            video_res = m and m.group(1)
+            if video_res is None:
+                continue
+
+            if 'p' not in video_res:
+                video_res = "{0}p".format(video_res)
+
+            if video_res in streams:
+                video_res = "{0}_alt".format(video_res)
+
+            streams[video_res] = HLSStream(self.session, stream['url'])
+
+        return streams
+
+    def get_title(self):
+        if self.title is not None:
+            return self.title
+
+    def get_author(self):
+        if self.author is not None:
+            return self.author
+
+    def get_category(self):
+        if self.category is not None:
+            return self.category
+
+    def _get_streams(self):
+        path, url_id = self.url_re.search(self.url).groups()
+        log.debug("Path={0}".format(path))
+        log.debug("URL ID={0}".format(url_id))
+
+        self.title = None
+        self.author = None
+        self.category = None
+
+        if path != '/':
+            return self._get_vod_streams(url_id)
+        else:
+            return self._get_live_streams(url_id)
 
 
 __plugin__ = Huomao

--- a/src/streamlink/plugins/huomao.py
+++ b/src/streamlink/plugins/huomao.py
@@ -9,7 +9,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
-from streamlink.utils.encoding import maybe_decode
 
 log = logging.getLogger(__name__)
 
@@ -52,14 +51,8 @@ class Huomao(Plugin):
     })
 
     _vod_data_schema = validate.Schema({
-        'title': validate.all(
-            validate.text,
-            validate.transform(maybe_decode),
-        ),
-        'username': validate.all(
-            validate.text,
-            validate.transform(maybe_decode),
-        ),
+        'title': validate.text,
+        'username': validate.text,
         'vaddress': validate.all(
             validate.text,
             validate.transform(parse_json),

--- a/src/streamlink/plugins/huomao.py
+++ b/src/streamlink/plugins/huomao.py
@@ -144,7 +144,7 @@ class Huomao(Plugin):
 
         m = self.title_re.search(res.text)
         if m:
-             self.title = m.group(1)
+            self.title = m.group(1)
 
         m = self.video_id_re.search(res.text)
         video_id = m and m.group(1)

--- a/tests/plugins/test_huomao.py
+++ b/tests/plugins/test_huomao.py
@@ -4,85 +4,68 @@ from streamlink.plugins.huomao import Huomao
 
 
 class TestPluginHuomao(unittest.TestCase):
-
-    def setUp(self):
-
-        # Create a mock source HTML with some example data:
-        #   room_id             = 123456
-        #   stream_id           = 9qsvyF24659
-        #   stream_url          = http://live-ws.huomaotv.cn/live/
-        #   stream_quality_name = source, 720 and 480
-        self.mock_html = """
-            <input id="html_stream" value="9qsvyF24659" type="hidden">
-            <source  src="http://live-ws-hls.huomaotv.cn/live/9qsvyF24659/playlist.m3u8">
-            <source  src="http://live-ws-hls.huomaotv.cn/live/9qsvyF24659_720/playlist.m3u8">
-            <source  src="http://live-ws-hls.huomaotv.cn/live/9qsvyF24659_480/playlist.m3u8">
-        """
-
-        # Create a mock Huomao object.
-        self.mock_huomao = Huomao("http://www.huomao.com/123456/")
-
-    def tearDown(self):
-        self.mock_html = None
-        self.mock_huomao = None
-
-    def test_get_stream_id(self):
-
-        # Assert that the stream_id from is correctly extracted from the mock HTML.
-        self.assertEqual(self.mock_huomao.get_stream_id(self.mock_html), "9qsvyF24659")
-
-    def test_get_stream_quality(self):
-
-        # Assert that the stream_url, stream_quality and stream_quality_name
-        # is correctly extracted from the mock HTML.
-        self.assertEqual(self.mock_huomao.get_stream_info(self.mock_html), [
-            ["http://live-ws-hls.huomaotv.cn/live/9qsvyF24659/playlist.m3u8", "source"],
-            ["http://live-ws-hls.huomaotv.cn/live/9qsvyF24659_720/playlist.m3u8", "720"],
-            ["http://live-ws-hls.huomaotv.cn/live/9qsvyF24659_480/playlist.m3u8", "480"]
-        ])
-
     def test_can_handle_url(self):
+        should_match = [
+            # Assert that an URL containing the http:// prefix is correctly read.
+            "http://www.huomao.com/123456",
+            "http://www.huomao.tv/123456",
+            "http://huomao.com/123456",
+            "http://huomao.tv/123456",
+            "http://www.huomao.com/video/v/123456",
+            "http://www.huomao.tv/video/v/123456",
+            "http://huomao.com/video/v/123456",
+            "http://huomao.tv/video/v/123456",
 
-        # Assert that an URL containing the http:// prefix is correctly read.
-        self.assertTrue(Huomao.can_handle_url("http://www.huomao.com/123456"))
-        self.assertTrue(Huomao.can_handle_url("http://www.huomao.tv/123456"))
-        self.assertTrue(Huomao.can_handle_url("http://huomao.com/123456"))
-        self.assertTrue(Huomao.can_handle_url("http://huomao.tv/123456"))
+            # Assert that an URL containing the https:// prefix is correctly read.
+            "https://www.huomao.com/123456",
+            "https://www.huomao.tv/123456",
+            "https://huomao.com/123456",
+            "https://huomao.tv/123456",
+            "https://www.huomao.com/video/v/123456",
+            "https://www.huomao.tv/video/v/123456",
+            "https://huomao.com/video/v/123456",
+            "https://huomao.tv/video/v/123456",
 
-        # Assert that an URL containing the https:// prefix is correctly read.
-        self.assertTrue(Huomao.can_handle_url("https://www.huomao.com/123456"))
-        self.assertTrue(Huomao.can_handle_url("https://www.huomao.tv/123456"))
-        self.assertTrue(Huomao.can_handle_url("https://huomao.com/123456"))
-        self.assertTrue(Huomao.can_handle_url("https://huomao.tv/123456"))
+            # Assert that an URL without the http(s):// prefix is correctly read.
+            "www.huomao.com/123456",
+            "www.huomao.tv/123456",
+            "www.huomao.com/video/v/123456",
+            "www.huomao.tv/video/v/123456",
 
-        # Assert that an URL without the http(s):// prefix is correctly read.
-        self.assertTrue(Huomao.can_handle_url("www.huomao.com/123456"))
-        self.assertTrue(Huomao.can_handle_url("www.huomao.tv/123456"))
+            # Assert that an URL without the www prefix is correctly read.
+            "huomao.com/123456",
+            "huomao.tv/123456",
+            "huomao.com/video/v/123456",
+            "huomao.tv/video/v/123456",
+        ]
+        for url in should_match:
+            self.assertTrue(Huomao.can_handle_url(url))
 
-        # Assert that an URL without the www prefix is correctly read.
-        self.assertTrue(Huomao.can_handle_url("huomao.com/123456"))
-        self.assertTrue(Huomao.can_handle_url("huomao.tv/123456"))
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            # Assert that an URL without a room_id can't be read.
+            "http://www.huomao.com/",
+            "http://www.huomao.tv/",
+            "http://huomao.com/",
+            "http://huomao.tv/",
+            "https://www.huomao.com/",
+            "https://www.huomao.tv/",
+            "https://huomao.com/",
+            "https://huomao.tv/",
+            "www.huomao.com/",
+            "www.huomao.tv/",
+            "huomao.tv/",
+            "huomao.tv/",
 
-        # Assert that an URL without a room_id can't be read.
-        self.assertFalse(Huomao.can_handle_url("http://www.huomao.com/"))
-        self.assertFalse(Huomao.can_handle_url("http://www.huomao.tv/"))
-        self.assertFalse(Huomao.can_handle_url("http://huomao.com/"))
-        self.assertFalse(Huomao.can_handle_url("http://huomao.tv/"))
-        self.assertFalse(Huomao.can_handle_url("https://www.huomao.com/"))
-        self.assertFalse(Huomao.can_handle_url("https://www.huomao.tv/"))
-        self.assertFalse(Huomao.can_handle_url("https://huomao.com/"))
-        self.assertFalse(Huomao.can_handle_url("https://huomao.tv/"))
-        self.assertFalse(Huomao.can_handle_url("www.huomao.com/"))
-        self.assertFalse(Huomao.can_handle_url("www.huomao.tv/"))
-        self.assertFalse(Huomao.can_handle_url("huomao.tv/"))
-        self.assertFalse(Huomao.can_handle_url("huomao.tv/"))
-
-        # Assert that an URL without "huomao" can't be read.
-        self.assertFalse(Huomao.can_handle_url("http://www.youtube.com/123456"))
-        self.assertFalse(Huomao.can_handle_url("http://www.youtube.tv/123456"))
-        self.assertFalse(Huomao.can_handle_url("http://youtube.com/123456"))
-        self.assertFalse(Huomao.can_handle_url("http://youtube.tv/123456"))
-        self.assertFalse(Huomao.can_handle_url("https://www.youtube.com/123456"))
-        self.assertFalse(Huomao.can_handle_url("https://www.youtube.tv/123456"))
-        self.assertFalse(Huomao.can_handle_url("https://youtube.com/123456"))
-        self.assertFalse(Huomao.can_handle_url("https://youtube.tv/123456"))
+            # Assert that an URL without "huomao" can't be read.
+            "http://www.youtube.com/123456",
+            "http://www.youtube.tv/123456",
+            "http://youtube.com/123456",
+            "http://youtube.tv/123456",
+            "https://www.youtube.com/123456",
+            "https://www.youtube.tv/123456",
+            "https://youtube.com/123456",
+            "https://youtube.tv/123456",
+        ]
+        for url in should_not_match:
+            self.assertFalse(Huomao.can_handle_url(url))


### PR DESCRIPTION
- Add support for VODs
- Add support for title, author and category information
- Update URLs in tests

I have a couple of things I'd like to ask you about with this PR:

The first thing is while attempting to play the very short (< 4s) clip at: ```https://www.huomao.com/video/v/96953```.  This requires either the use of ```--player-no-close``` or ```--hls-segment-stream-data``` options.  I think I understand the requirement for using either of those options.  In the case of the former, the clip plays eventually and streamlink will exit immediately.  In the case of the latter, the clip plays immediately but streamlink only exits after it has finished its attempts at reloading the playlist.  In both cases, streamlink makes 20+ attempts at reloading the playlist.  With the latter streamlink can at least be killed with ```^C``` to save time.  It's very unlikely that somebody would be playing this clip with streamlink and it's the only one I have found like it.  I just wondered about the mechanics of what's going on here regarding the 20+ playlist reload attempts?

Here's the ```m3u8``` data for that clip:
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:4
#EXT-X-MEDIA-SEQUENCE:0
#EXTINF:3.666667,
v.f2400.ts
#EXT-X-ENDLIST
```

My second query is regarding returning the title, author and category information.  I am attempting to do so and can ```log.debug()``` the Unicode characters to the terminal, but if I attempt to make use of them in ```--title``` I run into a problem:

Using, say: ```streamlink -l debug -p mpv --title "{title} -- {author} -- {category}" 
https://www.huomao.com/10519 480p```, gives me:
```
[cli][debug] OS:         Linux-4.5.1-040501-generic-x86_64-with-Ubuntu-16.04-xenial
[cli][debug] Python:     2.7.12
[cli][debug] Streamlink: 1.5.0+10.g00fd4d2
[cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.57.0)
[cli][info] Found matching plugin huomao for URL https://www.huomao.com/10519
[plugin.huomao][debug] Path=/
[plugin.huomao][debug] URL ID=10519
[plugin.huomao][debug] Title=【DPL-CDA S2】主舞台 精彩重播
[plugin.huomao][debug] Author=MarsTV官方02
[plugin.huomao][debug] Category=Live
[plugin.huomao][debug] Video ID=CdvfGdaXzeGbPhddM1s
[plugin.huomao][debug] Token=94b82b936910db38547ffdbb2cbc0ffc
[cli][info] Available streams: 480p_alt (worst), 480p, 720p, 1080p (best)
[cli][info] Opening stream: 480p (hls)
[stream.hls][debug] Reloading playlist
[stream.hls][debug] First Sequence: 1597986126; Last Sequence: 1597986128
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 1597986126; End Sequence: None
[stream.hls][debug] Adding segment 1597986126 to queue
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] Adding segment 1597986127 to queue
[stream.hls][debug] Adding segment 1597986128 to queue
[stream.hls][debug] Download of segment 1597986126 complete
[cli][info] Closing currently open stream...
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
Traceback (most recent call last):
  File "/home/iac2/streamlink/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink_cli/main.py", line 1027, in main
    handle_url()
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink_cli/main.py", line 602, in handle_url
    handle_stream(plugin, streams, stream_name)
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink_cli/main.py", line 455, in handle_stream
    success = output_stream(plugin, stream)
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink_cli/main.py", line 316, in output_stream
    output = create_output(plugin)
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink_cli/main.py", line 114, in create_output
    title = create_title(plugin)
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink_cli/main.py", line 154, in create_title
    url=plugin.url
  File "/home/iac2/streamlink/local/lib/python2.7/site-packages/streamlink/utils/lazy_formatter.py", line 22, in format
    return string.Formatter().vformat(fmt, (), cls(**lazy_props))
  File "/usr/lib/python2.7/string.py", line 563, in vformat
    result = self._vformat(format_string, args, kwargs, used_args, 2)
  File "/usr/lib/python2.7/string.py", line 598, in _vformat
    return ''.join(result)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe3 in position 0: ordinal not in range(128)
```
Can anybody advise me on what the issue is?  Is it not possible to use Unicode here or am I just doing something terribly wrong?

Many thanks, as always.

closes #2341
