### PR TITLE
chore: use new py3 yield from syntax

### DIFF
--- a/src/streamlink/plugin/api/mapper.py
+++ b/src/streamlink/plugin/api/mapper.py
@@ -43,11 +43,9 @@ class StreamMapper(object):
             else:
                 try:
                     if isinstance(value, dict):
-                        for __ in value.items():
-                            yield __
+                        yield from value.items()
                     else:
-                        for __ in value:
-                            yield __
+                        yield from value
                 except TypeError:
                     # Non-iterable returned
                     continue

--- a/src/streamlink/plugins/abweb.py
+++ b/src/streamlink/plugins/abweb.py
@@ -180,8 +180,7 @@ class ABweb(Plugin):
         log.debug('URL={0}'.format(hls_url))
         variant = HLSStream.parse_variant_playlist(self.session, hls_url)
         if variant:
-            for q, s in variant.items():
-                yield q, s
+            yield from variant.items()
         else:
             yield 'live', HLSStream(self.session, hls_url)
 

--- a/src/streamlink/plugins/app17.py
+++ b/src/streamlink/plugins/app17.py
@@ -69,8 +69,7 @@ class App17(Plugin):
                 for _n, _s in s.items():
                     yield "live", _s
             else:
-                for _s in s.items():
-                    yield _s
+                yield from s.items()
 
 
 __plugin__ = App17

--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -70,9 +70,8 @@ class ard_live(Plugin):
                     stream_ = stream_[0]
 
                 if ".m3u8" in stream_:
-                    for s in HLSStream.parse_variant_playlist(self.session, stream_).items():
-                        yield s
-                elif (".mp4" in stream_ and ".f4m" not in stream_):
+                    yield from HLSStream.parse_variant_playlist(self.session, stream_).items()
+                elif ".mp4" in stream_ and ".f4m" not in stream_:
                     yield "{0}".format(self._QUALITY_MAP[stream["_quality"]]), HTTPStream(self.session, stream_)
                 else:
                     if ".f4m" not in stream_:

--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -53,8 +53,7 @@ class ArteTV(Plugin):
                 if stream["mediaType"] == "hls":
                     try:
                         streams = HLSStream.parse_variant_playlist(self.session, stream["url"])
-                        for s in streams.items():
-                            yield s
+                        yield from streams.items()
                     except IOError as err:
                         log.warning(u"Failed to extract HLS streams for {0}/{1}: {2}".format(sname,
                                                                                              stream["versionLibelle"],

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -65,11 +65,9 @@ class AtresPlayer(Plugin):
                     if not streams:
                         yield "live", HLSStream(self.session, source["src"])
                     else:
-                        for s in streams.items():
-                            yield s
+                        yield from streams.items()
                 elif source["type"] == "application/dash+xml":
-                    for s in DASHStream.parse_manifest(self.session, source["src"]).items():
-                        yield s
+                    yield from DASHStream.parse_manifest(self.session, source["src"]).items()
 
 
 __plugin__ = AtresPlayer

--- a/src/streamlink/plugins/bfmtv.py
+++ b/src/streamlink/plugins/bfmtv.py
@@ -39,8 +39,7 @@ class BFMTV(Plugin):
             if match is not None:
                 video_url = match.group('video_url')
                 if '.m3u8' in video_url:
-                    for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
-                        yield stream
+                    yield from HLSStream.parse_variant_playlist(self.session, video_url).items()
 
 
 __plugin__ = BFMTV

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -203,11 +203,9 @@ class Bloomberg(Plugin):
         for video_url in streams:
             log.debug("Found stream: {0}".format(video_url))
             if '.f4m' in video_url:
-                for stream in HDSStream.parse_manifest(self.session, video_url).items():
-                    yield stream
+                yield from HDSStream.parse_manifest(self.session, video_url).items()
             elif '.m3u8' in video_url:
-                for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
-                    yield stream
+                yield from HLSStream.parse_variant_playlist(self.session, video_url).items()
             if '.mp4' in video_url:
                 match = self._mp4_bitrate_re.match(video_url)
                 if match is not None:

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -114,8 +114,7 @@ class BrightcovePlayer(object):
                 q = "live"
             if ((source.get("type") == "application/x-mpegURL" and source.get("src"))
                     or (source.get("src") and ".m3u8" in source.get("src"))):
-                for s in HLSStream.parse_variant_playlist(self.session, source.get("src"), headers=headers).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, source.get("src"), headers=headers).items()
             elif source.get("app_name"):
                 s = RTMPStream(self.session,
                                {"rtmp": source.get("app_name"),

--- a/src/streamlink/plugins/canalplus.py
+++ b/src/streamlink/plugins/canalplus.py
@@ -61,8 +61,7 @@ class CanalPlus(Plugin):
 
         # Some videos may be also available on Dailymotion (especially on CNews)
         if videos['ID_DM'] != '':
-            for stream in self.session.streams('https://www.dailymotion.com/video/' + videos['ID_DM']).items():
-                yield stream
+            yield from self.session.streams('https://www.dailymotion.com/video/' + videos['ID_DM']).items()
 
         for quality, video_url in list(videos['MEDIA']['VIDEOS'].items()):
             # Ignore empty URLs

--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -31,8 +31,7 @@ class CBSNews(Plugin):
         items = self.session.http.get(self.url, schema=self._schema_items)
         if items:
             for hls_url in items:
-                for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
 
 __plugin__ = CBSNews

--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -262,8 +262,7 @@ class CeskatelevizeAPI2(object):
         json_data = self.session.http.json(response, schema=self._playlist_schema)
         log.trace('{0!r}'.format(json_data))
         playlist = json_data['RESULT']['playlist'][0]['streamUrls']['main']
-        for s in DASHStream.parse_manifest(self.session, playlist).items():
-            yield s
+        yield from DASHStream.parse_manifest(self.session, playlist).items()
 
 
 __plugin__ = Ceskatelevize

--- a/src/streamlink/plugins/clubbingtv.py
+++ b/src/streamlink/plugins/clubbingtv.py
@@ -59,10 +59,7 @@ class ClubbingTV(Plugin):
             return
         stream_url = match.group("stream_url")
 
-        for stream in HLSStream.parse_variant_playlist(
-            self.session, stream_url
-        ).items():
-            yield stream
+        yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
 
     def _get_vod_streams(self, content):
         match = self._vod_re.search(content)

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -68,8 +68,7 @@ class DailyMotion(Plugin):
                     if quality != 'auto':
                         # Avoid duplicate HLS streams with bitrate selector in the URL query
                         continue
-                    for s in HLSStream.parse_variant_playlist(self.session, stream['url']).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, stream['url']).items()
                 elif stream['type'] == 'video/mp4':
                     # Drop FPS in quality
                     resolution = re.sub('@[0-9]+', '', quality) + 'p'

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -42,11 +42,9 @@ class Delfi(Plugin):
             for x in itertools.chain(*data['data']['versions'].values()):
                 src = update_scheme(self.url, x['src'])
                 if x['type'] == "application/x-mpegurl":
-                    for s in HLSStream.parse_variant_playlist(self.session, src).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, src).items()
                 elif x['type'] == "application/dash+xml":
-                    for s in DASHStream.parse_manifest(self.session, src).items():
-                        yield s
+                    yield from DASHStream.parse_manifest(self.session, src).items()
                 elif x['type'] == "video/mp4":
                     yield "{0}p".format(x['res']), HTTPStream(self.session, src)
         else:

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -91,8 +91,7 @@ class EarthCam(Plugin):
 
             log.debug("HLS URL: {0}".format(hls_url))
 
-            for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                yield s
+            yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
         if not (rtmp_playpath or hls_playpath):
             log.error("This cam stream appears to be in offline or "

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -61,8 +61,7 @@ class Facebook(Plugin):
                 # if the URL is json encoded, decode it
                 stream_url = parse_json("\"{}\"".format(stream_url))
             if ".mpd" in stream_url:
-                for s in DASHStream.parse_manifest(self.session, stream_url).items():
-                    yield s
+                yield from DASHStream.parse_manifest(self.session, stream_url).items()
             elif ".mp4" in stream_url:
                 yield match.group(1), HTTPStream(self.session, stream_url)
             else:
@@ -77,8 +76,7 @@ class Facebook(Plugin):
             if "SegmentBase" in manifest:
                 log.error("Skipped DASH manifest with SegmentBase streams")
             else:
-                for s in DASHStream.parse_manifest(self.session, manifest).items():
-                    yield s
+                yield from DASHStream.parse_manifest(self.session, manifest).items()
 
     def _get_streams(self):
         done = False

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -89,8 +89,7 @@ class FilmOnHLS(HLSStream):
         if self.channel:
             log.debug(f"Reloading FilmOn channel playlist: {self.channel}")
             data = self.api.channel(self.channel)
-            for stream in data["streams"]:
-                yield stream
+            yield from data["streams"]
         elif self.vod_id:
             log.debug(f"Reloading FilmOn VOD playlist: {self.vod_id}")
             data = self.api.vod(self.vod_id)
@@ -230,8 +229,7 @@ class Filmon(Plugin):
                 if not streams:
                     yield stream["quality"], HLSStream(self.session, stream["url"])
                 else:
-                    for s in streams.items():
-                        yield s
+                    yield from streams.items()
         else:
             if channel and not channel.isdigit():
                 _id = self.cache.get(channel)

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -71,8 +71,7 @@ class Gulli(Plugin):
 
             try:
                 if '.m3u8' in video_url:
-                    for stream in HLSStream.parse_variant_playlist(self.session, video_url).items():
-                        yield stream
+                    yield from HLSStream.parse_variant_playlist(self.session, video_url).items()
                 elif '.mp4' in video_url:
                     match = self._mp4_bitrate_re.match(video_url)
                     if match is not None:

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -82,8 +82,7 @@ class IDF1(Plugin):
 
             # Ignore HDS streams (broken)
             if '.m3u8' in video_url:
-                for s in HLSStream.parse_variant_playlist(self.session, video_url).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, video_url).items()
 
 
 __plugin__ = IDF1

--- a/src/streamlink/plugins/ine.py
+++ b/src/streamlink/plugins/ine.py
@@ -51,8 +51,7 @@ class INE(Plugin):
 
             for source in data["playlist"][0]["sources"]:
                 if source["type"] == "application/vnd.apple.mpegurl":
-                    for s in HLSStream.parse_variant_playlist(self.session, source["file"]).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, source["file"]).items()
                 elif source["type"] == "video/mp4":
                     yield "{0}p".format(source["height"]), HTTPStream(self.session, source["file"])
 

--- a/src/streamlink/plugins/kugou.py
+++ b/src/streamlink/plugins/kugou.py
@@ -79,8 +79,7 @@ class Kugou(Plugin):
                 if not s:
                     yield "live", HLSStream(self.session, hls_url)
                 else:
-                    for _s in s.items():
-                        yield _s
+                    yield from s.items()
 
         if stream_data.get("httpsflv"):
             for http_url in stream_data["httpsflv"]:

--- a/src/streamlink/plugins/live_russia_tv.py
+++ b/src/streamlink/plugins/live_russia_tv.py
@@ -84,8 +84,7 @@ class LiveRussia(Plugin):
                         if media_type == 'm3u8':
                             hls_url = media['sources'][media_type]['auto']
                             log.debug('hls_url={0}'.format(hls_url))
-                            for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                                yield s
+                            yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
                         elif media_type == 'http':
                             for pix, http_url in media['sources'][media_type].items():
                                 log.debug('http_url={0}'.format(http_url))

--- a/src/streamlink/plugins/liveedu.py
+++ b/src/streamlink/plugins/liveedu.py
@@ -127,8 +127,7 @@ class LiveEdu(Plugin):
                     yield label, RTMPStream(self.session, params)
 
                 elif url["type"] == "application/x-mpegURL":
-                    for s in HLSStream.parse_variant_playlist(self.session, url["src"]).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, url["src"]).items()
 
 
 __plugin__ = LiveEdu

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -42,8 +42,7 @@ class Livestream(Plugin):
 
         m3u8_url = stream_info.get("secure_m3u8_url")
         if m3u8_url:
-            for s in HLSStream.parse_variant_playlist(self.session, m3u8_url).items():
-                yield s
+            yield from HLSStream.parse_variant_playlist(self.session, m3u8_url).items()
 
 
 __plugin__ = Livestream

--- a/src/streamlink/plugins/lrt.py
+++ b/src/streamlink/plugins/lrt.py
@@ -24,8 +24,7 @@ class LRT(Plugin):
             data = self.session.http.get(self.API_URL.format(video_id)).json()
             hls_url = data["response"]["data"]["content"]
 
-            for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                yield s
+            yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
         else:
             log.debug("No match for video_id regex")
 

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -29,8 +29,7 @@ class Mjunoon(Plugin):
                 for key, url in parse_qsl(urlparts.query):
                     if key == "streamUrl":
                         i += 1
-                        for s in HLSStream.parse_variant_playlist(self.session, url, params=dict(id=i), verify=False).items():
-                            yield s
+                        yield from HLSStream.parse_variant_playlist(self.session, url, params=dict(id=i), verify=False).items()
 
 
 __plugin__ = Mjunoon

--- a/src/streamlink/plugins/mrtmk.py
+++ b/src/streamlink/plugins/mrtmk.py
@@ -36,8 +36,7 @@ class MRTmk(Plugin):
 
         for stream_url in stream_urls:
             try:
-                for s in HLSStream.parse_variant_playlist(self.session, stream_url).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
             except IOError as err:
                 if "403 Client Error" in str(err):
                     log.error("Failed to access stream, may be due to geo-restriction")

--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -98,8 +98,7 @@ class OKru(Plugin):
             for hls_url in [metadata.get('hlsManifestUrl'),
                             metadata.get('hlsMasterPlaylistUrl')]:
                 if hls_url is not None:
-                    for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
             if metadata.get('videos'):
                 for http_stream in metadata['videos']:

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -84,14 +84,12 @@ class OneTV(Plugin):
             if hls_streams:
                 url = random.choice(hls_streams)
                 url = url + '&' + urlencode(self.hls_session())  # TODO: use update_qsd
-                for s in HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items()
 
             mpd_streams = live_data.get("mpd")
             if mpd_streams:
                 url = random.choice(mpd_streams)
-                for s in DASHStream.parse_manifest(self.session, url).items():
-                    yield s
+                yield from DASHStream.parse_manifest(self.session, url).items()
 
         elif self.channel == "1tv":
             log.debug("Attempting to find VOD stream for {0}...".format(self.channel))

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -138,15 +138,13 @@ class OPENRECtv(Plugin):
         if mdata:
             log.debug("Found video: {0} ({1})".format(mdata["title"], mdata["id"]))
             if mdata["media"]["url"]:
-                for s in HLSStream.parse_variant_playlist(self.session, mdata["media"]["url"]).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, mdata["media"]["url"]).items()
             elif self.get_option("email") and self.get_option("password"):
                 if self.login(self.get_option("email"), self.get_option("password")):
                     details = self._get_details(mdata["id"])
                     if details:
                         for item in details["items"]:
-                            for s in HLSStream.parse_variant_playlist(self.session, item["media"]["url"]).items():
-                                yield s
+                            yield from HLSStream.parse_variant_playlist(self.session, item["media"]["url"]).items()
             else:
                 log.error("You must login to access this stream")
 

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -84,8 +84,7 @@ class Picarto(Plugin):
             page = self.session.http.get(self.url)
             vod_streams = self._get_vod_stream(page)
             if vod_streams:
-                for s in vod_streams.items():
-                    yield s
+                yield from vod_streams.items()
                 return
             else:
                 log.warning("Probably a VOD stream but no VOD found?")
@@ -118,8 +117,7 @@ class Picarto(Plugin):
 
         for i in info_json["techs"]:
             if i["label"] == "HLS":
-                for s in self._create_hls_stream(server, channel, token).items():
-                    yield s
+                yield from self._create_hls_stream(server, channel, token).items()
             elif i["label"] == "RTMP Flash":
                 stream = self._create_flash_stream(server, channel, token)
                 yield "live", stream

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -110,8 +110,7 @@ class Pixiv(Plugin):
 
     def hls_stream(self, hls_url):
         log.debug("URL={0}".format(hls_url))
-        for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-            yield s
+        yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
     def get_streamer_data(self):
         res = self.session.http.get(self.api_lives)

--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -35,8 +35,7 @@ class Radiko(Plugin):
             'X-Radiko-AuthToken': token
         }
         self.session.http.headers = headers
-        for s in HLSStream.parse_variant_playlist(self.session, url).items():
-            yield s
+        yield from HLSStream.parse_variant_playlist(self.session, url).items()
 
     def _live(self, station_id):
         live_url = 'http://f-radiko.smartstream.ne.jp/{}/_definst_/simul-stream.stream/playlist.m3u8'.format(station_id)

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -61,8 +61,7 @@ class RadioNet(Plugin):
                 if not streams:
                     yield stream["quality"], HLSStream(self.session, stream["url"])
                 else:
-                    for s in streams.items():
-                        yield s
+                    yield from streams.items()
 
 
 __plugin__ = RadioNet

--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -47,8 +47,7 @@ class RaiPlay(Plugin):
             log.error("Geo-restricted content")
             return
 
-        for stream in HLSStream.parse_variant_playlist(self.session, stream_url).items():
-            yield stream
+        yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
 
 
 __plugin__ = RaiPlay

--- a/src/streamlink/plugins/rtbf.py
+++ b/src/streamlink/plugins/rtbf.py
@@ -162,16 +162,14 @@ class RTBF(Plugin):
                 if stream_data.get('isLive', False):
                     # Live streams require a token
                     hls_url = self.tokenize_stream(hls_url)
-                for stream in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                    yield stream
+                yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
             dash_url = stream_data.get('urlDash') or stream_data.get('streamUrlDash')
             if dash_url:
                 if stream_data.get('isLive', False):
                     # Live streams require a token
                     dash_url = self.tokenize_stream(dash_url)
-                for stream in DASHStream.parse_manifest(self.session, dash_url).items():
-                    yield stream
+                yield from DASHStream.parse_manifest(self.session, dash_url).items()
 
         except IOError as err:
             if '403 Client Error' in str(err):

--- a/src/streamlink/plugins/ruv.py
+++ b/src/streamlink/plugins/ruv.py
@@ -91,8 +91,7 @@ class Ruv(Plugin):
             # Get available streams
             streams = HLSStream.parse_variant_playlist(self.session, url)
 
-            for quality, hls in streams.items():
-                yield quality, hls
+            yield from streams.items()
 
     def _get_sarpurinn_streams(self):
         # Get HTML page

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -176,8 +176,7 @@ class Showroom(Plugin):
                     quality = _rtmp_quality_lookup.get(stream_info["label"], "other")
                     yield quality, ShowroomHLSStream(self.session, stream_info["url"])
                 else:
-                    for s in streams.items():
-                        yield s
+                    yield from streams.items()
 
 
 __plugin__ = Showroom

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -45,8 +45,7 @@ class Sportschau(Plugin):
 
         hls_url = self.session.http.get(player_js, schema=self._schema_json)
 
-        for stream in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-            yield stream
+        yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
 
 __plugin__ = Sportschau

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -94,8 +94,7 @@ class SVTPlay(Plugin):
 
         for playlist in api_data['videoReferences']:
             if playlist['format'] == 'dashhbbtv':
-                for s in DASHStream.parse_manifest(self.session, playlist['url']).items():
-                    yield s
+                yield from DASHStream.parse_manifest(self.session, playlist['url']).items()
 
     def _get_vod(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -45,8 +45,7 @@ class Telefe(Plugin):
 
         if video_url_found_hls:
             hls_streams = HLSStream.parse_variant_playlist(self.session, video_url_found_hls)
-            for s in hls_streams.items():
-                yield s
+            yield from hls_streams.items()
 
         if video_url_found_http:
             yield "http", HTTPStream(self.session, video_url_found_http)

--- a/src/streamlink/plugins/trt.py
+++ b/src/streamlink/plugins/trt.py
@@ -36,14 +36,12 @@ class TRT(Plugin):
 
                 hls_url = url_m and url_m.group("url")
                 if hls_url:
-                    for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
                 f4m_m = self.f4mm_re.search(script_vars)
                 f4m_url = f4m_m and f4m_m.group("url")
                 if f4m_url:
-                    for n, s in HDSStream.parse_manifest(self.session, f4m_url).items():
-                        yield n, s
+                    yield from HDSStream.parse_manifest(self.session, f4m_url).items()
 
 
 __plugin__ = TRT

--- a/src/streamlink/plugins/trtspor.py
+++ b/src/streamlink/plugins/trtspor.py
@@ -22,14 +22,12 @@ class TRTSpor(Plugin):
         url_m = self.m3u8_re.search(res.text)
         hls_url = url_m and url_m.group("url")
         if hls_url:
-            for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                yield s
+            yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
         f4m_m = self.f4mm_re.search(res.text)
         f4m_url = f4m_m and f4m_m.group("url")
         if f4m_url:
-            for n, s in HDSStream.parse_manifest(self.session, f4m_url).items():
-                yield n, s
+            yield from HDSStream.parse_manifest(self.session, f4m_url).items()
 
 
 __plugin__ = TRTSpor

--- a/src/streamlink/plugins/tv5monde.py
+++ b/src/streamlink/plugins/tv5monde.py
@@ -67,8 +67,7 @@ class TV5Monde(Plugin):
 
         for url in videos:
             if '.m3u8' in url:
-                for stream in HLSStream.parse_variant_playlist(self.session, url).items():
-                    yield stream
+                yield from HLSStream.parse_variant_playlist(self.session, url).items()
             elif 'rtmp' in url:
                 yield 'vod', RTMPStream(self.session, {'rtmp': url})
             elif '.mp4' in url:

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -47,8 +47,7 @@ class TVRBy(Plugin):
         log.debug("Found {0} stream URL{1}".format(len(stream_urls), "" if len(stream_urls) == 1 else "s"))
 
         for stream_url in stream_urls:
-            for s in HLSStream.parse_variant_playlist(self.session, stream_url).items():
-                yield s
+            yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
 
 
 __plugin__ = TVRBy

--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -35,8 +35,7 @@ class TVRPlus(Plugin):
             stream_url = list(set(stream_url))
             for url in stream_url:
                 log.debug("URL={0}".format(url))
-                for s in HLSStream.parse_variant_playlist(self.session, url, headers=headers).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, url, headers=headers).items()
 
 
 __plugin__ = TVRPlus

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -164,8 +164,7 @@ class USTVNow(Plugin):
                 for stream in resp['data']['response']['streams']:
                     if stream['keys']['licenseKey']:
                         log.warning("Stream possibly protected by DRM")
-                    for q, s in HLSStream.parse_variant_playlist(self.session, stream['url']).items():
-                        yield (q, s)
+                    yield from HLSStream.parse_variant_playlist(self.session, stream['url']).items()
             else:
                 log.error("Could not find any streams: {code}: {message}".format(**resp['data']['error']))
         else:

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -77,8 +77,7 @@ class VK(Plugin):
             if _i.attributes.get('src'):
                 iframe_url = update_scheme(self.url, _i.attributes['src'])
                 log.debug('Found iframe: {0}'.format(iframe_url))
-                for s in self.session.streams(iframe_url).items():
-                    yield s
+                yield from self.session.streams(iframe_url).items()
 
         for _i in itertags(res.text.replace('\\', ''), 'source'):
             if _i.attributes.get('type') == 'application/vnd.apple.mpegurl':
@@ -88,8 +87,7 @@ class VK(Plugin):
                 if not streams:
                     yield 'live', HLSStream(self.session, video_url)
                 else:
-                    for s in streams.items():
-                        yield s
+                    yield from streams.items()
             elif _i.attributes.get('type') == 'video/mp4':
                 q = 'vod'
                 video_url = _i.attributes['src']

--- a/src/streamlink/plugins/vrtbe.py
+++ b/src/streamlink/plugins/vrtbe.py
@@ -81,14 +81,11 @@ class VRTbe(Plugin):
         for target in data["targetUrls"]:
             if data["drm"]:
                 if target["type"] == "hls_aes":
-                    for s in HLSStream.parse_variant_playlist(self.session, target["url"]).items():
-                        yield s
+                    yield from HLSStream.parse_variant_playlist(self.session, target["url"]).items()
             elif target["type"] == "hls":
-                for s in HLSStream.parse_variant_playlist(self.session, target["url"]).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, target["url"]).items()
             elif target["type"] == "mpeg_dash":
-                for s in DASHStream.parse_manifest(self.session, target["url"]).items():
-                    yield s
+                yield from DASHStream.parse_manifest(self.session, target["url"]).items()
 
 
 __plugin__ = VRTbe

--- a/src/streamlink/plugins/wasd.py
+++ b/src/streamlink/plugins/wasd.py
@@ -77,8 +77,7 @@ class WASD(Plugin):
                 elif stream['media_status'] == 'RUNNING':
                     hls_url = stream['media_meta']['media_url']
 
-                for s in HLSStream.parse_variant_playlist(self.session, hls_url).items():
-                    yield s
+                yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
 
 __plugin__ = WASD

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -69,8 +69,7 @@ class WebTV(Plugin):
                         # try to parse the stream as a variant playlist
                         variant = HLSStream.parse_variant_playlist(self.session, url, headers=headers)
                         if variant:
-                            for q, s in variant.items():
-                                yield q, s
+                            yield from variant.items()
                         else:
                             # and if that fails, try it as a plain HLS stream
                             yield 'live', HLSStream(self.session, url, headers=headers)

--- a/src/streamlink/plugins/zeenews.py
+++ b/src/streamlink/plugins/zeenews.py
@@ -24,8 +24,7 @@ class ZeeNews(Plugin):
         res = self.session.http.get(self.TOKEN_URL)
         token = self.session.http.json(res)['video_token']
         log.debug('video_token: {0}'.format(token))
-        for s in HLSStream.parse_variant_playlist(self.session, self.HLS_URL.format(token)).items():
-            yield s
+        yield from HLSStream.parse_variant_playlist(self.session, self.HLS_URL.format(token)).items()
 
 
 __plugin__ = ZeeNews

--- a/src/streamlink/plugins/zengatv.py
+++ b/src/streamlink/plugins/zengatv.py
@@ -44,8 +44,7 @@ class ZengaTV(Plugin):
         data = {"feed": "hd", "dvrId": dvr_id}
         res = self.session.http.post(self.api_url, headers=headers, data=data)
         if res.status_code == 200:
-            for s in HLSStream.parse_variant_playlist(self.session, res.text, headers=headers).items():
-                yield s
+            yield from HLSStream.parse_variant_playlist(self.session, res.text, headers=headers).items()
 
 
 __plugin__ = ZengaTV


### PR DESCRIPTION
Use the `yield from` syntax introduced in Python 3.3.

It's mainly used when returning streams from plugins, but there are a few other cases where the pattern is used. 