### PR TITLE
chore: remove u-strings

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -34,10 +34,10 @@ class AbemaTVLicenseAdapter(BaseAdapter):
 
     _LICENSE_API = "https://license.abema.io/abematv-hls"
 
-    _MEDIATOKEN_SCHEMA = validate.Schema({u"token": validate.text})
+    _MEDIATOKEN_SCHEMA = validate.Schema({"token": validate.text})
 
-    _LICENSE_SCHEMA = validate.Schema({u"k": validate.text,
-                                       u"cid": validate.text})
+    _LICENSE_SCHEMA = validate.Schema({"k": validate.text,
+                                       "cid": validate.text})
 
     def __init__(self, session, deviceid, usertoken):
         self._session = session
@@ -131,21 +131,18 @@ class AbemaTV(Plugin):
                  b"Rbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$"
                  b"k9cD=3TxwWe86!x#Zyhe")
 
-    _USER_SCHEMA = validate.Schema({u"profile": {u"userId": validate.text},
-                                    u"token": validate.text})
+    _USER_SCHEMA = validate.Schema({"profile": {"userId": validate.text},
+                                    "token": validate.text})
 
-    _CHANNEL_SCHEMA = validate.Schema({u"channels": [{u"id": validate.text,
+    _CHANNEL_SCHEMA = validate.Schema({"channels": [{"id": validate.text,
                                       "name": validate.text,
-                                       "playback": {validate.optional(u"dash"):
+                                       "playback": {validate.optional("dash"):
                                                     validate.text,
-                                                    u"hls": validate.text}}]})
+                                                    "hls": validate.text}}]})
 
-    _PRGM_SCHEMA = validate.Schema({u"label": {validate.optional(u"free"): bool
-                                               }})
+    _PRGM_SCHEMA = validate.Schema({"label": {validate.optional("free"): bool}})
 
-    _SLOT_SCHEMA = validate.Schema({u"slot": {u"flags": {
-                                    validate.optional("timeshiftFree"): bool}}}
-                                   )
+    _SLOT_SCHEMA = validate.Schema({"slot": {"flags": {validate.optional("timeshiftFree"): bool}}})
 
     @classmethod
     def can_handle_url(cls, url):

--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -47,7 +47,7 @@ class ArteTV(Plugin):
     def _create_stream(self, streams):
         variant, variantname = min([(stream["versionProg"], stream["versionLibelle"]) for stream in streams.values()],
                                    key=itemgetter(0))
-        log.debug(u"Using the '{0}' stream variant".format(variantname))
+        log.debug(f"Using the '{variantname}' stream variant")
         for sname, stream in streams.items():
             if stream["versionProg"] == variant:
                 if stream["mediaType"] == "hls":
@@ -55,9 +55,7 @@ class ArteTV(Plugin):
                         streams = HLSStream.parse_variant_playlist(self.session, stream["url"])
                         yield from streams.items()
                     except IOError as err:
-                        log.warning(u"Failed to extract HLS streams for {0}/{1}: {2}".format(sname,
-                                                                                             stream["versionLibelle"],
-                                                                                             err))
+                        log.warning(f"Failed to extract HLS streams for {sname}/{stream['versionLibelle']}: {err}")
 
     def _get_streams(self):
         match = _url_re.match(self.url)

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -310,7 +310,7 @@ class Crunchyroll(Plugin):
             # the media.stream_data field is required, no stream data is returned otherwise
             info = api.get_info(media_id, fields=["media.stream_data"], schema=_media_schema)
         except CrunchyrollAPIError as err:
-            raise PluginError(u"Media lookup error: {0}".format(err.msg))
+            raise PluginError(f"Media lookup error: {err.msg}")
 
         if not info:
             return
@@ -318,24 +318,24 @@ class Crunchyroll(Plugin):
         streams = {}
 
         # The adaptive quality stream sometimes a subset of all the other streams listed, ultra is no included
-        has_adaptive = any([s[u"quality"] == u"adaptive" for s in info[u"streams"]])
+        has_adaptive = any([s["quality"] == "adaptive" for s in info["streams"]])
         if has_adaptive:
-            log.debug(u"Loading streams from adaptive playlist")
-            for stream in filter(lambda x: x[u"quality"] == u"adaptive", info[u"streams"]):
-                for q, s in HLSStream.parse_variant_playlist(self.session, stream[u"url"]).items():
+            log.debug("Loading streams from adaptive playlist")
+            for stream in filter(lambda x: x["quality"] == "adaptive", info["streams"]):
+                for q, s in HLSStream.parse_variant_playlist(self.session, stream["url"]).items():
                     # rename the bitrates to low, mid, or high. ultra doesn't seem to appear in the adaptive streams
                     name = STREAM_NAMES.get(q, q)
                     streams[name] = s
 
         # If there is no adaptive quality stream then parse each individual result
-        for stream in info[u"streams"]:
-            if stream[u"quality"] != u"adaptive":
+        for stream in info["streams"]:
+            if stream["quality"] != "adaptive":
                 # the video_encode_id indicates that the stream is not a variant playlist
-                if u"video_encode_id" in stream:
-                    streams[stream[u"quality"]] = HLSStream(self.session, stream[u"url"])
+                if "video_encode_id" in stream:
+                    streams[stream["quality"]] = HLSStream(self.session, stream["url"])
                 else:
                     # otherwise the stream url is actually a list of stream qualities
-                    for q, s in HLSStream.parse_variant_playlist(self.session, stream[u"url"]).items():
+                    for q, s in HLSStream.parse_variant_playlist(self.session, stream["url"]).items():
                         # rename the bitrates to low, mid, or high. ultra doesn't seem to appear in the adaptive streams
                         name = STREAM_NAMES.get(q, q)
                         streams[name] = s
@@ -379,7 +379,7 @@ class Crunchyroll(Plugin):
                     log.info(f"Logged in as '{login_name}'")
 
                 except CrunchyrollAPIError as err:
-                    raise PluginError(u"Authentication error: {0}".format(err.msg))
+                    raise PluginError(f"Authentication error: {err.msg}")
             if not api.auth:
                 log.warning(
                     "No authentication provided, you won't be able to access "

--- a/src/streamlink/plugins/cubetv.py
+++ b/src/streamlink/plugins/cubetv.py
@@ -13,20 +13,20 @@ class CubeTV(Plugin):
     _stream_data_api_url_base = "https://www.cube.tv/studioApi/getStudioSrcBySid?sid={gid}&videoType=1&https=1"
 
     _channel_info_schema = validate.Schema({
-        u"code": 1,
-        u"msg": u"success",
-        u"data": {
-            u"gid": validate.text,
-            u"cube_id": validate.text
+        "code": 1,
+        "msg": "success",
+        "data": {
+            "gid": validate.text,
+            "cube_id": validate.text
         }
     })
 
     _stream_data_schema = validate.Schema({
-        u"code": 1,
-        u"msg": u"success",
-        u"data": {
-            u"video": u"hls",
-            u"video_src": validate.url()
+        "code": 1,
+        "msg": "success",
+        "data": {
+            "video": "hls",
+            "video_src": validate.url()
         }
     })
 

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -83,11 +83,11 @@ class Dogan(Plugin):
     def _get_streams(self):
         content_id = self._get_content_id()
         if content_id:
-            log.debug(u"Loading content: {0}".format(content_id))
+            log.debug(f"Loading content: {content_id}")
             hls_url = self._get_hls_url(content_id)
             return HLSStream.parse_variant_playlist(self.session, hls_url)
         else:
-            log.error(u"Could not find the contentId for this stream")
+            log.error("Could not find the contentId for this stream")
 
 
 __plugin__ = Dogan

--- a/src/streamlink/plugins/euronews.py
+++ b/src/streamlink/plugins/euronews.py
@@ -11,12 +11,12 @@ class Euronews(Plugin):
     _re_vod = re.compile(r'<meta\s+property="og:video"\s+content="(http.*?)"\s*/>')
     _live_api_url = "http://{0}.euronews.com/api/watchlive.json"
     _live_schema = validate.Schema({
-        u"url": validate.url()
+        "url": validate.url()
     })
     _stream_api_schema = validate.Schema({
-        u'status': u'ok',
-        u'primary': validate.url(),
-        validate.optional(u'backup'): validate.url()
+        "status": "ok",
+        "primary": validate.url(),
+        validate.optional("backup"): validate.url()
     })
 
     @classmethod

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -18,7 +18,7 @@ class GardenersWorld(Plugin):
 
     def _get_streams(self):
         page = self.session.http.get(self.url)
-        for iframe in itertags(page.text, u"iframe"):
+        for iframe in itertags(page.text, "iframe"):
             url = iframe.attributes["src"]
             log.debug("Handing off of {0}".format(url))
             try:

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -125,7 +125,7 @@ class NicoLive(Plugin):
         self.wss_api_url = "{0}&frontend_id={1}".format(self.wss_api_url, self.frontend_id)
 
         _log.debug("Video page response code: {0}".format(resp.status_code))
-        _log.trace(u"Video page response body: {0}".format(resp.text))
+        _log.trace("Video page response body: {0}".format(resp.text))
         _log.debug("Got wss_api_url: {0}".format(self.wss_api_url))
         _log.debug("Got frontend_id: {0}".format(self.frontend_id))
 
@@ -172,7 +172,7 @@ class NicoLive(Plugin):
     def send_message(self, type_, body):
         msg = {"type": type_, "body": body}
         msg_json = json.dumps(msg)
-        _log.debug(u"Sending: {0}".format(msg_json))
+        _log.debug(f"Sending: {msg_json}")
         if self._ws and self._ws.sock.connected:
             self._ws.send(msg_json)
         else:
@@ -181,7 +181,7 @@ class NicoLive(Plugin):
     def send_no_body_message(self, type_):
         msg = {"type": type_}
         msg_json = json.dumps(msg)
-        _log.debug(u"Sending: {0}".format(msg_json))
+        _log.debug(f"Sending: {msg_json}")
         if self._ws and self._ws.sock.connected:
             self._ws.send(msg_json)
         else:
@@ -189,7 +189,7 @@ class NicoLive(Plugin):
 
     def send_custom_message(self, msg):
         msg_json = json.dumps(msg)
-        _log.debug(u"Sending: {0}".format(msg_json))
+        _log.debug(f"Sending: {msg_json}")
         if self._ws and self._ws.sock.connected:
             self._ws.send(msg_json)
         else:
@@ -235,7 +235,7 @@ class NicoLive(Plugin):
         self.send_no_body_message("keepSeat")
 
     def handle_api_message(self, message):
-        _log.debug(u"Received: {0}".format(message))
+        _log.debug(f"Received: {message}")
         message_parsed = json.loads(message)
 
         if message_parsed["type"] == "stream":
@@ -311,7 +311,7 @@ class NicoLive(Plugin):
                                           params=_login_url_params)
 
             _log.debug("Login response code: {0}".format(resp.status_code))
-            _log.trace(u"Login response body: {0}".format(resp.text))
+            _log.trace("Login response body: {0}".format(resp.text))
             _log.debug("Cookies: {0}".format(
                 self.session.http.cookies.get_dict()))
 

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -94,7 +94,7 @@ class OneTV(Plugin):
             log.debug("Attempting to find VOD stream for {0}...".format(self.channel))
             vod_data = self.vod_data()
             if vod_data:
-                log.info(u"Found VOD: {0}".format(vod_data[0]['title']))
+                log.info(f"Found VOD: {vod_data[0]['title']}")
                 for stream in vod_data[0]['mbr']:
                     yield stream['name'], HTTPStream(self.session, update_scheme(self.url, stream['src']))
 

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -131,7 +131,7 @@ class Rtve(Plugin):
         qmap = {}
         for item in data["qualities"]:
             qname = {"MED": "Media", "HIGH": "Alta", "ORIGINAL": "Original"}.get(item["preset"], item["preset"])
-            qmap[qname] = u"{0}p".format(item["height"])
+            qmap[qname] = f"{item['height']}p"
         return qmap
 
     def _get_streams(self):

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -126,10 +126,10 @@ class SteamBroadcastPlugin(Plugin):
 
         resp = self.session.http.json(res, schema=self._dologin_schema)
 
-        if not resp[u"success"]:
-            if resp.get(u"captcha_needed"):
+        if not resp["success"]:
+            if resp.get("captcha_needed"):
                 # special case for captcha
-                captchagid = resp[u"captcha_gid"]
+                captchagid = resp["captcha_gid"]
                 log.error("Captcha result required, open this URL to see the captcha: {}".format(
                     self._captcha_url.format(captchagid)))
                 try:
@@ -140,7 +140,7 @@ class SteamBroadcastPlugin(Plugin):
                     return False
             else:
                 # If the user must enter the code that was emailed to them
-                if resp.get(u"emailauth_needed"):
+                if resp.get("emailauth_needed"):
                     if not emailauth:
                         try:
                             emailauth = self.input_ask("Email auth code required")
@@ -152,7 +152,7 @@ class SteamBroadcastPlugin(Plugin):
                         raise SteamLoginFailed("Email auth key error")
 
                 # If the user must enter a two factor auth code
-                if resp.get(u"requires_twofactor"):
+                if resp.get("requires_twofactor"):
                     try:
                         twofactorcode = self.input_ask("Two factor auth code required")
                     except FatalPluginError:
@@ -160,12 +160,12 @@ class SteamBroadcastPlugin(Plugin):
                     if not twofactorcode:
                         return False
 
-                if resp.get(u"message"):
-                    raise SteamLoginFailed(resp[u"message"])
+                if resp.get("message"):
+                    raise SteamLoginFailed(resp["message"])
 
             return self.dologin(email, password,
                                 emailauth=emailauth,
-                                emailsteamid=resp.get(u"emailsteamid", u""),
+                                emailsteamid=resp.get("emailsteamid", ""),
                                 captcha_text=captcha_text,
                                 captchagid=captchagid,
                                 twofactorcode=twofactorcode)
@@ -210,17 +210,17 @@ class SteamBroadcastPlugin(Plugin):
         res = self.session.http.get(self.url)  # get the page to set some cookies
         sessionid = res.cookies.get('sessionid')
 
-        while streamdata is None or streamdata[u"success"] in ("waiting", "waiting_for_start"):
+        while streamdata is None or streamdata["success"] in ("waiting", "waiting_for_start"):
             streamdata = self._get_broadcast_stream(steamid,
                                                     sessionid=sessionid)
 
-            if streamdata[u"success"] == "ready":
+            if streamdata["success"] == "ready":
                 return DASHStream.parse_manifest(self.session, streamdata["url"])
-            elif streamdata[u"success"] == "unavailable":
+            elif streamdata["success"] == "unavailable":
                 log.error("This stream is currently unavailable")
                 return
             else:
-                r = streamdata[u"retry"] / 1000.0
+                r = streamdata["retry"] / 1000.0
                 log.info("Waiting for stream, will retry again in {} seconds...".format(r))
                 time.sleep(r)
 

--- a/src/streamlink/plugins/tamago.py
+++ b/src/streamlink/plugins/tamago.py
@@ -13,19 +13,19 @@ class Tamago(Plugin):
     _api_url_base = "https://player.tamago.live/api/rooms/{id}"
 
     _api_response_schema = validate.Schema({
-        u"status": 200,
-        u"message": u"Success",
-        u"data": {
-            u"room_number": validate.text,
-            u"stream": {validate.text: validate.url()}
+        "status": 200,
+        "message": "Success",
+        "data": {
+            "room_number": validate.text,
+            "stream": {validate.text: validate.url()}
         }
     })
 
     _stream_qualities = {
-        u"150": "144p",
-        u"350": "360p",
-        u"550": "540p",
-        u"900": "720p",
+        "150": "144p",
+        "350": "360p",
+        "550": "540p",
+        "900": "720p",
     }
 
     @classmethod

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -19,7 +19,7 @@ class WebTV(Plugin):
     _sources_re = re.compile(r'"sources": (\[.*?\]),', re.DOTALL)
     _sources_schema = validate.Schema([
         {
-            u"src": validate.any(
+            "src": validate.any(
                 validate.contains("m3u8"),
                 validate.all(
                     validate.text,
@@ -27,8 +27,8 @@ class WebTV(Plugin):
                     validate.contains("m3u8")
                 )
             ),
-            u"type": validate.text,
-            u"label": validate.text
+            "type": validate.text,
+            "label": validate.text
         }
     ])
 
@@ -60,9 +60,9 @@ class WebTV(Plugin):
         if len(sources):
             sdata = parse_json(sources[0], schema=self._sources_schema)
             for source in sdata:
-                log.debug("Found stream of type: {}".format(source[u'type']))
-                if source[u'type'] == u"application/vnd.apple.mpegurl":
-                    url = update_scheme(self.url, source[u"src"])
+                log.debug(f"Found stream of type: {source['type']}")
+                if source["type"] == "application/vnd.apple.mpegurl":
+                    url = update_scheme(self.url, source["src"])
 
                     try:
                         # try to parse the stream as a variant playlist

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -81,7 +81,7 @@ class MPDParsers(object):
 
     @staticmethod
     def type(type_):
-        if type_ not in (u"static", u"dynamic"):
+        if type_ not in ("static", "dynamic"):
             raise MPDParsingError("@type must be static or dynamic")
         return type_
 
@@ -140,7 +140,7 @@ class MPDNode(object):
         self.node = node
         self.root = root
         self.parent = parent
-        self._base_url = kwargs.get(u"base_url")
+        self._base_url = kwargs.get("base_url")
         self.attributes = set([])
         if self.__tag__ and self.node.tag.lower() != self.__tag__.lower():
             raise MPDParsingError("root tag did not match the expected tag: {}".format(self.__tag__))
@@ -217,7 +217,7 @@ class MPD(MPDNode):
     Representation.
 
     """
-    __tag__ = u"MPD"
+    __tag__ = "MPD"
 
     def __init__(self, node, root=None, parent=None, url=None, *args, **kwargs):
         # top level has no parent
@@ -226,19 +226,19 @@ class MPD(MPDNode):
         self.url = url
         self.timelines = defaultdict(lambda: -1)
         self.timelines.update(kwargs.pop("timelines", {}))
-        self.id = self.attr(u"id")
-        self.profiles = self.attr(u"profiles", required=True)
-        self.type = self.attr(u"type", default=u"static", parser=MPDParsers.type)
-        self.minimumUpdatePeriod = self.attr(u"minimumUpdatePeriod", parser=MPDParsers.duration, default=Duration())
-        self.minBufferTime = self.attr(u"minBufferTime", parser=MPDParsers.duration, required=True)
-        self.timeShiftBufferDepth = self.attr(u"timeShiftBufferDepth", parser=MPDParsers.duration)
-        self.availabilityStartTime = self.attr(u"availabilityStartTime", parser=MPDParsers.datetime,
+        self.id = self.attr("id")
+        self.profiles = self.attr("profiles", required=True)
+        self.type = self.attr("type", default="static", parser=MPDParsers.type)
+        self.minimumUpdatePeriod = self.attr("minimumUpdatePeriod", parser=MPDParsers.duration, default=Duration())
+        self.minBufferTime = self.attr("minBufferTime", parser=MPDParsers.duration, required=True)
+        self.timeShiftBufferDepth = self.attr("timeShiftBufferDepth", parser=MPDParsers.duration)
+        self.availabilityStartTime = self.attr("availabilityStartTime", parser=MPDParsers.datetime,
                                                default=datetime.datetime.fromtimestamp(0, utc),  # earliest date
                                                required=self.type == "dynamic")
-        self.publishTime = self.attr(u"publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
-        self.availabilityEndTime = self.attr(u"availabilityEndTime", parser=MPDParsers.datetime)
-        self.mediaPresentationDuration = self.attr(u"mediaPresentationDuration", parser=MPDParsers.duration)
-        self.suggestedPresentationDelay = self.attr(u"suggestedPresentationDelay", parser=MPDParsers.duration)
+        self.publishTime = self.attr("publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
+        self.availabilityEndTime = self.attr("availabilityEndTime", parser=MPDParsers.datetime)
+        self.mediaPresentationDuration = self.attr("mediaPresentationDuration", parser=MPDParsers.duration)
+        self.suggestedPresentationDelay = self.attr("suggestedPresentationDelay", parser=MPDParsers.duration)
 
         # parse children
         location = self.children(Location)
@@ -290,15 +290,15 @@ class Location(MPDNode):
 
 
 class Period(MPDNode):
-    __tag__ = u"Period"
+    __tag__ = "Period"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super().__init__(node, root, parent, *args, **kwargs)
-        self.i = kwargs.get(u"i", 0)
-        self.id = self.attr(u"id")
-        self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.bool_str)
-        self.duration = self.attr(u"duration", default=Duration(), parser=MPDParsers.duration)
-        self.start = self.attr(u"start", default=Duration(), parser=MPDParsers.duration)
+        self.i = kwargs.get("i", 0)
+        self.id = self.attr("id")
+        self.bitstreamSwitching = self.attr("bitstreamSwitching", parser=MPDParsers.bool_str)
+        self.duration = self.attr("duration", default=Duration(), parser=MPDParsers.duration)
+        self.start = self.attr("start", default=Duration(), parser=MPDParsers.duration)
 
         if self.start is None and self.i == 0 and self.root.type == "static":
             self.start = 0
@@ -379,29 +379,29 @@ class SegmentList(MPDNode):
 
 
 class AdaptationSet(MPDNode):
-    __tag__ = u"AdaptationSet"
+    __tag__ = "AdaptationSet"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super().__init__(node, root, parent, *args, **kwargs)
 
-        self.id = self.attr(u"id")
-        self.group = self.attr(u"group")
-        self.mimeType = self.attr(u"mimeType")
-        self.lang = self.attr(u"lang")
-        self.contentType = self.attr(u"contentType")
-        self.par = self.attr(u"par")
-        self.minBandwidth = self.attr(u"minBandwidth")
-        self.maxBandwidth = self.attr(u"maxBandwidth")
-        self.minWidth = self.attr(u"minWidth", parser=int)
-        self.maxWidth = self.attr(u"maxWidth", parser=int)
-        self.minHeight = self.attr(u"minHeight", parser=int)
-        self.maxHeight = self.attr(u"maxHeight", parser=int)
-        self.minFrameRate = self.attr(u"minFrameRate", parser=MPDParsers.frame_rate)
-        self.maxFrameRate = self.attr(u"maxFrameRate", parser=MPDParsers.frame_rate)
-        self.segmentAlignment = self.attr(u"segmentAlignment", default=False, parser=MPDParsers.bool_str)
-        self.bitstreamSwitching = self.attr(u"bitstreamSwitching", parser=MPDParsers.bool_str)
-        self.subsegmentAlignment = self.attr(u"subsegmentAlignment", default=False, parser=MPDParsers.bool_str)
-        self.subsegmentStartsWithSAP = self.attr(u"subsegmentStartsWithSAP", default=0, parser=int)
+        self.id = self.attr("id")
+        self.group = self.attr("group")
+        self.mimeType = self.attr("mimeType")
+        self.lang = self.attr("lang")
+        self.contentType = self.attr("contentType")
+        self.par = self.attr("par")
+        self.minBandwidth = self.attr("minBandwidth")
+        self.maxBandwidth = self.attr("maxBandwidth")
+        self.minWidth = self.attr("minWidth", parser=int)
+        self.maxWidth = self.attr("maxWidth", parser=int)
+        self.minHeight = self.attr("minHeight", parser=int)
+        self.maxHeight = self.attr("maxHeight", parser=int)
+        self.minFrameRate = self.attr("minFrameRate", parser=MPDParsers.frame_rate)
+        self.maxFrameRate = self.attr("maxFrameRate", parser=MPDParsers.frame_rate)
+        self.segmentAlignment = self.attr("segmentAlignment", default=False, parser=MPDParsers.bool_str)
+        self.bitstreamSwitching = self.attr("bitstreamSwitching", parser=MPDParsers.bool_str)
+        self.subsegmentAlignment = self.attr("subsegmentAlignment", default=False, parser=MPDParsers.bool_str)
+        self.subsegmentStartsWithSAP = self.attr("subsegmentStartsWithSAP", default=0, parser=int)
 
         self.baseURLs = self.children(BaseURL)
         self.segmentTemplate = self.only_child(SegmentTemplate)
@@ -416,15 +416,15 @@ class SegmentTemplate(MPDNode):
         super().__init__(node, root, parent, *args, **kwargs)
         self.defaultSegmentTemplate = self.walk_back_get_attr('segmentTemplate')
 
-        self.initialization = self.attr(u"initialization", parser=MPDParsers.segment_template)
-        self.media = self.attr(u"media", parser=MPDParsers.segment_template)
-        self.duration = self.attr(u"duration", parser=int,
+        self.initialization = self.attr("initialization", parser=MPDParsers.segment_template)
+        self.media = self.attr("media", parser=MPDParsers.segment_template)
+        self.duration = self.attr("duration", parser=int,
                                   default=self.defaultSegmentTemplate.duration if self.defaultSegmentTemplate else None)
-        self.timescale = self.attr(u"timescale", parser=int,
+        self.timescale = self.attr("timescale", parser=int,
                                    default=self.defaultSegmentTemplate.timescale if self.defaultSegmentTemplate else 1)
-        self.startNumber = self.attr(u"startNumber", parser=int,
+        self.startNumber = self.attr("startNumber", parser=int,
                                      default=self.defaultSegmentTemplate.startNumber if self.defaultSegmentTemplate else 1)
-        self.presentationTimeOffset = self.attr(u"presentationTimeOffset", parser=MPDParsers.timedelta(self.timescale))
+        self.presentationTimeOffset = self.attr("presentationTimeOffset", parser=MPDParsers.timedelta(self.timescale))
 
         if self.duration:
             self.duration_seconds = self.duration / float(self.timescale)
@@ -469,7 +469,7 @@ class SegmentTemplate(MPDNode):
         :return:
         """
         log.debug("Generating segment numbers for {0} playlist (id={1})".format(self.root.type, self.parent.id))
-        if self.root.type == u"static":
+        if self.root.type == "static":
             available_iter = repeat(epoch_start)
             duration = self.period.duration.seconds or self.root.mediaPresentationDuration.seconds
             if duration:
@@ -557,28 +557,28 @@ class SegmentTemplate(MPDNode):
 
 
 class Representation(MPDNode):
-    __tag__ = u"Representation"
+    __tag__ = "Representation"
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super().__init__(node, root, parent, *args, **kwargs)
-        self.id = self.attr(u"id", required=True)
-        self.bandwidth = self.attr(u"bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
-        self.mimeType = self.attr(u"mimeType", required=True, inherited=True)
+        self.id = self.attr("id", required=True)
+        self.bandwidth = self.attr("bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
+        self.mimeType = self.attr("mimeType", required=True, inherited=True)
 
-        self.codecs = self.attr(u"codecs")
-        self.startWithSAP = self.attr(u"startWithSAP")
+        self.codecs = self.attr("codecs")
+        self.startWithSAP = self.attr("startWithSAP")
 
         # video
-        self.width = self.attr(u"width", parser=int)
-        self.height = self.attr(u"height", parser=int)
-        self.frameRate = self.attr(u"frameRate", parser=MPDParsers.frame_rate)
+        self.width = self.attr("width", parser=int)
+        self.height = self.attr("height", parser=int)
+        self.frameRate = self.attr("frameRate", parser=MPDParsers.frame_rate)
 
         # audio
-        self.audioSamplingRate = self.attr(u"audioSamplingRate", parser=int)
-        self.numChannels = self.attr(u"numChannels", parser=int)
+        self.audioSamplingRate = self.attr("audioSamplingRate", parser=int)
+        self.numChannels = self.attr("numChannels", parser=int)
 
         # subtitle
-        self.lang = self.attr(u"lang", inherited=True)
+        self.lang = self.attr("lang", inherited=True)
 
         self.baseURLs = self.children(BaseURL)
         self.subRepresentation = self.children(SubRepresentation)
@@ -665,6 +665,6 @@ class ContentProtection(MPDNode):
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super().__init__(node, root, parent, *args, **kwargs)
 
-        self.schemeIdUri = self.attr(u"schemeIdUri")
-        self.value = self.attr(u"value")
-        self.default_KID = self.attr(u"default_KID")
+        self.schemeIdUri = self.attr("schemeIdUri")
+        self.value = self.attr("value")
+        self.default_KID = self.attr("default_KID")

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -508,12 +508,11 @@ class HLSStream(HTTPStream):
             external_audio = preferred_audio or default_audio or fallback_audio
 
             if external_audio and FFMPEGMuxer.is_usable(session_):
-                external_audio_msg = u", ".join([
-                    u"(language={0}, name={1})".format(x.language, (x.name or "N/A"))
+                external_audio_msg = ", ".join([
+                    f"(language={x.language}, name={x.name or 'N/A'})"
                     for x in external_audio
                 ])
-                log.debug(u"Using external audio tracks for stream {0} {1}".format(
-                          stream_name, external_audio_msg))
+                log.debug(f"Using external audio tracks for stream {stream_name} {external_audio_msg}")
 
                 stream = MuxedHLSStream(session_,
                                         video=playlist.uri,

--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -48,14 +48,13 @@ class Country(object):
         )
 
     def __str__(self):
-        return self.__unicode__()
-
-    def __unicode__(self):
-        return u"Country({0!r}, {1!r}, {2!r}, {3!r}, official_name={4!r})".format(self.alpha2,
-                                                                                  self.alpha3,
-                                                                                  self.numeric,
-                                                                                  self.name,
-                                                                                  self.official_name)
+        return "Country({0!r}, {1!r}, {2!r}, {3!r}, official_name={4!r})".format(
+            self.alpha2,
+            self.alpha3,
+            self.numeric,
+            self.name,
+            self.official_name
+        )
 
 
 class Language(object):
@@ -99,13 +98,12 @@ class Language(object):
         )
 
     def __str__(self):
-        return self.__unicode__()
-
-    def __unicode__(self):
-        return u"Language({0!r}, {1!r}, {2!r}, bibliographic={3!r})".format(self.alpha2,
-                                                                            self.alpha3,
-                                                                            self.name,
-                                                                            self.bibliographic)
+        return "Language({0!r}, {1!r}, {2!r}, bibliographic={3!r})".format(
+            self.alpha2,
+            self.alpha3,
+            self.name,
+            self.bibliographic
+        )
 
 
 class Localization(object):

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -39,9 +39,9 @@ class ArgumentParser(argparse.ArgumentParser):
 
         name, value = option.group("name", "value")
         if name and value:
-            yield u"--{0}={1}".format(name, value)
+            yield f"--{name}={value}"
         elif name:
-            yield u"--{0}".format(name)
+            yield f"--{name}"
 
     def _match_argument(self, action, arg_strings_pattern):
         # - https://github.com/streamlink/streamlink/issues/971

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -60,9 +60,7 @@ class ConsoleOutput(object):
             return ""
 
     def msg(self, msg, *args, **kwargs):
-        formatted = msg.format(*args, **kwargs)
-        formatted = u"{0}\n".format(formatted)
-
+        formatted = f"{msg.format(*args, **kwargs)}\n"
         self.output.write(formatted)
 
     def msg_json(self, obj):
@@ -74,7 +72,7 @@ class ConsoleOutput(object):
 
         msg = json.dumps(obj, cls=JSONEncoder,
                          indent=2)
-        self.msg(u"{0}", msg)
+        self.msg("{0}", msg)
 
         if isinstance(obj, dict) and obj.get("error"):
             sys.exit(1)
@@ -86,8 +84,7 @@ class ConsoleOutput(object):
             obj = dict(error=formatted)
             self.msg_json(obj)
         else:
-            msg = u"error: {0}".format(formatted)
-            self.msg(u"{0}", msg)
+            self.msg("{0}", f"error: {formatted}")
 
         sys.exit(1)
 

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -2,12 +2,12 @@ import os
 
 from streamlink_cli.compat import is_win32
 
-DEFAULT_PLAYER_ARGUMENTS = u"{filename}"
+DEFAULT_PLAYER_ARGUMENTS = "{filename}"
 DEFAULT_STREAM_METADATA = {
-    "title": u"Unknown Title",
-    "author": u"Unknown Author",
-    "category": u"No Category",
-    "game": u"No Game/Category"
+    "title": "Unknown Title",
+    "author": "Unknown Author",
+    "category": "No Category",
+    "game": "No Game/Category"
 }
 # these are the players that streamlink knows how to set the window title for with `--title`.
 # key names are used in help text

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -219,7 +219,7 @@ def output_stream_http(plugin, initial_streams, external=False, port=0):
                     sleep(10)
                     continue
             except PluginError as err:
-                log.error(u"Unable to fetch new streams: {0}".format(err))
+                log.error(f"Unable to fetch new streams: {err}")
                 continue
 
             try:
@@ -467,7 +467,7 @@ def fetch_streams_with_retry(plugin, interval, count):
     try:
         streams = fetch_streams(plugin)
     except PluginError as err:
-        log.error(u"{0}".format(err))
+        log.error(err)
         streams = None
 
     if not streams:
@@ -483,7 +483,7 @@ def fetch_streams_with_retry(plugin, interval, count):
         except FatalPluginError:
             raise
         except PluginError as err:
-            log.error(u"{0}".format(err))
+            log.error(err)
 
         if count > 0:
             attempts += 1
@@ -581,7 +581,7 @@ def handle_url():
     except NoPluginError:
         console.exit("No plugin can handle URL: {0}", args.url)
     except PluginError as err:
-        console.exit(u"{0}", err)
+        console.exit("{0}", err)
 
     if not streams:
         console.exit("No playable streams found on this URL: {0}", args.url)

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -184,13 +184,13 @@ class PlayerOutput(Output):
             if self.player_name == "vlc":
                 # see https://wiki.videolan.org/Documentation:Format_String/, allow escaping with \$
                 self.title = self.title.replace("$", "$$").replace(r'\$$', "$")
-                extra_args.extend([u"--input-title-format", self.title])
+                extra_args.extend(["--input-title-format", self.title])
 
             # mpv
             if self.player_name == "mpv":
                 # see https://mpv.io/manual/stable/#property-expansion, allow escaping with \$, respect mpv's $>
                 self.title = self._mpv_title_escape(self.title)
-                extra_args.append(u"--title={}".format(self.title))
+                extra_args.append(f"--title={self.title}")
 
             # potplayer
             if self.player_name == "potplayer":
@@ -208,7 +208,7 @@ class PlayerOutput(Output):
         if is_win32:
             eargs = subprocess.list2cmdline(extra_args)
             # do not insert and extra " " when there are no extra_args
-            return u' '.join([cmd] + ([eargs] if eargs else []) + [args])
+            return " ".join([cmd] + ([eargs] if eargs else []) + [args])
         return shlex.split(cmd) + extra_args + shlex.split(args)
 
     def _open(self):
@@ -231,7 +231,7 @@ class PlayerOutput(Output):
             fargs = args
         else:
             fargs = subprocess.list2cmdline(args)
-        log.debug(u"Calling: {0}".format(fargs))
+        log.debug(f"Calling: {fargs}")
 
         subprocess.call(args,
                         stdout=self.stdout,
@@ -245,7 +245,7 @@ class PlayerOutput(Output):
             fargs = args
         else:
             fargs = subprocess.list2cmdline(args)
-        log.debug(u"Opening subprocess: {0}".format(fargs))
+        log.debug(f"Opening subprocess: {fargs}")
 
         self.player = subprocess.Popen(args,
                                        stdin=self.stdin, bufsize=0,

--- a/tests/plugins/test_albavision.py
+++ b/tests/plugins/test_albavision.py
@@ -28,5 +28,5 @@ class TestPluginAlbavision:
         assert not Albavision.can_handle_url(url), "url should not be handled"
 
     def test_transform(self):
-        token = Albavision.transform_token(u'6b425761cc8a86569b1a05a9bf1870c95fca717dOK', 436171)
+        token = Albavision.transform_token("6b425761cc8a86569b1a05a9bf1870c95fca717dOK", 436171)
         assert token == "6b425761cc8a86569b1a05a9bf1870c95fca717d"

--- a/tests/plugins/test_tvplayer.py
+++ b/tests/plugins/test_tvplayer.py
@@ -42,7 +42,7 @@ class TestPluginTVPlayer(unittest.TestCase):
         }
 
         page_resp = Mock()
-        page_resp.text = u"""
+        page_resp.text = """
             <div class="col-xs-12">
                 <div id="live-player-root"
                     data-player-library="videojs"
@@ -99,7 +99,7 @@ class TestPluginTVPlayer(unittest.TestCase):
 
     def test_get_invalid_page(self):
         page_resp = Mock()
-        page_resp.text = u"""
+        page_resp.text = """
             var validate = "foo";
             var resourceId = "1234";
         """

--- a/tests/plugins/testplugin.py
+++ b/tests/plugins/testplugin.py
@@ -27,7 +27,7 @@ class TestPlugin(Plugin):
         return "Test Title"
 
     def get_author(self):
-        return u"Tѥst Āuƭhǿr"
+        return "Tѥst Āuƭhǿr"
 
     def get_category(self):
         return None

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -21,7 +21,7 @@ class TestPluginAPIHTTPSession(unittest.TestCase):
         self.assertRaises(PluginError, stream_data)
 
     def test_json_encoding(self):
-        json_str = u"{\"test\": \"Α and Ω\"}"
+        json_str = "{\"test\": \"Α and Ω\"}"
 
         # encode the json string with each encoding and assert that the correct one is detected
         for encoding in ["UTF-32BE", "UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"]:
@@ -29,14 +29,14 @@ class TestPluginAPIHTTPSession(unittest.TestCase):
                 mock_content.return_value = json_str.encode(encoding)
                 res = requests.Response()
 
-                self.assertEqual(HTTPSession.json(res), {u"test": u"\u0391 and \u03a9"})
+                self.assertEqual(HTTPSession.json(res), {"test": "\u0391 and \u03a9"})
 
     def test_json_encoding_override(self):
-        json_text = u"{\"test\": \"Α and Ω\"}".encode("cp949")
+        json_text = "{\"test\": \"Α and Ω\"}".encode("cp949")
 
         with patch('requests.Response.content', new_callable=PropertyMock) as mock_content:
             mock_content.return_value = json_text
             res = requests.Response()
             res.encoding = "cp949"
 
-            self.assertEqual(HTTPSession.json(res), {u"test": u"\u0391 and \u03a9"})
+            self.assertEqual(HTTPSession.json(res), {"test": "\u0391 and \u03a9"})

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -18,7 +18,7 @@ class TestPluginAPIValidate(unittest.TestCase):
         assert validate(transform(int), "1") == 1
 
         assert validate(text, "abc") == "abc"
-        assert validate(text, u"日本語") == u"日本語"
+        assert validate(text, "日本語") == "日本語"
         assert validate(transform(text), 1) == "1"
 
         assert validate(list, ["a", 1]) == ["a", 1]
@@ -155,4 +155,4 @@ class TestPluginAPIValidate(unittest.TestCase):
         assert validate(startswith("abc"), "abcedf")
 
     def test_endswith(self):
-        assert validate(endswith(u"åäö"), u"xyzåäö")
+        assert validate(endswith("åäö"), "xyzåäö")

--- a/tests/test_cli_playerout.py
+++ b/tests/test_cli_playerout.py
@@ -3,7 +3,7 @@ from unittest.mock import ANY, patch
 from streamlink_cli.output import PlayerOutput
 from tests import posix_only, windows_only
 
-UNICODE_TITLE = u"기타치는소율 with UL섬 "
+UNICODE_TITLE = "기타치는소율 with UL섬 "
 
 
 @posix_only
@@ -12,7 +12,7 @@ def test_output_mpv_unicode_title_posix(popen):
     po = PlayerOutput("mpv", title=UNICODE_TITLE)
     popen().poll.side_effect = lambda: None
     po.open()
-    popen.assert_called_with(['mpv', u"--title=" + UNICODE_TITLE, '-'],
+    popen.assert_called_with(['mpv', f'--title={UNICODE_TITLE}', '-'],
                              bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
 
 
@@ -22,7 +22,7 @@ def test_output_vlc_unicode_title_posix(popen):
     po = PlayerOutput("vlc", title=UNICODE_TITLE)
     popen().poll.side_effect = lambda: None
     po.open()
-    popen.assert_called_with(['vlc', u'--input-title-format', UNICODE_TITLE, '-'],
+    popen.assert_called_with(['vlc', '--input-title-format', UNICODE_TITLE, '-'],
                              bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
 
 
@@ -32,7 +32,7 @@ def test_output_mpv_unicode_title_windows_py3(popen):
     po = PlayerOutput("mpv.exe", title=UNICODE_TITLE)
     popen().poll.side_effect = lambda: None
     po.open()
-    popen.assert_called_with("mpv.exe \"--title=" + UNICODE_TITLE + "\" -",
+    popen.assert_called_with(f"mpv.exe \"--title={UNICODE_TITLE}\" -",
                              bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
 
 
@@ -42,5 +42,5 @@ def test_output_vlc_unicode_title_windows_py3(popen):
     po = PlayerOutput("vlc.exe", title=UNICODE_TITLE)
     popen().poll.side_effect = lambda: None
     po.open()
-    popen.assert_called_with("vlc.exe --input-title-format \"" + UNICODE_TITLE + "\" -",
+    popen.assert_called_with(f"vlc.exe --input-title-format \"{UNICODE_TITLE}\" -",
                              bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -12,7 +12,7 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
 
     def test_open_player_with_unicode_author_vlc(self):
         self._test_args(["streamlink", "-p", "/usr/bin/vlc", "--title", "{author}", "http://test.se", "test"],
-                        ["/usr/bin/vlc", "--input-title-format", u"Tѥst Āuƭhǿr", "-"])
+                        ["/usr/bin/vlc", "--input-title-format", "Tѥst Āuƭhǿr", "-"])
 
     def test_open_player_with_default_title_vlc(self):
         self._test_args(["streamlink", "-p", "/usr/bin/vlc", "http://test.se", "test"],
@@ -28,7 +28,7 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
 
     def test_unicode_title_2444(self):
         self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
-                        ["mpv", u'--title=\u2605', "-"])
+                        ["mpv", "--title=\u2605", "-"])
 
 
 @unittest.skipIf(not is_win32, "test only applicable on Windows")
@@ -44,7 +44,7 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
         self._test_args(
             ["streamlink", "-p", "c:\\Program Files\\VideoLAN\\vlc.exe",
              "--title", "{author}", "http://test.se", "test"],
-            u"c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"Tѥst Āuƭhǿr\" -"
+            "c:\\Program Files\\VideoLAN\\vlc.exe --input-title-format \"Tѥst Āuƭhǿr\" -"
         )
 
     def test_open_player_with_default_title_vlc(self):
@@ -72,8 +72,8 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
         self._test_args(
             ["streamlink", "-p", "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\"",
              "--title", "{author}", "http://test.se/stream", "hls", "--player-passthrough", "hls"],
-            u"\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" "
-            + u"\"http://test.se/playlist.m3u8\\Tѥst Āuƭhǿr\"",
+            "\"c:\\Program Files\\DAUM\\PotPlayer\\PotPlayerMini64.exe\" "
+            + "\"http://test.se/playlist.m3u8\\Tѥst Āuƭhǿr\"",
             passthrough=True
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,48 +54,48 @@ class TestUtil(unittest.TestCase):
 
     def test_parse_xml(self):
         expected = ET.Element("test", {"foo": "bar"})
-        actual = parse_xml(u"""<test foo="bar"/>""", ignore_ns=True)
+        actual = parse_xml("""<test foo="bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_ns_ignore(self):
         expected = ET.Element("test", {"foo": "bar"})
-        actual = parse_xml(u"""<test foo="bar" xmlns="foo:bar"/>""", ignore_ns=True)
+        actual = parse_xml("""<test foo="bar" xmlns="foo:bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_ns_ignore_tab(self):
         expected = ET.Element("test", {"foo": "bar"})
-        actual = parse_xml(u"""<test	foo="bar"	xmlns="foo:bar"/>""", ignore_ns=True)
+        actual = parse_xml("""<test	foo="bar"	xmlns="foo:bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_ns(self):
         expected = ET.Element("{foo:bar}test", {"foo": "bar"})
-        actual = parse_xml(u"""<h:test foo="bar" xmlns:h="foo:bar"/>""")
+        actual = parse_xml("""<h:test foo="bar" xmlns:h="foo:bar"/>""")
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_fail(self):
         self.assertRaises(PluginError,
-                          parse_xml, u"1" * 1000)
+                          parse_xml, "1" * 1000)
         self.assertRaises(IOError,
-                          parse_xml, u"1" * 1000, exception=IOError)
+                          parse_xml, "1" * 1000, exception=IOError)
 
     def test_parse_xml_validate(self):
         expected = ET.Element("test", {"foo": "bar"})
-        actual = parse_xml(u"""<test foo="bar"/>""",
+        actual = parse_xml("""<test foo="bar"/>""",
                            schema=validate.Schema(xml_element(tag="test", attrib={"foo": text})))
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_entities_fail(self):
         self.assertRaises(PluginError,
-                          parse_xml, u"""<test foo="bar &"/>""")
+                          parse_xml, """<test foo="bar &"/>""")
 
     def test_parse_xml_entities(self):
         expected = ET.Element("test", {"foo": "bar &"})
-        actual = parse_xml(u"""<test foo="bar &"/>""",
+        actual = parse_xml("""<test foo="bar &"/>""",
                            schema=validate.Schema(xml_element(tag="test", attrib={"foo": text})),
                            invalid_char_entities=True)
         self.assertEqual(expected.tag, actual.tag)


### PR DESCRIPTION
This removes all superfluous u-strings and also removes the unnecessary `__unicode__` magic method from some of the classes in `streamlink.utils.l10n`.

Most u-strings which were format templates were replaced by f-strings where it made sense.

Also, just as an additional note, some of the unicode related tests are not relevant anymore due to the py2 removal and could be removed as well, but it's not really important.