### PR TITLE
plugins.bloomberg: fix regex module anchor

### DIFF
--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -37,7 +37,7 @@ class Bloomberg(Plugin):
     _live_stream_info_module_id_re = re.compile(
         r'{(?:(?:"[^"]+"|\w+):(?:\d+|"[^"]+"),)*"(?:[^"]*/)?config/livestreams":(\d+)(?:,(?:"[^"]+"|\w+):(?:\d+|"[^"]+"))*}'
     )
-    _live_stream_info_re = r'],{id}:\[function\(.+var n=({{.+}});r.default=n}},{{"[^"]+":\d+}}],{next}:\['
+    _live_stream_info_re = r'],{id}:\[function\(.+var n=({{.+}});r.default=n}},{{}}],{next}:\['
 
     _live_streams_schema = validate.Schema(
         validate.transform(_js_to_json_re),


### PR DESCRIPTION
Fixes #3130

The module structure has slightly changed after a recent update of their site, and now the regex doesn't match anymore.

See my comment from the previous plugin fix/rewrite:
https://github.com/streamlink/streamlink/pull/2825#issuecomment-599043223

Since some stream URLs seem to be static, an alternative to extracting the stream URLs could be hardcoding them into the plugin. This is the JSON data we're currently extracting:
https://gist.github.com/bastimeyer/ec6f3be45adc4a8ffdc476707564814a

----

```
$ streamlink https://www.bloomberg.com/live/us -l debug
[cli][debug] OS:         Linux-5.8.3-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.5
[cli][debug] Streamlink: 1.5.0+13.g80eb861
[cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin bloomberg for URL https://www.bloomberg.com/live/us
[plugin.bloomberg][debug] Found liveId: PHOENIX_US
[plugin.bloomberg][debug] Player URL: https://cdn.gotraffic.net/projector/v0.11.192/app.js
[plugin.bloomberg][debug] Webpack module ID: 203
[plugin.bloomberg][debug] Found stream: https://www.bloomberg.com/media-manifest/streams/phoenix-us.m3u8
[utils.l10n][debug] Language code: en_US
[plugin.bloomberg][debug] Found stream: https://www.bloomberg.com/media-manifest/streams/phoenix-us.m3u8?group=backup
[utils.l10n][debug] Language code: en_US
Available streams: 272p_alt (worst), 272p, 360p_alt, 360p, 720p_alt2, 720p_alt, 720p, 1080p_alt, 1080p (best)
```