### PR TITLE
cli.main: improvements

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -434,10 +434,10 @@ def handle_stream(plugin, streams, stream_name):
     else:
         # Find any streams with a '_alt' suffix and attempt
         # to use these in case the main stream is not usable.
-        def _name_endswith(ext, k):
-            return k.startswith(stream_name) and k.endswith(ext)
+        def _name_contains_alt(k):
+            return k.startswith(stream_name) and "_alt" in k
 
-        alt_streams = list(filter(lambda k: _name_endswith("_alt", k),
+        alt_streams = list(filter(lambda k: _name_contains_alt(k),
                                   sorted(streams.keys())))
         file_output = args.output or args.stdout
         stream_names = [stream_name] + alt_streams


### PR DESCRIPTION
related to #785

- improves output_stream()
- improves alt_streams selection

w/o the changes it's not possible to stream an alternate stream on an open error or e.g. if the main stream is a http-stream and the "_alt" stream is a hls-stream.