### PR TITLE
ci.github: run lint step before test step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Install dependencies
         continue-on-error: ${{ matrix.continue || false }}
         run: bash ./script/install-dependencies.sh
+      - name: Lint
+        continue-on-error: ${{ matrix.continue || false }}
+        run: flake8 --count
       - name: Test
         continue-on-error: ${{ matrix.continue || false }}
         run: pytest -r a --cov --cov-branch --cov-report=xml
-      - name: Lint
-        continue-on-error: ${{ matrix.continue || false }}
-        run: flake8
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}


### PR DESCRIPTION
As briefly mentioned in #3285, this will make the PR checks fail faster in case there are linting errors but all tests are passing.

Also added the `--statistics --count` parameters, so that a summary gets included in the output when there are linting errors.