### PR TITLE
plugins.picarto: explicitly detect and fail on private streams

### DIFF
--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -102,6 +102,10 @@ class Picarto(Plugin):
             log.error("The channel {0} is currently offline".format(url_channel_name))
             return
 
+        if channel_api_json["private"]:
+            log.error("The channel {0} is private, such streams are not yet supported".format(url_channel_name))
+            return
+
         server = None
         token = "public"
         channel = channel_api_json["name"]


### PR DESCRIPTION
I had a rather odd failure in viewing a picarto.tv stream, which turned out to be caused by the streamer setting their stream to private. The web interface asks for a password to view the stream. Unfortunately, I don't have any passwords to private streams, so the best I can do for now is to explicitly detect a private stream and cleanly error out.
