### PR TITLE
plugins.vk: remove '\' from data

### DIFF
--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -80,7 +80,7 @@ class VK(Plugin):
                 for s in self.session.streams(iframe_url).items():
                     yield s
 
-        for _i in itertags(res.text, 'source'):
+        for _i in itertags(res.text.replace('\\', ''), 'source'):
             if _i.attributes.get('type') == 'application/vnd.apple.mpegurl':
                 video_url = html_unescape(_i.attributes['src'])
                 streams = HLSStream.parse_variant_playlist(self.session,


### PR DESCRIPTION
```
$ streamlink https://vk.com/video?z=video-106042931_456240719
[cli][info] Found matching plugin vk for URL https://vk.com/video?z=video-106042931_456240719
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (hls)
```