### PR TITLE
chore: drop support for Python 2

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 12
+    after_n_builds: 10
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       # when changing the build matrix and changing the number of test runners
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [3.5, 3.6, 3.7, 3.8, 3.9]
 #       include:
 #         - python: X.Y-dev
 #           continue: true

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -295,22 +295,18 @@ To install Streamlink from source you will need these dependencies.
 ==================================== ===========================================
 Name                                 Notes
 ==================================== ===========================================
-`Python`_                            At least version **2.7** or **3.5**.
+`Python`_                            At least version **3.5**.
 `python-setuptools`_
 
 **Automatically installed by the setup script**
 --------------------------------------------------------------------------------
-`python-futures`_                    Only needed on Python **2.7**.
 `python-requests`_                   At least version **2.21.0**.
-`python-singledispatch`_             Only needed on Python **2.7**.
 `pycryptodome`_                      Required to play some encrypted streams
 `iso-639`_                           Used for localization settings, provides language information
 `iso3166`_                           Used for localization settings, provides country information
 `isodate`_                           Used for MPEG-DASH streams
 `PySocks`_                           Used for SOCKS Proxies
 `websocket-client`_                  Used for some plugins
-`shutil_get_terminal_size`_          Only needed on Python **2.7**.
-`shutil_which`_                      Only needed on Python **2.7**.
 
 **Optional**
 --------------------------------------------------------------------------------
@@ -332,9 +328,7 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 
 .. _Python: https://www.python.org/
 .. _python-setuptools: https://pypi.org/project/setuptools/
-.. _python-futures: https://pypi.org/project/futures/
 .. _python-requests: http://python-requests.org/
-.. _python-singledispatch: https://pypi.org/project/singledispatch/
 .. _RTMPDump: http://rtmpdump.mplayerhq.hu/
 .. _pycountry: https://pypi.org/project/pycountry/
 .. _pycrypto: https://www.dlitz.net/software/pycrypto/
@@ -345,8 +339,6 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 .. _isodate: https://pypi.org/project/isodate/
 .. _PySocks: https://github.com/Anorov/PySocks
 .. _websocket-client: https://pypi.org/project/websocket-client/
-.. _shutil_get_terminal_size: https://pypi.org/project/backports.shutil_get_terminal_size/
-.. _shutil_which: https://pypi.org/project/backports.shutil_which/
 
 
 Windows binaries

--- a/script/build-and-sign.sh
+++ b/script/build-and-sign.sh
@@ -25,11 +25,11 @@ mkdir -p "${dist_dir}"
 echo "build: Building Streamlink sdist" >&2
 python setup.py -q sdist --dist-dir "${dist_dir}"
 
-echo "build: Building Streamlink wheel (universal)" >&2
+echo "build: Building Streamlink bdist_wheel" >&2
 python setup.py -q bdist_wheel --dist-dir "${dist_dir}"
 
 for platform in "${wheel_platforms_windows[@]}"; do
-    echo "build: Building Streamlink wheel (${platform})" >&2
+    echo "build: Building Streamlink bdist_wheel (${platform})" >&2
     python setup.py -q bdist_wheel --plat-name "${platform}" --dist-dir "${dist_dir}"
 done
 

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -6,6 +6,5 @@ set -ex
 
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
-python -m pip install 'pycountry==19.8.18;python_version<"3.0"'
-python -m pip install 'pycountry;python_version>="3.0"'
+python -m pip install pycountry
 python -m pip install -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[wheel]
-universal = 1
-
 [metadata]
 license_file = LICENSE
 

--- a/setup.py
+++ b/setup.py
@@ -7,23 +7,13 @@ from setuptools import setup, find_packages
 
 import versioneer
 
+
 deps = [
-    # Require backport of concurrent.futures on Python 2
-    'futures;python_version<"3.0"',
-    # Require singledispatch on Python <3.4
-    'singledispatch;python_version<"3.4"',
     "requests>=2.21.0,<3.0",
-    'urllib3[secure]>=1.23;python_version<"3.0"',
     "isodate",
     "websocket-client",
     # Support for SOCKS proxies
     "PySocks!=1.5.7,>=1.5.6",
-    # win-inet-pton is missing a dependency in PySocks, this has been fixed but not released yet
-    # Required due to missing socket.inet_ntop & socket.inet_pton method in Windows Python 2.x
-    'win-inet-pton;python_version<"3.0" and platform_system=="Windows"',
-    # shutil.get_terminal_size and which were added in Python 3.3
-    'backports.shutil_which;python_version<"3.3"',
-    'backports.shutil_get_terminal_size;python_version<"3.3"'
 ]
 
 # for encrypted streams
@@ -76,7 +66,7 @@ if is_wheel_for_windows():
 setup(name="streamlink",
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
-      description="Streamlink is command-line utility that extracts streams "
+      description="Streamlink is a command-line utility that extracts streams "
                   "from various services and pipes them into a video player of "
                   "choice.",
       long_description=long_description,
@@ -97,7 +87,7 @@ setup(name="streamlink",
       entry_points=entry_points,
       install_requires=deps,
       test_suite="tests",
-      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4",
+      python_requires=">=3.5, <4",
       classifiers=["Development Status :: 5 - Production/Stable",
                    "License :: OSI Approved :: BSD License",
                    "Environment :: Console",
@@ -105,11 +95,13 @@ setup(name="streamlink",
                    "Operating System :: POSIX",
                    "Operating System :: Microsoft :: Windows",
                    "Operating System :: MacOS",
-                   "Programming Language :: Python :: 2.7",
+                   "Programming Language :: Python :: 3",
+                   "Programming Language :: Python :: 3 :: Only",
                    "Programming Language :: Python :: 3.5",
                    "Programming Language :: Python :: 3.6",
                    "Programming Language :: Python :: 3.7",
                    "Programming Language :: Python :: 3.8",
+                   "Programming Language :: Python :: 3.9",
                    "Topic :: Internet :: WWW/HTTP",
                    "Topic :: Multimedia :: Sound/Audio",
                    "Topic :: Multimedia :: Video",

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -3,7 +3,6 @@ import logging
 import pkgutil
 import sys
 import traceback
-import warnings
 
 import requests
 
@@ -52,12 +51,6 @@ class Streamlink(object):
        options and log settings."""
 
     def __init__(self, options=None):
-        if sys.version_info[0] == 2:
-            warnings.warn("Python 2.7 has reached the end of its life.  A future version of streamlink will drop "
-                          "support for Python 2.7. Please upgrade your Python to at least 3.5.",
-                          category=PythonDeprecatedWarning,
-                          stacklevel=2)
-
         self.http = api.HTTPSession()
         self.options = Options({
             "hds-live-edge": 10.0,


### PR DESCRIPTION
- Bump Python version requirement to 3.5
- Remove unneeded compatibility dependencies
- Remove py2 warning from streamlink.session
- Update pypi package classifiers
- Update docs
- Remove universal bdist_wheel
- Remove py2 from CI test runners

----

This is **WIP** and needs to be properly tested in a test-release first.

Additional resources:
- https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels
- https://packaging.python.org/guides/distributing-packages-using-setuptools/#classifiers
- https://pypi.org/classifiers/

Resolves #2896 
Closes #2920