### PR TITLE
plugins.nicolive: fix quality

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -200,7 +200,7 @@ class NicoLive(Plugin):
             "type": "startWatching",
             "data": {
                 "stream": {
-                    "quality": "high",
+                    "quality": "abr",
                     "protocol": "hls",
                     "latency": "high",
                     "chasePlay": False


### PR DESCRIPTION
```
$ streamlink "https://live2.nicovideo.jp/watch/lv327858775"
[cli][info] Found matching plugin nicolive for URL https://live2.nicovideo.jp/watch/lv327858775
[cli][info] Available streams: 3600k (worst, best)
[cli][info] Opening stream: 3600k (hls)
```

now

```
$ streamlink "https://live2.nicovideo.jp/watch/lv327858775"
[cli][info] Found matching plugin nicolive for URL https://live2.nicovideo.jp/watch/lv327858775
[cli][info] Available streams: 345k (worst), 691k, 1800k, 3600k, 5400k (best)
[cli][info] Opening stream: 5400k (hls)
```

closes https://github.com/streamlink/streamlink/issues/3151