### PR TITLE
docs: fix working tree check in deploy script

### DIFF
--- a/script/deploy-docs.sh
+++ b/script/deploy-docs.sh
@@ -4,7 +4,7 @@ set -eo pipefail
 
 [[ -n "${GITHUB_ACTIONS}" ]] || exit 1
 
-ROOT=$(realpath "$(dirname "$(readlink -f "${0}")")/..")
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$(readlink -f "${0}")")/..")
 
 DOCS_REPO=${DOCS_REPO:-streamlink/streamlink.github.io}
 DOCS_BRANCH=${DOCS_BRANCH:-master}
@@ -69,7 +69,7 @@ cp --archive "${SOURCE}/." "${DEST}/"
 echo Building a new file list in \'${DEST}\'
 ( cd "${SOURCE}"; find . -type f | sort | sed "s/^\\.\//${DEST}\//" > "${TEMP}/${DEST}/${FILELIST}" )
 
-if git diff-index --quiet HEAD --; then
+if [[ -z "$(git status --porcelain)" ]]; then
     echo No changes to be committed. Exiting...
     exit 0
 fi


### PR DESCRIPTION
This should fix the clean working tree check in the docs deploy script.

I've restarted the CI jobs earlier today because of an issue on codecov and wanted the reports to be re-uploaded. Then the deploy-docs job failed afterwards, because it tried to commit from a clean working tree. The `git diff-index --quiet HEAD --` check was supposed to catch that, but apparently it doesn't. Checking for an empty stdout of `git status --porcelain` catches all changes, untracked files, etc. and is therefore better, even though git's high-level "porcelain" commands are technically not meant for scripting.

- https://stackoverflow.com/questions/2657935/checking-for-a-dirty-index-or-untracked-files-with-git/5737794#5737794
- https://github.com/streamlink/streamlink/runs/1225045245#step:7:25
- https://github.com/streamlink/streamlink.github.io/tree/b9a60115179db13cb3900a5af0be51ca66155a9f

Also added a better root dir check...