### PR TITLE
plugins.twitch: player_type access token parameter

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -297,7 +297,7 @@ class TwitchAPI(object):
                 validate.get("sig"),
                 validate.get("token")
             ))
-        ))
+        ), player_type="frontpage")
 
     def token(self, tokenstr):
         return parse_json(tokenstr, schema=validate.Schema(


### PR DESCRIPTION
This sets the `player_type=frontpage` request parameter on the access token API call, which currently results in a streaming access token that doesn't embed ads into the HLS stream.

As already said in https://github.com/streamlink/streamlink/issues/3210#issuecomment-717735974, this might get changed again by Twitch, similar to the previous `platform=_` request parameter (#3220).

If this PR gets merged within the next 4.5 hours, it'll be included in the next Windows installer nightly build, which most people are probably looking forward to.