### PR TITLE
tests: fix early writer close in stream_hls mixin 

### DIFF
--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -164,6 +164,7 @@ class TestHlsPlaylistReloadTime(TestMixinStreamHLS, unittest.TestCase):
 
     def subject(self, *args, **kwargs):
         thread, _ = super(TestHlsPlaylistReloadTime, self).subject(*args, **kwargs)
+        self.await_read(read_all=True)
 
         return thread.reader.worker.playlist_reload_time
 


### PR DESCRIPTION
This should fix the following issue in #3227:
https://github.com/streamlink/streamlink/runs/1227523417?check_suite_focus=true#step:5:257

----

Two issues fixed in one PR (don't squash):

1. Sometimes the writer thread was too fast for the reader thread of the stream_hls test mixin to read, and it closed before the first read occured. The result was an empty read, since the buffer got closed by the writer thread too early. This PR makes the writer thread wait before closing until the reader thread has at least attempted to read once.

2. Currently, Streamlink doesn't wait for the spawned threads of the `ThreadPoolExecutor` to shut down and immediately clears all queued thread pool threads globally. This is not a particularly graceful way to close the writer thread:
   https://github.com/streamlink/streamlink/blob/cb5cee6109b98e61f98b42967185a379a4748e0a/src/streamlink/stream/segmented.py#L107-L109

   In Python 3.9, the `cancel_futures` parameter was just added to the `ThreadPoolExecutor.shutdown` method, which only clears the queue of the current ThreadPoolExecutor instance:
https://github.com/python/cpython/blame/3.9/Lib/concurrent/futures/thread.py#L210-L229

   This can be backported easily, so that the current ungraceful method can be removed. Also setting `wait=True` here will ensure that the writer thread has fully closed. For the HLS tests, this is a needed fix, and for streamlink_cli, I believe this won't make a difference, since it doesn't join the daemon thread anyway, but I'm not sure.
