### PR TITLE
tests: fix log tests when run on a system with a non-UTC timezone

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,5 +4,5 @@ pytest-cov
 coverage
 mock
 requests-mock
-freezegun
+freezegun>=1.0.0
 flake8

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -61,14 +61,14 @@ class TestLogging(unittest.TestCase):
         self.assertEqual(str(cm.exception), "Only {} and % formatting styles are supported")
 
     def test_datefmt_default(self):
-        with freezegun.freeze_time(datetime(2000, 1, 2, 3, 4, 5, 123456)):
+        with freezegun.freeze_time(datetime(2000, 1, 2, 3, 4, 5, 123456), tz_offset=0):
             log, output = self._new_logger(format="[{asctime}][{name}][{levelname}] {message}")
             logger.root.setLevel("info")
             log.info("test")
             self.assertEqual(output.getvalue(), "[03:04:05][test][info] test\n")
 
     def test_datefmt_custom(self):
-        with freezegun.freeze_time(datetime(2000, 1, 2, 3, 4, 5, 123456)):
+        with freezegun.freeze_time(datetime(2000, 1, 2, 3, 4, 5, 123456), tz_offset=0):
             log, output = self._new_logger(format="[{asctime}][{name}][{levelname}] {message}", datefmt="%H:%M:%S.%f")
             logger.root.setLevel("info")
             log.info("test")


### PR DESCRIPTION
Set `tz_offset=0` so that `time.asctime` returns the expected value. This requires a more recent version of `freezegun`, so I set a minimum version in dev_requirements.txt.