### PR TITLE
chore: implicit py3 super() calls

### DIFF
--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -50,13 +50,13 @@ def _is_re_match(value):
 class any(tuple):
     """At least one of the schemas must be valid."""
     def __new__(cls, *args):
-        return super(any, cls).__new__(cls, args)
+        return super().__new__(cls, args)
 
 
 class all(tuple):
     """All schemas must be valid."""
     def __new__(cls, *args):
-        return super(all, cls).__new__(cls, args)
+        return super().__new__(cls, args)
 
 
 class SchemaContainer(object):

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -43,7 +43,7 @@ class AbemaTVLicenseAdapter(BaseAdapter):
         self._session = session
         self.deviceid = deviceid
         self.usertoken = usertoken
-        super(AbemaTVLicenseAdapter, self).__init__()
+        super().__init__()
 
     def _get_videokey_from_ticket(self, ticket):
         params = {
@@ -152,7 +152,7 @@ class AbemaTV(Plugin):
         return cls._url_re.match(url) is not None
 
     def __init__(self, url):
-        super(AbemaTV, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers.update({'User-Agent': useragents.CHROME})
 
     def _generate_applicationkeysecret(self, deviceid):

--- a/src/streamlink/plugins/abweb.py
+++ b/src/streamlink/plugins/abweb.py
@@ -58,7 +58,7 @@ class ABweb(Plugin):
     )
 
     def __init__(self, url):
-        super(ABweb, self).__init__(url)
+        super().__init__(url)
         self._session_attributes = Cache(filename='plugin-cache.json', key_prefix='abweb:attributes')
         self._authed = self._session_attributes.get('ASP.NET_SessionId') and self._session_attributes.get('.abportail1')
         self._expires = self._session_attributes.get('expires', time.time() + self.expires_time)

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -35,7 +35,7 @@ class Albavision(Plugin):
     }
 
     def __init__(self, url):
-        super(Albavision, self).__init__(url)
+        super().__init__(url)
         self._page = None
 
     @classmethod

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -48,7 +48,7 @@ class AtresPlayer(Plugin):
 
     def __init__(self, url):
         # must be HTTPS
-        super(AtresPlayer, self).__init__(update_scheme("https://", url))
+        super().__init__(update_scheme("https://", url))
 
     def _get_streams(self):
         api_urls = self.session.http.get(self.url, schema=self.channel_id_schema)

--- a/src/streamlink/plugins/btsports.py
+++ b/src/streamlink/plugins/btsports.py
@@ -41,7 +41,7 @@ class BTSports(Plugin):
     login_url = "https://signin1.bt.com/siteminderagent/forms/login.fcc"
 
     def __init__(self, url):
-        super(BTSports, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers = {"User-Agent": useragents.FIREFOX}
 
     @classmethod

--- a/src/streamlink/plugins/dlive.py
+++ b/src/streamlink/plugins/dlive.py
@@ -61,7 +61,7 @@ class DLive(Plugin):
         return Plugin.stream_weight(key)
 
     def __init__(self, *args, **kwargs):
-        super(DLive, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.author = None
         self.title = None
 

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -74,7 +74,7 @@ class FilmOnHLS(HLSStream):
     __shortname__ = "hls-filmon"
 
     def __init__(self, session_, channel=None, vod_id=None, quality="high", **args):
-        super(FilmOnHLS, self).__init__(session_, None, **args)
+        super().__init__(session_, None, **args)
         self.channel = channel
         self.vod_id = vod_id
         if self.channel is None and self.vod_id is None:
@@ -197,7 +197,7 @@ class Filmon(Plugin):
     TIME_CHANNEL = 60 * 60 * 24 * 365
 
     def __init__(self, url):
-        super(Filmon, self).__init__(url)
+        super().__init__(url)
         parsed = urlparse(self.url)
         if parsed.path.startswith("/channel/"):
             self.url = urlunparse(parsed._replace(path=parsed.path.replace("/channel/", "/tv/")))

--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -44,7 +44,7 @@ class Mitele(Plugin):
     )
 
     def __init__(self, url):
-        super(Mitele, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers.update({
             "User-Agent": useragents.FIREFOX,
             "Referer": self.url

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -338,7 +338,7 @@ class NicoLive(Plugin):
 class NicoHLSStream(HLSStream):
 
     def __init__(self, hls_stream, nicolive_plugin):
-        super(NicoHLSStream, self).__init__(
+        super().__init__(
             hls_stream.session,
             force_restart=hls_stream.force_restart,
             start_offset=hls_stream.start_offset,
@@ -349,7 +349,7 @@ class NicoHLSStream(HLSStream):
         self.nicolive_plugin = nicolive_plugin
 
     def open(self):
-        reader = super(NicoHLSStream, self).open()
+        reader = super().open()
         self.nicolive_plugin.stream_reader = reader
         return reader
 

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -73,7 +73,7 @@ class OPENRECtv(Plugin):
     )
 
     def __init__(self, url):
-        super(OPENRECtv, self).__init__(url)
+        super().__init__(url)
         self._pdata = None
         self._pres = None
         self._pconfig = None

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -87,7 +87,7 @@ class Pixiv(Plugin):
     )
 
     def __init__(self, url):
-        super(Pixiv, self).__init__(url)
+        super().__init__(url)
         self._authed = (self.session.http.cookies.get("PHPSESSID")
                         and self.session.http.cookies.get("device_token"))
         self.session.http.headers.update({

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -45,7 +45,7 @@ class Reuters(Plugin):
     )
 
     def __init__(self, url):
-        super(Reuters, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers.update({'User-Agent': useragents.FIREFOX})
         self.title = None
 

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -76,7 +76,7 @@ class SteamBroadcastPlugin(Plugin):
         ))
 
     def __init__(self, url):
-        super(SteamBroadcastPlugin, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers["User-Agent"] = self._user_agent
 
     @classmethod

--- a/src/streamlink/plugins/streamme.py
+++ b/src/streamlink/plugins/streamme.py
@@ -65,7 +65,7 @@ class StreamMe(Plugin):
     }
 
     def __init__(self, url):
-        super(StreamMe, self).__init__(url)
+        super().__init__(url)
         self.author = None
         self.title = None
         self.session.http.headers.update({'User-Agent': useragents.FIREFOX})

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -25,7 +25,7 @@ class Streann(Plugin):
     passphrase_re = re.compile(r'''CryptoJS\.AES\.decrypt\(.*?,\s*(['"])(?P<passphrase>(?:(?!\1).)*)\1\s*?\);''')
 
     def __init__(self, url):
-        super(Streann, self).__init__(url)
+        super().__init__(url)
         self._device_id = None
         self._headers = {"User-Agent": useragents.FIREFOX}
 

--- a/src/streamlink/plugins/tvplayer.py
+++ b/src/streamlink/plugins/tvplayer.py
@@ -45,7 +45,7 @@ class TVPlayer(Plugin):
         return match is not None
 
     def __init__(self, url):
-        super(TVPlayer, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers.update({"User-Agent": useragents.CHROME})
 
     def authenticate(self, username, password):

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -28,7 +28,7 @@ class TVRBy(Plugin):
         # ensure the URL ends with a /
         if not url.endswith("/"):
             url += "/"
-        super(TVRBy, self).__init__(url)
+        super().__init__(url)
 
     @classmethod
     def can_handle_url(cls, url):

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -190,7 +190,7 @@ class TwitCastingReader(StreamIO):
 
 class TwitCastingStream(Stream):
     def __init__(self, session, url):
-        super(TwitCastingStream, self).__init__(session)
+        super().__init__(session)
         self.url = url
 
     def __repr__(self):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -26,7 +26,7 @@ LOW_LATENCY_MAX_LIVE_EDGE = 2
 
 class TwitchM3U8(M3U8):
     def __init__(self):
-        super(TwitchM3U8, self).__init__()
+        super().__init__()
         self.dateranges_ads = []
 
 
@@ -37,7 +37,7 @@ class TwitchM3U8Parser(M3U8Parser):
             segments.append(segments[-1]._replace(uri=self.uri(value), prefetch=True))
 
     def parse_tag_ext_x_daterange(self, value):
-        super(TwitchM3U8Parser, self).parse_tag_ext_x_daterange(value)
+        super().parse_tag_ext_x_daterange(value)
         daterange = self.m3u8.dateranges[-1]
         is_ad = (
             daterange.classname == "twitch-stitched-ad"
@@ -73,7 +73,7 @@ class TwitchM3U8Parser(M3U8Parser):
 class TwitchHLSStreamWorker(HLSStreamWorker):
     def __init__(self, reader, *args, **kwargs):
         self.had_content = False
-        super(TwitchHLSStreamWorker, self).__init__(reader, *args, **kwargs)
+        super().__init__(reader, *args, **kwargs)
 
     def _reload_playlist(self, *args):
         return load_hls_playlist(*args, parser=TwitchM3U8Parser, m3u8=TwitchM3U8)
@@ -82,7 +82,7 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
         if self.stream.low_latency and sequences:
             return sequences[-1].segment.duration
 
-        return super(TwitchHLSStreamWorker, self)._playlist_reload_time(playlist, sequences)
+        return super()._playlist_reload_time(playlist, sequences)
 
     def process_sequences(self, playlist, sequences):
         # ignore prefetch segments if not LL streaming
@@ -106,7 +106,7 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
         if self.stream.disable_ads and self.playlist_sequence == -1 and not self.had_content:
             log.info("Waiting for pre-roll ads to finish, be patient")
 
-        return super(TwitchHLSStreamWorker, self).process_sequences(playlist, sequences)
+        return super().process_sequences(playlist, sequences)
 
 
 class TwitchHLSStreamWriter(FilteredHLSStreamWriter):
@@ -121,7 +121,7 @@ class TwitchHLSStreamReader(FilteredHLSStreamReader):
 
 class TwitchHLSStream(HLSStream):
     def __init__(self, *args, **kwargs):
-        super(TwitchHLSStream, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.disable_ads = self.session.get_plugin_option("twitch", "disable-ads")
         self.low_latency = self.session.get_plugin_option("twitch", "low-latency")
 
@@ -443,7 +443,7 @@ class Twitch(Plugin):
         return cls._re_url.match(url)
 
     def __init__(self, url):
-        super(Twitch, self).__init__(url)
+        super().__init__(url)
         match = self._re_url.match(url).groupdict()
         parsed = urlparse(url)
         self.params = parse_query(parsed.query)

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -336,7 +336,7 @@ class UHSStream(Stream):
                                      datetime.datetime.now(tz=utc))
 
     def __init__(self, session, api, first_chunk_data, template_url):
-        super(UHSStream, self).__init__(session)
+        super().__init__(session)
         self.session = session
         self.poller = self.APIPoller(api)
         self.poller.setDaemon(True)

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -44,7 +44,7 @@ class USTVNow(Plugin):
     )
 
     def __init__(self, url):
-        super(USTVNow, self).__init__(url)
+        super().__init__(url)
         self._encryption_config = {}
         self._token = None
 

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -45,7 +45,7 @@ class WWENetwork(Plugin):
     )
 
     def __init__(self, url):
-        super(WWENetwork, self).__init__(url)
+        super().__init__(url)
         self.session.http.headers.update({"User-Agent": useragents.CHROME})
         self.auth_token = None
 

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -123,7 +123,7 @@ class YouTube(Plugin):
     }
 
     def __init__(self, url):
-        super(YouTube, self).__init__(url)
+        super().__init__(url)
         parsed = urlparse(self.url)
         if parsed.netloc == 'gaming.youtube.com':
             self.url = urlunparse(parsed._replace(netloc='www.youtube.com'))

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -42,7 +42,7 @@ class YuppTV(Plugin):
     )
 
     def __init__(self, url):
-        super(YuppTV, self).__init__(url)
+        super().__init__(url)
         self._authed = (self.session.http.cookies.get("BoxId")
                         and self.session.http.cookies.get("YuppflixToken"))
 

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -126,7 +126,7 @@ class Zattoo(Plugin):
     )
 
     def __init__(self, url):
-        super(Zattoo, self).__init__(url)
+        super().__init__(url)
         self.domain = self._url_re.match(url).group('base_url')
         self._session_attributes = Cache(
             filename='plugin-cache.json',

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -151,7 +151,7 @@ class DASHStream(Stream):
                  audio_representation=None,
                  period=0,
                  **args):
-        super(DASHStream, self).__init__(session)
+        super().__init__(session)
         self.mpd = mpd
         self.video_representation = video_representation
         self.audio_representation = audio_representation

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -221,7 +221,7 @@ class MPD(MPDNode):
 
     def __init__(self, node, root=None, parent=None, url=None, *args, **kwargs):
         # top level has no parent
-        super(MPD, self).__init__(node, root=self, *args, **kwargs)
+        super().__init__(node, root=self, *args, **kwargs)
         # parser attributes
         self.url = url
         self.timelines = defaultdict(lambda: -1)
@@ -263,7 +263,7 @@ class BaseURL(MPDNode):
     __tag__ = "BaseURL"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(BaseURL, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
         self.url = self.node.text.strip()
 
     @property
@@ -293,7 +293,7 @@ class Period(MPDNode):
     __tag__ = u"Period"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(Period, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
         self.i = kwargs.get(u"i", 0)
         self.id = self.attr(u"id")
         self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.bool_str)
@@ -335,7 +335,7 @@ class Initialization(MPDNode):
     __tag__ = "Initialization"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(Initialization, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
         self.source_url = self.attr("sourceURL")
 
 
@@ -343,7 +343,7 @@ class SegmentURL(MPDNode):
     __tag__ = "SegmentURL"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(SegmentURL, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
         self.media = self.attr("media")
         self.media_range = self.attr("mediaRange", parser=MPDParsers.range)
 
@@ -352,7 +352,7 @@ class SegmentList(MPDNode):
     __tag__ = "SegmentList"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(SegmentList, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
 
         self.presentation_time_offset = self.attr("presentationTimeOffset")
         self.timescale = self.attr("timescale", parser=int)
@@ -382,7 +382,7 @@ class AdaptationSet(MPDNode):
     __tag__ = u"AdaptationSet"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(AdaptationSet, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
 
         self.id = self.attr(u"id")
         self.group = self.attr(u"group")
@@ -413,7 +413,7 @@ class SegmentTemplate(MPDNode):
     __tag__ = "SegmentTemplate"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(SegmentTemplate, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
         self.defaultSegmentTemplate = self.walk_back_get_attr('segmentTemplate')
 
         self.initialization = self.attr(u"initialization", parser=MPDParsers.segment_template)
@@ -560,7 +560,7 @@ class Representation(MPDNode):
     __tag__ = u"Representation"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(Representation, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
         self.id = self.attr(u"id", required=True)
         self.bandwidth = self.attr(u"bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
         self.mimeType = self.attr(u"mimeType", required=True, inherited=True)
@@ -630,7 +630,7 @@ class SegmentTimeline(MPDNode):
     TimelineSegment = namedtuple("TimelineSegment", "t d")
 
     def __init__(self, node, *args, **kwargs):
-        super(SegmentTimeline, self).__init__(node, *args, **kwargs)
+        super().__init__(node, *args, **kwargs)
 
         self.timescale = self.walk_back_get_attr("timescale")
 
@@ -652,7 +652,7 @@ class _TimelineSegment(MPDNode):
     __tag__ = "S"
 
     def __init__(self, node, *args, **kwargs):
-        super(_TimelineSegment, self).__init__(node, *args, **kwargs)
+        super().__init__(node, *args, **kwargs)
 
         self.t = self.attr("t", parser=int)
         self.d = self.attr("d", parser=int)
@@ -663,7 +663,7 @@ class ContentProtection(MPDNode):
     __tag__ = "ContentProtection"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
-        super(ContentProtection, self).__init__(node, root, parent, *args, **kwargs)
+        super().__init__(node, root, parent, *args, **kwargs)
 
         self.schemeIdUri = self.attr(u"schemeIdUri")
         self.value = self.attr(u"value")

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -18,7 +18,7 @@ class MuxedStream(Stream):
     __shortname__ = "muxed-stream"
 
     def __init__(self, session, *substreams, **options):
-        super(MuxedStream, self).__init__(session)
+        super().__init__(session)
         self.substreams = substreams
         self.subtitles = options.pop("subtitles", {})
         self.options = options

--- a/src/streamlink/stream/file.py
+++ b/src/streamlink/stream/file.py
@@ -8,7 +8,7 @@ class FileStream(Stream):
     __shortname__ = "file"
 
     def __init__(self, session, path=None, fileobj=None):
-        super(FileStream, self).__init__(session)
+        super().__init__(session)
         self.path = path
         self.fileobj = fileobj
         if not self.path and not self.fileobj:

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -352,7 +352,7 @@ class MuxedHLSStream(MuxedStream):
         substreams = map(lambda url: HLSStream(session, url, force_restart=force_restart, **args), tracks)
         ffmpeg_options = ffmpeg_options or {}
 
-        super(MuxedHLSStream, self).__init__(session, *substreams, format="mpegts", maps=maps, **ffmpeg_options)
+        super().__init__(session, *substreams, format="mpegts", maps=maps, **ffmpeg_options)
 
 
 class HLSStream(HTTPStream):

--- a/src/streamlink/stream/hls_filtered.py
+++ b/src/streamlink/stream/hls_filtered.py
@@ -13,7 +13,7 @@ class FilteredHLSStreamWriter(HLSStreamWriter):
     def write(self, sequence, *args, **kwargs):
         if not self.should_filter_sequence(sequence):
             try:
-                return super(FilteredHLSStreamWriter, self).write(sequence, *args, **kwargs)
+                return super().write(sequence, *args, **kwargs)
             finally:
                 # unblock reader thread after writing data to the buffer
                 if not self.reader.filter_event.is_set():
@@ -28,14 +28,14 @@ class FilteredHLSStreamWriter(HLSStreamWriter):
 
 class FilteredHLSStreamReader(HLSStreamReader):
     def __init__(self, *args, **kwargs):
-        super(FilteredHLSStreamReader, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.filter_event = Event()
         self.filter_event.set()
 
     def read(self, size):
         while True:
             try:
-                return super(FilteredHLSStreamReader, self).read(size)
+                return super().read(size)
             except IOError:
                 # wait indefinitely until filtering ends
                 self.filter_event.wait()
@@ -48,5 +48,5 @@ class FilteredHLSStreamReader(HLSStreamReader):
                 raise
 
     def close(self):
-        super(FilteredHLSStreamReader, self).close()
+        super().close()
         self.filter_event.set()

--- a/src/streamlink/stream/streamprocess.py
+++ b/src/streamlink/stream/streamprocess.py
@@ -18,7 +18,7 @@ class StreamProcessIO(StreamIOThreadWrapper):
     def __init__(self, session, process, fd, **kwargs):
         self.process = process
 
-        super(StreamProcessIO, self).__init__(session, fd, **kwargs)
+        super().__init__(session, fd, **kwargs)
 
     def close(self):
         try:
@@ -26,7 +26,7 @@ class StreamProcessIO(StreamIOThreadWrapper):
         except Exception:
             pass
         finally:
-            super(StreamProcessIO, self).close()
+            super().close()
 
 
 class StreamProcess(Stream):
@@ -38,7 +38,7 @@ class StreamProcess(Stream):
         :param args: positional arguments
         :param timeout: timeout for process
         """
-        super(StreamProcess, self).__init__(session)
+        super().__init__(session)
 
         self.parameters = params or {}
         self.arguments = args or []

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -47,7 +47,7 @@ class Output(object):
 
 class FileOutput(Output):
     def __init__(self, filename=None, fd=None, record=None):
-        super(FileOutput, self).__init__()
+        super().__init__()
         self.filename = filename
         self.fd = fd
         self.record = record
@@ -79,7 +79,7 @@ class PlayerOutput(Output):
 
     def __init__(self, cmd, args=DEFAULT_PLAYER_ARGUMENTS, filename=None, quiet=True, kill=True,
                  call=False, http=None, namedpipe=None, record=None, title=None):
-        super(PlayerOutput, self).__init__()
+        super().__init__()
         self.cmd = cmd
         self.args = args
         self.kill = kill

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -149,7 +149,7 @@ class TestMixinStreamHLS(unittest.TestCase):
     __readthread__ = HLSStreamReadThread
 
     def __init__(self, *args, **kwargs):
-        super(TestMixinStreamHLS, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mocker = requests_mock.Mocker()
         self.mocks = {}
         self.session = None
@@ -157,11 +157,11 @@ class TestMixinStreamHLS(unittest.TestCase):
         self.thread = None
 
     def setUp(self):
-        super(TestMixinStreamHLS, self).setUp()
+        super().setUp()
         self.mocker.start()
 
     def tearDown(self):
-        super(TestMixinStreamHLS, self).tearDown()
+        super().tearDown()
         self.close_thread()
         self.mocker.stop()
         self.mocks.clear()

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -24,18 +24,18 @@ class TagDateRangeAd(Tag):
         }
         if custom is not None:
             attrs.update(**{key: self.val_quoted_string(value) for (key, value) in custom.items()})
-        super(TagDateRangeAd, self).__init__("EXT-X-DATERANGE", attrs)
+        super().__init__("EXT-X-DATERANGE", attrs)
 
 
 class Segment(_Segment):
     def __init__(self, num, title="live", *args, **kwargs):
-        super(Segment, self).__init__(num, title, *args, **kwargs)
+        super().__init__(num, title, *args, **kwargs)
         self.date = DATETIME_BASE + timedelta(seconds=num)
 
     def build(self, namespace):
         return "#EXT-X-PROGRAM-DATE-TIME:{0}\n{1}".format(
             self.date.strftime(DATETIME_FORMAT),
-            super(Segment, self).build(namespace)
+            super().build(namespace)
         )
 
 
@@ -69,7 +69,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = TwitchHLSStream
 
     def get_session(self, options=None, disable_ads=False, low_latency=False):
-        session = super(TestTwitchHLSStream, self).get_session(options)
+        session = super().get_session(options)
         session.set_option("hls-live-edge", 4)
         session.set_plugin_option("twitch", "disable-ads", disable_ads)
         session.set_plugin_option("twitch", "low-latency", low_latency)

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -36,16 +36,16 @@ class TagKey(Tag):
             attrs.update({"KEYFORMAT": self.val_quoted_string(keyformat)})
         if keyformatversions is not None:  # pragma: no branch
             attrs.update({"KEYFORMATVERSIONS": self.val_quoted_string(keyformatversions)})
-        super(TagKey, self).__init__("EXT-X-KEY", attrs)
+        super().__init__("EXT-X-KEY", attrs)
         self.uri = uri
 
     def url(self, namespace):
-        return self.uri.format(namespace=namespace) if self.uri else super(TagKey, self).url(namespace)
+        return self.uri.format(namespace=namespace) if self.uri else super().url(namespace)
 
 
 class SegmentEnc(Segment):
     def __init__(self, num, key, iv, *args, **kwargs):
-        super(SegmentEnc, self).__init__(num, *args, **kwargs)
+        super().__init__(num, *args, **kwargs)
         self.content_plain = self.content
         self.content = encrypt(self.content, key, iv)
 
@@ -82,7 +82,7 @@ class TestHLSVariantPlaylist(unittest.TestCase):
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", Mock(return_value=True))
 class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
     def get_session(self, options=None, *args, **kwargs):
-        session = super(TestHLSStream, self).get_session(options)
+        session = super().get_session(options)
         session.set_option("hls-live-edge", 3)
 
         return session
@@ -101,7 +101,7 @@ class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", Mock(return_value=True))
 class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
     def get_session(self, options=None, *args, **kwargs):
-        session = super(TestHLSStreamEncrypted, self).get_session(options)
+        session = super().get_session(options)
         session.set_option("hls-live-edge", 3)
 
         return session
@@ -155,13 +155,13 @@ class TestHlsPlaylistReloadTime(TestMixinStreamHLS, unittest.TestCase):
     segments = [Segment(0, "", 11), Segment(1, "", 7), Segment(2, "", 5), Segment(3, "", 3)]
 
     def get_session(self, options=None, reload_time=None, *args, **kwargs):
-        return super(TestHlsPlaylistReloadTime, self).get_session(dict(options or {}, **{
+        return super().get_session(dict(options or {}, **{
             "hls-live-edge": 3,
             "hls-playlist-reload-time": reload_time
         }))
 
     def subject(self, *args, **kwargs):
-        thread, _ = super(TestHlsPlaylistReloadTime, self).subject(*args, **kwargs)
+        thread, _ = super().subject(*args, **kwargs)
         self.await_read(read_all=True)
 
         return thread.reader.worker.playlist_reload_time

--- a/tests/streams/test_hls_filtered.py
+++ b/tests/streams/test_hls_filtered.py
@@ -12,13 +12,13 @@ FILTERED = "filtered"
 
 class SegmentFiltered(Segment):
     def __init__(self, *args, **kwargs):
-        super(SegmentFiltered, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.title = FILTERED
 
 
 class _TestSubjectFilteredHLSStreamWriter(FilteredHLSStreamWriter):
     def __init__(self, *args, **kwargs):
-        super(_TestSubjectFilteredHLSStreamWriter, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.write_wait = Event()
         self.write_done = Event()
 
@@ -30,7 +30,7 @@ class _TestSubjectFilteredHLSStreamWriter(FilteredHLSStreamWriter):
         try:
             # don't write again during teardown
             if not self.closed:
-                super(_TestSubjectFilteredHLSStreamWriter, self).write(*args, **kwargs)
+                super().write(*args, **kwargs)
         finally:
             # notify main thread that writing has finished
             self.write_done.set()
@@ -58,7 +58,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
     def close_thread(self):
         self.thread.reader.writer.write_wait.set()
-        super(TestFilteredHLSStream, self).close_thread()
+        super().close_thread()
 
     # make one write call on the write thread and wait until it has finished
     def await_write(self):
@@ -68,7 +68,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
         writer.write_done.clear()
 
     def get_session(self, options=None, *args, **kwargs):
-        session = super(TestFilteredHLSStream, self).get_session(options)
+        session = super().get_session(options)
         session.set_option("hls-live-edge", 2)
         session.set_option("hls-timeout", 0)
         session.set_option("stream-timeout", 0)
@@ -76,7 +76,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
         return session
 
     def subject(self, *args, **kwargs):
-        thread, segments = super(TestFilteredHLSStream, self).subject(*args, **kwargs)
+        thread, segments = super().subject(*args, **kwargs)
 
         return thread, thread.reader, thread.reader.writer, segments
 


### PR DESCRIPTION
This changes all explicit `super(type, object)` calls to implicit py3 `super()` calls, as they are easier to read and maintain.

Most of the super calls here are in a single inheritance scheme, and only some of the tests have multiple inheritance, but the MRO is correct, so nothing will change logic-wise.

All other methods in the Streamlink codebase which are calling methods of their parent classes do this directly without calling `super()`, which may be a tiny bit faster, but it also makes it less extensible. I obviously didn't change it in this PR, but believe it would be better having it changed at some point in the future. Not important for now though.