### PR TITLE
ci.coverage: increase threshold of tests status

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -38,7 +38,6 @@ coverage:
         paths:
           - "src/streamlink/plugins/"
       tests:
-        # new tests should always be fully covered
-        threshold: 0
+        threshold: 1
         paths:
           - "tests/"


### PR DESCRIPTION
Removing covered test lines will reduce the coverage percentage. This is the case for example in plugin removals, and those are not supposed to fail. If we had 100% coverage in a status where the threshold is set to 0, removing lines wouldn't be a problem, but the tests are currently at 99.56%, which means we need to increase the threshold by a bit. This also means that poorly written tests won't fail anymore unless they reduce the overall percentage by 1%.

A proper fix would be increasing the tests coverage to 100%, but some of the missed lines can't be annotated. And then there are also partial hits.