### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,6 +51,8 @@ https://streamlink.github.io/cli.html#cmdoption-l
 
 Make sure to **remove usernames and passwords**
 You can copy the output to https://gist.github.com/ or paste it below.
+
+Don't post screenshots of the log output and instead copy the text from your terminal application.
 -->
 
 ```
@@ -58,7 +60,7 @@ REPLACE THIS TEXT WITH THE LOG OUTPUT
 ```
 
 
-### Additional comments, screenshots, etc.
+### Additional comments, etc.
 
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -35,7 +35,7 @@ Please see the text preview to avoid unnecessary formatting errors.
 <!-- What do you expect to happen with this new feature, and what is happening currently that does not satisfy this need? -->
 
 
-### Additional comments, screenshots, etc.
+### Additional comments, etc.
 
 
 

--- a/.github/ISSUE_TEMPLATE/plugin_issue.md
+++ b/.github/ISSUE_TEMPLATE/plugin_issue.md
@@ -46,6 +46,8 @@ https://streamlink.github.io/cli.html#cmdoption-l
 
 Make sure to **remove usernames and passwords**
 You can copy the output to https://gist.github.com/ or paste it below.
+
+Don't post screenshots of the log output and instead copy the text from your terminal application.
 -->
 
 ```
@@ -53,7 +55,7 @@ REPLACE THIS TEXT WITH THE LOG OUTPUT
 ```
 
 
-### Additional comments, screenshots, etc.
+### Additional comments, etc.
 
 
 

--- a/.github/ISSUE_TEMPLATE/plugin_request.md
+++ b/.github/ISSUE_TEMPLATE/plugin_request.md
@@ -39,7 +39,7 @@ Please see the text preview to avoid unnecessary formatting errors.
 3. ...
 
 
-### Additional comments, screenshots, etc.
+### Additional comments, etc.
 
 
 

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -52,6 +52,8 @@ https://streamlink.github.io/cli.html#cmdoption-l
 
 Make sure to **remove usernames and passwords**
 You can copy the output to https://gist.github.com/ or paste it below.
+
+Don't post screenshots of the log output and instead copy the text from your terminal application.
 -->
 
 ```
@@ -59,7 +61,7 @@ REPLACE THIS TEXT WITH THE LOG OUTPUT
 ```
 
 
-### Additional comments, screenshots, etc.
+### Additional comments, etc.
 
 
 


### PR DESCRIPTION
I don't know if it'll help or perhaps you don't think it's that much of a problem...  It is, however, nice to get log output in text, if only for copying the URL, rather than having to manually type it in if the URL has not been specified in text form elsewhere in the issue.