### PR TITLE
plugins.twitch: block ads using the same method as uBlock

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -663,8 +663,10 @@ class Twitch(Plugin):
                 endpoint = "vods"
                 value = self.video_id
 
+            disable_ads = self.session.get_plugin_option("twitch", "disable-ads")
             sig, token = self.api.access_token(endpoint, value,
-                                               schema=_access_token_schema)
+                                               schema=_access_token_schema,
+                                               platform="_" if disable_ads else None)
         except PluginError as err:
             if "404 Client Error" in str(err):
                 raise NoStreamsError(self.url)


### PR DESCRIPTION
Implements [uBlock's method](https://github.com/gorhill/uBlock/blob/da7ff2b382c0382e044a4fc2523018a3ea388322/assets/resources/scriptlets.js#L1221-L1225) of blocking ads on twitch. Which basically involves putting the `platform=_` parameter in the `access_token` URLs. Doing that removes ad segments from the stream.

I removed the tests related to removing ad segments since that isn't done anymore. I'm not sure how I'd test the new way of disabling ads so I didn't add any tests.

Also closes #3120 as passthrough should now be compatible with disabling ads.