### PR TITLE
plugins.urplay: add UR Play plugin

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -237,6 +237,7 @@ tvrplus                 tvrplus.ro           Yes   No    Streams may be geo-rest
 tvtoya                  tvtoya.pl            Yes   --
 twitcasting             twitcasting.tv       Yes   No
 twitch                  twitch.tv            Yes   Yes
+urplay                  urplay.se            No    Yes   Streams may be geo-restricted to Sweden.
 ustreamtv               - ustream.tv         Yes   Yes
                         - video.ibm.com
 ustvnow                 ustvnow.com          Yes   --    All streams require an account, some streams require a subscription.

--- a/src/streamlink/plugins/urplay.py
+++ b/src/streamlink/plugins/urplay.py
@@ -1,0 +1,64 @@
+import logging
+import re
+import html
+import json
+
+from streamlink.plugin import Plugin
+from streamlink.stream import HLSStream
+
+log = logging.getLogger(__name__)
+
+
+class URPlay(Plugin):
+    api_url = 'https://api.svt.se/videoplayer-api/video/{0}'
+
+    author = None
+    category = None
+    title = None
+
+    url_re = re.compile(r'https?://(?:www\.)?urplay\.se/program/.*', re.VERBOSE)
+
+    data_re = re.compile(r'''
+        data-react-class="components/Player/Player"\sdata-react-props="(?P<json>[^"]+)"
+    ''', re.VERBOSE)
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls.url_re.match(url) is not None
+
+    def get_author(self):
+        if self.author is not None:
+            return self.author
+
+    def get_category(self):
+        if self.category is not None:
+            return self.category
+
+    def get_title(self):
+        if self.title is not None:
+            return self.title
+
+    def _get_streams(self):
+        res = self.session.http.get(self.url)
+        match = self.data_re.search(res.text)
+
+        obj = json.loads(html.unescape(match.group('json')))
+        data = obj["currentProduct"]
+
+        self.title = data["title"]
+        self.author = data["mainTitle"]
+        self.category = data["mainGenre"]
+
+        for type in data["streamingInfo"]["raw"]:
+
+            if not isinstance(data["streamingInfo"]["raw"][type], dict):
+                continue
+
+            urlpart = data["streamingInfo"]["raw"][type]["location"]
+            url = "https://streaming10.ur.se/{}playlist.m3u8".format(urlpart)
+
+            for s in HLSStream.parse_variant_playlist(self.session, url).items():
+                yield s
+
+
+__plugin__ = URPlay

--- a/tests/plugins/test_urplay.py
+++ b/tests/plugins/test_urplay.py
@@ -1,0 +1,23 @@
+import unittest
+
+from streamlink.plugins.urplay import URPlay
+
+
+class TestPluginURPlay(unittest.TestCase):
+    def test_can_handle_url(self):
+        should_match = [
+            'https://urplay.se/program/217458-lex-lapidus-rattssystemet-i-usa',
+            'https://urplay.se/program/178137-livet-i-bokstavslandet-alfabetet',
+            'https://urplay.se/program/212550-15-grader-ostlig-langd-djurliv-och-vacker-natur',
+            'https://urplay.se/program/217715-ajankohtaista-suomeksi-2020-10-03',
+        ]
+        for url in should_match:
+            self.assertTrue(URPlay.can_handle_url(url))
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            'https://www.ur.se/aktuellt#clara-henry-johanna-franden-och-nadim-ghazale-utmanar-alla-sjundeklassare',
+            'https://example.com/index.html',
+        ]
+        for url in should_not_match:
+            self.assertFalse(URPlay.can_handle_url(url))


### PR DESCRIPTION
This adds support for the free and independent educational service UR's (Utbildningsradion) play site -  <http://urplay.se>. Mostly this is programs in Swedish, but some shows in different languages exist as well. The content might be geo-locked.
