### PR TITLE
docs: use recommonmark as an extension

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,2 +1,2 @@
 sphinx>=1.6,<1.7
-recommonmark
+recommonmark>=0.5.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,16 +18,10 @@ sys.path.insert(0, os.path.abspath('.'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'ext_argparse', 'ext_github', 'ext_releaseref']
+extensions = ['sphinx.ext.autodoc', 'ext_argparse', 'ext_github', 'ext_releaseref', 'recommonmark']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
-
-# The suffix of source filenames.
-source_suffix = ['.rst', '.md']
-source_parsers = {
-   '.md': 'recommonmark.parser.CommonMarkParser',
-}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
Sphinx v1.8 has [deprecated source_parsers](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_parsers) which is used for recommonmark.

This commit replace the use of source_parsers for recommonmark with the
use of recommonmark as an extension (supported by recommonmark since
0.5.0).

Note: I've made a version requirement on recommonmark of >= 0.5.0 as recommonmark can't be used as a sphinx extension before that version.

If you want to keep compatibility with recommonmark v0.4.0 and older, just close this PR :-) 