### PR TITLE
ci.codecov: remove additional coverage checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,28 +16,9 @@ coverage:
   status:
     changes: false
     patch: false
-    # split up coverage reports by path
-    # don't set coverage targets and instead set coverage thresholds
     project:
-      # we can't disable the overall default project, because only this will have PR check summaries / comments
-      # this replaces the PR comment
+      # the "default project" PR status check replaces the PR comment with the coverage change message
+      # set threshold to 100% and informational to true, so that the check always passes
       default:
-        target: 50
-      streamlink:
-        threshold: 1
-        paths:
-          - "src/streamlink/"
-          - "!src/streamlink/plugins/"
-      streamlink_cli:
-        threshold: 1
-        paths:
-          - "src/streamlink_cli/"
-      plugins:
-        # don't set a threshold on plugins
-        target: 30
-        paths:
-          - "src/streamlink/plugins/"
-      tests:
-        threshold: 1
-        paths:
-          - "tests/"
+        threshold: 100
+        informational: true


### PR DESCRIPTION
The codecov coverage data is currently totally broken, because of the bug I've reported here:
https://community.codecov.io/t/bug-project-path-prefix-of-codecov-action-running-on-windows-is-incorrectly-kept-in-report-data/2141

This unfortunately also affects the latest commit of the master branch and PRs are failing because of the incorrect coverage base.

For now, I've removed the codecov "default project" status check from the master branch protection list, so that the PR checks at least don't stall.

If this bug gets fixed by codecov, we could theoretically keep the current config with the split up projects / PR statuses, but since it hasn't worked that great so far, I think reducing it to the default and having an overall coverage status report there (instead of the bot comment) is enough for now. I would have preferred having reports on the individual PR statuses, but that doesn't work currently.

This change will also make the coverage status always succeed. I've set both the threshold to 100% and informational to true.