### PR TITLE
tests: clean up existing HLS stream tests

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -2,7 +2,7 @@ import logging
 import re
 import struct
 
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, OrderedDict
 from Crypto.Cipher import AES
 from requests.exceptions import ChunkedEncodingError
 
@@ -429,7 +429,7 @@ class HLSStream(HTTPStream):
         except ValueError as err:
             raise IOError("Failed to parse playlist: {0}".format(err))
 
-        streams = {}
+        streams = OrderedDict()
         for playlist in filter(lambda p: not p.is_iframe, parser.playlists):
             names = dict(name=None, pixels=None, bitrate=None)
             audio_streams = []

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -1,0 +1,215 @@
+from binascii import hexlify
+from collections import OrderedDict
+from functools import partial
+from threading import Event, Thread
+
+import requests_mock
+import unittest
+
+from streamlink import Streamlink
+from streamlink.stream.hls import HLSStream
+
+
+class HLSItemBase(object):
+    path = ""
+
+    def url(self, namespace):
+        return "http://mocked/{namespace}/{path}".format(namespace=namespace, path=self.path)
+
+
+class Playlist(HLSItemBase):
+    path = "playlist.m3u8"
+
+    def __init__(self, mediasequence=None, segments=None, end=False, targetduration=0, version=7):
+        self.items = [
+            Tag("EXTM3U"),
+            Tag("EXT-X-VERSION", int(version)),
+            Tag("EXT-X-TARGETDURATION", int(targetduration))
+        ]
+        if mediasequence is not None:  # pragma: no branch
+            self.items.append(Tag("EXT-X-MEDIA-SEQUENCE", int(mediasequence)))
+        self.items += segments or []
+        if end:
+            self.items.append(Tag("EXT-X-ENDLIST"))
+
+    def build(self, *args, **kwargs):
+        return "\n".join([item.build(*args, **kwargs) for item in self.items])
+
+
+class Tag(HLSItemBase):
+    def __init__(self, name, attrs=None):
+        self.name = name
+        self.attrs = attrs
+
+    @classmethod
+    def val_quoted_string(cls, value):
+        return "\"{0}\"".format(value)
+
+    @classmethod
+    def val_hex(cls, value):
+        return "0x{0}".format(hexlify(value).decode("ascii"))
+
+    def build(self, *args, **kwargs):
+        attrs = None
+        if type(self.attrs) == dict:
+            attrs = ",".join([
+                "{0}={1}".format(key, value(self, *args, **kwargs) if callable(value) else value)
+                for (key, value) in self.attrs.items()
+            ])
+        elif self.attrs is not None:
+            attrs = str(self.attrs)
+
+        return "#{name}{attrs}".format(name=self.name, attrs=":{0}".format(attrs) if attrs else "")
+
+
+class Segment(HLSItemBase):
+    def __init__(self, num, title=None, duration=None, path_relative=True):
+        self.num = int(num or 0)
+        self.title = str(title or "")
+        self.duration = float(duration or 1)
+        self.path_relative = bool(path_relative)
+        self.content = "[{0}]".format(self.num).encode("ascii")
+
+    @property
+    def path(self):
+        return "segment{0}.ts".format(self.num)
+
+    def build(self, namespace):
+        return "#EXTINF:{duration:.3f},{title}\n{path}".format(
+            duration=self.duration,
+            title=self.title,
+            path=self.path if self.path_relative else self.url(namespace)
+        )
+
+
+class HLSStreamReadThread(Thread):
+    """
+    Run the reader on a separate thread, so that each read can be controlled from within the main thread
+    """
+    def __init__(self, session, stream, *args, **kwargs):
+        """
+        :param Streamlink session:
+        :param HLSStream stream:
+        """
+        Thread.__init__(self, *args, **kwargs)
+        self.daemon = True
+
+        self.read_wait = Event()
+        self.read_done = Event()
+        self.read_all = False
+        self.data = []
+        self.error = None
+
+        self.session = session
+        self.stream = stream
+        self.reader = stream.open()
+
+    def run(self):
+        while not self.reader.buffer.closed:
+            # only read once per step
+            self.read_wait.wait()
+            self.read_wait.clear()
+
+            try:
+                # don't read again during teardown
+                # if there is data left, close() was called manually, and it needs to be read
+                if self.reader.buffer.closed and self.reader.buffer.length == 0:
+                    return
+
+                if self.read_all:
+                    self.data += list(iter(partial(self.reader.read, -1), b""))
+                    return
+
+                self.data.append(self.reader.read(-1))
+            except IOError as err:
+                self.error = err
+                return
+            finally:
+                # notify main thread that reading has finished
+                self.read_done.set()
+
+    def reset(self):
+        self.data[:] = []
+        self.error = None
+
+
+class TestMixinStreamHLS(unittest.TestCase):
+    __stream__ = HLSStream
+    __readthread__ = HLSStreamReadThread
+
+    def __init__(self, *args, **kwargs):
+        super(TestMixinStreamHLS, self).__init__(*args, **kwargs)
+        self.mocker = requests_mock.Mocker()
+        self.mocks = {}
+        self.session = None
+        self.stream = None
+        self.thread = None
+
+    def setUp(self):
+        super(TestMixinStreamHLS, self).setUp()
+        self.mocker.start()
+
+    def tearDown(self):
+        super(TestMixinStreamHLS, self).tearDown()
+        self.close_thread()
+        self.mocker.stop()
+        self.mocks.clear()
+        self.session = None
+        self.stream = None
+        self.thread = None
+
+    def mock(self, method, url, *args, **kwargs):
+        self.mocks[url] = self.mocker.request(method, url, *args, **kwargs)
+
+    def called(self, item):
+        return self.mocks[self.url(item)].called
+
+    def url(self, item):
+        return item.url(self.id())
+
+    def content(self, segments, prop="content", cond=None):
+        return b"".join([getattr(segment, prop) for segment in segments.values() if cond is None or cond(segment)])
+
+    # close read thread and make sure that all threads have terminated before moving on
+    def close_thread(self):
+        thread = self.thread
+        thread.reader.close()
+        thread.read_wait.set()
+        thread.reader.writer.join()
+        thread.reader.worker.join()
+        thread.join()
+
+    # make one read call on the read thread and wait until it has finished
+    def await_read(self, read_all=False, timeout=5):
+        thread = self.thread
+        thread.read_all = read_all
+        thread.read_wait.set()
+        thread.read_done.wait(timeout)
+        thread.read_done.clear()
+
+        try:
+            if thread.error:
+                raise thread.error
+            return b"".join(thread.data)
+        finally:
+            thread.reset()
+
+    def get_session(self, options=None, *args, **kwargs):
+        return Streamlink(options)
+
+    # set up HLS responses, create the session and read thread and start it
+    def subject(self, playlists, options=None, streamoptions=None, threadoptions=None, *args, **kwargs):
+        # filter out tags and duplicate segments between playlist responses while keeping index order
+        segments_all = [item for playlist in playlists for item in playlist.items if isinstance(item, Segment)]
+        segments = OrderedDict([(segment.num, segment) for segment in segments_all])
+
+        self.mock("GET", self.url(playlists[0]), [{"text": pl.build(self.id())} for pl in playlists])
+        for segment in segments.values():
+            self.mock("GET", self.url(segment), content=segment.content)
+
+        self.session = self.get_session(options, *args, **kwargs)
+        self.stream = self.__stream__(self.session, self.url(playlists[0]), **(streamoptions or {}))
+        self.thread = self.__readthread__(self.session, self.stream, **(threadoptions or {}))
+        self.thread.start()
+
+        return self.thread, segments

--- a/tests/streams/test_hls_filtered.py
+++ b/tests/streams/test_hls_filtered.py
@@ -1,15 +1,21 @@
-import requests_mock
-from tests.mock import MagicMock, call, patch
+from threading import Event
+
 import unittest
 
-import itertools
-from textwrap import dedent
-from threading import Event, Thread
-from time import sleep
+from tests.mixins.stream_hls import Playlist, Segment, TestMixinStreamHLS
+from tests.mock import MagicMock, call, patch
 
-from streamlink.session import Streamlink
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.hls_filtered import FilteredHLSStreamWriter, FilteredHLSStreamReader
+
+
+FILTERED = "filtered"
+
+
+class SegmentFiltered(Segment):
+    def __init__(self, *args, **kwargs):
+        super(SegmentFiltered, self).__init__(*args, **kwargs)
+        self.title = FILTERED
 
 
 class _TestSubjectFilteredHLSStreamWriter(FilteredHLSStreamWriter):
@@ -36,233 +42,168 @@ class _TestSubjectFilteredHLSReader(FilteredHLSStreamReader):
     __writer__ = _TestSubjectFilteredHLSStreamWriter
 
 
-class _TestSubjectReadThread(Thread):
-    """
-    Run the reader on a separate thread, so that each read can be controlled from within the main thread
-    """
-    def __init__(self):
-        Thread.__init__(self)
-        self.daemon = True
+class _TestSubjectFilteredHLSStream(HLSStream):
+    def open(self):
+        reader = _TestSubjectFilteredHLSReader(self)
+        reader.open()
 
-        session = Streamlink()
-        session.set_option("hls-live-edge", 2)
-        session.set_option("hls-timeout", 0)
-        session.set_option("stream-timeout", 0)
+        return reader
 
-        self.read_wait = Event()
-        self.read_done = Event()
-        self.data = []
-        self.error = None
 
-        self.stream = HLSStream(session, TestFilteredHLSStream.url_playlist)
-        self.reader = _TestSubjectFilteredHLSReader(self.stream)
-        self.reader.open()
+@patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))
+class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
+    __stream__ = _TestSubjectFilteredHLSStream
 
-    def run(self):
-        while not self.reader.buffer.closed:
-            # only read once per step
-            self.read_wait.wait()
-            self.read_wait.clear()
+    @classmethod
+    def filter_sequence(cls, sequence):
+        return sequence.segment.title == FILTERED
 
-            try:
-                # don't read again during teardown
-                # if there is data left, close() was called manually, and it needs to be read
-                if self.reader.buffer.closed and self.reader.buffer.length == 0:
-                    return
-                data = self.reader.read(-1)
-                self.data.append(data)
-            except IOError as err:
-                self.error = err
-                return
-            finally:
-                # notify main thread that reading has finished
-                self.read_done.set()
+    def close_thread(self):
+        self.thread.reader.writer.write_wait.set()
+        super(TestFilteredHLSStream, self).close_thread()
 
+    # make one write call on the write thread and wait until it has finished
     def await_write(self):
-        writer = self.reader.writer
-        # make one write call and wait until it has finished
+        writer = self.thread.reader.writer
         writer.write_wait.set()
         writer.write_done.wait()
         writer.write_done.clear()
 
-    def await_read(self):
-        # make one read call and wait until it has finished
-        self.read_wait.set()
-        self.read_done.wait()
-        self.read_done.clear()
+    def get_session(self, options=None, *args, **kwargs):
+        session = super(TestFilteredHLSStream, self).get_session(options)
+        session.set_option("hls-live-edge", 2)
+        session.set_option("hls-timeout", 0)
+        session.set_option("stream-timeout", 0)
 
+        return session
 
-@patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))
-class TestFilteredHLSStream(unittest.TestCase):
-    url_playlist = "http://mocked/test-hls-filtered/playlist.m3u8"
-    url_segment = "http://mocked/test-hls-filtered/stream{0}.ts"
+    def subject(self, *args, **kwargs):
+        thread, segments = super(TestFilteredHLSStream, self).subject(*args, **kwargs)
 
-    @classmethod
-    def get_segments(cls, num):
-        return ["[{0}]".format(i).encode("ascii") for i in range(num)]
-
-    @classmethod
-    def get_playlist(cls, media_sequence, items, filtered=False, end=False):
-        playlist = dedent("""
-            #EXTM3U
-            #EXT-X-VERSION:5
-            #EXT-X-TARGETDURATION:1
-            #EXT-X-MEDIA-SEQUENCE:{0}
-        """.format(media_sequence))
-
-        for item in items:
-            playlist += "#EXTINF:1.000,{1}\nstream{0}.ts\n".format(item, "filtered" if filtered else "live")
-
-        if end:
-            playlist += "#EXT-X-ENDLIST\n"
-
-        return playlist
-
-    @classmethod
-    def filter_sequence(cls, sequence):
-        return sequence.segment.title == "filtered"
-
-    def setUp(self):
-        self.mock = requests_mock.Mocker()
-        self.mock.start()
-        self.mocks = {}
-
-    def tearDown(self):
-        self.thread.reader.close()
-
-        # make sure that worker, write and read threads halt
-        self.thread.reader.writer.write_wait.set()
-        self.thread.read_wait.set()
-        self.thread.reader.writer.join()
-        self.thread.reader.worker.join()
-        self.thread.join()
-
-        self.mocks.clear()
-        self.mock.stop()
-
-    def subject(self, segments, playlists):
-        self.mocks[self.url_playlist] = self.mock.get(self.url_playlist, [{"text": p} for p in playlists])
-        for i, segment in enumerate(segments):
-            url = self.url_segment.format(i)
-            self.mocks[url] = self.mock.get(url, content=segment)
-
-        self.thread = _TestSubjectReadThread()
-        self.thread.start()
-
-        return self.thread, self.thread.reader, self.thread.reader.writer
+        return thread, thread.reader, thread.reader.writer, segments
 
     # don't patch should_filter_sequence here (it always returns False)
     def test_not_filtered(self):
-        segments = self.get_segments(2)
-        thread, reader, writer = self.subject(segments, [
-            self.get_playlist(0, [0, 1], filtered=True, end=True)
+        thread, reader, writer, segments = self.subject([
+            Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)], end=True)
         ])
 
-        thread.await_write()
-        thread.await_write()
-        thread.await_read()
-        self.assertEqual(b"".join(thread.data), b"".join(segments[0:2]), "Does not filter by default")
+        self.await_write()
+        self.await_write()
+        data = self.await_read()
+        self.assertEqual(data, self.content(segments), "Does not filter by default")
 
     @patch("streamlink.stream.hls_filtered.FilteredHLSStreamWriter.should_filter_sequence", new=filter_sequence)
     @patch("streamlink.stream.hls_filtered.log")
     def test_filtered_logging(self, mock_log):
-        segments = self.get_segments(8)
-        thread, reader, writer = self.subject(segments, [
-            self.get_playlist(0, [0, 1], filtered=True),
-            self.get_playlist(2, [2, 3], filtered=False),
-            self.get_playlist(4, [4, 5], filtered=True),
-            self.get_playlist(6, [6, 7], filtered=False, end=True)
+        thread, reader, writer, segments = self.subject([
+            Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)]),
+            Playlist(2, [Segment(2), Segment(3)]),
+            Playlist(4, [SegmentFiltered(4), SegmentFiltered(5)]),
+            Playlist(6, [Segment(6), Segment(7)], end=True)
         ])
+        data = b""
 
         self.assertTrue(reader.filter_event.is_set(), "Doesn't let the reader wait if not filtering")
 
         for i in range(2):
-            thread.await_write()
-            thread.await_write()
+            self.await_write()
+            self.await_write()
             self.assertEqual(len(mock_log.info.mock_calls), i * 2 + 1)
             self.assertEqual(mock_log.info.mock_calls[i * 2 + 0], call("Filtering out segments and pausing stream output"))
             self.assertFalse(reader.filter_event.is_set(), "Lets the reader wait if filtering")
 
-            thread.await_write()
-            thread.await_write()
+            self.await_write()
+            self.await_write()
             self.assertEqual(len(mock_log.info.mock_calls), i * 2 + 2)
             self.assertEqual(mock_log.info.mock_calls[i * 2 + 1], call("Resuming stream output"))
             self.assertTrue(reader.filter_event.is_set(), "Doesn't let the reader wait if not filtering")
 
-            thread.await_read()
+            data += self.await_read()
 
         self.assertEqual(
-            b"".join(thread.data),
-            b"".join(list(itertools.chain(segments[2:4], segments[6:8]))),
+            data,
+            self.content(segments, cond=lambda s: s.num % 4 > 1),
             "Correctly filters out segments"
         )
-        for i, _ in enumerate(segments):
-            self.assertTrue(self.mocks[self.url_segment.format(i)].called, "Downloads all segments")
+        self.assertTrue(all([self.called(s) for s in segments.values()]), "Downloads all segments")
 
     @patch("streamlink.stream.hls_filtered.FilteredHLSStreamWriter.should_filter_sequence", new=filter_sequence)
     def test_filtered_timeout(self):
-        segments = self.get_segments(2)
-        thread, reader, writer = self.subject(segments, [
-            self.get_playlist(0, [0, 1], filtered=False, end=True)
+        thread, reader, writer, segments = self.subject([
+            Playlist(0, [Segment(0), Segment(1)], end=True)
         ])
 
-        thread.await_write()
-        thread.await_read()
-        self.assertEqual(thread.data, segments[0:1], "Has read the first segment")
+        self.await_write()
+        data = self.await_read()
+        self.assertEqual(data, segments[0].content, "Has read the first segment")
 
         # simulate a timeout by having an empty buffer
         # timeout value is set to 0
-        thread.await_read()
-        self.assertIsInstance(thread.error, IOError, "Raises a timeout error when no data is available to read")
+        with self.assertRaises(IOError) as cm:
+            self.await_read()
+        self.assertEqual(str(cm.exception), "Read timeout", "Raises a timeout error when no data is available to read")
 
     @patch("streamlink.stream.hls_filtered.FilteredHLSStreamWriter.should_filter_sequence", new=filter_sequence)
     def test_filtered_no_timeout(self):
-        segments = self.get_segments(4)
-        thread, reader, writer = self.subject(segments, [
-            self.get_playlist(0, [0, 1], filtered=True),
-            self.get_playlist(2, [2, 3], filtered=False, end=True)
+        thread, reader, writer, segments = self.subject([
+            Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)]),
+            Playlist(2, [Segment(2), Segment(3)], end=True)
         ])
 
         self.assertTrue(reader.filter_event.is_set(), "Doesn't let the reader wait if not filtering")
 
-        thread.await_write()
-        thread.await_write()
+        self.await_write()
+        self.await_write()
         self.assertFalse(reader.filter_event.is_set(), "Lets the reader wait if filtering")
 
         # make reader read (no data available yet)
         thread.read_wait.set()
         # once data becomes available, the reader continues reading
-        thread.await_write()
+        self.await_write()
         self.assertTrue(reader.filter_event.is_set(), "Reader is not waiting anymore")
 
         thread.read_done.wait()
         thread.read_done.clear()
         self.assertFalse(thread.error, "Doesn't time out when filtering")
-        self.assertEqual(thread.data, segments[2:3], "Reads next available buffer data")
+        self.assertEqual(b"".join(thread.data), segments[2].content, "Reads next available buffer data")
 
-        thread.await_write()
-        thread.await_read()
-        self.assertEqual(thread.data, segments[2:4])
+        self.await_write()
+        data = self.await_read()
+        self.assertEqual(data, self.content(segments, cond=lambda s: s.num >= 2))
 
     @patch("streamlink.stream.hls_filtered.FilteredHLSStreamWriter.should_filter_sequence", new=filter_sequence)
     def test_filtered_closed(self):
-        segments = self.get_segments(2)
-        thread, reader, writer = self.subject(segments, [
-            self.get_playlist(0, [0, 1], filtered=True)
+        thread, reader, writer, segments = self.subject([
+            Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)])
         ])
 
+        # mock the reader thread's filter_event.wait method, so that the main thread can wait on its call
+        filter_event_wait_called = Event()
+        orig_wait = reader.filter_event.wait
+
+        def mocked_wait(*args, **kwargs):
+            filter_event_wait_called.set()
+            return orig_wait(*args, **kwargs)
+
+        mock = patch.object(reader.filter_event, "wait", side_effect=mocked_wait)
+        mock.start()
+
+        # write first filtered segment and trigger the filter_event's lock
         self.assertTrue(reader.filter_event.is_set(), "Doesn't let the reader wait if not filtering")
-        thread.await_write()
+        self.await_write()
         self.assertFalse(reader.filter_event.is_set(), "Lets the reader wait if filtering")
 
         # make reader read (no data available yet)
         thread.read_wait.set()
+        # before calling reader.close(), wait until reader thread's filter_event.wait was called
+        filter_event_wait_called.wait()
 
         # close stream while reader is waiting for filtering to end
-        # FIXME: sleep for 100ms here, so that the reader thread runs into its filter_event before calling close()
-        sleep(0.1)
         thread.reader.close()
         thread.read_done.wait()
         thread.read_done.clear()
         self.assertEqual(thread.data, [b""], "Stops reading on stream close")
         self.assertFalse(thread.error, "Is not a read timeout on stream close")
+
+        mock.stop()


### PR DESCRIPTION
Sorry for another wall of text, but this is a fix / cleanup for all existing HLS integration tests which I've mentioned in #3194. Please bear with me, because that are quite a lot of changes, although not too difficult and also split up into multiple commits. Except for a few cases, the logic of the individual tests was not changed and just cleaned up / simplified.

Description of the individual commits:

1. Adds the `TestMixinStreamHLS` class and related ones for simplification of all HLS integration tests. The module was added to the `tests.mixins.stream_hls` import path, but I'm not sure if it's a good choice or if it breaks any conventions. If so, this needs to be moved elsewhere.

   The mixin provides methods for creating a fake HLS stream, mocking the requests, creating a dedicated read thread which can be controlled from the main thread and it adds proper tear-down methods, so that all threads properly terminate first before continuing with the next test. Its logic is partly taken from the previous implementation of the `hls_filtered` tests.

   Instead of manually building the fake HLS streams, they can now be created via extensible `Playlist`, `Tag` and `Segment` classes. This is rather basic right now and doesn't cover every existing HLS tag, but it provides a much simpler interface which makes the test more clean and easier to write.

2. Refactors the `streams.test_hls_filtered` test and makes use of the new mixin. The logic for stepping through each write call individually (due to the test's hls-timeout value of 0) is not part of the mixin and has been kept here, as it's not needed anywhere else.

   The changes also resolve the sloppy `time.sleep(0.1)` workaround from the previous PR by mocking the `filter_event.wait()` call of the reader thread with another `threading.Event.wait()` call on the main thread. The solution is a bit weird unfortunately, because Python doesn't support wait-until-executed Mocks (there's a stale PR on cpython for that exact thing).

3. Refactors the `plugins.test_twitch` tests. Not much to see here apart from the removed unnecessary master playlist setup, the added test assertion messages and overall cleanup.

4. Refactors the `TestHlsPlaylistReloadTime` tests in `streams.test_hls` and makes use of the new mixin. This should fix the test coverage wonkiness, because the HLS streams previously kept running for half a second or so, still trying to make network requests.

5. Separates the `HLSStream.parse_variant_playlist` tests from the existing HLS tests in `streams.test_hls`. Since the master playlist has nothing to do with those stream tests, it needs to be tested in its own testcase class.

   I've added a few more assertions here which required me to change the return value of the `HLSStream.parse_variant_playlist` method to be an `OrderedDict` instead of a `dict`, because there was a difference between py2 and py3 when not sorting the streams (like the plugin API does). Also the usual unicode nonsense in py2.

6. Separates the regular and encrypted HLS stream tests in `streams.test_hls` and makes use of the new mixin.

   I've added a couple more test assertions and changed the parameters a bit.

   The encryption key override test has exposed a minor issue with the `{query}` variable and the quotation mark had to be added to the URL override template.