### PR TITLE
support `python -m` invocation style

### DIFF
--- a/src/streamlink/__main__.py
+++ b/src/streamlink/__main__.py
@@ -1,0 +1,3 @@
+if __name__ == "__main__":
+    from streamlink_cli.main import main
+    main()

--- a/src/streamlink_cli/__main__.py
+++ b/src/streamlink_cli/__main__.py
@@ -1,0 +1,3 @@
+if __name__ == "__main__":
+    from .main import main
+    main()


### PR DESCRIPTION
It seems that `python -m streamlink -h` raises an error, at least on Windows:
```
# after python -mpip install streamlink
python -m streamlink -h
No module named streamlink.__main__; 'streamlink' is a package and cannot be directly executed
```

This can be fixed by adding the `__main__.py` files to both `streamlink_cli` and `streamlink` packages with the appropriate content.