### PR TITLE
plugins.artetv: only pick the first variant of the stream

### DIFF
--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -1,16 +1,14 @@
 """Plugin for Arte.tv, bi-lingual art and culture channel."""
 
+import logging
 import re
+from operator import itemgetter
 
-from itertools import chain
-
-from streamlink.compat import urlparse
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HDSStream
 from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
 
+log = logging.getLogger(__name__)
 JSON_VOD_URL = "https://api.arte.tv/api/player/v1/config/{0}/{1}?platform=ARTE_NEXT"
 JSON_LIVE_URL = "https://api.arte.tv/api/player/v1/livestream/{0}"
 
@@ -32,7 +30,8 @@ _video_schema = validate.Schema({
                     "height": int,
                     "mediaType": validate.text,
                     "url": validate.text,
-                    "versionShortLibelle": validate.text
+                    "versionProg": int,
+                    "versionLibelle": validate.text
                 },
             },
         )
@@ -45,44 +44,21 @@ class ArteTV(Plugin):
     def can_handle_url(cls, url):
         return _url_re.match(url)
 
-    def _create_stream(self, stream, language):
-        stream_name = "{0}p".format(stream["height"])
-        stream_type = stream["mediaType"]
-        stream_url = stream["url"]
-        stream_language = stream["versionShortLibelle"]
-
-        if language == "de":
-            language = ["DE", "VOST-DE", "VA", "VOA", "Dt. Live", "OV", "OmU"]
-        elif language == "en":
-            language = ["ANG", "VOST-ANG"]
-        elif language == "es":
-            language = ["ESP", "VOST-ESP"]
-        elif language == "fr":
-            language = ["FR", "VOST-FR", "VF", "VOF", "Frz. Live", "VO", "ST mal"]
-        elif language == "pl":
-            language = ["POL", "VOST-POL"]
-
-        if stream_language in language:
-            if stream_type in ("hls", "mp4"):
-                if urlparse(stream_url).path.endswith("m3u8"):
+    def _create_stream(self, streams):
+        variant, variantname = min([(stream["versionProg"], stream["versionLibelle"]) for stream in streams.values()],
+                                   key=itemgetter(0))
+        log.debug(u"Using the '{0}' stream variant".format(variantname))
+        for sname, stream in streams.items():
+            if stream["versionProg"] == variant:
+                if stream["mediaType"] == "hls":
                     try:
-                        streams = HLSStream.parse_variant_playlist(self.session, stream_url)
-
-                        for stream in streams.items():
-                            yield stream
+                        streams = HLSStream.parse_variant_playlist(self.session, stream["url"])
+                        for s in streams.items():
+                            yield s
                     except IOError as err:
-                        self.logger.error("Failed to extract HLS streams: {0}", err)
-                else:
-                    yield stream_name, HTTPStream(self.session, stream_url)
-
-            elif stream_type == "f4m":
-                try:
-                    streams = HDSStream.parse_manifest(self.session, stream_url)
-
-                    for stream in streams.items():
-                        yield stream
-                except IOError as err:
-                    self.logger.error("Failed to extract HDS streams: {0}", err)
+                        log.warning(u"Failed to extract HLS streams for {0}/{1}: {2}".format(sname,
+                                                                                             stream["versionLibelle"],
+                                                                                             err))
 
     def _get_streams(self):
         match = _url_re.match(self.url)
@@ -98,10 +74,8 @@ class ArteTV(Plugin):
         if not video["videoJsonPlayer"]["VSR"]:
             return
 
-        vsr = video["videoJsonPlayer"]["VSR"].values()
-        streams = (self._create_stream(stream, language) for stream in vsr)
-
-        return chain.from_iterable(streams)
+        vsr = video["videoJsonPlayer"]["VSR"]
+        return self._create_stream(vsr)
 
 
 __plugin__ = ArteTV


### PR DESCRIPTION
Removes the f4m and http streams from the returned list, and only returns the default variant for the stream. I believe this will match the expected behaviour. 

see #3167