### PR TITLE
ci.github: install latest version of pynsist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
-          python -m pip install pynsist==2.4
+          python -m pip install pynsist
           sudo apt update
           sudo apt install -y nsis imagemagick inkscape
       - name: Installer file name


### PR DESCRIPTION
This installs the latest version of pynsist instead of pinning it to `2.4`. It was pinned to `2.4` because of #2655.

According to the [pynsist release notes](https://pynsist.readthedocs.io/en/latest/releasenotes.html), the newer versions (current one is `2.5.1`) assemble the executables during build-time rather than run-time/install-time. This cleans up the install directory by a bit and is less confusing for the enduser.

The NSIS GUI has also been improved with proper DPI scaling, but that requires NSIS 3.0 which is currently unavailable on the `ubuntu-18.04` CI image and `ubuntu-latest` still points towards `18.04`. That will change soon though, and once it does, the installer will see those improvements automatically. We could also manually set it to `ubuntu-20.04`.

----

While building the installer locally, I also tried bumping the included Python version, but there's currently an issue in pynsist and it doesn't recognize the new wheel naming scheme since py38 and pycryptodome can't be found. I will see if I can submit a PR there and fix it when I get the time. There's already a PR for it, but it's stale since April and just a hack rather than a proper fix.