### PR TITLE
ci: add python 3.9 test runners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 10
+    after_n_builds: 12
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       # when changing the build matrix and changing the number of test runners
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
 #       include:
 #         - python: X.Y-dev
 #           continue: true
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies


### PR DESCRIPTION
Python 3.9 has been released yesterday / two days ago and Github has added Python 3.9 builds a few hours ago. This requires a bump of the `actions/setup-python` action to `v2`, since it's not available in the default virtual environments of the CI runners.
- https://docs.python.org/release/3.9.0/whatsnew/3.9.html
- https://github.com/actions/setup-python
- https://github.com/actions/python-versions/commit/1430296346bab896c21a97ff3396425c26ad87b1

----

Python 3.5 is also no longer supported now and should be dropped now once we finally drop 2.7:
- https://blog.python.org/2020/10/python-35-is-no-longer-supported.html

That's currently an overall number of 12 test runners now. A bit much. Dropping 2.7 and 3.5 would reduce it to 8.