### PR TITLE
flake8: add import-order linting config

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ mock
 requests-mock
 freezegun>=1.0.0
 flake8
+flake8-import-order

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,9 @@ exclude =
   versioneer.py,
   win32/,
 per-file-ignores =
-  src/streamlink/__init__.py:E402,F401,
+  src/streamlink/__init__.py:E402,F401,I100,I101,I201,I202,I666,
+  src/streamlink/packages/*:I100,I101,I201,I202,I666,
+  src/streamlink/packages/**/*:I100,I101,I201,I202,I666,
   src/streamlink/plugin/api/useragents.py:E501,
   src/streamlink/plugins/__init__.py:F401,
   src/streamlink/stream/__init__.py:F401,
@@ -43,3 +45,9 @@ builtins =
   raw_input,
   unicode,
   xrange,
+import-order-style = pycharm
+application-import-names =
+  streamlink,
+  streamlink_cli,
+  tests,
+  versioneer,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import codecs
 from os import environ, path
 from sys import argv, path as sys_path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 import versioneer
 

--- a/src/streamlink/__init__.py
+++ b/src/streamlink/__init__.py
@@ -8,7 +8,8 @@ An API is also provided that allows direct access to stream data.
 Full documentation is available at https://streamlink.github.io.
 
 """
-from ._version import get_versions
+from streamlink._version import get_versions
+
 __version__ = get_versions()['version']
 del get_versions
 __title__ = "streamlink"
@@ -17,7 +18,7 @@ __author__ = "Streamlink"
 __copyright__ = "Copyright 2020 Streamlink"
 __credits__ = ["https://github.com/streamlink/streamlink/blob/master/AUTHORS"]
 
-from .api import streams
-from .exceptions import (StreamlinkError, PluginError, NoStreamsError,
-                         NoPluginError, StreamError)
-from .session import Streamlink
+from streamlink.api import streams
+from streamlink.exceptions import (StreamlinkError, PluginError, NoStreamsError,
+                                   NoPluginError, StreamError)
+from streamlink.session import Streamlink

--- a/src/streamlink/api.py
+++ b/src/streamlink/api.py
@@ -1,4 +1,4 @@
-from .session import Streamlink
+from streamlink.session import Streamlink
 
 
 def streams(url, **params):

--- a/src/streamlink/cache.py
+++ b/src/streamlink/cache.py
@@ -2,9 +2,9 @@ import json
 import os
 import shutil
 import tempfile
-from time import time, mktime
+from time import mktime, time
 
-from .compat import is_win32
+from streamlink.compat import is_win32
 
 if is_win32:
     xdg_cache = os.environ.get("APPDATA", os.path.expanduser("~"))

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -1,8 +1,7 @@
-from datetime import datetime
 import logging
-from logging import NOTSET, ERROR, WARN, INFO, DEBUG, CRITICAL
+from datetime import datetime
+from logging import CRITICAL, DEBUG, ERROR, INFO, NOTSET, WARN
 from threading import Lock
-
 
 TRACE = 5
 _levelToName = dict([(CRITICAL, "critical"), (ERROR, "error"), (WARN, "warning"), (INFO, "info"), (DEBUG, "debug"),

--- a/src/streamlink/plugin/__init__.py
+++ b/src/streamlink/plugin/__init__.py
@@ -1,6 +1,5 @@
-from .plugin import Plugin
-from ..exceptions import PluginError
-from ..options import Options as PluginOptions
-from ..options import Arguments as PluginArguments, Argument as PluginArgument
+from streamlink.exceptions import PluginError
+from streamlink.options import Argument as PluginArgument, Arguments as PluginArguments, Options as PluginOptions
+from streamlink.plugin.plugin import Plugin
 
 __all__ = ["Plugin", "PluginError", "PluginOptions", "PluginArguments", "PluginArgument"]

--- a/src/streamlink/plugin/api/__init__.py
+++ b/src/streamlink/plugin/api/__init__.py
@@ -1,10 +1,9 @@
 import sys
-
 from types import ModuleType as module
 
-from .http_session import HTTPSession
-from .mapper import StreamMapper
-from .support_plugin import load_support_plugin
+from streamlink.plugin.api.http_session import HTTPSession
+from streamlink.plugin.api.mapper import StreamMapper
+from streamlink.plugin.api.support_plugin import load_support_plugin
 
 __all__ = ["HTTPSession", "StreamMapper", "load_support_plugin", "http"]
 

--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -1,9 +1,12 @@
 import time
+
 from requests import Session, __build__ as requests_version
 from requests.adapters import HTTPAdapter
 
+from streamlink.exceptions import PluginError
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.plugin.api import useragents
+from streamlink.utils import parse_json, parse_xml
 
 try:
     from requests.packages.urllib3.util import Timeout
@@ -20,9 +23,6 @@ try:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 except (ImportError, AttributeError):
     pass
-
-from ...exceptions import PluginError
-from ...utils import parse_json, parse_xml
 
 __all__ = ["HTTPSession"]
 

--- a/src/streamlink/plugin/api/support_plugin.py
+++ b/src/streamlink/plugin/api/support_plugin.py
@@ -1,5 +1,6 @@
-import os
 import inspect
+import os
+
 from streamlink.utils import load_module
 
 __all__ = ["load_support_plugin"]

--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -2,7 +2,7 @@
 import re
 from collections import namedtuple
 
-from ...utils import parse_qsd as parse_query, parse_json, parse_xml
+from streamlink.utils import parse_json, parse_qsd as parse_query, parse_xml
 
 __all__ = ["parse_json", "parse_xml", "parse_query"]
 

--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -21,7 +21,7 @@ from functools import singledispatch
 from urllib.parse import urlparse
 from xml.etree import ElementTree as ET
 
-from ...exceptions import PluginError
+from streamlink.exceptions import PluginError
 
 __all__ = [
     "any", "all", "filter", "get", "getattr", "hasattr", "length", "optional",

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -3,14 +3,14 @@ import logging
 import operator
 import re
 import time
+from collections import OrderedDict
+from functools import partial
+
 import requests.cookies
 
-from functools import partial
-from collections import OrderedDict
-
 from streamlink.cache import Cache
-from streamlink.exceptions import PluginError, NoStreamsError, FatalPluginError
-from streamlink.options import Options, Arguments
+from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
+from streamlink.options import Arguments, Options
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/__init__.py
+++ b/src/streamlink/plugins/__init__.py
@@ -4,5 +4,7 @@
     compatibility.
 """
 
-from ..exceptions import PluginError, NoStreamsError, NoPluginError
-from ..plugin import Plugin
+from streamlink.exceptions import NoPluginError, NoStreamsError, PluginError
+from streamlink.plugin.plugin import Plugin
+
+__all__ = ['Plugin', 'PluginError', 'NoStreamsError', 'NoPluginError']

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -5,19 +5,16 @@ import re
 import struct
 import time
 import uuid
-
 from base64 import urlsafe_b64encode
 from binascii import unhexlify
 
 from Crypto.Cipher import AES
-
 from requests import Response
 from requests.adapters import BaseAdapter
 
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils.url import update_qsd
 

--- a/src/streamlink/plugins/abweb.py
+++ b/src/streamlink/plugins/abweb.py
@@ -4,12 +4,10 @@ import time
 
 from streamlink.cache import Cache
 from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
-from streamlink.plugin import PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -1,11 +1,9 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
-from streamlink.plugin import PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -6,7 +6,6 @@ from streamlink.plugin.plugin import parse_url_params
 from streamlink.stream import AkamaiHDStream
 from streamlink.utils import update_scheme
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/animelab.py
+++ b/src/streamlink/plugins/animelab.py
@@ -1,11 +1,10 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
 from streamlink.utils import parse_json
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/app17.py
+++ b/src/streamlink/plugins/app17.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream, RTMPStream, HTTPStream
+from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -4,8 +4,8 @@ from functools import partial
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, DASHStream
-from streamlink.utils import parse_json, update_scheme, search_dict
+from streamlink.stream import DASHStream, HLSStream
+from streamlink.utils import parse_json, search_dict, update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -1,15 +1,14 @@
 import base64
-from collections import defaultdict
-from hashlib import sha1
 import logging
 import re
+from collections import defaultdict
+from hashlib import sha1
 from urllib.parse import urlparse
 
 from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
-from streamlink.stream import HDSStream
-from streamlink.stream import HLSStream
+from streamlink.stream import HDSStream, HLSStream
 from streamlink.stream.dash import DASHStream
 from streamlink.utils import parse_json
 

--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -3,7 +3,7 @@ import re
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate, useragents
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HTTPStream
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -3,7 +3,7 @@ import re
 from functools import partial
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate, useragents
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HDSStream, HLSStream, HTTPStream
 from streamlink.utils import parse_json, update_scheme
 

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -1,16 +1,15 @@
-from io import BytesIO
 import logging
 import random
 import re
-from urllib.parse import urlparse, parse_qsl
+from io import BytesIO
+from urllib.parse import parse_qsl, urlparse
 
 from streamlink import PluginError
 from streamlink.packages.flashmedia import AMFMessage, AMFPacket
 from streamlink.packages.flashmedia.types import AMF3ObjectBase
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate, useragents
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/btsports.py
+++ b/src/streamlink/plugins/btsports.py
@@ -4,7 +4,7 @@ import time
 from urllib.parse import quote
 from uuid import uuid4
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 

--- a/src/streamlink/plugins/canalplus.py
+++ b/src/streamlink/plugins/canalplus.py
@@ -5,7 +5,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HDSStream, HLSStream, HTTPStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -3,8 +3,7 @@ import re
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
 

--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -11,16 +11,16 @@ Following channels are working:
 
 Additionally, videos from iVysilani archive should work as well.
 """
-from html import unescape as html_unescape
 import json
 import logging
 import re
+from html import unescape as html_unescape
 from urllib.parse import quote
 
+from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream, DASHStream
-from streamlink.exceptions import PluginError
+from streamlink.stream import DASHStream, HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/common_jwplayer.py
+++ b/src/streamlink/plugins/common_jwplayer.py
@@ -1,5 +1,4 @@
 import re
-
 from functools import partial
 
 from streamlink.plugin.api import validate

--- a/src/streamlink/plugins/common_swf.py
+++ b/src/streamlink/plugins/common_swf.py
@@ -1,8 +1,8 @@
 from collections import namedtuple
 from io import BytesIO
 
-from streamlink.utils import swfdecompress
 from streamlink.packages.flashmedia.types import U16LE, U32LE
+from streamlink.utils import swfdecompress
 
 __all__ = ["parse_swf"]
 

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -1,9 +1,9 @@
 import datetime
-import re
 import logging
+import re
 from uuid import uuid4
 
-from streamlink.plugin import Plugin, PluginError, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 

--- a/src/streamlink/plugins/cubetv.py
+++ b/src/streamlink/plugins/cubetv.py
@@ -1,9 +1,9 @@
 import re
 
+from streamlink import NoStreamsError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink import NoStreamsError
 
 
 class CubeTV(Plugin):

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -6,7 +6,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 
-
 log = logging.getLogger(__name__)
 
 COOKIES = {

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -3,8 +3,7 @@ import re
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import stream_weight
-from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
+from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, stream_weight
 from streamlink.stream.dash import DASHStream
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -3,14 +3,13 @@ Plugin to support the videos from Delfi.lt
 
 https://en.wikipedia.org/wiki/Delfi_(web_portal)
 """
-import re
-import logging
-
 import itertools
+import logging
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HTTPStream, HLSStream, DASHStream
+from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -1,11 +1,10 @@
 import logging
 import re
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/dlive.py
+++ b/src/streamlink/plugins/dlive.py
@@ -7,7 +7,6 @@ from streamlink.plugin import Plugin, PluginError
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -6,7 +6,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/dogus.py
+++ b/src/streamlink/plugins/dogus.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api.utils import itertags

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -6,7 +6,6 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
 from streamlink.utils import parse_json, update_scheme
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/ellobo.py
+++ b/src/streamlink/plugins/ellobo.py
@@ -1,7 +1,6 @@
 import re
 
-from streamlink import NoPluginError
-from streamlink import PluginError
+from streamlink import NoPluginError, PluginError
 from streamlink.plugin import Plugin
 
 

--- a/src/streamlink/plugins/eltrecetv.py
+++ b/src/streamlink/plugins/eltrecetv.py
@@ -6,7 +6,6 @@ from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -1,6 +1,6 @@
-from html import unescape as html_unescape
 import logging
 import re
+from html import unescape as html_unescape
 from urllib.parse import unquote_plus, urlencode
 
 from streamlink.plugin import Plugin

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 import time
 from urllib.parse import urlparse, urlunparse
 
@@ -7,7 +7,7 @@ from streamlink.exceptions import PluginError, StreamError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, hls_playlist
-from streamlink.stream.hls import HLSStreamWorker, HLSStreamReader, Sequence
+from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker, Sequence
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -2,12 +2,10 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -6,7 +6,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api.utils import itertags
 from streamlink.utils import update_scheme
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream

--- a/src/streamlink/plugins/googledrive.py
+++ b/src/streamlink/plugins/googledrive.py
@@ -5,7 +5,6 @@ from urllib.parse import parse_qsl
 from streamlink.plugin import Plugin
 from streamlink.stream import HTTPStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -6,7 +6,6 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -2,7 +2,7 @@ import re
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
+from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, parse_url_params
 from streamlink.stream import HDSStream
 from streamlink.utils import update_scheme
 

--- a/src/streamlink/plugins/hitbox.py
+++ b/src/streamlink/plugins/hitbox.py
@@ -1,13 +1,12 @@
-from itertools import chain
 import logging
 import re
+from itertools import chain
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import StreamMapper, validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 from streamlink.utils import absolute_url
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -3,10 +3,9 @@ import re
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
+from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, parse_url_params
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -6,7 +6,6 @@ from streamlink.plugin.plugin import parse_url_params
 from streamlink.stream import HTTPStream
 from streamlink.utils import update_scheme
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/huajiao.py
+++ b/src/streamlink/plugins/huajiao.py
@@ -1,14 +1,14 @@
 import base64
+import json
+import random
 import re
 import time
 import uuid
-import random
-import json
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.useragents import CHROME as USER_AGENT
-from streamlink.stream import (HTTPStream, HLSStream)
+from streamlink.stream import (HLSStream, HTTPStream)
 
 HUAJIAO_URL = "http://www.huajiao.com/l/{}"
 LAPI_URL = "http://g2.live.360.cn/liveplay?stype=flv&channel={}&bid=huajiao&sn={}&sid={}&_rate=xd&ts={}&r={}" \

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -1,9 +1,8 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.plugin.api import useragents
 from streamlink.utils import update_scheme
 
 HUYA_URL = "http://m.huya.com/%s"

--- a/src/streamlink/plugins/ine.py
+++ b/src/streamlink/plugins/ine.py
@@ -7,7 +7,6 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import update_scheme
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/invintus.py
+++ b/src/streamlink/plugins/invintus.py
@@ -1,8 +1,8 @@
-import re
 import json
+import re
 
-from streamlink.plugin.api import validate
 from streamlink.plugin import Plugin
+from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils.url import update_scheme
 

--- a/src/streamlink/plugins/kingkong.py
+++ b/src/streamlink/plugins/kingkong.py
@@ -3,8 +3,7 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream, HLSStream
-
+from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/liveedu.py
+++ b/src/streamlink/plugins/liveedu.py
@@ -3,11 +3,9 @@ import re
 from urllib.parse import urljoin
 
 from streamlink import PluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
-from streamlink.stream import RTMPStream
-
+from streamlink.stream import HLSStream, RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/liveme.py
+++ b/src/streamlink/plugins/liveme.py
@@ -1,13 +1,11 @@
 import logging
 import random
 import re
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
-
+from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -2,8 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -1,15 +1,15 @@
 import json
 import logging
 import re
-import websocket
 import threading
 import time
-from urllib.parse import urlparse, unquote_plus
+from urllib.parse import unquote_plus, urlparse
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+import websocket
+
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
-
 
 _log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/nownews.py
+++ b/src/streamlink/plugins/nownews.py
@@ -1,6 +1,6 @@
+import json
 import logging
 import re
-import json
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream

--- a/src/streamlink/plugins/ntv.py
+++ b/src/streamlink/plugins/ntv.py
@@ -1,4 +1,5 @@
 import re
+
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream
 

--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -1,6 +1,6 @@
-from html import unescape as html_unescape
 import logging
 import re
+from html import unescape as html_unescape
 from urllib.parse import unquote
 
 from streamlink.exceptions import PluginError

--- a/src/streamlink/plugins/olympicchannel.py
+++ b/src/streamlink/plugins/olympicchannel.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 from time import time
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urljoin, urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -1,13 +1,12 @@
-from base64 import b64decode
-from html.parser import HTMLParser
 import logging
 import re
+from base64 import b64decode
+from html.parser import HTMLParser
 from urllib.parse import urlparse
 
 from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -1,13 +1,12 @@
 import logging
 import random
 import re
-from urllib.parse import urlencode, unquote, urljoin
+from urllib.parse import unquote, urlencode, urljoin
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import stream_weight
-from streamlink.stream import HLSStream, HTTPStream, DASHStream
+from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.utils import update_scheme
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/orf_tvthek.py
+++ b/src/streamlink/plugins/orf_tvthek.py
@@ -1,5 +1,5 @@
-import re
 import json
+import re
 
 from streamlink.plugin import Plugin, PluginError
 from streamlink.stream import HLSStream

--- a/src/streamlink/plugins/periscope.py
+++ b/src/streamlink/plugins/periscope.py
@@ -6,7 +6,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 STREAM_INFO_URL = "https://api.periscope.tv/api/v2/getAccessPublic"

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -4,10 +4,8 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
-from streamlink.stream import RTMPStream
+from streamlink.stream import HLSStream, RTMPStream
 from streamlink.utils import parse_json
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 

--- a/src/streamlink/plugins/playtv.py
+++ b/src/streamlink/plugins/playtv.py
@@ -7,7 +7,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream, HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -3,7 +3,7 @@ import re
 import sys
 import time
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HDSStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream

--- a/src/streamlink/plugins/qq.py
+++ b/src/streamlink/plugins/qq.py
@@ -7,7 +7,6 @@ from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -3,8 +3,8 @@ import datetime
 import hashlib
 import random
 import re
-from urllib.parse import urlencode
 import xml.etree.ElementTree as ET
+from urllib.parse import urlencode
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, urlunparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream, HLSStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -7,7 +7,6 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/rtbf.py
+++ b/src/streamlink/plugins/rtbf.py
@@ -1,13 +1,12 @@
 import datetime
-from html import unescape as html_unescape
 import logging
 import re
+from html import unescape as html_unescape
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.utils import parse_json
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/rtlxl.py
+++ b/src/streamlink/plugins/rtlxl.py
@@ -1,5 +1,5 @@
-import re
 import json
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream

--- a/src/streamlink/plugins/rtmp.py
+++ b/src/streamlink/plugins/rtmp.py
@@ -5,7 +5,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.plugin import parse_url_params
 from streamlink.stream import RTMPStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -5,12 +5,10 @@ from functools import partial
 
 from Crypto.Cipher import Blowfish
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
 from streamlink.utils import parse_xml
 

--- a/src/streamlink/plugins/rtvs.py
+++ b/src/streamlink/plugins/rtvs.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import RTMPStream, HLSStream
+from streamlink.stream import HLSStream, RTMPStream
 
 RUURL = "b=chrome&p=win&v=56&f=0&d=1"
 

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -2,7 +2,7 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -2,9 +2,8 @@ import logging
 import re
 from functools import partial
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
 

--- a/src/streamlink/plugins/senategov.py
+++ b/src/streamlink/plugins/senategov.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -2,10 +2,9 @@ import logging
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate, useragents
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, RTMPStream
 from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/skai.py
+++ b/src/streamlink/plugins/skai.py
@@ -3,7 +3,6 @@ import re
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 
-
 _url_re = re.compile(r'http(s)?://www\.skai(?:tv)?.gr/.*')
 _api_url = "http://www.skaitv.gr/json/live.php"
 _api_res_schema = validate.Schema(validate.all(

--- a/src/streamlink/plugins/stadium.py
+++ b/src/streamlink/plugins/stadium.py
@@ -1,5 +1,5 @@
-import re
 import logging
+import re
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -1,15 +1,15 @@
 import base64
-from html import unescape as html_unescape
 import logging
 import re
 import time
+from html import unescape as html_unescape
 
 from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
 
 import streamlink
 from streamlink.exceptions import FatalPluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags, parse_json
 from streamlink.plugin.api.validate import Schema

--- a/src/streamlink/plugins/streamingvideoprovider.py
+++ b/src/streamlink/plugins/streamingvideoprovider.py
@@ -4,8 +4,7 @@ from time import time
 
 from streamlink.plugin import Plugin, PluginError
 from streamlink.plugin.api import validate
-from streamlink.stream import RTMPStream, HLSStream
-
+from streamlink.stream import HLSStream, RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -11,7 +11,6 @@ from streamlink.stream import HLSStream
 from streamlink.utils import parse_qsd
 from streamlink.utils.crypto import decrypt_openssl
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream

--- a/src/streamlink/plugins/swisstxt.py
+++ b/src/streamlink/plugins/swisstxt.py
@@ -1,10 +1,9 @@
 import logging
 import re
-from urllib.parse import urlparse, parse_qsl, urlunparse
+from urllib.parse import parse_qsl, urlparse, urlunparse
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tamago.py
+++ b/src/streamlink/plugins/tamago.py
@@ -1,9 +1,9 @@
 import re
 
+from streamlink import NoStreamsError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
-from streamlink import NoStreamsError
 
 
 class Tamago(Plugin):

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -6,7 +6,6 @@ from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/theplatform.py
+++ b/src/streamlink/plugins/theplatform.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/tigerdile.py
+++ b/src/streamlink/plugins/tigerdile.py
@@ -3,9 +3,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.stream import RTMPStream
-from streamlink.stream import HLSStream
-
+from streamlink.stream import HLSStream, RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/trt.py
+++ b/src/streamlink/plugins/trt.py
@@ -1,6 +1,6 @@
-from base64 import b64decode
 import logging
 import re
+from base64 import b64decode
 from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin

--- a/src/streamlink/plugins/trtspor.py
+++ b/src/streamlink/plugins/trtspor.py
@@ -1,8 +1,7 @@
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.stream import HDSStream
-from streamlink.stream import HLSStream
+from streamlink.stream import HDSStream, HLSStream
 
 
 class TRTSpor(Plugin):

--- a/src/streamlink/plugins/turkuvaz.py
+++ b/src/streamlink/plugins/turkuvaz.py
@@ -2,10 +2,8 @@ import logging
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv3cat.py
+++ b/src/streamlink/plugins/tv3cat.py
@@ -2,8 +2,8 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, PluginError
-from streamlink.stream import HLSStream
 from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv5monde.py
+++ b/src/streamlink/plugins/tv5monde.py
@@ -2,9 +2,9 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
+from streamlink.plugins.common_jwplayer import _js_to_json
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 from streamlink.utils import parse_json
-from streamlink.plugins.common_jwplayer import _js_to_json
 
 
 class TV5Monde(Plugin):

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -4,9 +4,7 @@ import re
 from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
-from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
-
+from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -1,11 +1,9 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
-from streamlink.plugin.api import validate
-from streamlink.plugin.api import useragents
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -5,7 +5,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -2,10 +2,8 @@ import logging
 import re
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -1,16 +1,16 @@
 import logging
 import re
-from urllib.parse import urlparse, unquote_plus
+from threading import Event, Thread
+from urllib.parse import unquote_plus, urlparse
+
 import websocket
 
 from streamlink import logger
 from streamlink.buffers import RingBuffer
 from streamlink.plugin import Plugin, PluginError
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
-from streamlink.stream import Stream
+from streamlink.plugin.api import useragents, validate
+from streamlink.stream.stream import Stream
 from streamlink.stream.stream import StreamIO
-from threading import Thread, Event
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -1,22 +1,21 @@
-from collections import namedtuple
 import json
 import logging
-from random import random
 import re
+from collections import namedtuple
+from random import random
 from urllib.parse import urlparse
 
 import requests
 
 from streamlink.exceptions import NoStreamsError, PluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import parse_json, parse_query
-from streamlink.stream import HTTPStream, HLSStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.hls import HLSStreamWorker
-from streamlink.stream.hls_filtered import FilteredHLSStreamWriter, FilteredHLSStreamReader
+from streamlink.stream.hls_filtered import FilteredHLSStreamReader, FilteredHLSStreamWriter
 from streamlink.stream.hls_playlist import M3U8, M3U8Parser, load as load_hls_playlist
 from streamlink.utils.times import hours_minutes_seconds
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -3,24 +3,22 @@ import errno
 import json
 import logging
 import re
-from urllib.parse import urljoin, urlunparse, urlparse, unquote_plus
-import websocket
-
 from collections import deque, namedtuple
 from random import randint
 from socket import error as SocketError
-from threading import Thread, Event
+from threading import Event, Thread
 from time import sleep
+from urllib.parse import unquote_plus, urljoin, urlparse, urlunparse
+
+import websocket
 
 from streamlink.exceptions import PluginError, StreamError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import Stream
 from streamlink.stream.dash_manifest import sleep_until, utc
 from streamlink.stream.flvconcat import FLVTagConcat
-from streamlink.stream.segmented import (
-    SegmentedStreamReader, SegmentedStreamWriter, SegmentedStreamWorker
-)
+from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
+from streamlink.stream.stream import Stream
 from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -10,7 +10,7 @@ from Crypto.Hash import SHA256
 from Crypto.Util.Padding import pad, unpad
 
 from streamlink import PluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/viasat.py
+++ b/src/streamlink/plugins/viasat.py
@@ -8,7 +8,6 @@ from streamlink.plugin.api import StreamMapper, validate
 from streamlink.stream import HDSStream, HLSStream, RTMPStream
 from streamlink.utils import rtmpparse
 
-
 log = logging.getLogger(__name__)
 
 STREAM_API_URL = "https://playapi.mtgx.tv/v3/videos/stream/{0}"

--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -11,7 +11,6 @@ from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -1,9 +1,9 @@
-from html import unescape as html_unescape
 import logging
 import re
+from html import unescape as html_unescape
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream

--- a/src/streamlink/plugins/viutv.py
+++ b/src/streamlink/plugins/viutv.py
@@ -1,8 +1,8 @@
 import datetime
+import json
 import logging
 import random
 import re
-import json
 
 from streamlink.plugin import Plugin
 from streamlink.stream import HLSStream

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -1,12 +1,12 @@
-from html import unescape as html_unescape
 import logging
 import re
-from urllib.parse import urlparse, unquote
+from html import unescape as html_unescape
+from urllib.parse import unquote, urlparse
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HTTPStream, HLSStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/vlive.py
+++ b/src/streamlink/plugins/vlive.py
@@ -5,7 +5,6 @@ import re
 from streamlink.plugin import Plugin, PluginError
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/vrtbe.py
+++ b/src/streamlink/plugins/vrtbe.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream, DASHStream
+from streamlink.stream import DASHStream, HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/wasd.py
+++ b/src/streamlink/plugins/wasd.py
@@ -3,8 +3,8 @@ import re
 
 from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
-from streamlink.stream import HLSStream
 from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/webcast_india_gov.py
+++ b/src/streamlink/plugins/webcast_india_gov.py
@@ -5,7 +5,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -11,7 +11,6 @@ from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, update_scheme
 from streamlink.utils.crypto import unpad_pkcs5
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/willax.py
+++ b/src/streamlink/plugins/willax.py
@@ -1,6 +1,6 @@
-from html import unescape as html_unescape
 import logging
 import re
+from html import unescape as html_unescape
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import re
-from urllib.parse import urlparse, parse_qsl
+from urllib.parse import parse_qsl, urlparse
 
 from streamlink import PluginError
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils import memoize

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -3,9 +3,9 @@ import re
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
 from streamlink.plugin import Plugin, PluginError
-from streamlink.plugin.api import validate, useragents
+from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags, parse_query
-from streamlink.stream import HTTPStream, HLSStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
 from streamlink.utils import parse_json, search_dict
 

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -2,10 +2,9 @@ import logging
 import re
 import time
 
-from streamlink.plugin import Plugin, PluginArguments, PluginArgument
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -6,10 +6,8 @@ from requests.cookies import cookiejar_from_dict
 
 from streamlink import PluginError
 from streamlink.cache import Cache
-from streamlink.plugin import Plugin
-from streamlink.plugin import PluginArguments, PluginArgument
-from streamlink.plugin.api import useragents
-from streamlink.plugin.api import validate
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin.api import useragents, validate
 from streamlink.stream import DASHStream, HLSStream
 from streamlink.utils.args import comma_list_filter
 

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -7,7 +7,6 @@ from streamlink.stream import HDSStream, HLSStream
 from streamlink.utils import parse_json
 from streamlink.utils.url import url_concat
 
-
 log = logging.getLogger(__name__)
 
 API_URL = "https://api.zdf.de"

--- a/src/streamlink/plugins/zengatv.py
+++ b/src/streamlink/plugins/zengatv.py
@@ -5,7 +5,6 @@ from streamlink.plugin import Plugin
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
-
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/zhanqi.py
+++ b/src/streamlink/plugins/zhanqi.py
@@ -3,8 +3,7 @@ import re
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream, HLSStream
-
+from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -3,19 +3,18 @@ import logging
 import pkgutil
 import sys
 import traceback
+from collections import OrderedDict
 
 import requests
 
-from collections import OrderedDict
-
+from streamlink import __version__, plugins
+from streamlink.compat import is_win32
+from streamlink.exceptions import NoPluginError, PluginError
 from streamlink.logger import StreamlinkLogger
-from streamlink.utils import update_scheme, memoize
+from streamlink.options import Options
+from streamlink.plugin import api
+from streamlink.utils import memoize, update_scheme
 from streamlink.utils.l10n import Localization
-from . import plugins, __version__
-from .compat import is_win32
-from .exceptions import NoPluginError, PluginError
-from .options import Options
-from .plugin import api
 
 # Ensure that the Logger class returned is Streamslink's for using the API (for backwards compatibility)
 logging.setLoggerClass(StreamlinkLogger)

--- a/src/streamlink/stream/__init__.py
+++ b/src/streamlink/stream/__init__.py
@@ -1,14 +1,11 @@
-from ..exceptions import StreamError
-from streamlink.stream.stream import Stream
-
 from streamlink.stream.akamaihd import AkamaiHDStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.flvconcat import extract_flv_header_tags
 from streamlink.stream.hds import HDSStream
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
+from streamlink.stream.playlist import FLVPlaylist, Playlist
 from streamlink.stream.rtmpdump import RTMPStream
-from streamlink.stream.dash import DASHStream
+from streamlink.stream.stream import Stream
 from streamlink.stream.streamprocess import StreamProcess
-from streamlink.stream.wrappers import StreamIOWrapper, StreamIOIterWrapper, StreamIOThreadWrapper
-
-from streamlink.stream.flvconcat import extract_flv_header_tags
-from streamlink.stream.playlist import Playlist, FLVPlaylist
+from streamlink.stream.wrappers import StreamIOIterWrapper, StreamIOThreadWrapper, StreamIOWrapper

--- a/src/streamlink/stream/akamaihd.py
+++ b/src/streamlink/stream/akamaihd.py
@@ -2,19 +2,17 @@ import base64
 import hashlib
 import hmac
 import io
+import logging
 import random
 from urllib.parse import urlparse
 
-from .stream import Stream
-from .wrappers import StreamIOThreadWrapper, StreamIOIterWrapper
-
-from ..buffers import Buffer
-from ..exceptions import StreamError
-from ..utils import swfdecompress
-
-from ..packages.flashmedia import FLV, FLVError
-from ..packages.flashmedia.tag import ScriptData
-import logging
+from streamlink.buffers import Buffer
+from streamlink.exceptions import StreamError
+from streamlink.packages.flashmedia import FLV, FLVError
+from streamlink.packages.flashmedia.tag import ScriptData
+from streamlink.stream.stream import Stream
+from streamlink.stream.wrappers import StreamIOIterWrapper, StreamIOThreadWrapper
+from streamlink.utils import swfdecompress
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -7,12 +7,12 @@ from urllib.parse import urlparse, urlunparse
 
 import requests
 
-from streamlink import StreamError, PluginError
-from streamlink.stream.http import valid_args, normalize_key
-from streamlink.stream.stream import Stream
-from streamlink.stream.dash_manifest import MPD, sleeper, sleep_until, utc, freeze_timeline
+from streamlink import PluginError, StreamError
+from streamlink.stream.dash_manifest import MPD, freeze_timeline, sleep_until, sleeper, utc
 from streamlink.stream.ffmpegmux import FFMPEGMuxer
+from streamlink.stream.http import normalize_key, valid_args
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
+from streamlink.stream.stream import Stream
 from streamlink.utils import parse_xml
 from streamlink.utils.l10n import Language
 

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -1,16 +1,15 @@
-from collections import defaultdict, namedtuple
-from contextlib import contextmanager
 import copy
 import datetime
-from itertools import repeat, count
 import logging
 import math
 import re
 import time
-from urllib.parse import urlparse, urljoin, urlunparse, urlsplit, urlunsplit
+from collections import defaultdict, namedtuple
+from contextlib import contextmanager
+from itertools import count, repeat
+from urllib.parse import urljoin, urlparse, urlsplit, urlunparse, urlunsplit
 
-from isodate import parse_datetime, parse_duration, Duration
-
+from isodate import Duration, parse_datetime, parse_duration
 
 if hasattr(datetime, "timezone"):
     utc = datetime.timezone.utc

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -1,17 +1,15 @@
 import logging
 import os
 import random
-from shutil import which
 import subprocess
 import sys
 import threading
+from shutil import which
 
 from streamlink import StreamError
-from streamlink.stream import Stream
-from streamlink.stream.stream import StreamIO
-from streamlink.utils import NamedPipe
 from streamlink.compat import devnull
-
+from streamlink.stream.stream import Stream, StreamIO
+from streamlink.utils import NamedPipe
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/file.py
+++ b/src/streamlink/stream/file.py
@@ -1,7 +1,7 @@
 """
 Stream wrapper around a file
 """
-from streamlink.stream import Stream
+from streamlink.stream.stream import Stream
 
 
 class FileStream(Stream):

--- a/src/streamlink/stream/flvconcat.py
+++ b/src/streamlink/stream/flvconcat.py
@@ -4,17 +4,13 @@ from io import IOBase
 from itertools import chain, islice
 from threading import Thread
 
-from ..buffers import RingBuffer
-from ..packages.flashmedia import FLVError
-from ..packages.flashmedia.tag import (AudioData, AACAudioData, VideoData,
-                                       AVCVideoData, VideoCommandFrame,
-                                       Header, ScriptData, Tag)
-from ..packages.flashmedia.tag import (AAC_PACKET_TYPE_SEQUENCE_HEADER,
-                                       AVC_PACKET_TYPE_SEQUENCE_HEADER,
-                                       AUDIO_CODEC_ID_AAC,
-                                       VIDEO_CODEC_ID_AVC,
-                                       TAG_TYPE_AUDIO,
-                                       TAG_TYPE_VIDEO)
+from streamlink.buffers import RingBuffer
+from streamlink.packages.flashmedia import FLVError
+from streamlink.packages.flashmedia.tag import (
+    AACAudioData, AAC_PACKET_TYPE_SEQUENCE_HEADER, AUDIO_CODEC_ID_AAC, AVCVideoData,
+    AVC_PACKET_TYPE_SEQUENCE_HEADER, AudioData, Header, ScriptData, TAG_TYPE_AUDIO,
+    TAG_TYPE_VIDEO, Tag, VIDEO_CODEC_ID_AVC, VideoCommandFrame, VideoData
+)
 
 __all__ = ["extract_flv_header_tags", "FLVTagConcat", "FLVTagConcatIO"]
 log = logging.getLogger(__name__)

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -1,11 +1,10 @@
-import logging
 import base64
 import hmac
+import logging
+import os.path
 import random
 import re
-import os.path
 import string
-
 from binascii import unhexlify
 from collections import namedtuple
 from copy import deepcopy
@@ -14,20 +13,16 @@ from io import BytesIO
 from math import ceil
 from urllib.parse import parse_qsl, urljoin, urlparse, urlunparse
 
-from .flvconcat import FLVTagConcat
-from .segmented import (SegmentedStreamReader,
-                        SegmentedStreamWriter,
-                        SegmentedStreamWorker)
-from .stream import Stream
-from .wrappers import StreamIOIterWrapper
-
-from ..cache import Cache
-from ..exceptions import StreamError, PluginError
-from ..utils import absolute_url, swfdecompress
-
-from ..packages.flashmedia import F4V, F4VError
-from ..packages.flashmedia.box import Box
-from ..packages.flashmedia.tag import ScriptData, Tag, TAG_TYPE_SCRIPT
+from streamlink.cache import Cache
+from streamlink.exceptions import PluginError, StreamError
+from streamlink.packages.flashmedia import F4V, F4VError
+from streamlink.packages.flashmedia.box import Box
+from streamlink.packages.flashmedia.tag import ScriptData, TAG_TYPE_SCRIPT, Tag
+from streamlink.stream.flvconcat import FLVTagConcat
+from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
+from streamlink.stream.stream import Stream
+from streamlink.stream.wrappers import StreamIOIterWrapper
+from streamlink.utils import absolute_url, swfdecompress
 
 log = logging.getLogger(__name__)
 # Akamai HD player verification key

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -1,7 +1,7 @@
-from collections import defaultdict, namedtuple, OrderedDict
 import logging
 import re
 import struct
+from collections import OrderedDict, defaultdict, namedtuple
 from urllib.parse import urlparse
 
 from Crypto.Cipher import AES
@@ -11,9 +11,7 @@ from streamlink.exceptions import StreamError
 from streamlink.stream import hls_playlist
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, MuxedStream
 from streamlink.stream.http import HTTPStream
-from streamlink.stream.segmented import (SegmentedStreamReader,
-                                         SegmentedStreamWriter,
-                                         SegmentedStreamWorker)
+from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
 from streamlink.utils import LazyFormatter
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/stream/hls_filtered.py
+++ b/src/streamlink/stream/hls_filtered.py
@@ -1,8 +1,7 @@
 import logging
 from threading import Event
 
-from .hls import HLSStreamWriter, HLSStreamReader
-
+from streamlink.stream.hls import HLSStreamReader, HLSStreamWriter
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -1,13 +1,12 @@
+import logging
+import re
 from binascii import unhexlify
 from collections import namedtuple
 from datetime import timedelta
 from itertools import starmap
-import logging
-import re
 from urllib.parse import urljoin, urlparse
 
 from isodate import parse_datetime
-
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -3,8 +3,8 @@ from inspect import getfullargspec
 import requests
 
 from streamlink.exceptions import StreamError
-from streamlink.stream import Stream
-from streamlink.stream.wrappers import StreamIOThreadWrapper, StreamIOIterWrapper
+from streamlink.stream.stream import Stream
+from streamlink.stream.wrappers import StreamIOIterWrapper, StreamIOThreadWrapper
 
 
 def normalize_key(keyval):

--- a/src/streamlink/stream/playlist.py
+++ b/src/streamlink/stream/playlist.py
@@ -1,7 +1,8 @@
-from .flvconcat import FLVTagConcatIO
-from .stream import Stream
-from ..exceptions import StreamError
 import logging
+
+from streamlink.exceptions import StreamError
+from streamlink.stream.flvconcat import FLVTagConcatIO
+from streamlink.stream.stream import Stream
 
 __all__ = ["Playlist", "FLVPlaylist"]
 log = logging.getLogger(__name__)

--- a/src/streamlink/stream/rtmpdump.py
+++ b/src/streamlink/stream/rtmpdump.py
@@ -1,14 +1,13 @@
 import logging
-from operator import itemgetter
 import re
-from shutil import which
 import subprocess
+from operator import itemgetter
+from shutil import which
 
 from streamlink import logger
-from streamlink.stream.streamprocess import StreamProcess
 from streamlink.exceptions import StreamError
-from streamlink.utils import rtmpparse, escape_librtmp
-
+from streamlink.stream.streamprocess import StreamProcess
+from streamlink.utils import escape_librtmp, rtmpparse
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -1,12 +1,12 @@
-from concurrent import futures
-from concurrent.futures.thread import ThreadPoolExecutor
 import logging
 import queue
-from threading import Thread, Event
+from concurrent import futures
+from concurrent.futures.thread import ThreadPoolExecutor
 from sys import version_info
+from threading import Event, Thread
 
-from .stream import StreamIO
-from ..buffers import RingBuffer
+from streamlink.buffers import RingBuffer
+from streamlink.stream.stream import StreamIO
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/streamprocess.py
+++ b/src/streamlink/stream/streamprocess.py
@@ -1,16 +1,15 @@
 import logging
-from operator import itemgetter
 import os.path
-from shutil import which
 import subprocess
 import tempfile
 import time
+from operator import itemgetter
+from shutil import which
 
-from streamlink.stream import Stream
-from streamlink.stream.wrappers import StreamIOThreadWrapper
 from streamlink.compat import devnull
 from streamlink.exceptions import StreamError
-
+from streamlink.stream.stream import Stream
+from streamlink.stream.wrappers import StreamIOThreadWrapper
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/wrappers.py
+++ b/src/streamlink/stream/wrappers.py
@@ -1,8 +1,7 @@
-from ..buffers import Buffer, RingBuffer
-
+import io
 from threading import Thread
 
-import io
+from streamlink.buffers import Buffer, RingBuffer
 
 
 class StreamIOWrapper(io.IOBase):

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -1,13 +1,13 @@
 import functools
 import json
 import re
-from urllib.parse import urljoin, urlparse, parse_qsl
 import xml.etree.ElementTree as ET
 import zlib
+from urllib.parse import parse_qsl, urljoin, urlparse
 
 from streamlink.exceptions import PluginError
-from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.lazy_formatter import LazyFormatter
+from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.url import update_scheme, url_equal
 
 

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -1,8 +1,7 @@
 import os
 import tempfile
 
-from ..compat import is_win32
-
+from streamlink.compat import is_win32
 
 if is_win32:
     from ctypes import windll, cast, c_ulong, c_void_p, byref

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from urllib.parse import urljoin, urlparse, urlunparse, parse_qsl, urlencode
+from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
 
 
 def update_scheme(current, target):

--- a/src/streamlink_cli/__main__.py
+++ b/src/streamlink_cli/__main__.py
@@ -1,3 +1,3 @@
 if __name__ == "__main__":
-    from .main import main
+    from streamlink_cli.main import main
     main()

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -4,15 +4,13 @@ import re
 from string import printable
 from textwrap import dedent
 
-from streamlink import logger, __version__ as streamlink_version
+from streamlink import __version__ as streamlink_version, logger
 from streamlink.utils.args import (
     boolean, comma_list, comma_list_filter, filesize, keyvalue, num
 )
 from streamlink.utils.times import hours_minutes_seconds
-from .constants import (
-    STREAM_PASSTHROUGH, DEFAULT_PLAYER_ARGUMENTS, DEFAULT_STREAM_METADATA, SUPPORTED_PLAYERS
-)
-from .utils import find_default_player
+from streamlink_cli.constants import (DEFAULT_PLAYER_ARGUMENTS, DEFAULT_STREAM_METADATA, STREAM_PASSTHROUGH, SUPPORTED_PLAYERS)
+from streamlink_cli.utils import find_default_player
 
 _printable_re = re.compile(r"[{0}]".format(printable))
 _option_re = re.compile(r"""

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -4,7 +4,7 @@ import sys
 from getpass import getpass
 
 from streamlink.plugin.plugin import UserInputRequester
-from .utils import JSONEncoder
+from streamlink_cli.utils import JSONEncoder
 
 log = logging.getLogger("streamlink.cli")
 

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -1,6 +1,6 @@
 import os
 
-from .compat import is_win32
+from streamlink_cli.compat import is_win32
 
 DEFAULT_PLAYER_ARGUMENTS = u"{filename}"
 DEFAULT_STREAM_METADATA = {

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -3,37 +3,33 @@ import errno
 import logging
 import os
 import platform
-from collections import OrderedDict
-from gettext import gettext
-
-import requests
-import sys
 import signal
-
+import sys
+from collections import OrderedDict
 from contextlib import closing
 from distutils.version import StrictVersion
 from functools import partial
+from gettext import gettext
 from itertools import chain
-from socks import __version__ as socks_version
 from time import sleep
+
+import requests
+from socks import __version__ as socks_version
 from websocket import __version__ as websocket_version
 
-from streamlink import __version__ as streamlink_version
-from streamlink import (Streamlink, StreamError, PluginError,
-                        NoPluginError)
+import streamlink.logger as logger
+from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __version__ as streamlink_version
 from streamlink.cache import Cache
 from streamlink.exceptions import FatalPluginError
-from streamlink.stream import StreamProcess
 from streamlink.plugin import PluginOptions
+from streamlink.stream import StreamProcess
 from streamlink.utils import LazyFormatter
-
-import streamlink.logger as logger
-from .argparser import build_parser
-from .compat import stdout, is_win32
-from .console import ConsoleOutput, ConsoleUserInputRequester
-from .constants import CONFIG_FILES, PLUGINS_DIR, STREAM_SYNONYMS, DEFAULT_STREAM_METADATA
-from .output import FileOutput, PlayerOutput
-from .utils import NamedPipe, HTTPServer, ignored, progress, stream_to_url
+from streamlink_cli.argparser import build_parser
+from streamlink_cli.compat import is_win32, stdout
+from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
+from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, PLUGINS_DIR, STREAM_SYNONYMS
+from streamlink_cli.output import FileOutput, PlayerOutput
+from streamlink_cli.utils import HTTPServer, NamedPipe, ignored, progress, stream_to_url
 
 ACCEPTABLE_ERRNO = (errno.EPIPE, errno.EINVAL, errno.ECONNRESET)
 try:

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -5,9 +5,9 @@ import subprocess
 import sys
 from time import sleep
 
-from .compat import is_win32, stdout
-from .constants import DEFAULT_PLAYER_ARGUMENTS, SUPPORTED_PLAYERS
-from .utils import ignored
+from streamlink_cli.compat import is_win32, stdout
+from streamlink_cli.constants import DEFAULT_PLAYER_ARGUMENTS, SUPPORTED_PLAYERS
+from streamlink_cli.utils import ignored
 
 if is_win32:
     import msvcrt

--- a/src/streamlink_cli/utils/http_server.py
+++ b/src/streamlink_cli/utils/http_server.py
@@ -1,5 +1,4 @@
 import socket
-
 from io import BytesIO
 
 try:

--- a/src/streamlink_cli/utils/named_pipe.py
+++ b/src/streamlink_cli/utils/named_pipe.py
@@ -1,6 +1,5 @@
 # These imports, while unused, are here to provide API compatibility for this module
-from streamlink.utils.named_pipe import NamedPipe
-from ..compat import is_win32
+from streamlink.compat import is_win32
 
 if is_win32:
     from streamlink.utils.named_pipe import (
@@ -10,3 +9,11 @@ if is_win32:
         PIPE_WAIT,
         PIPE_UNLIMITED_INSTANCES,
         INVALID_HANDLE_VALUE)
+
+__all__ = ['is_win32',
+           'PIPE_ACCESS_OUTBOUND',
+           'PIPE_TYPE_BYTE',
+           'PIPE_READMODE_BYTE',
+           'PIPE_WAIT',
+           'PIPE_UNLIMITED_INSTANCES',
+           'INVALID_HANDLE_VALUE']

--- a/src/streamlink_cli/utils/player.py
+++ b/src/streamlink_cli/utils/player.py
@@ -1,7 +1,6 @@
 import os
-import sys
-
 import subprocess
+import sys
 
 
 def check_paths(exes, paths):

--- a/src/streamlink_cli/utils/progress.py
+++ b/src/streamlink_cli/utils/progress.py
@@ -1,10 +1,9 @@
 import sys
-
 from collections import deque
-from time import time
 from shutil import get_terminal_size
+from time import time
 
-from ..compat import is_win32
+from streamlink_cli.compat import is_win32
 
 PROGRESS_FORMATS = (
     "[download][{prefix}] Written {written} ({elapsed} @ {speed}/s)",

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -1,10 +1,10 @@
+import unittest
 from binascii import hexlify
 from collections import OrderedDict
 from functools import partial
 from threading import Event, Thread
 
 import requests_mock
-import unittest
 
 from streamlink import Streamlink
 from streamlink.stream.hls import HLSStream

--- a/tests/plugins/test_cbsnews.py
+++ b/tests/plugins/test_cbsnews.py
@@ -1,5 +1,7 @@
 import unittest  # noqa: F401
+
 import pytest
+
 from streamlink.plugins.cbsnews import CBSNews
 
 

--- a/tests/plugins/test_cubetv.py
+++ b/tests/plugins/test_cubetv.py
@@ -1,5 +1,6 @@
-from streamlink.plugins.cubetv import CubeTV
 import unittest
+
+from streamlink.plugins.cubetv import CubeTV
 
 
 class TestPluginCubeTV(unittest.TestCase):

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from streamlink import Streamlink
-from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, BIT_RATE_WEIGHT_RATIO
+from streamlink.plugin.plugin import BIT_RATE_WEIGHT_RATIO, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.plugins.dash import MPEGDASH
 
 

--- a/tests/plugins/test_garena.py
+++ b/tests/plugins/test_garena.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 from streamlink import Streamlink
 from streamlink.plugin.api import HTTPSession

--- a/tests/plugins/test_kingkong.py
+++ b/tests/plugins/test_kingkong.py
@@ -1,4 +1,5 @@
 import unittest
+
 from streamlink.plugins.kingkong import Kingkong
 
 

--- a/tests/plugins/test_mjunoon.py
+++ b/tests/plugins/test_mjunoon.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, Mock, ANY, call
+from unittest.mock import ANY, Mock, call, patch
 
 import requests_mock
 

--- a/tests/plugins/test_senategov.py
+++ b/tests/plugins/test_senategov.py
@@ -1,5 +1,6 @@
-from streamlink.plugins.senategov import SenateGov
 import unittest
+
+from streamlink.plugins.senategov import SenateGov
 
 
 class TestPluginSenateGov(unittest.TestCase):

--- a/tests/plugins/test_stadium.py
+++ b/tests/plugins/test_stadium.py
@@ -1,5 +1,6 @@
-from streamlink.plugins.stadium import Stadium
 import unittest
+
+from streamlink.plugins.stadium import Stadium
 
 
 class TestPluginStadium(unittest.TestCase):

--- a/tests/plugins/test_stream.py
+++ b/tests/plugins/test_stream.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from streamlink import Streamlink
-from streamlink.plugin.plugin import stream_weight, parse_params
+from streamlink.plugin.plugin import parse_params, stream_weight
 from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream
 
 

--- a/tests/plugins/test_tvplayer.py
+++ b/tests/plugins/test_tvplayer.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, Mock, ANY, MagicMock, call
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 from streamlink import Streamlink
 from streamlink.plugin.api import HTTPSession

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -1,14 +1,13 @@
-from datetime import datetime, timedelta
 import unittest
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, call, patch
 
 import requests_mock
 
-from tests.mixins.stream_hls import Playlist, Tag, Segment as _Segment, TestMixinStreamHLS
-
 from streamlink import Streamlink
 from streamlink.plugin import PluginError
 from streamlink.plugins.twitch import Twitch, TwitchHLSStream
+from tests.mixins.stream_hls import Playlist, Segment as _Segment, Tag, TestMixinStreamHLS
 
 
 DATETIME_BASE = datetime(2000, 1, 1, 0, 0, 0, 0)

--- a/tests/plugins/testplugin.py
+++ b/tests/plugins/testplugin.py
@@ -1,11 +1,10 @@
 from io import BytesIO
 
 from streamlink import NoStreamsError
-from streamlink.plugins import Plugin
 from streamlink.options import Options
-from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream, Stream
-
 from streamlink.plugin.api.support_plugin import testplugin_support
+from streamlink.plugins import Plugin
+from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream, Stream
 
 
 class TestStream(Stream):

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,12 +1,11 @@
 import codecs
 import os.path
 import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+from io import BytesIO
 
 import requests_mock
 import six
-
-from contextlib import contextmanager
-from io import BytesIO
 
 __here__ = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -1,12 +1,11 @@
 import unittest
-from unittest.mock import MagicMock, patch, ANY, Mock, call
-
-from tests.resources import text, xml
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 from streamlink import PluginError
 from streamlink.stream import DASHStream
 from streamlink.stream.dash import DASHStreamWorker
 from streamlink.stream.dash_manifest import MPD
+from tests.resources import text, xml
 
 
 class TestDASHStream(unittest.TestCase):

--- a/tests/streams/test_dash_parser.py
+++ b/tests/streams/test_dash_parser.py
@@ -1,15 +1,14 @@
 import datetime
 import itertools
-from operator import attrgetter
 import unittest
+from operator import attrgetter
 from unittest.mock import Mock
 
 from freezegun import freeze_time
 from freezegun.api import FakeDatetime
 
+from streamlink.stream.dash_manifest import MPD, MPDParsers, MPDParsingError, Representation, utc
 from tests.resources import xml
-
-from streamlink.stream.dash_manifest import MPD, MPDParsers, MPDParsingError, utc, Representation
 
 
 class TestMPDParsers(unittest.TestCase):

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -1,16 +1,15 @@
 import os
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
-from Crypto.Cipher import AES
 import pytest
 import requests_mock
-
-from tests.mixins.stream_hls import Playlist, Tag, Segment, TestMixinStreamHLS
-from tests.resources import text
+from Crypto.Cipher import AES
 
 from streamlink.session import Streamlink
 from streamlink.stream import hls
+from tests.mixins.stream_hls import Playlist, Segment, Tag, TestMixinStreamHLS
+from tests.resources import text
 
 
 def pkcs7_encode(data, keySize):

--- a/tests/streams/test_hls_filtered.py
+++ b/tests/streams/test_hls_filtered.py
@@ -1,11 +1,10 @@
-from threading import Event
 import unittest
+from threading import Event
 from unittest.mock import MagicMock, call, patch
 
-from tests.mixins.stream_hls import Playlist, Segment, TestMixinStreamHLS
-
 from streamlink.stream.hls import HLSStream
-from streamlink.stream.hls_filtered import FilteredHLSStreamWriter, FilteredHLSStreamReader
+from streamlink.stream.hls_filtered import FilteredHLSStreamReader, FilteredHLSStreamWriter
+from tests.mixins.stream_hls import Playlist, Segment, TestMixinStreamHLS
 
 
 FILTERED = "filtered"

--- a/tests/streams/test_hls_playlist.py
+++ b/tests/streams/test_hls_playlist.py
@@ -1,11 +1,10 @@
-from datetime import datetime, timedelta
 import unittest
+from datetime import datetime, timedelta
 
 from isodate import tzinfo
 
+from streamlink.stream.hls_playlist import DateRange, Media, Resolution, Segment, StreamInfo, load
 from tests.resources import text
-
-from streamlink.stream.hls_playlist import load, StreamInfo, Resolution, Media, DateRange, Segment
 
 
 class TestHLSPlaylist(unittest.TestCase):

--- a/tests/streams/test_stream_streamprocess.py
+++ b/tests/streams/test_stream_streamprocess.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 import pytest
 

--- a/tests/streams/test_stream_to_url.py
+++ b/tests/streams/test_stream_to_url.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 from streamlink import Streamlink
 from streamlink.plugins.filmon import FilmOnHLS
@@ -8,7 +8,7 @@ from streamlink.stream import HDSStream
 from streamlink.stream import HLSStream
 from streamlink.stream import HTTPStream
 from streamlink.stream import RTMPStream
-from streamlink.stream import Stream
+from streamlink.stream.stream import Stream
 from streamlink_cli.utils import stream_to_url
 
 

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 
 import requests
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1,12 +1,11 @@
 import re
 import unittest
-
 from xml.etree.ElementTree import Element
 
 from streamlink.plugin.api.validate import (
-    validate, all, any, optional, transform, text, filter, map, hasattr,
-    get, getattr, length, xml_element, xml_find, xml_findtext, xml_findall,
-    union, attr, url, startswith, endswith
+    all, any, attr, endswith, filter, get, getattr, hasattr,
+    length, map, optional, startswith, text, transform, union, url,
+    validate, xml_element, xml_find, xml_findall, xml_findtext
 )
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,8 +1,8 @@
 import datetime
 import os.path
-from shutil import rmtree
 import tempfile
 import unittest
+from shutil import rmtree
 from unittest.mock import patch
 
 import streamlink.cache

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -4,9 +4,9 @@ import unittest
 from unittest.mock import Mock, patch
 
 import streamlink_cli.main
-from streamlink_cli.main import resolve_stream_name, format_valid_streams, check_file_output, create_output
-from streamlink_cli.output import FileOutput, PlayerOutput
 from streamlink.plugin.plugin import Plugin
+from streamlink_cli.main import check_file_output, create_output, format_valid_streams, resolve_stream_name
+from streamlink_cli.output import FileOutput, PlayerOutput
 
 
 class FakePlugin:

--- a/tests/test_cli_playerout.py
+++ b/tests/test_cli_playerout.py
@@ -1,6 +1,7 @@
+from unittest.mock import ANY, patch
+
 from streamlink_cli.output import PlayerOutput
 from tests import posix_only, windows_only
-from unittest.mock import patch, ANY
 
 UNICODE_TITLE = u"기타치는소율 with UL섬 "
 

--- a/tests/test_cli_util_progress.py
+++ b/tests/test_cli_util_progress.py
@@ -1,5 +1,6 @@
-from streamlink_cli.utils.progress import terminal_width, get_cut_prefix
 import unittest
+
+from streamlink_cli.utils.progress import get_cut_prefix, terminal_width
 
 
 class TestCliUtilProgess(unittest.TestCase):

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,9 +1,9 @@
 import os.path
 import unittest
-from unittest.mock import patch, ANY
+from unittest.mock import ANY, patch
 
-from streamlink import Streamlink
 import streamlink_cli.main
+from streamlink import Streamlink
 from streamlink_cli.compat import is_win32
 
 

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -1,5 +1,5 @@
-from io import StringIO
 import unittest
+from io import StringIO
 from unittest.mock import patch
 
 from streamlink_cli.console import ConsoleOutput

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,7 +1,7 @@
-from datetime import datetime
-from io import StringIO
 import logging
 import unittest
+from datetime import datetime
+from io import StringIO
 
 import freezegun
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import Mock
 
+from streamlink.options import Argument, Arguments, Options
 from streamlink_cli.main import setup_plugin_args
-from streamlink.options import Options, Arguments, Argument
 
 
 class TestOptions(unittest.TestCase):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,9 +1,9 @@
 import imp
 import os.path
 import pkgutil
-import six
-
 import unittest
+
+import six
 
 import streamlink.plugins
 from streamlink import Streamlink

--- a/tests/test_plugins_input.py
+++ b/tests/test_plugins_input.py
@@ -1,13 +1,12 @@
-from contextlib import contextmanager
 import os.path
 import unittest
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
-from tests.plugins.testplugin import TestPlugin as _TestPlugin
-
-from streamlink import Streamlink, PluginError
-from streamlink_cli.console import ConsoleUserInputRequester
+from streamlink import PluginError, Streamlink
 from streamlink.plugin.plugin import UserInputRequester
+from streamlink_cli.console import ConsoleUserInputRequester
+from tests.plugins.testplugin import TestPlugin as _TestPlugin
 
 
 class TestPluginUserInput(unittest.TestCase):

--- a/tests/test_plugins_meta.py
+++ b/tests/test_plugins_meta.py
@@ -1,8 +1,8 @@
 import os.path
 import re
 import unittest
-
 from glob import glob
+
 from streamlink import Streamlink
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,8 +1,8 @@
 import os
 import unittest
-from unittest.mock import patch, call
+from unittest.mock import call, patch
 
-from streamlink import Streamlink, NoPluginError
+from streamlink import NoPluginError, Streamlink
 from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY
 from streamlink.plugins import Plugin
 from streamlink.session import print_small_exception

--- a/tests/test_stream_file.py
+++ b/tests/test_stream_file.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch, mock_open
+from unittest.mock import Mock, mock_open, patch
 
 from streamlink import Streamlink
 from streamlink.stream.file import FileStream

--- a/tests/test_stream_json.py
+++ b/tests/test_stream_json.py
@@ -6,7 +6,7 @@ from streamlink.stream import HDSStream
 from streamlink.stream import HLSStream
 from streamlink.stream import HTTPStream
 from streamlink.stream import RTMPStream
-from streamlink.stream import Stream
+from streamlink.stream.stream import Stream
 
 
 class TestStreamToJSON(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,8 +5,8 @@ import unittest
 import xml.etree.ElementTree as ET
 
 from streamlink.exceptions import PluginError
-from streamlink.plugin.api.validate import xml_element, text
 from streamlink.plugin.api import validate
+from streamlink.plugin.api.validate import text, xml_element
 from streamlink.utils import (
     absolute_url,
     load_module,

--- a/tests/test_utils_args.py
+++ b/tests/test_utils_args.py
@@ -1,6 +1,6 @@
 import unittest
-
 from argparse import ArgumentTypeError
+
 from streamlink.utils.args import (
     boolean, comma_list, comma_list_filter, filesize, keyvalue, num
 )

--- a/tests/test_utils_crypto.py
+++ b/tests/test_utils_crypto.py
@@ -1,8 +1,7 @@
 import base64
-
 import unittest
 
-from streamlink.utils.crypto import evp_bytestokey, decrypt_openssl
+from streamlink.utils.crypto import decrypt_openssl, evp_bytestokey
 
 
 class TestUtil(unittest.TestCase):

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,8 +1,6 @@
 from collections import OrderedDict
 
-from streamlink.utils.url import (
-    update_scheme, url_equal, url_concat, update_qsd
-)
+from streamlink.utils.url import update_qsd, update_scheme, url_concat, url_equal
 
 
 def test_update_scheme():


### PR DESCRIPTION
As discussed in #3279, we should add rules for the module import order, because it's total chaos right now and everyone uses their own style, which leads to a lot of problems.

This PR therefore adds [`flake8-import-order`](https://github.com/PyCQA/flake8-import-order) as a plugin for flake8. The provided `pycharm` import style rules should match the import style of 153bb2ef4494a5ea03ed34f7ef18d458772e45be with 18 remaining errors.

Since we don't care about `src/streamlink/__init__.py` and `src/streamlink/packages/*`, I've put those paths onto the ignore list.

And just in case that it's not obvious, this PR will fail and can only be merged once the import orders have been fixed (in a separate PR). I will rebase it then.

Btw, should we do the linting steps before the test steps in the CI runners? That would make it fail faster if there are linting issues, which is usually the case when PRs are submitted.