### PR TITLE
plugins.raiplay: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -1,35 +1,54 @@
-from __future__ import print_function
+import logging
 import re
 
+from streamlink.compat import urlparse, urlunparse
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class RaiPlay(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?raiplay\.it/dirette/(\w+)/?")
-    stream_re = re.compile(r"data-video-url.*?=.*?\"([^\"]+)\"")
-    stream_schema = validate.Schema(
-        validate.all(
-            validate.transform(stream_re.search),
-            validate.any(
-                None,
-                validate.all(validate.get(1), validate.url())
-            )
-        )
+    _re_url = re.compile(r"https?://(?:www\.)?raiplay\.it/dirette/(\w+)/?")
+
+    _re_data = re.compile(r"data-video-json\s*=\s*\"([^\"]+)\"")
+    _schema_data = validate.Schema(
+        validate.transform(_re_data.search),
+        validate.any(None, validate.get(1))
+    )
+    _schema_json = validate.Schema(
+        validate.transform(parse_json),
+        validate.get("video"),
+        validate.get("content_url"),
+        validate.url()
     )
 
     @classmethod
     def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
+        return cls._re_url.match(url) is not None
 
     def _get_streams(self):
-        channel = self.url_re.match(self.url).group(1)
-        self.logger.debug("Found channel: {0}", channel)
-        stream_url = self.session.http.get(self.url, schema=self.stream_schema)
-        if stream_url:
-            return HLSStream.parse_variant_playlist(self.session, stream_url, headers={"User-Agent": useragents.CHROME})
+        json_url = self.session.http.get(self.url, schema=self._schema_data)
+        if not json_url:
+            return
+
+        json_url = urlunparse(urlparse(self.url)._replace(path=json_url))
+        log.debug("Found JSON URL: {0}".format(json_url))
+
+        stream_url = self.session.http.get(json_url, schema=self._schema_json)
+        log.debug("Found stream URL: {0}".format(stream_url))
+
+        res = self.session.http.request("HEAD", stream_url)
+        # status code will be 200 even if geo-blocked, so check the returned content-type
+        if not res or not res.headers or res.headers["Content-Type"] == "video/mp4":
+            log.error("Geo-restricted content")
+            return
+
+        for stream in HLSStream.parse_variant_playlist(self.session, stream_url).items():
+            yield stream
 
 
 __plugin__ = RaiPlay


### PR DESCRIPTION
Fixes #3143

Would appreciate it if someone with an italian IP could test that it's working correctly for geo-restricted content.

```
$ streamlink -l debug 'https://www.raiplay.it/dirette/rainews24'
[cli][debug] OS:         Linux-5.8.3-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.5
[cli][debug] Streamlink: 1.5.0+20.g8cf9306
[cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin raiplay for URL https://www.raiplay.it/dirette/rainews24
[plugin.raiplay][debug] Found JSON URL: https://www.raiplay.it/dirette/rainews24.json
[plugin.raiplay][debug] Found stream URL: http://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=1
[utils.l10n][debug] Language code: en_US
Available streams: 288p (worst), 352p, 396p (best)
```

```
$ streamlink -l debug 'https://www.raiplay.it/dirette/rai1'
[cli][debug] OS:         Linux-5.8.3-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.5
[cli][debug] Streamlink: 1.5.0+20.g8cf9306
[cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin raiplay for URL https://www.raiplay.it/dirette/rai1
[plugin.raiplay][debug] Found JSON URL: https://www.raiplay.it/dirette/rai1.json
[plugin.raiplay][debug] Found stream URL: https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=2606803
[plugin.raiplay][error] Geo-restricted content
error: No playable streams found on this URL: https://www.raiplay.it/dirette/rai1
```