### PR TITLE
logger: replace all invalid log calls

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -370,8 +370,7 @@ class Plugin(object):
             if match:
                 name = match.group(1)
             else:
-                self.logger.debug("The stream '{0}' has been ignored "
-                                  "since it is badly named.", name)
+                self.logger.debug(f"The stream '{name}' has been ignored since it is badly named.")
                 continue
 
             # Force lowercase name and replace space with underscore.

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin import PluginArguments, PluginArgument
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 CHANNEL_API_URL = "http://live.afreecatv.com:8057/afreeca/player_live_api.php"
 STREAM_INFO_URLS = "{rmd}/broad_stream_assign.html"
@@ -143,21 +147,21 @@ class AfreecaTV(Plugin):
         login_username = self.get_option("username")
         login_password = self.get_option("password")
         if login_username and login_password:
-            self.logger.debug("Attempting login as {0}".format(login_username))
+            log.debug("Attempting login as {0}".format(login_username))
             if self._login(login_username, login_password):
-                self.logger.info("Successfully logged in as {0}".format(login_username))
+                log.info("Successfully logged in as {0}".format(login_username))
             else:
-                self.logger.info("Failed to login as {0}".format(login_username))
+                log.info("Failed to login as {0}".format(login_username))
 
         match = _url_re.match(self.url)
         username = match.group("username")
 
         channel = self._get_channel_info(username)
         if channel.get("BPWD") == "Y":
-            self.logger.error("Stream is Password-Protected")
+            log.error("Stream is Password-Protected")
             return
         elif channel.get("RESULT") == -6:
-            self.logger.error("Login required")
+            log.error("Login required")
             return
         elif channel.get("RESULT") != CHANNEL_RESULT_OK:
             return

--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import parse_url_params
 from streamlink.stream import AkamaiHDStream
 from streamlink.utils import update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class AkamaiHDPlugin(Plugin):
@@ -18,7 +22,7 @@ class AkamaiHDPlugin(Plugin):
         urlnoproto = self._url_re.match(url).group(1)
         urlnoproto = update_scheme("http://", urlnoproto)
 
-        self.logger.debug("URL={0}; params={1}", urlnoproto, params)
+        log.debug("URL={0}; params={1}".format(urlnoproto, params))
         return {"live": AkamaiHDStream(self.session, urlnoproto, **params)}
 
 

--- a/src/streamlink/plugins/animelab.py
+++ b/src/streamlink/plugins/animelab.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin, PluginArguments, PluginArgument
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class AnimeLab(Plugin):
@@ -52,7 +56,7 @@ class AnimeLab(Plugin):
         return cls.url_re.match(url) is not None
 
     def login(self, email, password):
-        self.logger.debug("Attempting to log in as {0}", email)
+        log.debug("Attempting to log in as {0}".format(email))
         res = self.session.http.post(
             self.login_url,
             data=dict(email=email, password=password),
@@ -61,9 +65,9 @@ class AnimeLab(Plugin):
         )
         loc = res.headers.get("Location", "")
         if "geoblocked" in loc.lower():
-            self.logger.error("AnimeLab is not available in your territory")
+            log.error("AnimeLab is not available in your territory")
         elif res.status_code >= 400:
-            self.logger.error("Failed to login to AnimeLab, check your email/password combination")
+            log.error("Failed to login to AnimeLab, check your email/password combination")
         else:
             return True
 
@@ -72,21 +76,22 @@ class AnimeLab(Plugin):
     def _get_streams(self):
         email, password = self.get_option("email"), self.get_option("password")
         if not email or not password:
-            self.logger.error("AnimeLab requires authentication, use --animelab-email "
-                              "and --animelab-password to set your email/password combination")
+            log.error("AnimeLab requires authentication, use --animelab-email "
+                      "and --animelab-password to set your email/password combination")
             return
 
         if self.login(email, password):
-            self.logger.info("Successfully logged in as {0}", email)
+            log.info("Successfully logged in as {0}", email)
             video_collection = self.session.http.get(self.url, schema=self.video_collection_schema)
             if video_collection["playlist"] is None or video_collection["position"] is None:
                 return
 
             data = video_collection["playlist"][video_collection["position"]]
 
-            self.logger.debug("Found {0} version {1} hard-subs",
-                              data["language"]["name"],
-                              "with" if data["hardSubbed"] else "without")
+            log.debug("Found {0} version {1} hard-subs".format(
+                data["language"]["name"],
+                "with" if data["hardSubbed"] else "without"
+            ))
 
             for video in data["videoInstances"]:
                 if video["httpUrl"]:

--- a/src/streamlink/plugins/animelab.py
+++ b/src/streamlink/plugins/animelab.py
@@ -81,7 +81,7 @@ class AnimeLab(Plugin):
             return
 
         if self.login(email, password):
-            log.info("Successfully logged in as {0}", email)
+            log.info(f"Successfully logged in as {email}")
             video_collection = self.session.http.get(self.url, schema=self.video_collection_schema)
             if video_collection["playlist"] is None or video_collection["position"] is None:
                 return

--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -56,7 +56,7 @@ class ard_live(Plugin):
             return
 
         data_url = urljoin(res.url, data_url)
-        log.debug("Player URL: '{0}'", data_url)
+        log.debug(f"Player URL: '{data_url}'")
         res = self.session.http.get(data_url)
         mediainfo = parse_json(res.text, name="MEDIAINFO", schema=self._mediainfo_schema)
         log.trace("Mediainfo: {0!r}".format(mediainfo))

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -101,7 +101,7 @@ class BBCiPlayer(Plugin):
         :return: Video Packet ID for a Programme in iPlayer
         :rtype: string
         """
-        log.debug("Looking for vpid on {0}", url)
+        log.debug(f"Looking for vpid on {url}")
         # Use pre-fetched page if available
         res = res or self.session.http.get(url)
         m = self.mediator_re.search(res.text)
@@ -124,14 +124,14 @@ class BBCiPlayer(Plugin):
         for platform in self.platforms:
             url = self.api_url.format(vpid=vpid, vpid_hash=self._hash_vpid(vpid),
                                       platform=platform)
-            log.debug("Info API request: {0}", url)
+            log.debug(f"Info API request: {url}")
             medias = self.session.http.get(url, schema=self.mediaselector_schema)
             for media in medias:
                 for connection in media["connection"]:
                     urls[connection.get("transferFormat")].add(connection["href"])
 
         for stream_type, urls in urls.items():
-            log.debug("{0} {1} streams", len(urls), stream_type)
+            log.debug(f"{len(urls)} {stream_type} streams")
             for url in list(urls):
                 try:
                     if stream_type == "hds":
@@ -146,9 +146,9 @@ class BBCiPlayer(Plugin):
                         for s in DASHStream.parse_manifest(self.session,
                                                            url).items():
                             yield s
-                    log.debug("  OK:   {0}", url)
+                    log.debug(f"  OK:   {url}")
                 except Exception:
-                    log.debug("  FAIL: {0}", url)
+                    log.debug(f"  FAIL: {url}")
 
     def login(self, ptrt_url):
         """
@@ -205,32 +205,30 @@ class BBCiPlayer(Plugin):
         channel_name = m.group("channel_name")
 
         if episode_id:
-            log.debug("Loading streams for episode: {0}", episode_id)
+            log.debug(f"Loading streams for episode: {episode_id}")
             vpid = self.find_vpid(self.url)
             if vpid:
-                log.debug("Found VPID: {0}", vpid)
+                log.debug(f"Found VPID: {vpid}")
                 for s in self.mediaselector(vpid):
                     yield s
             else:
-                log.error("Could not find VPID for episode {0}",
-                          episode_id)
+                log.error(f"Could not find VPID for episode {episode_id}")
         elif channel_name:
-            log.debug("Loading stream for live channel: {0}", channel_name)
+            log.debug(f"Loading stream for live channel: {channel_name}")
             if self.get_option("hd"):
                 tvip = self.find_tvip(self.url, master=True) + "_hd"
                 if tvip:
-                    log.debug("Trying HD stream {0}...", tvip)
+                    log.debug(f"Trying HD stream {tvip}...")
                     try:
                         for s in self.mediaselector(tvip):
                             yield s
                     except PluginError:
-                        log.error(
-                            "Failed to get HD streams, falling back to SD")
+                        log.error("Failed to get HD streams, falling back to SD")
                     else:
                         return
             tvip = self.find_tvip(self.url)
             if tvip:
-                log.debug("Found TVIP: {0}", tvip)
+                log.debug(f"Found TVIP: {tvip}")
                 for s in self.mediaselector(tvip):
                     yield s
 

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -12,6 +12,9 @@ from streamlink.plugin.api import validate, useragents
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
 
+log = logging.getLogger(__name__)
+
+
 @AMF3ObjectBase.register("com.brightcove.experience.ViewerExperienceRequest")
 class ViewerExperienceRequest(AMF3ObjectBase):
     def __init__(self, experienceId, URL, playerKey, deliveryType, TTLToken, contentOverrides):
@@ -60,8 +63,7 @@ class BrightcovePlayer(object):
 
     def __init__(self, session, account_id, player_id="default_default"):
         self.session = session
-        self.logger = logging.getLogger("streamlink.plugins.brightcove")
-        self.logger.debug("Creating player for account {0} (player_id={1})", account_id, player_id)
+        log.debug("Creating player for account {0} (player_id={1})".format(account_id, player_id))
         self.account_id = account_id
         self.player_id = player_id
 
@@ -96,9 +98,9 @@ class BrightcovePlayer(object):
         return policy_key
 
     def get_streams(self, video_id):
-        self.logger.debug("Finding streams for video: {0}", video_id)
+        log.debug("Finding streams for video: {0}".format(video_id))
         policy_key = self.policy_key(video_id)
-        self.logger.debug("Found policy key: {0}", policy_key)
+        log.debug("Found policy key: {0}".format(policy_key))
         data = self.video_info(video_id, policy_key)
         headers = {"Referer": self.player_url(video_id)}
 

--- a/src/streamlink/plugins/btsports.py
+++ b/src/streamlink/plugins/btsports.py
@@ -68,12 +68,12 @@ class BTSports(Plugin):
         log.debug("Redirected to: {0}".format(res.url))
 
         if "loginerror" not in res.text:
-            self.logger.debug("Login successful, getting SAML token")
+            log.debug("Login successful, getting SAML token")
             res = self.session.http.get("https://samlfed.bt.com/sportgetfedwebhls?bt.cid={0}".format(self.acid()))
             d = self.saml_re.search(res.text)
             if d:
                 saml_data = d.group(1)
-                self.logger.debug("BT Sports federated login...")
+                log.debug("BT Sports federated login...")
                 res = self.session.http.post(
                     self.api_url,
                     params={"action": "LoginBT", "channel": "WEBHLS", "bt.cid": self.acid},
@@ -82,8 +82,7 @@ class BTSports(Plugin):
                 fed_json = self.session.http.json(res)
                 success = fed_json['resultCode'] == "OK"
                 if not success:
-                    self.logger.error("Failed to login: {0} - {1}".format(fed_json['errorDescription'],
-                                                                          fed_json['message']))
+                    log.error("Failed to login: {0} - {1}".format(fed_json['errorDescription'], fed_json['message']))
                 return success
         else:
             return False

--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -56,7 +56,7 @@ class BTV(Plugin):
         media_match = self.media_id_re.search(res.text)
         media_id = media_match and media_match.group(1)
         if media_id:
-            log.debug("Found media id: {0}", media_id)
+            log.debug(f"Found media id: {media_id}")
             stream_url = self.get_hls_url(media_id)
             if stream_url:
                 return HLSStream.parse_variant_playlist(self.session, stream_url)

--- a/src/streamlink/plugins/canalplus.py
+++ b/src/streamlink/plugins/canalplus.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HDSStream, HLSStream, HTTPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class CanalPlus(Plugin):
@@ -96,7 +100,7 @@ class CanalPlus(Plugin):
                                               headers=headers)
             except IOError as err:
                 if '403 Client Error' in str(err):
-                    self.logger.error('Failed to access stream, may be due to geo-restriction')
+                    log.error('Failed to access stream, may be due to geo-restriction')
 
 
 __plugin__ = CanalPlus

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -47,7 +47,7 @@ class CDNBG(Plugin):
         p = urlparse(url)
         for iframe_url in self.iframe_re.findall(res.text):
             if "googletagmanager" not in iframe_url:
-                log.debug("Found iframe: {0}", iframe_url)
+                log.debug(f"Found iframe: {iframe_url}")
                 iframe_url = iframe_url.replace("&#58;", ":")
                 if iframe_url.startswith("//"):
                     return update_scheme(p.scheme, iframe_url)

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -367,23 +367,23 @@ class Crunchyroll(Plugin):
                              locale=locale)
 
         if not self.get_option("session_id"):
-            log.debug("Creating session with locale: {0}", locale)
+            log.debug(f"Creating session with locale: {locale}")
             api.start_session()
 
             if api.auth:
                 log.debug("Using saved credentials")
                 login = api.authenticate()
                 if login:
-                    log.info("Successfully logged in as '{0}'",
-                             login["user"]["username"] or login["user"]["email"])
+                    login_name = login["user"]["username"] or login["user"]["email"]
+                    log.info(f"Successfully logged in as '{login_name}'")
             if not api.auth and self.options.get("username"):
                 try:
                     log.debug("Attempting to login using username and password")
                     api.login(self.options.get("username"),
                               self.options.get("password"))
                     login = api.authenticate()
-                    log.info("Logged in as '{0}'",
-                             login["user"]["username"] or login["user"]["email"])
+                    login_name = login["user"]["username"] or login["user"]["email"]
+                    log.info(f"Logged in as '{login_name}'")
 
                 except CrunchyrollAPIError as err:
                     raise PluginError(u"Authentication error: {0}".format(err.msg))

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
+
+
+log = logging.getLogger(__name__)
 
 COOKIES = {
     "family_filter": "off",
@@ -55,7 +59,7 @@ class DailyMotion(Plugin):
         media = self.session.http.json(res, schema=_media_schema)
 
         if media.get("error"):
-            self.logger.error("Failed to get stream: {0}".format(media["error"]["title"]))
+            log.error("Failed to get stream: {0}".format(media["error"]["title"]))
             return
 
         for quality, streams in media['qualities'].items():
@@ -85,7 +89,7 @@ class DailyMotion(Plugin):
                 params=params
             )
         except Exception:
-            self.logger.error("invalid username")
+            log.error("invalid username")
             raise NoStreamsError(self.url)
 
         data = self.session.http.json(res, schema=_live_id_schema)
@@ -103,7 +107,7 @@ class DailyMotion(Plugin):
             media_id = self.get_live_id(username)
 
         if media_id:
-            self.logger.debug("Found media ID: {0}", media_id)
+            log.debug("Found media ID: {0}".format(media_id))
             return self._get_streams_from_media(media_id)
 
 

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -53,7 +53,7 @@ class MPEGDASH(Plugin):
     def _get_streams(self):
         mpdurl = self._url_re.match(self.url).group(2)
 
-        self.logger.debug("Parsing MPD URL: {0}".format(mpdurl))
+        log.debug("Parsing MPD URL: {0}".format(mpdurl))
 
         return DASHStream.parse_manifest(self.session, mpdurl)
 

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -1,9 +1,13 @@
+import logging
 import re
 from urllib.parse import urlparse, parse_qsl
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class DeutscheWelle(Plugin):
@@ -73,7 +77,7 @@ class DeutscheWelle(Plugin):
             m = self.channel_re.search(page.text)
             channel = m and m.group(1)
 
-        self.logger.debug("Using sub-channel ID: {0}", channel)
+        log.debug("Using sub-channel ID: {0}".format(channel))
 
         # extract the streams from the page, mapping between channel-id and stream url
         media_items = self.live_stream_div.finditer(page.text)

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -1,9 +1,13 @@
+import logging
 import re
 from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class Dogan(Plugin):
@@ -44,7 +48,7 @@ class Dogan(Plugin):
         # find the contentId
         content_id_m = self.content_id_re.search(res.text)
         if content_id_m:
-            self.logger.debug("Found contentId by contentId regex")
+            log.debug("Found contentId by contentId regex")
             return content_id_m.group(1)
 
         # find the PlayerCtrl div
@@ -54,19 +58,19 @@ class Dogan(Plugin):
             player_ctrl_div = player_ctrl_m.group(0)
             content_id_m = self.data_id_re.search(player_ctrl_div)
             if content_id_m:
-                self.logger.debug("Found contentId by player data-id regex")
+                log.debug("Found contentId by player data-id regex")
                 return content_id_m.group("id")
 
         # find the itemId var
         item_id_m = self.item_id_re.search(res.text)
         if item_id_m:
-            self.logger.debug("Found contentId by itemId regex")
+            log.debug("Found contentId by itemId regex")
             return item_id_m.group(1)
 
     def _get_hls_url(self, content_id):
         # make the api url relative to the current domain
         if "cnnturk" in self.url or "teve2.com.tr" in self.url:
-            self.logger.debug("Using new content API url")
+            log.debug("Using new content API url")
             api_url = urljoin(self.url, self.new_content_api.format(id=content_id))
         else:
             api_url = urljoin(self.url, self.content_api.format(id=content_id))
@@ -80,11 +84,11 @@ class Dogan(Plugin):
     def _get_streams(self):
         content_id = self._get_content_id()
         if content_id:
-            self.logger.debug(u"Loading content: {}", content_id)
+            log.debug(u"Loading content: {0}".format(content_id))
             hls_url = self._get_hls_url(content_id)
             return HLSStream.parse_variant_playlist(self.session, hls_url)
         else:
-            self.logger.error(u"Could not find the contentId for this stream")
+            log.error(u"Could not find the contentId for this stream")
 
 
 __plugin__ = Dogan

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
 from streamlink.utils import parse_json, update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class EarthCam(Plugin):
@@ -36,7 +40,7 @@ class EarthCam(Plugin):
 
         cam_data = json_base["cam"][cam_name]
 
-        self.logger.debug("Found cam for {0} - {1}", cam_data["group"], cam_data["title"])
+        log.debug("Found cam for {0} - {1}".format(cam_data["group"], cam_data["title"]))
 
         is_live = (cam_data["liveon"] == "true" and cam_data["defaulttab"] == "live")
 
@@ -68,7 +72,7 @@ class EarthCam(Plugin):
 
         # RTMP stream
         if rtmp_playpath:
-            self.logger.debug("RTMP URL: {0}{1}", rtmp_url, rtmp_playpath)
+            log.debug("RTMP URL: {0}{1}".format(rtmp_url, rtmp_playpath))
 
             params = {
                 "rtmp": rtmp_url,
@@ -85,14 +89,14 @@ class EarthCam(Plugin):
             hls_url = hls_domain + hls_playpath
             hls_url = update_scheme(self.url, hls_url)
 
-            self.logger.debug("HLS URL: {0}", hls_url)
+            log.debug("HLS URL: {0}".format(hls_url))
 
             for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
                 yield s
 
         if not (rtmp_playpath or hls_playpath):
-            self.logger.error("This cam stream appears to be in offline or "
-                              "snapshot mode and not live stream can be played.")
+            log.error("This cam stream appears to be in offline or "
+                      "snapshot mode and not live stream can be played.")
             return
 
 

--- a/src/streamlink/plugins/eltrecetv.py
+++ b/src/streamlink/plugins/eltrecetv.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class ElTreceTV(Plugin):
@@ -25,7 +29,7 @@ class ElTreceTV(Plugin):
                 yt_url = "https://www.youtube.com/watch?v={0}".format(yt_id)
                 return self.session.streams(yt_url)
             except BaseException:
-                self.logger.info("Live content is temporarily unavailable. Please try again later.")
+                log.info("Live content is temporarily unavailable. Please try again later.")
         else:
             try:
                 self.session.http.headers = {
@@ -42,7 +46,7 @@ class ElTreceTV(Plugin):
                           "{0}/format/applehttp/protocol/https/a.m3u8".format(entry_id)
                 return HLSStream.parse_variant_playlist(self.session, hls_url)
             except BaseException:
-                self.logger.error("The requested VOD content is unavailable.")
+                log.error("The requested VOD content is unavailable.")
 
 
 __plugin__ = ElTreceTV

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -42,7 +42,7 @@ class FilmOnHLSStreamWorker(HLSStreamWorker):
                                                     "502 Server Error"))):
                 self.stream.watch_timeout = 0
                 self.playlist_reload_time = 0
-                log.debug("Force reloading the channel playlist on error: {0}", err)
+                log.debug(f"Force reloading the channel playlist on error: {err}")
                 return
             raise err
 
@@ -87,12 +87,12 @@ class FilmOnHLS(HLSStream):
 
     def _get_stream_data(self):
         if self.channel:
-            log.debug("Reloading FilmOn channel playlist: {0}", self.channel)
+            log.debug(f"Reloading FilmOn channel playlist: {self.channel}")
             data = self.api.channel(self.channel)
             for stream in data["streams"]:
                 yield stream
         elif self.vod_id:
-            log.debug("Reloading FilmOn VOD playlist: {0}", self.vod_id)
+            log.debug(f"Reloading FilmOn VOD playlist: {self.vod_id}")
             data = self.api.vod(self.vod_id)
             for _, stream in data["streams"].items():
                 yield stream
@@ -237,12 +237,12 @@ class Filmon(Plugin):
                 _id = self.cache.get(channel)
                 if _id is None:
                     _id = self.session.http.get(self.url, schema=self._channel_id_schema)
-                    log.debug("Found channel ID: {0}", _id)
+                    log.debug(f"Found channel ID: {_id}")
                     # do not cache a group url
                     if _id and not is_group:
                         self.cache.set(channel, _id, expires=self.TIME_CHANNEL)
                 else:
-                    log.debug("Found cached channel ID: {0}", _id)
+                    log.debug(f"Found cached channel ID: {_id}")
             else:
                 _id = channel
 
@@ -256,7 +256,7 @@ class Filmon(Plugin):
             except Exception:
                 if channel and not channel.isdigit():
                     self.cache.set(channel, None, expires=0)
-                    log.debug("Reset cached channel: {0}", channel)
+                    log.debug(f"Reset cached channel: {channel}")
 
                 raise
 

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -221,33 +221,32 @@ class FunimationNow(Plugin):
         id_m = self.experience_id_re.search(res.text)
         experience_id = id_m and int(id_m.group(1))
         if experience_id:
-            log.debug("Found experience ID: {0}", experience_id)
+            log.debug(f"Found experience ID: {experience_id}")
             exp = Experience(self.session, experience_id)
             if self.get_option("email") and self.get_option("password"):
                 if exp.login(self.get_option("email"), self.get_option("password")):
-                    log.info("Logged in to Funimation as {0}", self.get_option("email"))
+                    log.info(f"Logged in to Funimation as {self.get_option('email')}")
                 else:
                     log.warning("Failed to login")
 
             if exp.episode_info:
-                log.debug("Found episode: {0}", exp.episode_info["episodeTitle"])
-                log.debug("  has languages: {0}", ", ".join(exp.episode_info["languages"].keys()))
-                log.debug("  requested language: {0}", rlanguage)
-                log.debug("  current language:   {0}", exp.language)
+                log.debug(f"Found episode: {exp.episode_info['episodeTitle']}")
+                log.debug(f"  has languages: {', '.join(exp.episode_info['languages'].keys())}")
+                log.debug(f"  requested language: {rlanguage}")
+                log.debug(f"  current language:   {exp.language}")
                 if rlanguage != exp.language:
-                    log.debug("switching language to: {0}", rlanguage)
+                    log.debug(f"switching language to: {rlanguage}")
                     exp.set_language(rlanguage)
                     if exp.language != rlanguage:
-                        log.warning("Requested language {0} is not available, continuing with {1}",
-                                    rlanguage, exp.language)
+                        log.warning(f"Requested language {rlanguage} is not available, continuing with {exp.language}")
                     else:
-                        log.debug("New experience ID: {0}", exp.experience_id)
+                        log.debug(f"New experience ID: {exp.experience_id}")
 
                 subtitles = None
                 stream_metadata = {}
                 disposition = {}
                 for subtitle in exp.subtitles():
-                    log.debug("Subtitles: {0}", subtitle["src"])
+                    log.debug(f"Subtitles: {subtitle['src']}")
                     if subtitle["src"].endswith(".vtt") or subtitle["src"].endswith(".srt"):
                         sub_lang = {"en": "eng", "ja": "jpn"}[subtitle["language"]]
                         # pick the first suitable subtitle stream

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink import NoPluginError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api.utils import itertags
 from streamlink.utils import update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class GardenersWorld(Plugin):
@@ -17,11 +21,11 @@ class GardenersWorld(Plugin):
         page = self.session.http.get(self.url)
         for iframe in itertags(page.text, u"iframe"):
             url = iframe.attributes["src"]
-            self.logger.debug("Handing off of {0}".format(url))
+            log.debug("Handing off of {0}".format(url))
             try:
                 return self.session.streams(update_scheme(self.url, url))
             except NoPluginError:
-                self.logger.error("Handing off of {0} failed".format(url))
+                log.error("Handing off of {0} failed".format(url))
                 return None
 
 

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -45,7 +45,7 @@ class GoodGame(Plugin):
         match = _apidata_re.search(res.text)
         channel_info = match and parse_json(match.group("data"))
         if not channel_info:
-            self.logger.error("Could not find channel info")
+            log.error("Could not find channel info")
             return
 
         log.debug("Found channel info: id={id} channelkey={channelkey} pid={streamkey} online={status}".format(**channel_info))

--- a/src/streamlink/plugins/googledrive.py
+++ b/src/streamlink/plugins/googledrive.py
@@ -1,8 +1,12 @@
+import logging
 import re
 from urllib.parse import parse_qsl
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HTTPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class GoogleDocs(Plugin):
@@ -15,7 +19,7 @@ class GoogleDocs(Plugin):
 
     def _get_streams(self):
         docid = self.url_re.match(self.url).group(1)
-        self.logger.debug("Google Docs ID: {0}", docid)
+        log.debug("Google Docs ID: {0}".format(docid))
         res = self.session.http.get(self.api_url, params=dict(docid=docid))
         data = dict(parse_qsl(res.text))
 
@@ -26,7 +30,7 @@ class GoogleDocs(Plugin):
                 _, h = fmts[qcode].split("x")
                 yield "{0}p".format(h), HTTPStream(self.session, url)
         else:
-            self.logger.error("{0} (ID: {1})", data["reason"], docid)
+            log.error("{0} (ID: {1})".format(data["reason"], docid))
 
 
 __plugin__ = GoogleDocs

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class Gulli(Plugin):
@@ -78,7 +82,7 @@ class Gulli(Plugin):
                     yield bitrate, HTTPStream(self.session, video_url)
             except IOError as err:
                 if '403 Client Error' in str(err):
-                    self.logger.error('Failed to access stream, may be due to geo-restriction')
+                    log.error('Failed to access stream, may be due to geo-restriction')
                 raise
 
 

--- a/src/streamlink/plugins/hitbox.py
+++ b/src/streamlink/plugins/hitbox.py
@@ -1,4 +1,5 @@
 from itertools import chain
+import logging
 import re
 from urllib.parse import urlparse
 
@@ -6,6 +7,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import StreamMapper, validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 from streamlink.utils import absolute_url
+
+
+log = logging.getLogger(__name__)
 
 HLS_PLAYLIST_BASE = "http://www.smashcast.tv{0}"
 LIVE_API = "http://www.smashcast.tv/api/media/live/{0}?showHidden=true&liveonly=false"
@@ -99,7 +103,7 @@ class Hitbox(Plugin):
                 streams = HLSStream.parse_variant_playlist(self.session, url)
                 return streams.items()
             except IOError as err:
-                self.logger.warning("Failed to extract HLS streams: {0}", err)
+                log.warning("Failed to extract HLS streams: {0}".format(err))
         else:
             return quality, HLSStream(self.session, url)
 
@@ -150,7 +154,7 @@ class Hitbox(Plugin):
             try:
                 return cls.parse_variant_playlist(self.session, url).items()
             except IOError as err:
-                self.logger.warning("Failed to extract HLS streams: {0}", err)
+                log.warning("Failed to extract HLS streams: {0}".format(err))
                 return
 
         quality = self._get_quality(bitrate["label"])
@@ -173,13 +177,13 @@ class Hitbox(Plugin):
             return
 
         channel, media_id = match.group("channel", "media_id")
-        self.logger.debug("Matched URL: channel={0}, media_id={1}".format(channel, media_id))
+        log.debug("Matched URL: channel={0}, media_id={1}".format(channel, media_id))
         if not media_id:
             res = self.session.http.get(LIVE_API.format(channel))
             livestream = self.session.http.json(res, schema=_live_schema)
             if livestream.get("media_hosted_media"):
                 hosted = _live_schema.validate(livestream["media_hosted_media"])
-                self.logger.info("{0} is hosting {1}", livestream["media_user_name"], hosted["media_user_name"])
+                log.info("{0} is hosting {1}".format(livestream["media_user_name"], hosted["media_user_name"]))
                 livestream = hosted
 
             if not livestream["media_is_live"]:

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from urllib.parse import urlparse
 
@@ -5,6 +6,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import parse_url_params, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class HLSPlugin(Plugin):
@@ -40,7 +44,7 @@ class HLSPlugin(Plugin):
         urlnoproto = self._url_re.match(url).group(2)
         urlnoproto = update_scheme("http://", urlnoproto)
 
-        self.logger.debug("URL={0}; params={1}", urlnoproto, params)
+        log.debug("URL={0}; params={1}".format(urlnoproto, params))
         streams = HLSStream.parse_variant_playlist(self.session, urlnoproto, **params)
         if not streams:
             return {"live": HLSStream(self.session, urlnoproto, **params)}

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import parse_url_params
 from streamlink.stream import HTTPStream
 from streamlink.utils import update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class HTTPStreamPlugin(Plugin):
@@ -18,7 +22,7 @@ class HTTPStreamPlugin(Plugin):
         urlnoproto = self._url_re.match(url).group(1)
         urlnoproto = update_scheme("http://", urlnoproto)
 
-        self.logger.debug("URL={0}; params={1}", urlnoproto, params)
+        log.debug("URL={0}; params={1}".format(urlnoproto, params))
         return {"live": HTTPStream(self.session, urlnoproto, **params)}
 
 

--- a/src/streamlink/plugins/ine.py
+++ b/src/streamlink/plugins/ine.py
@@ -1,10 +1,14 @@
 import json
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class INE(Plugin):
@@ -33,13 +37,13 @@ class INE(Plugin):
 
     def _get_streams(self):
         vid = self.url_re.match(self.url).group(1)
-        self.logger.debug("Found video ID: {0}", vid)
+        log.debug("Found video ID: {0}".format(vid))
 
         page = self.session.http.get(self.play_url.format(vid=vid))
         js_url_m = self.js_re.search(page.text)
         if js_url_m:
             js_url = js_url_m.group(1)
-            self.logger.debug("Loading player JS: {0}", js_url)
+            log.debug("Loading player JS: {0}".format(js_url))
 
             res = self.session.http.get(js_url)
             metadata_url = update_scheme(self.url, self.setup_schema.validate(res.text))

--- a/src/streamlink/plugins/kingkong.py
+++ b/src/streamlink/plugins/kingkong.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream, HLSStream
+
+
+log = logging.getLogger(__name__)
 
 API_URL = "https://g-api.langlive.com/webapi/v1/room/info?room_id={0}"
 VOD_API_URL = (
@@ -81,12 +85,12 @@ class Kingkong(Plugin):
         res = self.session.http.get(API_URL.format(channel))
         room = self.session.http.json(res, schema=_room_schema)
         if not room:
-            self.logger.info("Not a valid room url.")
+            log.info("Not a valid room url.")
             return
 
         live_info = room["live_info"]
         if live_info["live_status"] != STATUS_ONLINE:
-            self.logger.info("Stream currently unavailable.")
+            log.info("Stream currently unavailable.")
             return
 
         for item in live_info["stream_items"]:

--- a/src/streamlink/plugins/liveedu.py
+++ b/src/streamlink/plugins/liveedu.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from urllib.parse import urljoin
 
@@ -6,6 +7,9 @@ from streamlink.plugin import Plugin, PluginArguments, PluginArgument
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.stream import RTMPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class LiveEdu(Plugin):
@@ -60,7 +64,7 @@ class LiveEdu(Plugin):
             res = self.session.http.get(self.login_url)
             csrf_match = self.csrf_re.search(res.text)
             token = csrf_match and csrf_match.group(1)
-            self.logger.debug("Attempting login as {0} (token={1})", email, token)
+            log.debug("Attempting login as {0} (token={1})".format(email, token))
 
             res = self.session.http.post(
                 self.login_url,
@@ -71,7 +75,7 @@ class LiveEdu(Plugin):
             )
 
             if res.status_code != 302:
-                self.logger.error("Failed to login to LiveEdu account: {0}", email)
+                log.error("Failed to login to LiveEdu account: {0}".format(email))
 
     def _get_streams(self):
         """
@@ -93,10 +97,10 @@ class LiveEdu(Plugin):
             return
 
         if config["selectedVideoHID"]:
-            self.logger.debug("Found video hash ID: {0}", config["selectedVideoHID"])
+            log.debug("Found video hash ID: {0}".format(config["selectedVideoHID"]))
             api_url = urljoin(self.url, urljoin(config["videosURL"], config["selectedVideoHID"]))
         elif config["livestreamURL"]:
-            self.logger.debug("Found live stream URL: {0}", config["livestreamURL"])
+            log.debug("Found live stream URL: {0}".format(config["livestreamURL"]))
             api_url = urljoin(self.url, config["livestreamURL"])
         else:
             return
@@ -106,7 +110,7 @@ class LiveEdu(Plugin):
         viewing_urls = data["viewing_urls"]
 
         if "error" in viewing_urls:
-            self.logger.error("Failed to load streams: {0}", viewing_urls["error"])
+            log.error("Failed to load streams: {0}".format(viewing_urls["error"]))
         else:
             for url in viewing_urls["urls"]:
                 try:

--- a/src/streamlink/plugins/liveme.py
+++ b/src/streamlink/plugins/liveme.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import re
 from urllib.parse import urlparse, parse_qsl
@@ -6,6 +7,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.stream import HTTPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class LiveMe(Plugin):
@@ -47,7 +51,7 @@ class LiveMe(Plugin):
                 'h5': 1,
                 'vali': vali
             }
-            self.logger.debug("Found Video ID: {0}".format(video_id))
+            log.debug("Found Video ID: {0}".format(video_id))
             res = self.session.http.post(self.api_url, data=data)
             data = self.session.http.json(res, schema=self.api_schema)
             hls = self._make_stream(data["video_info"]["hlsvideosource"])

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -1,3 +1,4 @@
+import logging
 import random
 import re
 from urllib.parse import urlencode, unquote, urljoin
@@ -6,6 +7,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import stream_weight
 from streamlink.stream import HLSStream, HTTPStream, DASHStream
 from streamlink.utils import update_scheme
+
+
+log = logging.getLogger(__name__)
 
 
 class OneTV(Plugin):
@@ -64,13 +68,13 @@ class OneTV(Plugin):
         m = self._vod_re.search(page.text)
         vod_data_url = m and urljoin(self.url, m.group(0))
         if vod_data_url:
-            self.logger.debug("Found VOD data url: {0}", vod_data_url)
+            log.debug("Found VOD data url: {0}".format(vod_data_url))
             res = self.session.http.get(vod_data_url)
             return self.session.http.json(res)
 
     def _get_streams(self):
         if self.is_live:
-            self.logger.debug("Loading live stream for {0}...", self.channel)
+            log.debug("Loading live stream for {0}...".format(self.channel))
 
             res = self.session.http.get(self.live_api_url, data={"r": random.randint(1, 100000)})
             live_data = self.session.http.json(res)
@@ -90,10 +94,10 @@ class OneTV(Plugin):
                     yield s
 
         elif self.channel == "1tv":
-            self.logger.debug("Attempting to find VOD stream...", self.channel)
+            log.debug("Attempting to find VOD stream for {0}...".format(self.channel))
             vod_data = self.vod_data()
             if vod_data:
-                self.logger.info(u"Found VOD: {0}".format(vod_data[0]['title']))
+                log.info(u"Found VOD: {0}".format(vod_data[0]['title']))
                 for stream in vod_data[0]['mbr']:
                     yield stream['name'], HTTPStream(self.session, update_scheme(self.url, stream['src']))
 

--- a/src/streamlink/plugins/periscope.py
+++ b/src/streamlink/plugins/periscope.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 STREAM_INFO_URL = "https://api.periscope.tv/api/v2/getAccessPublic"
 
@@ -51,7 +55,7 @@ class Periscope(Plugin):
             hls_url = data["hls_url"]
             hls_name = "live"
         elif data.get("replay_url"):
-            self.logger.info("Live Stream ended, using replay instead")
+            log.info("Live Stream ended, using replay instead")
             hls_url = data["replay_url"]
             hls_name = "replay"
         else:

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -1,11 +1,15 @@
-import re
 import json
+import logging
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.stream import RTMPStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class Picarto(Plugin):
@@ -49,10 +53,10 @@ class Picarto(Plugin):
                                                        token=token),
                                                    verify=False)
         if len(streams) > 1:
-            self.logger.debug("Multiple HLS streams found")
+            log.debug("Multiple HLS streams found")
             return streams
         elif len(streams) == 0:
-            self.logger.warning("No HLS streams found when expected")
+            log.warning("No HLS streams found when expected")
             return {}
         else:
             # one HLS streams, rename it to live
@@ -76,7 +80,7 @@ class Picarto(Plugin):
 
         # Handle VODs first, since their "channel name" is different
         if url_channel_name.endswith((".flv", ".mkv")):
-            self.logger.debug("Possible VOD stream...")
+            log.debug("Possible VOD stream...")
             page = self.session.http.get(self.url)
             vod_streams = self._get_vod_stream(page)
             if vod_streams:
@@ -84,18 +88,18 @@ class Picarto(Plugin):
                     yield s
                 return
             else:
-                self.logger.warning("Probably a VOD stream but no VOD found?")
+                log.warning("Probably a VOD stream but no VOD found?")
 
         ci = self.session.http.get(self.CHANNEL_API_URL.format(channel=url_channel_name), raise_for_status=False)
 
         if ci.status_code == 404:
-            self.logger.error("The channel {0} does not exist".format(url_channel_name))
+            log.error("The channel {0} does not exist".format(url_channel_name))
             return
 
         channel_api_json = json.loads(ci.text)
 
         if not channel_api_json["online"]:
-            self.logger.error("The channel {0} is currently offline".format(url_channel_name))
+            log.error("The channel {0} is currently offline".format(url_channel_name))
             return
 
         server = None
@@ -110,10 +114,7 @@ class Picarto(Plugin):
             if i["id"] == pref:
                 server = i["ep"]
                 break
-        self.logger.debug("Using load balancing server {0} : {1} for channel {2}",
-                          pref,
-                          server,
-                          channel)
+        log.debug("Using load balancing server {0} : {1} for channel {2}".format(pref, server, channel))
 
         for i in info_json["techs"]:
             if i["label"] == "HLS":

--- a/src/streamlink/plugins/piczel.py
+++ b/src/streamlink/plugins/piczel.py
@@ -44,7 +44,7 @@ class Piczel(Plugin):
             if not stream["live"]:
                 return
 
-            log.debug("HLS stream URL: {}", HLS_URL.format(stream["id"]))
+            log.debug(f"HLS stream URL: {HLS_URL.format(stream['id'])}")
 
             return {"live": HLSStream(self.session, HLS_URL.format(stream["id"]))}
 

--- a/src/streamlink/plugins/playtv.py
+++ b/src/streamlink/plugins/playtv.py
@@ -1,10 +1,14 @@
 import base64
 import json
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream, HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 def jwt_decode(token):
@@ -54,7 +58,7 @@ class PlayTV(Plugin):
         res = self.session.http.get(self.FORMATS_URL.format(channel))
         streams = self.session.http.json(res, schema=self._formats_schema)['streams']
         if streams == []:
-            self.logger.error('Channel may be geo-restricted, not directly provided by PlayTV or not freely available')
+            log.error('Channel may be geo-restricted, not directly provided by PlayTV or not freely available')
             return
 
         for language in streams:

--- a/src/streamlink/plugins/qq.py
+++ b/src/streamlink/plugins/qq.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from streamlink.exceptions import NoStreamsError
@@ -5,6 +6,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class QQ(Plugin):
@@ -46,7 +50,7 @@ class QQ(Plugin):
         except Exception:
             raise NoStreamsError(self.url)
 
-        self.logger.debug("URL={0}".format(hls_url))
+        log.debug("URL={0}".format(hls_url))
         return {"live": HLSStream(self.session, hls_url)}
 
 

--- a/src/streamlink/plugins/rtbf.py
+++ b/src/streamlink/plugins/rtbf.py
@@ -1,11 +1,15 @@
-from html import unescape as html_unescape
 import datetime
+from html import unescape as html_unescape
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class RTBF(Plugin):
@@ -130,12 +134,12 @@ class RTBF(Plugin):
 
         # Check geolocation to prevent further errors when stream is parsed
         if not self.check_geolocation(stream_data['geoLocRestriction']):
-            self.logger.error('Stream is geo-restricted')
+            log.error('Stream is geo-restricted')
             return
 
         # Check whether streams are DRM-protected
         if stream_data.get('drm', False):
-            self.logger.error('Stream is DRM-protected')
+            log.error('Stream is DRM-protected')
             return
 
         now = datetime.datetime.now()
@@ -174,10 +178,10 @@ class RTBF(Plugin):
                 # Check whether video is expired
                 if 'startDate' in stream_data:
                     if now < self.iso8601_to_epoch(stream_data['startDate']):
-                        self.logger.error('Stream is not yet available')
+                        log.error('Stream is not yet available')
                 elif 'endDate' in stream_data:
                     if now > self.iso8601_to_epoch(stream_data['endDate']):
-                        self.logger.error('Stream has expired')
+                        log.error('Stream has expired')
 
     def _get_streams(self):
         match = self.can_handle_url(self.url)

--- a/src/streamlink/plugins/rtmp.py
+++ b/src/streamlink/plugins/rtmp.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import parse_url_params
 from streamlink.stream import RTMPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class RTMPPlugin(Plugin):
@@ -20,7 +24,7 @@ class RTMPPlugin(Plugin):
             if boolkey in params:
                 params[boolkey] = bool(params[boolkey])
 
-        self.logger.debug("params={0}", params)
+        log.debug("params={0}".format(params))
         return {"live": RTMPStream(self.session, params)}
 
 

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -140,7 +140,7 @@ class Rtve(Plugin):
         streams = []
         content_id = self._get_content_id()
         if content_id:
-            log.debug("Found content with id: {0}", content_id)
+            log.debug(f"Found content with id: {content_id}")
             stream_data = self.zclient.get_cdn_list(content_id, schema=self.cdn_schema)
             quality_map = None
 

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -99,14 +99,14 @@ class Schoolism(Plugin):
     def _get_streams(self):
         user = self.login(self.options.get("email"), self.options.get("password"))
         if user:
-            log.debug("Logged in to Schoolism as {0}", user)
+            log.debug(f"Logged in to Schoolism as {user}")
             res = self.session.http.get(self.url, headers={"User-Agent": useragents.SAFARI_8})
             lesson_playlist = self.playlist_schema.validate(res.text)
 
             part = self.options.get("part")
             video_type = "Lesson" if "lesson" in self.url_re.match(self.url).group(1).lower() else "Assignment Feedback"
 
-            log.info("Attempting to play {0} Part {1}", video_type, part)
+            log.info(f"Attempting to play {video_type} Part {part}")
             found = False
 
             # make request to key-time api, to get key specific headers
@@ -128,7 +128,7 @@ class Schoolism(Plugin):
                                 yield s
 
             if not found:
-                log.error("Could not find {0} Part {1}", video_type, part)
+                log.error(f"Could not find {video_type} Part {part}")
 
 
 __plugin__ = Schoolism

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate, useragents
 from streamlink.stream import HLSStream, RTMPStream
 from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker
+
+
+log = logging.getLogger(__name__)
 
 _url_re = re.compile(r'''^https?://
     (?:\w*.)?
@@ -140,10 +144,10 @@ class Showroom(Plugin):
             match = _room_id_re.search(res.text)
             if not match:
                 title = self.url.rsplit('/', 1)[-1]
-                self.logger.debug(_room_id_lookup_failure_log.format(title, 'primary'))
+                log.debug(_room_id_lookup_failure_log.format(title, 'primary'))
                 match = _room_id_alt_re.search(res.text)
                 if not match:
-                    self.logger.debug(_room_id_lookup_failure_log.format(title, 'secondary'))
+                    log.debug(_room_id_lookup_failure_log.format(title, 'secondary'))
                     return  # Raise exception?
             return match.group('room_id')
 

--- a/src/streamlink/plugins/streamingvideoprovider.py
+++ b/src/streamlink/plugins/streamingvideoprovider.py
@@ -1,10 +1,13 @@
+import logging
 import re
-
 from time import time
 
 from streamlink.plugin import Plugin, PluginError
 from streamlink.plugin.api import validate
 from streamlink.stream import RTMPStream, HLSStream
+
+
+log = logging.getLogger(__name__)
 
 SWF_URL = "http://play.streamingvideoprovider.com/player2.swf"
 API_URL = "http://player.webvideocore.net/index.php"
@@ -75,14 +78,14 @@ class Streamingvideoprovider(Plugin):
             stream = self._get_rtmp_stream(channel_name)
             yield "live", stream
         except PluginError as err:
-            self.logger.error("Unable to extract RTMP stream: {0}", err)
+            log.error("Unable to extract RTMP stream: {0}".format(err))
 
         try:
             stream = self._get_hls_stream(channel_name)
             if stream:
                 yield "live", stream
         except PluginError as err:
-            self.logger.error("Unable to extract HLS stream: {0}", err)
+            log.error("Unable to extract HLS stream: {0}".format(err))
 
 
 __plugin__ = Streamingvideoprovider

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -1,4 +1,5 @@
 import base64
+import logging
 import random
 import re
 import time
@@ -9,6 +10,9 @@ from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_qsd
 from streamlink.utils.crypto import decrypt_openssl
+
+
+log = logging.getLogger(__name__)
 
 
 class Streann(Plugin):
@@ -48,13 +52,13 @@ class Streann(Plugin):
         return str(data.get("serverTime", int(time.time() * 1000)))
 
     def passphrase(self):
-        self.logger.debug("passphrase ...")
+        log.debug("passphrase ...")
         res = self.session.http.get(self.url, headers=self._headers)
         passphrase_m = self.passphrase_re.search(res.text)
         return passphrase_m and passphrase_m.group("passphrase").encode("utf8")
 
     def get_token(self, **config):
-        self.logger.debug("get_token ...")
+        log.debug("get_token ...")
         pdata = dict(arg1=base64.b64encode("www.ellobo106.com".encode("utf8")),
                      arg2=base64.b64encode(self.time.encode("utf8")))
 
@@ -80,14 +84,14 @@ class Streann(Plugin):
         # and decrypt it
         passphrase = self.passphrase()
         if passphrase:
-            self.logger.debug("Found passphrase")
+            log.debug("Found passphrase")
             params = decrypt_openssl(data, passphrase)
             config = parse_qsd(params.decode("utf8"))
             hls_url = self.stream_url.format(time=self.time,
                                              deviceId=self.device_id,
                                              token=self.get_token(**config),
                                              **config)
-            self.logger.debug("URL={0}".format(hls_url))
+            log.debug("URL={0}".format(hls_url))
             return HLSStream.parse_variant_playlist(self.session, hls_url, headers=self._headers)
 
 

--- a/src/streamlink/plugins/swisstxt.py
+++ b/src/streamlink/plugins/swisstxt.py
@@ -1,8 +1,12 @@
+import logging
 import re
 from urllib.parse import urlparse, parse_qsl, urlunparse
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class Swisstxt(Plugin):
@@ -24,7 +28,7 @@ class Swisstxt(Plugin):
         url_m = self.url_re.match(self.url)
         site = url_m.group(1) or url_m.group(2)
         api_url = self.api_url.format(id=event_id, site=site.upper())
-        self.logger.debug("Calling API: {0}", api_url)
+        log.debug("Calling API: {0}".format(api_url))
 
         stream_url = self.session.http.get(api_url).text.strip("\"'")
 

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class Telefe(Plugin):
@@ -24,14 +28,14 @@ class Telefe(Plugin):
 
         json_video_search = parse_json(video_search)
         json_video_search_sources = json_video_search["top"]["model"]["videos"][0]["sources"]
-        self.logger.debug('Video ID found: {0}', json_video_search["top"]["model"]["id"])
+        log.debug('Video ID found: {0}'.format(json_video_search["top"]["model"]["id"]))
         for current_video_source in json_video_search_sources:
             if "HLS" in current_video_source["type"]:
                 video_url_found_hls = "http://telefe.com" + current_video_source["url"]
-                self.logger.debug("HLS content available")
+                log.debug("HLS content available")
             if "HTTP" in current_video_source["type"]:
                 video_url_found_http = "http://telefe.com" + current_video_source["url"]
-                self.logger.debug("HTTP content available")
+                log.debug("HTTP content available")
 
         self.session.http.headers = {
             'Referer': self.url,

--- a/src/streamlink/plugins/theplatform.py
+++ b/src/streamlink/plugins/theplatform.py
@@ -1,7 +1,11 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class ThePlatform(Plugin):
@@ -30,9 +34,10 @@ class ThePlatform(Plugin):
                 })
             else:
                 error = self.session.http.json(res)
-                self.logger.error("{0}: {1}",
-                                  error.get("title", "Error"),
-                                  error.get("description", "An unknown error occurred"))
+                log.error("{0}: {1}".format(
+                    error.get("title", "Error"),
+                    error.get("description", "An unknown error occurred")
+                ))
 
 
 __plugin__ = ThePlatform

--- a/src/streamlink/plugins/tigerdile.py
+++ b/src/streamlink/plugins/tigerdile.py
@@ -1,9 +1,13 @@
-import re
 import json
+import logging
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.stream import RTMPStream
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 PAGE_URL = "https://www.tigerdile.com/stream/"
 ROOT_URL = "rtmp://stream.tigerdile.com/live/{0}"
@@ -29,11 +33,11 @@ class Tigerdile(Plugin):
         api_json = json.loads(ci.text)
 
         if not api_json or len(api_json) == 0:
-            self.logger.error("The channel {0} does not exist or is marked private".format(streamname))
+            log.error("The channel {0} does not exist or is marked private".format(streamname))
             return
 
         if not api_json[0]["online"]:
-            self.logger.error("The channel {0} is not online".format(streamname))
+            log.error("The channel {0} is not online".format(streamname))
             return
 
         streams = {}

--- a/src/streamlink/plugins/turkuvaz.py
+++ b/src/streamlink/plugins/turkuvaz.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class Turkuvaz(Plugin):
@@ -54,7 +58,7 @@ class Turkuvaz(Plugin):
 
         secure_hls_url = self.session.http.json(res, schema=self._token_schema)
 
-        self.logger.debug("Found HLS URL: {0}".format(secure_hls_url))
+        log.debug("Found HLS URL: {0}".format(secure_hls_url))
         return HLSStream.parse_variant_playlist(self.session, secure_hls_url)
 
 

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from streamlink.exceptions import PluginError
@@ -5,6 +6,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.stream import HTTPStream
+
+
+log = logging.getLogger(__name__)
 
 
 class TVP(Plugin):
@@ -30,7 +34,7 @@ class TVP(Plugin):
             raise PluginError('Unable to find a video id')
 
         video_id = m.group('video_id')
-        self.logger.debug('Found video id: {0}'.format(video_id))
+        log.debug('Found video id: {0}'.format(video_id))
         p_url = self.player_url.format(video_id)
         return p_url
 
@@ -45,7 +49,7 @@ class TVP(Plugin):
 
         streams = []
         for url in m:
-            self.logger.debug('URL={0}'.format(url))
+            log.debug('URL={0}'.format(url))
             if url.endswith('.m3u8'):
                 for s in HLSStream.parse_variant_playlist(self.session, url, name_fmt='{pixels}_{bitrate}').items():
                     streams.append(s)

--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -92,11 +92,11 @@ class TVPlayer(Plugin):
     def _get_stream_attrs(self, page):
         stream_attrs = dict((k.replace("-", "_"), v.strip('"')) for k, v in self.stream_attrs_re.findall(page.text))
 
-        log.debug("Got stream attributes: {0}", str(stream_attrs))
+        log.debug(f"Got stream attributes: {str(stream_attrs)}")
         valid = True
         for a in ("expiry", "key", "token", "uvid"):
             if a not in stream_attrs:
-                log.debug("Missing '{0}' from stream attributes", a)
+                log.debug(f"Missing '{a}' from stream attributes")
                 valid = False
 
         return stream_attrs if valid else {}
@@ -113,9 +113,8 @@ class TVPlayer(Plugin):
 
         if "enter your postcode" in res.text:
             log.info(
-                "Setting your postcode to: {0}. "
-                "This can be changed in the settings on tvplayer.com",
-                self.dummy_postcode
+                f"Setting your postcode to: {self.dummy_postcode}. "
+                f"This can be changed in the settings on tvplayer.com"
             )
             res = self.session.http.post(
                 self.update_url,

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class TVRBy(Plugin):
@@ -40,8 +44,7 @@ class TVRBy(Plugin):
         player_url = m.group("url")
         res = self.session.http.get(player_url)
         stream_urls = self.stream_schema.validate(res.text)
-        self.logger.debug("Found {0} stream URL{1}", len(stream_urls),
-                          "" if len(stream_urls) == 1 else "s")
+        log.debug("Found {0} stream URL{1}".format(len(stream_urls), "" if len(stream_urls) == 1 else "s"))
 
         for stream_url in stream_urls:
             for s in HLSStream.parse_variant_playlist(self.session, stream_url).items():

--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -1,9 +1,13 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class TVRPlus(Plugin):
@@ -30,7 +34,7 @@ class TVRPlus(Plugin):
         if stream_url:
             stream_url = list(set(stream_url))
             for url in stream_url:
-                self.logger.debug("URL={0}".format(url))
+                log.debug("URL={0}".format(url))
                 for s in HLSStream.parse_variant_playlist(self.session, url, headers=headers).items():
                     yield s
 

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -180,7 +180,7 @@ class UHSStreamWriter(SegmentedStreamWriter):
                                          timeout=self.timeout,
                                          exception=StreamError)
         except StreamError as err:
-            log.error("Failed to open chunk {0}: {1}", chunk.num, err)
+            log.error(f"Failed to open chunk {chunk.num}: {err}")
             return self.fetch(chunk, retries - 1)
 
     def write(self, chunk, res, chunk_size=8192):
@@ -191,9 +191,9 @@ class UHSStreamWriter(SegmentedStreamWriter):
                 if self.closed:
                     return
             else:
-                log.debug("Download of chunk {0} complete", chunk.num)
+                log.debug(f"Download of chunk {chunk.num} complete")
         except IOError as err:
-            log.error("Failed to read chunk {0}: {1}", chunk.num, err)
+            log.error(f"Failed to read chunk {chunk.num}: {err}")
 
 
 class UHSStreamWorker(SegmentedStreamWorker):
@@ -207,8 +207,7 @@ class UHSStreamWorker(SegmentedStreamWorker):
 
         self.process_chunks()
         if self.chunks:
-            log.debug("First Chunk: {0}; Last Chunk: {1}",
-                      self.chunks[0].num, self.chunks[-1].num)
+            log.debug(f"First Chunk: {self.chunks[0].num}; Last Chunk: {self.chunks[-1].num}")
 
     def process_chunks(self):
         chunk_data = []
@@ -245,7 +244,7 @@ class UHSStreamWorker(SegmentedStreamWorker):
     def iter_segments(self):
         while not self.closed:
             for chunk in filter(self.valid_chunk, self.chunks):
-                log.debug("Adding chunk {0} to queue", chunk.num)
+                log.debug(f"Adding chunk {chunk.num} to queue")
                 yield chunk
                 # End of stream
                 if self.closed:
@@ -257,7 +256,7 @@ class UHSStreamWorker(SegmentedStreamWorker):
                 try:
                     self.process_chunks()
                 except StreamError as err:
-                    log.warning("Failed to process module info: {0}", err)
+                    log.warning(f"Failed to process module info: {err}")
 
 
 class UHSStreamReader(SegmentedStreamReader):
@@ -315,7 +314,7 @@ class UHSStream(Stream):
                 if not cmd_args:
                     continue
                 if cmd_args["cmd"] == "warning":
-                    log.warning("{code}: {message}", **cmd_args["args"])
+                    log.warning(f"{cmd_args['args']['code']}: {cmd_args['args']['message']}")
                 if cmd_args["cmd"] == "moduleInfo":
                     data = self.handle_module_info(cmd_args["args"])
                     if data:
@@ -460,8 +459,8 @@ class UStreamTV(Plugin):
                             cluster="live",
                             password=self.get_option("password"),
                             proxy=self.session.get_option("http-proxy"))
-            log.debug("Connecting to UStream API: media_id={0}, application={1}, referrer={2}, cluster={3}",
-                      media_id, application, self.url, "live")
+            log.debug(f"Connecting to UStream API: "
+                      f"media_id={media_id}, application={application}, referrer={self.url}, cluster=live")
             api.connect()
 
             streams_data = {}

--- a/src/streamlink/plugins/viasat.py
+++ b/src/streamlink/plugins/viasat.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from streamlink import NoStreamsError
@@ -6,6 +7,9 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import StreamMapper, validate
 from streamlink.stream import HDSStream, HLSStream, RTMPStream
 from streamlink.utils import rtmpparse
+
+
+log = logging.getLogger(__name__)
 
 STREAM_API_URL = "https://playapi.mtgx.tv/v3/videos/stream/{0}"
 
@@ -73,7 +77,7 @@ class Viasat(Plugin):
             streams = parser(self.session, video[1])
             return streams.items()
         except IOError as err:
-            self.logger.error("Failed to extract {0} streams: {1}", stream_type, err)
+            log.error("Failed to extract {0} streams: {1}".format(stream_type, err))
 
     def _create_rtmp_stream(self, video):
         name, stream_url = video
@@ -98,7 +102,7 @@ class Viasat(Plugin):
 
         if stream_info.get("msg"):
             # error message
-            self.logger.error(stream_info.get("msg"))
+            log.error(stream_info.get("msg"))
             raise NoStreamsError(self.url)
 
         mapper = StreamMapper(lambda pattern, video: re.search(pattern, video[1]))

--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -3,12 +3,16 @@ Plugin for vidio.com
 - https://www.vidio.com/live/5075-dw-tv-stream
 - https://www.vidio.com/watch/766861-5-rekor-fantastis-zidane-bersama-real-madrid
 """
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
+
+
+log = logging.getLogger(__name__)
 
 
 class Vidio(Plugin):
@@ -33,7 +37,7 @@ class Vidio(Plugin):
         )
 
     def get_url_tokens(self, stream_id):
-        self.logger.debug("Getting stream tokens")
+        log.debug("Getting stream tokens")
         csrf_token = self.get_csrf_tokens()
         return self.session.http.post(
             self.tokens_url.format(id=stream_id),
@@ -57,8 +61,8 @@ class Vidio(Plugin):
         tokens = self.get_url_tokens(stream_id)
 
         if hls_url:
-            self.logger.debug("HLS URL: {0}".format(hls_url))
-            self.logger.debug("Tokens: {0}".format(tokens))
+            log.debug("HLS URL: {0}".format(hls_url))
+            log.debug("Tokens: {0}".format(tokens))
             return HLSStream.parse_variant_playlist(self.session,
                                                     hls_url + "?" + tokens,
                                                     headers={"User-Agent": useragents.CHROME,

--- a/src/streamlink/plugins/vlive.py
+++ b/src/streamlink/plugins/vlive.py
@@ -1,8 +1,12 @@
-import re
 import json
+import logging
+import re
 
 from streamlink.plugin import Plugin, PluginError
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class Vlive(Plugin):
@@ -45,7 +49,7 @@ class Vlive(Plugin):
         for i in stream_info['resolutions']:
             res_streams = HLSStream.parse_variant_playlist(self.session, i['cdnUrl'])
             if len(res_streams.values()) > 1:
-                self.logger.warning('More than one stream in variant playlist, using first entry!')
+                log.warning('More than one stream in variant playlist, using first entry!')
 
             streams[i['name']] = res_streams.popitem()[1]
 

--- a/src/streamlink/plugins/webcast_india_gov.py
+++ b/src/streamlink/plugins/webcast_india_gov.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class WebcastIndiaGov(Plugin):
@@ -25,7 +29,7 @@ class WebcastIndiaGov(Plugin):
             hls_url = hls_url[hls_url.rindex('"') + 1:]
             return HLSStream.parse_variant_playlist(self.session, hls_url)
         except BaseException:
-            self.logger.error("The requested channel is unavailable.")
+            log.error("The requested channel is unavailable.")
 
 
 __plugin__ = WebcastIndiaGov

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -1,7 +1,7 @@
-import re
 import base64
-
 import binascii
+import logging
+import re
 
 from Crypto.Cipher import AES
 
@@ -10,6 +10,9 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, update_scheme
 from streamlink.utils.crypto import unpad_pkcs5
+
+
+log = logging.getLogger(__name__)
 
 
 class WebTV(Plugin):
@@ -58,7 +61,7 @@ class WebTV(Plugin):
         if len(sources):
             sdata = parse_json(sources[0], schema=self._sources_schema)
             for source in sdata:
-                self.logger.debug("Found stream of type: {}", source[u'type'])
+                log.debug("Found stream of type: {}".format(source[u'type']))
                 if source[u'type'] == u"application/vnd.apple.mpegurl":
                     url = update_scheme(self.url, source[u"src"])
 
@@ -72,7 +75,7 @@ class WebTV(Plugin):
                             # and if that fails, try it as a plain HLS stream
                             yield 'live', HLSStream(self.session, url, headers=headers)
                     except IOError:
-                        self.logger.warning("Could not open the stream, perhaps the channel is offline")
+                        log.warning("Could not open the stream, perhaps the channel is offline")
 
 
 __plugin__ = WebTV

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -80,7 +80,7 @@ class WWENetwork(Plugin):
         return data
 
     def login(self, email, password):
-        self.logger.debug("Attempting login as {0}", email)
+        log.debug("Attempting login as {0}".format(email))
         # sets some required cookies to login
         data = self.request('POST', self.login_url,
                             data=json.dumps({"id": email, "secret": password}),
@@ -150,7 +150,7 @@ class WWENetwork(Plugin):
         content_id = self._get_video_id()
 
         if content_id:
-            self.logger.debug("Found content ID: {0}", content_id)
+            log.debug("Found content ID: {0}".format(content_id))
             info = self._get_media_info(content_id)
             if info.get("hlsUrl"):
                 for s in HLSStream.parse_variant_playlist(

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -308,7 +308,7 @@ class YouTube(Plugin):
         is_live = False
 
         self.video_id = self._find_video_id(self.url)
-        log.debug("Using video ID: {0}", self.video_id)
+        log.debug(f"Using video ID: {self.video_id}")
 
         info = self._get_stream_info(self.video_id)
         if info and info.get("status") == "fail":
@@ -349,7 +349,7 @@ class YouTube(Plugin):
                 )
                 streams.update(hls_streams)
             except IOError as err:
-                log.warning("Failed to extract HLS streams: {0}", err)
+                log.warning(f"Failed to extract HLS streams: {err}")
 
         if not streams and protected:
             raise PluginError("This plugin does not support protected videos, "

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -1,3 +1,4 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
@@ -5,6 +6,9 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream, HLSStream
 from streamlink.utils import parse_json
 from streamlink.utils.url import url_concat
+
+
+log = logging.getLogger(__name__)
 
 API_URL = "https://api.zdf.de"
 
@@ -96,7 +100,7 @@ class zdf_mediathek(Plugin):
 
     def _extract_streams(self, response):
         if "priorityList" not in response:
-            self.logger.error("Invalid response! Contains no priorityList!")
+            log.error("Invalid response! Contains no priorityList!")
 
         for priority in response["priorityList"]:
             for format_ in priority["formitaeten"]:
@@ -106,7 +110,7 @@ class zdf_mediathek(Plugin):
         try:
             return parser(self.session, track["uri"])
         except IOError as err:
-            self.logger.error("Failed to extract {0} streams: {1}", name, err)
+            log.error("Failed to extract {0} streams: {1}".format(name, err))
 
     def _extract_from_format(self, format_):
         qualities = {}

--- a/src/streamlink/plugins/zengatv.py
+++ b/src/streamlink/plugins/zengatv.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class ZengaTV(Plugin):
@@ -32,11 +36,11 @@ class ZengaTV(Plugin):
             break
 
         if not m:
-            self.logger.error("No video id found")
+            log.error("No video id found")
             return
 
         dvr_id = m.group("id")
-        self.logger.debug("Found video id: {0}".format(dvr_id))
+        log.debug("Found video id: {0}".format(dvr_id))
         data = {"feed": "hd", "dvrId": dvr_id}
         res = self.session.http.post(self.api_url, headers=headers, data=data)
         if res.status_code == 200:

--- a/src/streamlink/plugins/zhanqi.py
+++ b/src/streamlink/plugins/zhanqi.py
@@ -1,8 +1,12 @@
+import logging
 import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream, HLSStream
+
+
+log = logging.getLogger(__name__)
 
 API_URL = "https://www.zhanqi.tv/api/static/v2.1/room/domain/{0}.json"
 
@@ -40,11 +44,11 @@ class Zhanqitv(Plugin):
         res = self.session.http.get(API_URL.format(channel))
         room = self.session.http.json(res, schema=_room_schema)
         if not room:
-            self.logger.info("Not a valid room url.")
+            log.info("Not a valid room url.")
             return
 
         if room["status"] != STATUS_ONLINE:
-            self.logger.info("Stream currently unavailable.")
+            log.info("Stream currently unavailable.")
             return
 
         url = "http://wshdl.load.cdn.zhanqi.tv/zqlive/{room[videoId]}.flv?get_url=".format(room=room)

--- a/src/streamlink/stream/akamaihd.py
+++ b/src/streamlink/stream/akamaihd.py
@@ -101,7 +101,7 @@ class AkamaiHDStreamIO(io.IOBase):
         url = self.StreamURLFormat.format(host=self.host, streamname=self.streamname)
         params = self._create_params(seek=self.seek)
 
-        log.debug("Opening host={} streamname={}", self.host, self.streamname)
+        log.debug(f"Opening host={self.host} streamname={self.streamname}")
 
         try:
             res = self.session.http.get(url, stream=True, params=params)
@@ -201,7 +201,7 @@ class AkamaiHDStreamIO(io.IOBase):
             if isinstance(val, str):
                 val = val[:50]
 
-            log.debug(" {}={}", key, val)
+            log.debug(f" {key}={val}")
 
         updateattr("islive", "isLive")
         updateattr("sessionid", "session")

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -55,7 +55,7 @@ class DASHStreamWriter(SegmentedStreamWriter):
                                          headers=headers,
                                          **request_args)
         except StreamError as err:
-            log.error("Failed to open segment {0}: {1}", segment.url, err)
+            log.error(f"Failed to open segment {segment.url}: {err}")
             return self.fetch(segment, retries - 1)
 
     def write(self, segment, res, chunk_size=8192):
@@ -96,7 +96,7 @@ class DASHStreamWorker(SegmentedStreamWorker):
                         if self.closed:
                             break
                         yield segment
-                        # log.debug("Adding segment {0} to queue", segment.url)
+                        # log.debug(f"Adding segment {segment.url} to queue")
 
                     if self.mpd.type == "dynamic":
                         if not self.reload():

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -80,8 +80,7 @@ class HDSStreamWriter(SegmentedStreamWriter):
                                          params=params,
                                          **request_params)
         except StreamError as err:
-            log.error("Failed to open fragment {0}-{1}: {2}",
-                      fragment.segment, fragment.fragment, err)
+            log.error(f"Failed to open fragment {fragment.segment}-{fragment.fragment}: {err}")
             return self.fetch(fragment, retries - 1)
 
     def write(self, fragment, res, chunk_size=8192):
@@ -98,13 +97,11 @@ class HDSStreamWriter(SegmentedStreamWriter):
                     mdat = box.payload.data
                     break
         except F4VError as err:
-            log.error("Failed to parse fragment {0}-{1}: {2}",
-                      fragment.segment, fragment.fragment, err)
+            log.error(f"Failed to parse fragment {fragment.segment}-{fragment.fragment}: {err}")
             return
 
         if not mdat:
-            log.error("No MDAT box found in fragment {0}-{1}",
-                      fragment.segment, fragment.fragment)
+            log.error(f"No MDAT box found in fragment {fragment.segment}-{fragment.fragment}")
             return
 
         try:
@@ -114,17 +111,14 @@ class HDSStreamWriter(SegmentedStreamWriter):
                 if self.closed:
                     break
             else:
-                log.debug("Download of fragment {0}-{1} complete",
-                          fragment.segment, fragment.fragment)
+                log.debug(f"Download of fragment {fragment.segment}-{fragment.fragment} complete")
         except IOError as err:
             if "Unknown tag type" in str(err):
-                log.error("Unknown tag type found, this stream is "
-                          "probably encrypted")
+                log.error("Unknown tag type found, this stream is probably encrypted")
                 self.close()
                 return
 
-            log.error("Error reading fragment {0}-{1}: {2}",
-                      fragment.segment, fragment.fragment, err)
+            log.error(f"Error reading fragment {fragment.segment}-{fragment.fragment}: {err}")
 
 
 class HDSStreamWorker(SegmentedStreamWorker):
@@ -180,8 +174,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
                 current_fragment = max(self.first_fragment,
                                        current_fragment - (fragment_buffer - 1))
 
-                log.debug("Live edge buffer {0} sec is {1} fragments",
-                          self.live_edge, fragment_buffer)
+                log.debug(f"Live edge buffer {self.live_edge} sec is {fragment_buffer} fragments")
 
                 # Make sure we don't have a duration set when it's a
                 # live stream since it will just confuse players anyway.
@@ -191,12 +184,12 @@ class HDSStreamWorker(SegmentedStreamWorker):
 
             self.current_fragment = current_fragment
 
-        log.debug("Current timestamp: {0}", self.timestamp / self.time_scale)
-        log.debug("Current segment: {0}", self.current_segment)
-        log.debug("Current fragment: {0}", self.current_fragment)
-        log.debug("First fragment: {0}", self.first_fragment)
-        log.debug("Last fragment: {0}", self.last_fragment)
-        log.debug("End fragment: {0}", self.end_fragment)
+        log.debug(f"Current timestamp: {self.timestamp / self.time_scale}")
+        log.debug(f"Current segment: {self.current_segment}")
+        log.debug(f"Current fragment: {self.current_fragment}")
+        log.debug(f"First fragment: {self.first_fragment}")
+        log.debug(f"Last fragment: {self.last_fragment}")
+        log.debug(f"End fragment: {self.end_fragment}")
 
         self.bootstrap_reload_time = fragment_duration
 
@@ -323,8 +316,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
                 fragment = Fragment(self.current_segment, fragment,
                                     fragment_duration, fragment_url)
 
-                log.debug("Adding fragment {0}-{1} to queue",
-                          fragment.segment, fragment.fragment)
+                log.debug(f"Adding fragment {fragment.segment}-{fragment.fragment} to queue")
                 yield fragment
 
                 # End of stream
@@ -336,7 +328,7 @@ class HDSStreamWorker(SegmentedStreamWorker):
                 try:
                     self.update_bootstrap()
                 except StreamError as err:
-                    log.warning("Failed to update bootstrap: {0}", err)
+                    log.warning(f"Failed to update bootstrap: {err}")
 
 
 class HDSStreamReader(SegmentedStreamReader):
@@ -456,7 +448,7 @@ class HDSStream(Stream):
                                     exception=IOError)
 
         if manifest.findtext("drmAdditionalHeader"):
-            log.debug("Omitting HDS stream protected by DRM: {}", url)
+            log.debug(f"Omitting HDS stream protected by DRM: {url}")
             if raise_for_drm:
                 raise PluginError("{} is protected by DRM".format(url))
             log.warning("Some or all streams are unavailable as they are protected by DRM")

--- a/src/streamlink/stream/playlist.py
+++ b/src/streamlink/stream/playlist.py
@@ -32,7 +32,7 @@ class FLVPlaylistIO(FLVTagConcatIO):
     def open(self, streams):
         def generator():
             for stream in streams:
-                log.debug("Opening substream: {0}", stream)
+                log.debug(f"Opening substream: {stream}")
 
                 # No need for multiple ringbuffers
                 if hasattr(stream, "buffered"):
@@ -41,7 +41,7 @@ class FLVPlaylistIO(FLVTagConcatIO):
                 try:
                     fd = stream.open()
                 except StreamError as err:
-                    log.error("Failed to open stream: {0}", err)
+                    log.error(f"Failed to open stream: {err}")
                     continue
 
                 yield fd

--- a/src/streamlink/stream/rtmpdump.py
+++ b/src/streamlink/stream/rtmpdump.py
@@ -97,7 +97,7 @@ class RTMPStream(StreamProcess):
             redirect = m.group(1)
 
         if redirect:
-            log.debug("Found redirect tcUrl: {0}", redirect)
+            log.debug(f"Found redirect tcUrl: {redirect}")
 
             if "rtmp" in self.parameters:
                 tcurl, playpath = rtmpparse(self.parameters["rtmp"])

--- a/src/streamlink/stream/streamprocess.py
+++ b/src/streamlink/stream/streamprocess.py
@@ -136,7 +136,7 @@ class StreamProcess(Stream):
         """
         stderr = stderr or self.stderr
         cmd = self.bake(self._check_cmd(), parameters, arguments, short_option_prefix, long_option_prefix)
-        log.debug("Spawning command: {0}", subprocess.list2cmdline(cmd))
+        log.debug(f"Spawning command: {subprocess.list2cmdline(cmd)}")
 
         try:
             process = subprocess.Popen(cmd, stderr=stderr, stdout=subprocess.PIPE)


### PR DESCRIPTION
Lots of changes today... (sorry :innocent:)

----

First commit replaces the `self.logger` calls in all plugin modules with proper log calls. The `self.logger` calls in the `Plugin` base class can't be replaced, as the `logger` attribute is dynamic and based on the module name.

I've committed these changes last week and unfortunately forgot to use f-strings instead of string.format here. Doesn't matter though as there are countless of other string.format calls which can be automatically translated.

----

The second commit (hopefully) fixes all remaining log calls throughout the entire project which add custom `LogRecord` args via `log.info("foo {0}", bar)` by pre-formatting the log messages.

By doing this, the custom `LogRecord` class and `makeRecord` method in the `StreamlinkLogger` class can be removed (see #3273) and Python's default behavior of percent-formatted log messages can be restored.

After this change, the log message format becomes irrelevant for Streamlink, as all log messages should be pre-formatted now. This means that external loggers using Streamlink's root logger can keep using the percent-format syntax and Streamlink doesn't have to deal with the origin of the log message anymore.

This also means that all log calls need to be pre-formatted once #3273 has been (updated and) merged, but this isn't a big deal, especially due to the simplified f-string syntax. Or the percent-style format needs to be used, like this `log.info("foo %s", bar)`. The curly-brace syntax `log.info("foo {0}", bar)` is not going to work anymore.