### PR TITLE
chore: make mux-subtitles a global CLI argument

### DIFF
--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -177,15 +177,6 @@ class FunimationNow(Plugin):
 
             Default is "english".
             """
-        ),
-        PluginArgument(
-            "mux-subtitles",
-            argument_name="funimation-mux-subtitles",
-            action="store_true",
-            help="""
-            Enable automatically including available subtitles in to the output
-            stream.
-            """
         )
     )
 
@@ -264,7 +255,7 @@ class FunimationNow(Plugin):
                     url = item["src"]
                     if ".m3u8" in url:
                         for q, s in HLSStream.parse_variant_playlist(self.session, url).items():
-                            if self.get_option("mux_subtitles") and subtitles:
+                            if self.session.get_option("mux_subtitles") and subtitles:
                                 yield q, MuxedStream(self.session, s, subtitles, metadata=stream_metadata,
                                                      disposition=disposition)
                             else:
@@ -272,7 +263,7 @@ class FunimationNow(Plugin):
                     elif ".mp4" in url:
                         # TODO: fix quality
                         s = HTTPStream(self.session, url)
-                        if self.get_option("mux_subtitles") and subtitles:
+                        if self.session.get_option("mux_subtitles") and subtitles:
                             yield self.mp4_quality, MuxedStream(self.session, s, subtitles, metadata=stream_metadata,
                                                                 disposition=disposition)
                         else:

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -3,7 +3,7 @@ import re
 import sys
 import time
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HDSStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -83,16 +83,6 @@ class Pluzz(Plugin):
     })
 
     _player_schema = validate.Schema({'result': validate.url()})
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "mux-subtitles",
-            action="store_true",
-            help="""
-        Automatically mux available subtitles in to the output stream.
-        """
-        )
-    )
 
     @classmethod
     def can_handle_url(cls, url):
@@ -196,7 +186,7 @@ class Pluzz(Plugin):
                     bitrate = '1500k'
                 streams.append((bitrate, HTTPStream(self.session, video_url)))
 
-        if self.get_option("mux_subtitles") and videos['subtitles'] != []:
+        if self.session.get_option("mux_subtitles") and videos['subtitles'] != []:
             substreams = {}
             for subtitle in videos['subtitles']:
                 # TTML subtitles are available but not supported by FFmpeg

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from Crypto.Cipher import Blowfish
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
@@ -96,15 +96,6 @@ class Rtve(Plugin):
         validate.get("page"),
         validate.get("items"),
         validate.get(0))
-    arguments = PluginArguments(
-        PluginArgument(
-            "mux-subtitles",
-            action="store_true",
-            help="""
-        Automatically mux available subtitles in to the output stream.
-        """
-        )
-    )
 
     @classmethod
     def can_handle_url(cls, url):
@@ -160,7 +151,7 @@ class Rtve(Plugin):
                         streams.append((quality, HTTPStream(self.session, url)))
 
             subtitles = None
-            if self.get_option("mux_subtitles"):
+            if self.session.get_option("mux_subtitles"):
                 subtitles = self._get_subtitles(content_id)
             if subtitles:
                 substreams = {}

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -45,14 +45,6 @@ class SVTPlay(Plugin):
             'format': validate.text,
         }],
     })
-
-    arguments = PluginArguments(
-        PluginArgument(
-            'mux-subtitles',
-            action='store_true',
-            help="Automatically mux available subtitles in to the output stream.",
-        ),
-    )
 
     @classmethod
     def can_handle_url(cls, url):

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -3,7 +3,7 @@ import logging
 import re
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -50,14 +50,6 @@ class Vimeo(Plugin):
         validate.any(None, validate.Schema(validate.get(1), _config_schema)),
     )
 
-    arguments = PluginArguments(
-        PluginArgument(
-            "mux-subtitles",
-            action="store_true",
-            help="Automatically mux available subtitles in to the output stream.",
-        )
-    )
-
     @classmethod
     def can_handle_url(cls, url):
         return cls._url_re.match(url)
@@ -101,7 +93,7 @@ class Vimeo(Plugin):
         for stream in videos.get("progressive", []):
             streams.append((stream["quality"], HTTPStream(self.session, stream["url"])))
 
-        if self.get_option("mux_subtitles") and data["request"].get("text_tracks"):
+        if self.session.get_option("mux_subtitles") and data["request"].get("text_tracks"):
             substreams = {
                 s["lang"]: HTTPStream(self.session, "https://vimeo.com" + s["url"])
                 for s in data["request"]["text_tracks"]

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -553,6 +553,15 @@ def build_parser():
         You will be prompted if the file already exists.
         """
     )
+    output.add_argument(
+        "--mux-subtitles",
+        action="store_true",
+        help="""
+        Automatically mux available subtitles in to the output stream.
+
+        If supported by the plugin.
+        """,
+    )
 
     stream = parser.add_argument_group("Stream options")
     stream.add_argument(

--- a/tests/plugins/test_funimationnow.py
+++ b/tests/plugins/test_funimationnow.py
@@ -39,5 +39,4 @@ class TestPluginFunimationNow(unittest.TestCase):
                                   call('--funimation-password', help=ANY),
                                   call('--funimation-language',
                                        choices=["en", "ja", "english", "japanese"],
-                                       default="english", help=ANY),
-                                  call('--funimation-mux-subtitles', action="store_true", help=ANY)])
+                                       default="english", help=ANY)])


### PR DESCRIPTION
removes the plugin specific `mux-subtitles` arguments in favour a a global `--mux-subtitles` option. 