### PR TITLE
plugins.twitch: remove platform access token param

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -317,7 +317,7 @@ class TwitchAPI(object):
     # Private API calls
 
     def access_token(self, endpoint, asset, **params):
-        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), private=True, **dict(platform="_", **params))
+        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), private=True, **params)
 
     def hosted_channel(self, **params):
         return self.call_subdomain("tmi", "/hosts", format="", **params)


### PR DESCRIPTION
This once again removes the `platform=_` parameter from the stream access token request.

See #3210
As mentioned there, we need a better solution for this. Am happy to discuss this.

----

History of the parameter:
1. Added in #2358
2. Removed in #2692
3. Added in #3173