### PR TITLE
chore: remove deprecated CLI arguments

### DIFF
--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -1,8 +1,7 @@
-import argparse
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -11,18 +10,6 @@ log = logging.getLogger(__name__)
 
 
 class BTV(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            help=argparse.SUPPRESS
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            help=argparse.SUPPRESS
-        )
-    )
-
     url_re = re.compile(r"https?://(?:www\.)?btvplus\.bg/live/?")
     api_url = "https://btvplus.bg/lbin/v3/btvplus/player_config.php"
 

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -1,4 +1,3 @@
-import argparse
 import datetime
 import re
 import logging
@@ -287,12 +286,6 @@ class Crunchyroll(Plugin):
             Note: The session ID will be overwritten if authentication is used
             and the session ID does not match the account.
             """
-        ),
-        # Deprecated, uses the general locale setting
-        PluginArgument(
-            "locale",
-            metavar="LOCALE",
-            help=argparse.SUPPRESS
         )
     )
 

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 import re
 
@@ -53,8 +52,6 @@ class Pixiv(Plugin):
     login_url_post = "https://accounts.pixiv.net/api/login"
 
     arguments = PluginArguments(
-        PluginArgument("username", help=argparse.SUPPRESS),
-        PluginArgument("password", help=argparse.SUPPRESS),
         PluginArgument(
             "sessionid",
             requires=["devicetoken"],

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -1,4 +1,3 @@
-import argparse
 from collections import namedtuple
 import json
 import logging
@@ -386,16 +385,6 @@ class TwitchAPI(object):
 
 class Twitch(Plugin):
     arguments = PluginArguments(
-        PluginArgument(
-            "oauth-token",
-            sensitive=True,
-            help=argparse.SUPPRESS
-        ),
-        PluginArgument(
-            "cookie",
-            sensitive=True,
-            help=argparse.SUPPRESS
-        ),
         PluginArgument(
             "disable-hosting",
             action="store_true",

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -1,4 +1,3 @@
-import argparse
 import base64
 import json
 import logging
@@ -41,12 +40,7 @@ class USTVNow(Plugin):
             required=True,
             help="Your USTV Now account password",
             prompt="Enter USTV Now account password"
-        ),
-        PluginArgument(
-            "station-code",
-            metavar="CODE",
-            help=argparse.SUPPRESS
-        ),
+        )
     )
 
     def __init__(self, url):

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -1,9 +1,8 @@
-import argparse
 import logging
 import re
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
-from streamlink.plugin import Plugin, PluginError, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginError
 from streamlink.plugin.api import validate, useragents
 from streamlink.plugin.api.utils import itertags, parse_query
 from streamlink.stream import HTTPStream, HLSStream
@@ -122,14 +121,6 @@ class YouTube(Plugin):
         256: 256,
         258: 258,
     }
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "api-key",
-            sensitive=True,
-            help=argparse.SUPPRESS  # no longer used
-        )
-    )
 
     def __init__(self, url):
         super(YouTube, self).__init__(url)

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 import re
 import time
@@ -17,8 +16,6 @@ class YuppTV(Plugin):
     _cookie_expiry = 3600 * 24 * 365
 
     arguments = PluginArguments(
-        PluginArgument("email", help=argparse.SUPPRESS),
-        PluginArgument("password", help=argparse.SUPPRESS),
         PluginArgument(
             "boxid",
             requires=["yuppflixtoken"],

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -275,10 +275,6 @@ def build_parser():
         Default is system locale.
         """
     )
-    general.add_argument(
-        "--twitch-oauth-authenticate",
-        help=argparse.SUPPRESS
-    )
 
     player = parser.add_argument_group("Player options")
     player.add_argument(
@@ -1209,27 +1205,6 @@ def build_parser():
         """
     )
 
-    # Deprecated options
-    http.add_argument(
-        "--http-cookies",
-        metavar="COOKIES",
-        help=argparse.SUPPRESS
-    )
-    http.add_argument(
-        "--http-headers",
-        metavar="HEADERS",
-        help=argparse.SUPPRESS
-    )
-    http.add_argument(
-        "--http-query-params",
-        metavar="PARAMS",
-        help=argparse.SUPPRESS
-    )
-    general.add_argument(
-        "--no-version-check",
-        action="store_true",
-        help=argparse.SUPPRESS
-    )
     return parser
 
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -732,15 +732,6 @@ def setup_http_session():
     if args.http_timeout:
         streamlink.set_option("http-timeout", args.http_timeout)
 
-    if args.http_cookies:
-        streamlink.set_option("http-cookies", args.http_cookies)
-
-    if args.http_headers:
-        streamlink.set_option("http-headers", args.http_headers)
-
-    if args.http_query_params:
-        streamlink.set_option("http-query-params", args.http_query_params)
-
 
 def setup_plugins(extra_plugin_dir=None):
     """Loads any additional plugins."""
@@ -1004,7 +995,7 @@ def main():
     check_root()
     log_current_versions()
 
-    if args.version_check or (not args.no_version_check and args.auto_version_check):
+    if args.version_check or args.auto_version_check:
         with ignored(Exception):
             check_version(force=args.version_check)
 


### PR DESCRIPTION
This removes the following deprecated/suppressed CLI arguments:

- `--http-cookies`
  Multiple `--http-cookie` arguments need to be used
- `--http-headers`
  Multiple `--http-header` arguments need to be used
- `--http-query-params`
  Multiple `--http-query-param` arguments need to be used
- `--no-version-check`
  Version checking is opt-in via `--version-check` or `--auto-version-check`
- `--twitch-oauth-authenticate`
  Auth on Twitch is not possible with OAuth tokens generated by 3rd-party client-IDs like Streamlink's

And the following deprecated/suppressed plugin arguments:

- `--btv-username` / `--btv-password`
- `--crunchyroll-locale`
  Generic `--locale` argument needs to be used
- `--pixiv-username` / `--pixiv-password`
- `--twitch-oauth-token` / `--twitch-cookie`
  As a workaround, `--http-header="Authorization=OAuth oauth-token-from-twitch-website"` can be used
- `--ustvnow-station-code`
- `--youtube-api-key`