### PR TITLE
plugins.twitch: refactor plugin

### DIFF
--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -291,11 +291,11 @@ class TestTwitchMetadata(unittest.TestCase):
 
     def subject_channel(self, data=True, failure=False):
         self.mock.get(
-            "https://api.twitch.tv/kraken/users.json?login=foo",
+            "https://api.twitch.tv/kraken/users?login=foo",
             json={"users": [{"_id": 1234}]}
         )
         self.mock.get(
-            "https://api.twitch.tv/kraken/streams/1234.json",
+            "https://api.twitch.tv/kraken/streams/1234",
             status_code=200 if not failure else 404,
             json={"stream": None} if not data else {"stream": {
                 "channel": {
@@ -309,7 +309,7 @@ class TestTwitchMetadata(unittest.TestCase):
 
     def subject_video(self, data=True, failure=False):
         self.mock.get(
-            "https://api.twitch.tv/kraken/videos/1337.json",
+            "https://api.twitch.tv/kraken/videos/1337",
             status_code=200 if not failure else 404,
             json={} if not data else {
                 "title": "video title",
@@ -362,11 +362,11 @@ class TestTwitchReruns(unittest.TestCase):
     def start(self, *mocked, **params):
         with requests_mock.Mocker() as mock:
             mocked_users = mock.get(
-                "https://api.twitch.tv/kraken/users.json?login=foo",
+                "https://api.twitch.tv/kraken/users?login=foo",
                 json={"users": [{"_id": 1234}]}
             )
             mocked_stream = mock.get(
-                "https://api.twitch.tv/kraken/streams/1234.json",
+                "https://api.twitch.tv/kraken/streams/1234",
                 json={"stream": None} if params.pop("offline", False) else {"stream": {
                     "stream_type": params.pop("stream_type", "live"),
                     "broadcast_platform": params.pop("broadcast_platform", "live"),


### PR DESCRIPTION
Opening this as a draft PR for now, because it's still WIP.
As already said in #3206, I wanted to refactor the entire Twitch plugin, as it hasn't been done in years and there's a ton of cruft.

I've split this up into multiple commits for reviewing reasons, but this should be squashed if it gets merged. Commits are therefore probably not 100% optimal and also don't have a proper commit message.

I can rebase this into fewer proper commits though, if you feel like it's too many changes for a single commit if squashed.

----

**My goals with the code-refactor are the following:**

1. Move most from the module's global context to class attributes, where it belongs
2. Remove old and now unsupported stuff (also affects plugin's URL regex)
   - Remove different video types
     [There's only one type now](https://dev.twitch.tv/docs/v5/reference/videos)
   - Remove VOD playlists
     Removed in favor of ["collections"](https://dev.twitch.tv/docs/v5/reference/collections) in 2017, but doesn't matter, since Streamlink can output only a single stream anyway and videos in a collection have their own canonical URL.
   - Remove FLV stuff
     Which year is it again?
3. Improve Twitch plugin class
   - Split up `_get_hls_streams` and `_access_token` by stream type ("live" and "video")
     Simplifies logic and removes dead code paths
   - Improve hosted channel logic
     This is a private API call which can break at any time. It's currently being used on each live stream and doesn't have a try/except block. Also currently calls `_get_hls_streams` multiple times instead of just resolving the hosted channel chain in a loop.
     Now it also automatically updates the metadata on channel switch.
   - Refactor rerun logic and its tests
   - Refactor metadata code (already done that in #3223)
     This PR moves it to its correct position within the plugin class.
   - WIP: Improve main API calls
     Validation schemas should be added and redundancies removed.
   - Various minor changes
4. Improve TwitchAPI class
   - Remove unused API calls and API versions/subdomains
     Keep the new Twitch API in mind
   - Add GQL API calls
   - WIP: move validation schemas here and add methods for each request type, not for each API endpoint
4. Add tests
   At least for the stuff that doesn't require mocking every network request
