### PR TITLE
cli: add support for stream manifest URL output

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -262,3 +262,6 @@ class DASHStream(Stream):
 
     def to_url(self):
         return self.mpd.url
+
+    def to_manifest_url(self):
+        return self.mpd.url

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -339,7 +339,7 @@ class HLSStreamReader(SegmentedStreamReader):
 class MuxedHLSStream(MuxedStream):
     __shortname__ = "hls-multi"
 
-    def __init__(self, session, video, audio, force_restart=False, ffmpeg_options=None, **args):
+    def __init__(self, session, video, audio, url_master=None, force_restart=False, ffmpeg_options=None, **args):
         tracks = [video]
         maps = ["0:v?", "0:a?"]
         if audio:
@@ -353,6 +353,10 @@ class MuxedHLSStream(MuxedStream):
         ffmpeg_options = ffmpeg_options or {}
 
         super().__init__(session, *substreams, format="mpegts", maps=maps, **ffmpeg_options)
+        self.url_master = url_master
+
+    def to_manifest_url(self):
+        return self.url_master
 
 
 class HLSStream(HTTPStream):
@@ -368,23 +372,30 @@ class HLSStream(HTTPStream):
 
     __shortname__ = "hls"
 
-    def __init__(self, session_, url, force_restart=False, start_offset=0, duration=None, **args):
+    def __init__(self, session_, url, url_master=None, force_restart=False, start_offset=0, duration=None, **args):
         HTTPStream.__init__(self, session_, url, **args)
+        self.url_master = url_master
         self.force_restart = force_restart
         self.start_offset = start_offset
         self.duration = duration
 
     def __repr__(self):
-        return "<HLSStream({0!r})>".format(self.url)
+        return f"<HLSStream({self.url!r}, {self.url_master!r})>"
 
     def __json__(self):
         json = HTTPStream.__json__(self)
+
+        if self.url_master:
+            json["master"] = self.url_master
 
         # Pretty sure HLS is GET only.
         del json["method"]
         del json["body"]
 
         return json
+
+    def to_manifest_url(self):
+        return self.url_master
 
     def open(self):
         reader = HLSStreamReader(self)
@@ -517,6 +528,7 @@ class HLSStream(HTTPStream):
                 stream = MuxedHLSStream(session_,
                                         video=playlist.uri,
                                         audio=[x.uri for x in external_audio if x.uri],
+                                        url_master=url,
                                         force_restart=force_restart,
                                         start_offset=start_offset,
                                         duration=duration,
@@ -524,6 +536,7 @@ class HLSStream(HTTPStream):
             else:
                 stream = cls(session_,
                              playlist.uri,
+                             url_master=url,
                              force_restart=force_restart,
                              start_offset=start_offset,
                              duration=duration,

--- a/src/streamlink/stream/stream.py
+++ b/src/streamlink/stream/stream.py
@@ -43,6 +43,9 @@ class Stream(object):
     def to_url(self):
         raise TypeError("{0} cannot be converted to a URL".format(self.shortname()))
 
+    def to_manifest_url(self):
+        raise TypeError("{0} cannot be converted to a URL".format(self.shortname()))
+
 
 class StreamIO(io.IOBase):
     pass

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -606,12 +606,16 @@ def handle_url():
         else:
             console.exit("{0}.\n       Available streams: {1}",
                          err, validstreams)
+    elif console.json:
+        console.msg_json(dict(plugin=plugin.module, streams=streams))
+    elif args.stream_url:
+        try:
+            console.msg("{0}", streams[list(streams)[-1]].to_manifest_url())
+        except TypeError:
+            console.exit("The stream specified cannot be translated to a URL")
     else:
-        if console.json:
-            console.msg_json(dict(streams=streams, plugin=plugin.module))
-        else:
-            validstreams = format_valid_streams(plugin, streams)
-            console.msg("Available streams: {0}", validstreams)
+        validstreams = format_valid_streams(plugin, streams)
+        console.msg("Available streams: {0}", validstreams)
 
 
 def print_plugins():

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -50,6 +50,17 @@ class SegmentEnc(Segment):
         self.content = encrypt(self.content, key, iv)
 
 
+class TestHLSStreamRepr(unittest.TestCase):
+    def test_repr(self):
+        session = Streamlink()
+
+        stream = hls.HLSStream(session, "https://foo.bar/playlist.m3u8")
+        self.assertEqual(repr(stream), "<HLSStream('https://foo.bar/playlist.m3u8', None)>")
+
+        stream = hls.HLSStream(session, "https://foo.bar/playlist.m3u8", "https://foo.bar/master.m3u8")
+        self.assertEqual(repr(stream), "<HLSStream('https://foo.bar/playlist.m3u8', 'https://foo.bar/master.m3u8')>")
+
+
 class TestHLSVariantPlaylist(unittest.TestCase):
     @classmethod
     def get_master_playlist(cls, playlist):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,11 +1,13 @@
 import os.path
 import tempfile
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 import streamlink_cli.main
 from streamlink.plugin.plugin import Plugin
-from streamlink_cli.main import check_file_output, create_output, format_valid_streams, resolve_stream_name
+from streamlink_cli.main import (
+    check_file_output, create_output, format_valid_streams, handle_stream, handle_url, resolve_stream_name
+)
 from streamlink_cli.output import FileOutput, PlayerOutput
 
 
@@ -129,6 +131,60 @@ class TestCLIMain(unittest.TestCase):
                 "1080p (best-unfiltered)"
             ])
         )
+
+    @patch("streamlink_cli.main.args", stream_url=True, subprocess_cmdline=False)
+    @patch("streamlink_cli.main.console", json=True)
+    def test_handle_stream_with_json_and_stream_url(self, console, args):
+        stream = Mock()
+        streams = dict(best=stream)
+        plugin = Mock(FakePlugin(), module="fake", arguments=[], streams=Mock(return_value=streams))
+
+        handle_stream(plugin, streams, "best")
+        self.assertEqual(console.msg.mock_calls, [])
+        self.assertEqual(console.msg_json.mock_calls, [call(stream)])
+        self.assertEqual(console.error.mock_calls, [])
+        console.msg_json.mock_calls.clear()
+
+        console.json = False
+        handle_stream(plugin, streams, "best")
+        self.assertEqual(console.msg.mock_calls, [call("{0}", stream.to_url())])
+        self.assertEqual(console.msg_json.mock_calls, [])
+        self.assertEqual(console.error.mock_calls, [])
+        console.msg.mock_calls.clear()
+
+        stream.to_url.side_effect = TypeError()
+        handle_stream(plugin, streams, "best")
+        self.assertEqual(console.msg.mock_calls, [])
+        self.assertEqual(console.msg_json.mock_calls, [])
+        self.assertEqual(console.exit.mock_calls, [call("The stream specified cannot be translated to a URL")])
+
+    @patch("streamlink_cli.main.args", stream_url=True, stream=[], default_stream=[], retry_max=0, retry_streams=0)
+    @patch("streamlink_cli.main.console", json=True)
+    def test_handle_url_with_json_and_stream_url(self, console, args):
+        stream = Mock()
+        streams = dict(worst=Mock(), best=stream)
+        plugin = Mock(FakePlugin(), module="fake", arguments=[], streams=Mock(return_value=streams))
+
+        with patch("streamlink_cli.main.streamlink", resolve_url=Mock(return_value=plugin)):
+            handle_url()
+            self.assertEqual(console.msg.mock_calls, [])
+            self.assertEqual(console.msg_json.mock_calls, [call(dict(plugin="fake", streams=streams))])
+            self.assertEqual(console.error.mock_calls, [])
+            console.msg_json.mock_calls.clear()
+
+            console.json = False
+            handle_url()
+            self.assertEqual(console.msg.mock_calls, [call("{0}", stream.to_manifest_url())])
+            self.assertEqual(console.msg_json.mock_calls, [])
+            self.assertEqual(console.error.mock_calls, [])
+            console.msg.mock_calls.clear()
+
+            stream.to_manifest_url.side_effect = TypeError()
+            handle_url()
+            self.assertEqual(console.msg.mock_calls, [])
+            self.assertEqual(console.msg_json.mock_calls, [])
+            self.assertEqual(console.exit.mock_calls, [call("The stream specified cannot be translated to a URL")])
+            console.exit.mock_calls.clear()
 
     def test_create_output_no_file_output_options(self):
         streamlink_cli.main.console = Mock()

--- a/tests/test_stream_json.py
+++ b/tests/test_stream_json.py
@@ -39,16 +39,36 @@ class TestStreamToJSON(unittest.TestCase):
 
     def test_hls_stream(self):
         url = "http://test.se/stream.m3u8"
+        master = "http://test.se/master.m3u8"
+
         stream = HLSStream(self.session, url, headers={"User-Agent": "Test"})
         self.assertEqual(
-            {"type": "hls",
-             "url": url,
-             "headers": {
-                 "User-Agent": "Test",
-                 "Accept": "*/*",
-                 "Accept-Encoding": "gzip, deflate",
-                 "Connection": "keep-alive",
-             }},
+            {
+                "type": "hls",
+                "url": url,
+                "headers": {
+                    "User-Agent": "Test",
+                    "Accept": "*/*",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Connection": "keep-alive",
+                }
+            },
+            stream.__json__()
+        )
+
+        stream = HLSStream(self.session, url, master, headers={"User-Agent": "Test"})
+        self.assertEqual(
+            {
+                "type": "hls",
+                "url": url,
+                "headers": {
+                    "User-Agent": "Test",
+                    "Accept": "*/*",
+                    "Accept-Encoding": "gzip, deflate",
+                    "Connection": "keep-alive",
+                },
+                "master": master
+            },
             stream.__json__()
         )
 


### PR DESCRIPTION
Resolves #3098

This enables the output of the input-stream's manifest/master URL via
`streamlink --stream-url URL` / `streamlink --json URL`
in addition to the already supported output when selecting a stream via
`streamlink --stream-url URL STREAM` / `streamlink --json URL STREAM`

This is primarily helpful for HLS streams with a variant playlist.

----

Things to note:
- This ignores cases where a plugin yields streams from different sources. Only the last stream in the returned `dict/OrderedDict` gets used, which is usually `best` or `best-unfiltered`. `--stream-types` can still be used though for filtering out unwanted stream types.
- I didn't add the manifest/master URL to the HLSStream's string representation and own JSON output, as it'd spam the output by a lot. Maybe it should be added though, at least to the JSON output, as it would (partly) solve the issue mentioned in the previous point.
- Added tests for both `handle_url` and `handle_stream` (output without and with stream/quality selection)
- IMO, `streamlink_cli.main.handle_url` needs to be refactored, because patching `streamlink_cli.main.args` is awkward and lots of unrelated args need to be set. The entire main CLI module needs to be simplified and modularized.
- I'm not sure why the other test methods don't mock the globals in a context manager. That introduces side-effects, no?
