### PR TITLE
Add Yotta plugin

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -269,6 +269,7 @@ webtv                   web.tv               Yes   --
 welt                    welt.de              Yes   Yes   Streams may be geo-restricted to Germany.
 willax                  willax.tv            Yes   No
 wwenetwork              network.wwe.com      Yes   Yes   Requires an account to access any content.
+yotta                   yottau.com.tw        --    Yes   Requires an account to access any content.
 youtube                 - youtube.com        Yes   Yes   Protected videos are not supported.
                         - youtu.be
 yupptv                  yupptv.com           Yes   Yes   Some streams require an account and subscription.

--- a/src/streamlink/plugins/yotta.py
+++ b/src/streamlink/plugins/yotta.py
@@ -1,0 +1,166 @@
+from __future__ import print_function
+
+import logging
+import re
+
+from streamlink.exceptions import PluginError
+from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin.api import useragents
+from streamlink.plugin.api import validate
+from streamlink.stream import HTTPStream, HLSStream
+from streamlink.stream.hls import HLSStreamReader, HLSStreamWriter, HLSStreamWorker
+from streamlink.stream.hls_playlist import M3U8Parser, load as load_hls_playlist
+from streamlink.stream.ffmpegmux import MuxedStream
+
+log = logging.getLogger(__name__)
+
+class YottaM3U8Parser(M3U8Parser):
+    def __init__(self, base_uri=None, **kwargs):
+        super(YottaM3U8Parser, self).__init__(base_uri, **kwargs)
+
+    def parse_extinf(self, value):
+        duration, _ = super(YottaM3U8Parser, self).parse_extinf(value)
+        return duration, None
+
+class YottaHLSStreamWorker(HLSStreamWorker):
+    def _reload_playlist(self, text, url):
+        playlist = load_hls_playlist(
+            text,
+            url,
+            parser=YottaM3U8Parser,
+        )
+        return playlist
+
+class YottaHLSStreamWriter(HLSStreamWriter):
+    def write(self, sequence, *args, **kwargs):
+        return super(YottaHLSStreamWriter, self).write(sequence, *args, **kwargs)
+
+class YottaHLSStreamReader(HLSStreamReader):
+    __worker__ = YottaHLSStreamWorker
+    __writer__ = YottaHLSStreamWriter
+
+class YottaHLSStream(HLSStream):
+    __shortname__ = "yottahls"
+    def __init__(self, *args, **kwargs):
+        super(YottaHLSStream, self).__init__(*args, **kwargs)
+
+    def open(self):
+        reader = YottaHLSStreamReader(self)
+        reader.open()
+
+        return reader
+
+    @classmethod
+    def _get_variant_playlist(cls, res):
+        return load_hls_playlist(res.text, base_uri=res.url, parser=YottaM3U8Parser)
+
+class Yotta(Plugin):
+    url_re = re.compile(r"https://www\.yottau\.com\.tw/course/player/(\d+)/(\d+)")
+    login_url = "https://www.yottau.com.tw/member/login"
+    list_api_url = "https://www.yottau.com.tw/chapter/list"
+    playlist_schema = validate.Schema(
+        {
+            "data": {
+                "current": {
+                    "id": int,
+                    "video": validate.all([{
+                        "file": validate.any(validate.url(scheme="http", path=validate.contains(".mp4")), validate.url(scheme="http", path=validate.endswith(".m3u8"))),
+                        "label": validate.text
+                    }]),
+                    "subtitle": validate.any([{
+                        "file": validate.any(None, validate.url(scheme="http", path=validate.contains(".vtt"))),
+                    }])
+                }
+            }
+        }
+    )
+    arguments = PluginArguments(
+        PluginArgument(
+            "email",
+            required=True,
+            requires=["password"],
+            metavar="EMAIL",
+            help="""
+        The email associated with your Yotta account,
+        required to access any Yotta stream.
+        """
+        ),
+        PluginArgument(
+            "password",
+            sensitive=True,
+            metavar="PASSWORD",
+            help="A Yotta account password to use with --yotta-email."
+        )
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def login(self, email, password):
+        """
+        Login to the yotta account and return the users account
+        :param email: (str) email for account
+        :param password: (str) password for account
+        :return: (str) users email
+        """
+        if self.options.get("email") and self.options.get("password"):
+            
+            res = self.session.http.post(self.login_url, data={"account": email,
+                                                               "password": password})
+            
+            if res.json()['code'] == 0 :
+                return email
+            else:
+                log.error("login response code {0}", res.json()['code'])
+                log.error("Failed to login to Yotta, incorrect email/password combination")
+        else:
+            log.error("An email and password are required to access Yotta streams")
+
+    def _get_streams(self):
+        user = self.login(self.options.get("email"), self.options.get("password"))
+        if user:
+            log.error("Logged in to Yotta as {0}", user)
+            # list api: get playlist.m3u8, 1080p.m3u8 and subtitles
+            # url: /{course_id}/l{chapter_id}
+            course_id = int(self.url_re.match(self.url).group(1))
+            chapter_id = int(self.url_re.match(self.url).group(2))
+            res = self.session.http.post(self.list_api_url, headers={"User-Agent": useragents.SAFARI_8}, data={"id": course_id, "chapter_id": chapter_id})
+            playlist = self.session.http.json(res, schema=self.playlist_schema)
+            videos = playlist['data']['current']['video']
+            subtitles = playlist['data']['current']['subtitle']
+
+            #Traditional Chinese subtitle only
+            stream_metadata = {}
+            subtitle = {}
+            if subtitles != []:
+                subtitle["chi"] = HTTPStream(self.session, subtitles[0]['file'])
+                stream_metadata["s:a:0"] = ["language={0}".format("chi")]
+            
+            #get playlist.m3u8 and the best quality of video
+            video_url = ""
+            qualities = []
+            for video in videos:
+                quality = video['label']
+                if "playlist" in video['label']:
+                    video_url = video['file']
+                else:
+                    #"1080P" to int(1080)
+                    qualities.append(int(quality[:-1]))
+            best = max(qualities)
+            try:
+                masterStreams = YottaHLSStream.parse_variant_playlist(self.session, video_url)
+                stream = masterStreams["{0}p".format(best)]
+            except IOError as err:
+                err = str(err)
+                if "404 Client Error" in err or "Failed to parse playlist" in err:
+                    return
+                else:
+                    raise PluginError(err)
+
+            if subtitle:
+                yield "{0}p".format(best), MuxedStream(self.session, stream, subtitles=subtitle)
+            else:
+                yield "{0}p".format(best), stream
+            
+__plugin__ = Yotta

--- a/tests/plugins/test_yotta.py
+++ b/tests/plugins/test_yotta.py
@@ -1,0 +1,96 @@
+import logging
+import unittest
+from functools import partial
+
+from streamlink.plugins.yotta import Yotta, YottaHLSStream
+
+import requests_mock
+from tests.mock import MagicMock, call, patch
+
+from streamlink.session import Streamlink
+from tests.resources import text
+
+
+log = logging.getLogger(__name__)
+
+
+class TestPluginYotta(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://www.yottau.com.tw/course/player/'
+        ]
+        for url in should_match:
+            self.assertTrue(Yotta.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://yottau.com.tw',
+        ]
+        for url in should_not_match:
+            self.assertFalse(Yotta.can_handle_url(url))
+
+
+@patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))
+class TestYottaHLSStream(unittest.TestCase):
+    url_master = "http://mocked/path/playlist.m3u8"
+    url_playlist = "http://mocked/path/1080P.m3u8"
+    url_segment = "http://mocked/path/1080P{0}.ts"
+
+    segment = "#EXTINF:1.000,\n1080P{0}.ts\n"
+
+    def getMasterPlaylist(self):
+        with text("hls/test_master.m3u8") as pl:
+            return pl.read()
+
+    def getPlaylist(self, media_sequence, items, ads=False, prefetch=None):
+        playlist = """
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-ALLOW-CACHE:YES
+#EXT-X-TARGETDURATION:13
+#EXT-X-MEDIA-SEQUENCE:{0}
+""".format(media_sequence)
+
+        segment = self.segment
+        for item in items:
+            playlist += segment.format(item)
+
+        return playlist
+
+    def start_streamlink(self):
+        log.info("Executing streamlink")
+        streamlink = Streamlink()
+        streamlink.set_option("hls-live-edge", 4)
+        masterStream = YottaHLSStream.parse_variant_playlist(streamlink, self.url_master)
+        stream = masterStream["1080p"].open()
+        data = b"".join(iter(partial(stream.read, 8192), b""))
+        stream.close()
+        log.info("End of streamlink execution")
+        return streamlink, data
+
+    def mock(self, mocked, method, url, *args, **kwargs):
+        mocked[url] = method(url, *args, **kwargs)
+
+    def get_result(self, streams, playlists):
+        mocked = {}
+        with requests_mock.Mocker() as mock:
+            self.mock(mocked, mock.get, self.url_master, text=self.getMasterPlaylist())
+            self.mock(mocked, mock.get, self.url_playlist, [{"text": p} for p in playlists])
+            for i, stream in enumerate(streams):
+                self.mock(mocked, mock.get, self.url_segment.format(i), content=stream)
+            streamlink, data = self.start_streamlink()
+            return streamlink, data, mocked
+
+    @patch("streamlink.plugins.yotta.log")
+    def test_playlist_parse(self, mock_logging):
+        streams = ["[{0}]".format(i).encode("ascii") for i in range(4)]
+        playlists = [
+            self.getPlaylist(0, [0, 1]),
+            self.getPlaylist(2, [2, 3]) + "#EXT-X-ENDLIST\n"
+        ]
+        streamlink, result, mocked = self.get_result(streams, playlists)
+
+        self.assertEqual(result, b''.join(streams[0:4]))
+        for i in range(0, 4):
+            self.assertTrue(mocked[self.url_segment.format(i)].called, i)
+        mock_logging.info.assert_has_calls([])


### PR DESCRIPTION
# Add plugin to support Yotta
[Yotta](www.yottau.com.tw) is an online e-learning platform based in Taiwan. I created a plugin for this website.
- Login is required. `--yotta-email`, `--yotta-password`
- Purchases are required to view all the course videos.
- URL format must be `https://www.yottau.com.tw/course/player/<course_id>/<chapter_id>`
- For streaming qualities, I only choose the best (1080P) quality. (Maybe this can be added to the options?)
- Subtitles are only in Traditional Chinese.
- Noted: `--ffmpeg-audio-transcode aac` must be specified in options or else MuxedStream will fail (return pip abort error).

For testing, there's some free course you can purchase (for example, [This course](https://www.yottau.com.tw/course/intro/960#intro) ), but you still need to create an account in advance.
I've tested on my account and here's the log:

```
$ streamlink -l debug 'https://www.yottau.com.tw/course/player/960/23510' best -o=1_1.ts --yotta-email=<email-omitted> --yotta-password=<password omitted> --ffmpeg-audio-transcode aac
[cli][debug] OS:         Linux-4.4.0-18362-Microsoft-x86_64-with-Ubuntu-18.04-bionic
[cli][debug] Python:     3.6.9
[cli][debug] Streamlink: 1.5.0+14.gdf5ab06.dirty
[cli][debug] Requests(2.24.0), Socks(1.6.5), Websocket(0.57.0)
[cli][info] Found matching plugin yotta for URL https://www.yottau.com.tw/course/player/960/23510
[cli][debug] Plugin specific arguments:
[cli][debug]  --yotta-email=<email-omitted> (email)
[cli][debug]  --yotta-password=******** (password)
[plugin.yotta][error] Logged in to Yotta as <email-omitted>
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 1080p (worst, best)
[cli][info] Opening stream: 1080p (muxed-stream)
[stream.ffmpegmux][debug] Opening yottahls substream
[stream.hls][debug] Reloading playlist
[stream.hls][debug] First Sequence: 0; Last Sequence: 49
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 0; End Sequence: 49
[stream.hls][debug] Adding segment 0 to queue
[stream.ffmpegmux][debug] Opening http subtitle stream
[stream.hls][debug] Adding segment 1 to queue
[stream.hls][debug] Adding segment 2 to queue
[stream.hls][debug] Adding segment 3 to queue
[stream.hls][debug] Adding segment 4 to queue
[stream.hls][debug] Adding segment 5 to queue
[stream.hls][debug] Adding segment 6 to queue
[stream.hls][debug] Adding segment 7 to queue
[stream.hls][debug] Adding segment 8 to queue
[stream.hls][debug] Adding segment 9 to queue
[stream.hls][debug] Adding segment 10 to queue
[stream.hls][debug] Adding segment 11 to queue
[stream.hls][debug] Adding segment 12 to queue
[stream.hls][debug] Adding segment 13 to queue
[stream.hls][debug] Adding segment 14 to queue
[stream.hls][debug] Adding segment 15 to queue
[stream.hls][debug] Adding segment 16 to queue
[stream.hls][debug] Adding segment 17 to queue
[stream.hls][debug] Adding segment 18 to queue
[stream.hls][debug] Adding segment 19 to queue
[stream.hls][debug] Adding segment 20 to queue
[stream.hls][debug] Adding segment 21 to queue
[stream.ffmpegmux][debug] ffmpeg command: ffmpeg -nostats -y -i /tmp/ffmpeg-3424-614 -i /tmp/ffmpeg-3424-868 -c:v copy -c:a aac -map 0 -map 1 -metadata:s:s:0 language=chi -f matroska pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/ffmpeg-3424-614
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/ffmpeg-3424-868
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] Download of segment 0 complete
[stream.hls][debug] Adding segment 22 to queue
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/ffmpeg-3424-868
[cli][debug] Checking file output
[cli][debug] Writing stream to output
[stream.hls][debug] Download of segment 1 complete
[stream.hls][debug] Adding segment 23 to queue
[stream.hls][debug] Download of segment 2 complete
[stream.hls][debug] Adding segment 24 to queue
[stream.hls][debug] Download of segment 3 complete
[stream.hls][debug] Adding segment 25 to queue
[stream.hls][debug] Download of segment 4 complete
[stream.hls][debug] Adding segment 26 to queue
[stream.hls][debug] Download of segment 5 complete
[stream.hls][debug] Adding segment 27 to queue
[stream.hls][debug] Download of segment 6 complete
[stream.hls][debug] Adding segment 28 to queue
[stream.hls][debug] Download of segment 7 complete
[stream.hls][debug] Adding segment 29 to queue
[stream.hls][debug] Download of segment 8 complete
[stream.hls][debug] Adding segment 30 to queue
[stream.hls][debug] Download of segment 9 complete
[stream.hls][debug] Adding segment 31 to queue
[stream.hls][debug] Download of segment 10 complete
[stream.hls][debug] Adding segment 32 to queue
[stream.hls][debug] Download of segment 11 complete
[stream.hls][debug] Adding segment 33 to queue
[stream.hls][debug] Download of segment 12 complete
[stream.hls][debug] Adding segment 34 to queue
[stream.hls][debug] Download of segment 13 complete
[stream.hls][debug] Adding segment 35 to queue
[stream.hls][debug] Download of segment 14 complete
[stream.hls][debug] Adding segment 36 to queue
[stream.hls][debug] Download of segment 15 complete
[stream.hls][debug] Adding segment 37 to queue
[stream.hls][debug] Download of segment 16 complete
[stream.hls][debug] Adding segment 38 to queue
[stream.hls][debug] Download of segment 17 complete
[stream.hls][debug] Adding segment 39 to queue
[stream.hls][debug] Download of segment 18 complete
[stream.hls][debug] Adding segment 40 to queue
[stream.hls][debug] Download of segment 19 complete
[stream.hls][debug] Adding segment 41 to queue
[stream.hls][debug] Download of segment 20 complete
[stream.hls][debug] Adding segment 42 to queue
[stream.hls][debug] Download of segment 21 complete
[stream.hls][debug] Adding segment 43 to queue
[stream.hls][debug] Download of segment 22 complete
[stream.hls][debug] Adding segment 44 to queue
[stream.hls][debug] Download of segment 23 complete
[stream.hls][debug] Adding segment 45 to queue
[stream.hls][debug] Download of segment 24 complete
[stream.hls][debug] Adding segment 46 to queue
[stream.hls][debug] Download of segment 25 complete
[stream.hls][debug] Adding segment 47 to queue
[stream.hls][debug] Download of segment 26 complete
[stream.hls][debug] Adding segment 48 to queue
[stream.hls][debug] Download of segment 27 complete
[stream.hls][debug] Adding segment 49 to queue
[stream.hls][debug] Download of segment 28 complete
[stream.hls][debug] Download of segment 29 complete
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Download of segment 30 complete
[stream.hls][debug] Download of segment 31 complete
[stream.hls][debug] Download of segment 32 complete
[stream.hls][debug] Download of segment 33 complete
[stream.hls][debug] Download of segment 34 complete
[stream.hls][debug] Download of segment 35 complete
[stream.hls][debug] Download of segment 36 complete
[stream.hls][debug] Download of segment 37 complete
[stream.hls][debug] Download of segment 38 complete
[stream.hls][debug] Download of segment 39 complete
[stream.hls][debug] Download of segment 40 complete
[stream.hls][debug] Download of segment 41 complete
[stream.hls][debug] Download of segment 42 complete
[stream.hls][debug] Download of segment 43 complete
[stream.hls][debug] Download of segment 44 complete
[stream.hls][debug] Download of segment 45 complete
[stream.hls][debug] Download of segment 46 complete
[stream.hls][debug] Download of segment 47 complete
[stream.hls][debug] Download of segment 48 complete
[stream.hls][debug] Download of segment 49 complete
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/ffmpeg-3424-614
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
```