### PR TITLE
plugins.tv3cat: update URL match, test and plugin matrix

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -219,7 +219,7 @@ turkuvaz                - atv.com.tr         Yes   No    Streams may be geo-rest
                         - minikacocuk.com.tr
                         - minikago.com.tr
                         - sabah.com.tr
-tv3cat                  tv3.cat              Yes   Yes   Streams may be geo-restricted to Spain.
+tv3cat                  ccma.cat             Yes   Yes   Streams may be geo-restricted to Spain.
 tv4play                 - tv4play.se         Yes   Yes   Streams may be geo-restricted to Sweden.
                                                          Only non-premium streams currently supported.
                         - fotbollskanalen.se

--- a/src/streamlink/plugins/tv3cat.py
+++ b/src/streamlink/plugins/tv3cat.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 class TV3Cat(Plugin):
-    _url_re = re.compile(r"http://(?:www.)?ccma.cat/tv3/directe/(.+?)/")
+    _url_re = re.compile(r"https?://(?:www\.)?ccma\.cat/tv3/directe/(.+?)/")
     _stream_info_url = "http://dinamics.ccma.cat/pvideo/media.jsp" \
                        "?media=video&version=0s&idint={ident}&profile=pc&desplacament=0"
     _media_schema = validate.Schema({
@@ -39,7 +39,6 @@ class TV3Cat(Plugin):
                     return HLSStream.parse_variant_playlist(self.session, stream['url'], name_fmt="{pixels}_{bitrate}")
                 except PluginError:
                     log.debug("Failed to get streams for: {0}".format(stream['geo']))
-                    pass
 
 
 __plugin__ = TV3Cat

--- a/tests/plugins/test_tv3cat.py
+++ b/tests/plugins/test_tv3cat.py
@@ -6,8 +6,14 @@ from streamlink.plugins.tv3cat import TV3Cat
 class TestPluginTV3Cat(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
+            'http://ccma.cat/tv3/directe/tv3/',
+            'http://ccma.cat/tv3/directe/324/',
+            'https://ccma.cat/tv3/directe/tv3/',
+            'https://ccma.cat/tv3/directe/324/',
             'http://www.ccma.cat/tv3/directe/tv3/',
             'http://www.ccma.cat/tv3/directe/324/',
+            'https://www.ccma.cat/tv3/directe/tv3/',
+            'https://www.ccma.cat/tv3/directe/324/',
         ]
         for url in should_match:
             self.assertTrue(TV3Cat.can_handle_url(url))


### PR DESCRIPTION
- allow http and https schemes in URL match
- escape literal dots in URL match
- remove unnecessary pass statement in except
- update test for both http and https
- update plugin matrix with correct domain

I'm not sure why the LGTM check didn't flag the un-escaped literal dots in the URL match for this plugin before...

closes  #3246
