### PR TITLE
cli: make config based args available during early setup

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -666,10 +666,10 @@ def setup_args(parser, config_files=[], ignore_unknown=False):
         args.url = args.url_param
 
 
-def setup_config_args(parser):
+def setup_config_args(parser, ignore_unknown=False):
     config_files = []
 
-    if args.url:
+    if streamlink and args.url:
         with ignored(NoPluginError):
             plugin = streamlink.resolve_url(args.url)
             config_files += ["{0}.{1}".format(fn, plugin.module) for fn in CONFIG_FILES]
@@ -684,7 +684,7 @@ def setup_config_args(parser):
             break
 
     if config_files:
-        setup_args(parser, config_files)
+        setup_args(parser, config_files, ignore_unknown=ignore_unknown)
 
 
 def setup_console(output):
@@ -971,6 +971,8 @@ def main():
     parser = build_parser()
 
     setup_args(parser, ignore_unknown=True)
+    # call argument set up as early as possible to load args from config files
+    setup_config_args(parser, ignore_unknown=True)
 
     # Console output should be on stderr if we are outputting
     # a stream to stdout.


### PR DESCRIPTION
As arguments can be loaded from a config file these need to be loaded as soon as possible otherwise some options will not have the desired effect. For example, `quiet` can be specified in `.streamlinkrc`, however it will not take effect. With this change the default config args are loaded earlier, however plugin specific config files are still loaded later.

Options that will take effect from the config file now include:
 - `loglevel` **
 - `json`
 - `stream_url`
 - `subprocess-cmdline`
 - `quiet`
 - `stdout`
 - `output`
 - `record-and-pipe`
 - `plugin-dirs`

The plugin specific config option behaviour remains unchanged, and `loglevel` is the only option that is affected.

I do not think it is possible to sensibly load the plugin specific options early, there are too many opportunities for errors. I noticed this was not working as expected because `plugin-dirs` was not being set from the config file and is the primary reason for this fix. 
`setup_args` is also called twice, and the way I see it `setup_config_args` should have been called twice as well, as `setup_args` only does half the job. 

** `loglevel` is slightly different, it would take affect, but only after the initial setup had been completed. This means that if there were `debug` log messages during the setup they would not have been logged unless `loglevel` was set on the command line. 