### PR TITLE
plugins.navernow: new plugin for https://now.naver.com/

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -121,6 +121,7 @@ mitele                  mitele.es            Yes   No    Streams may be geo-rest
 mjunoon                 mjunoon.tv           Yes   Yes
 mrtmk                   play.mrt.com.mk      Yes   Yes   Streams may be geo-restricted to North Macedonia.
 n13tv                   13tv.co.il           Yes   Yes   Streams may be geo-restricted to Israel.
+navernow                now.naver.com        Yes   --
 nbc                     nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
 nbcnews                 nbcnews.com          Yes   No
 nbcsports               nbcsports.com        No    Yes   Streams maybe be geo-restricted to USA. Authentication is not supported.

--- a/src/streamlink/plugins/navernow.py
+++ b/src/streamlink/plugins/navernow.py
@@ -1,7 +1,9 @@
-import re, json
+import re
+import json
 
 from streamlink.plugin import Plugin, PluginError
 from streamlink.stream import HLSStream
+
 
 class NaverNow(Plugin):
     _url_re = re.compile(r"https?://now\.naver\.com/(\d+)")
@@ -21,22 +23,22 @@ class NaverNow(Plugin):
 
         if stream_info.status_code != 200:
             raise PluginError("Could not get stream info. HTTP Status Code %s" % stream_info.status_code)
-        
+
         stream_json = json.loads(stream_info.text)
 
         if stream_json["status"]["status"] != "ONAIR":
             raise PluginError("Stream is offline.")
-        
+
         streams = dict()
         stream_audio = stream_json["status"]["liveStreamUrl"]
         stream_video = stream_json["status"]["videoStreamUrl"]
 
         if not stream_audio:
             raise PluginError("Could not find stream url!")
-        
+
         streams["audio"] = HLSStream.parse_variant_playlist(self.session, stream_audio).popitem()[1]
 
-        if stream_video:            
+        if stream_video:
             resolutions = HLSStream.parse_variant_playlist(self.session, stream_video)
             for k, v in resolutions.items():
                 streams[k] = v
@@ -44,3 +46,4 @@ class NaverNow(Plugin):
         return streams
 
 __plugin__ = NaverNow
+

--- a/src/streamlink/plugins/navernow.py
+++ b/src/streamlink/plugins/navernow.py
@@ -1,0 +1,46 @@
+import re, json
+
+from streamlink.plugin import Plugin, PluginError
+from streamlink.stream import HLSStream
+
+class NaverNow(Plugin):
+    _url_re = re.compile(r"https?://now\.naver\.com/(\d+)")
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._url_re.match(url) is not None
+
+    @property
+    def channel_id(self):
+        return self._url_re.match(self.url).group(1)
+
+    def _get_streams(self):
+        self._stream_status_url = "https://now.naver.com/api/nnow/v1/stream/%s/livestatus/" % self.channel_id
+
+        stream_info = self.session.http.get(self._stream_status_url)
+
+        if stream_info.status_code != 200:
+            raise PluginError("Could not get stream info. HTTP Status Code %s" % stream_info.status_code)
+        
+        stream_json = json.loads(stream_info.text)
+
+        if stream_json["status"]["status"] != "ONAIR":
+            raise PluginError("Stream is offline.")
+        
+        streams = dict()
+        stream_audio = stream_json["status"]["liveStreamUrl"]
+        stream_video = stream_json["status"]["videoStreamUrl"]
+
+        if not stream_audio:
+            raise PluginError("Could not find stream url!")
+        
+        streams["audio"] = HLSStream.parse_variant_playlist(self.session, stream_audio).popitem()[1]
+
+        if stream_video:            
+            resolutions = HLSStream.parse_variant_playlist(self.session, stream_video)
+            for k, v in resolutions.items():
+                streams[k] = v
+
+        return streams
+
+__plugin__ = NaverNow

--- a/src/streamlink/plugins/navernow.py
+++ b/src/streamlink/plugins/navernow.py
@@ -45,5 +45,5 @@ class NaverNow(Plugin):
 
         return streams
 
-__plugin__ = NaverNow
 
+__plugin__ = NaverNow

--- a/tests/plugins/test_navernow.py
+++ b/tests/plugins/test_navernow.py
@@ -1,0 +1,23 @@
+import unittest
+
+from streamlink.plugins.navernow import NaverNow
+
+
+class TestPluginNaverNow(unittest.TestCase):
+
+    def test_can_handle_url(self):
+        should_match = [
+            "https://now.naver.com/705",
+            "https://now.naver.com/680",
+            "https://now.naver.com/719?airbridge_referrer=airbridge" # url with parameter
+        ]
+        for url in should_match:
+            self.assertTrue(NaverNow.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            "https://now.naver.com/about",
+            "https://example.com/index.html"
+        ]
+        for url in should_not_match:
+            self.assertFalse(NaverNow.can_handle_url(url))

--- a/tests/plugins/test_navernow.py
+++ b/tests/plugins/test_navernow.py
@@ -9,7 +9,7 @@ class TestPluginNaverNow(unittest.TestCase):
         should_match = [
             "https://now.naver.com/705",
             "https://now.naver.com/680",
-            "https://now.naver.com/719?airbridge_referrer=airbridge" # url with parameter
+            "https://now.naver.com/719?airbridge_referrer=airbridge"  # url with parameter
         ]
         for url in should_match:
             self.assertTrue(NaverNow.can_handle_url(url))


### PR DESCRIPTION
Add plugin for Naver Now.

Naver Now is 24/7 Radio streaming service operated by Naver.

You can check the site here: [https://now.naver.com/](https://now.naver.com/)