### PR TITLE
plugins.twitch: platform=_ in access_token request

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -328,7 +328,7 @@ class TwitchAPI(object):
     # Private API calls
 
     def access_token(self, endpoint, asset, **params):
-        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), private=True, **params)
+        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), private=True, **dict(platform="_", **params))
 
     def hosted_channel(self, **params):
         return self.call_subdomain("tmi", "/hosts", format="", **params)


### PR DESCRIPTION
Since there hasn't been another response in #3170 and I don't want to wait any longer, I'm opening a PR myself with the platform=_ "workaround".

As I've said in the other PR, we've already had added the `platform=_` request parameter to the access token API endpoint when embedded ads were first implemented, but we removed it again when it became obsolete after a few days when Twitch made further changes.

This is basically the same situation and I don't expect this "workaround" to keep working indefinitely. We'll see.

Added first in: #2358
Stopped working in: #2368
Got removed in: #2692

Closes #3170