### PR TITLE
plugins.nrk: fix/rewrite plugin

### DIFF
--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -41,6 +41,7 @@ _playable_schema = validate.Schema({
     },
 })
 
+
 class NRK(Plugin):
     _psapi_url = 'https://psapi.nrk.no'
 
@@ -49,9 +50,6 @@ class NRK(Plugin):
         return _url_re.match(url)
 
     def _get_streams(self):
-        # Get the stream type from the url (tv/radio).
-        stream_type = _url_re.match(self.url).group(1).upper()
-
         # Construct manifest URL for this program.
         program_type, program_id = _id_re.search(self.url).groups()
         if program_type == 'direkte':
@@ -84,5 +82,6 @@ class NRK(Plugin):
         if not data:
             return None
         return data.get("title")
+
 
 __plugin__ = NRK

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -73,7 +73,7 @@ class NRK(Plugin):
         if m is not None:
             program_id = m.group(1)
         elif program_id is None:
-            log.error(f"Could not extract program ID from URL")
+            log.error("Could not extract program ID from URL")
             return None
 
         manifest_url = urljoin(self._psapi_url, f"playback/manifest/{manifest_type}/{program_id}")

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -3,30 +3,10 @@ from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream import HLSStream, HTTPStream
 
-COOKIE_PARAMS = (
-    "devicetype=desktop&"
-    "preferred-player-odm=hlslink&"
-    "preferred-player-live=hlslink"
-)
-
-_id_re = re.compile(r"/(?:program|direkte|serie/[^/]+)/([^/]+)")
+_id_re = re.compile(r"/(program|direkte|serie|podkast)(?:/.+)?/([^/]+)")
 _url_re = re.compile(r"https?://(tv|radio).nrk.no/")
-_api_baseurl_re = re.compile(r'''apiBaseUrl:\s*["'](?P<baseurl>[^"']+)["']''')
-
-_schema = validate.Schema(
-    validate.transform(_api_baseurl_re.search),
-    validate.any(
-        None,
-        validate.all(
-            validate.get("baseurl"),
-            validate.url(
-                scheme="http"
-            )
-        )
-    )
-)
 
 _mediaelement_schema = validate.Schema({
     "mediaUrl": validate.url(
@@ -35,8 +15,35 @@ _mediaelement_schema = validate.Schema({
     )
 })
 
+_playable_schema = validate.Schema({
+    "playable": validate.all(
+        {
+            "assets": validate.all(
+                [{
+                    "url": validate.url(
+                        scheme="http",
+                        path=validate.any(
+                            validate.endswith(".m3u8"),
+                            validate.endswith(".mp3")
+                        ),
+                    ),
+                    "format": validate.all(validate.text),
+                }]
+            ),
+        }
+    ),
+    "statistics": {
+        "luna": {
+            "data": {
+                "title": validate.text,
+            },
+        },
+    },
+})
 
 class NRK(Plugin):
+    _psapi_url = 'https://psapi.nrk.no'
+
     @classmethod
     def can_handle_url(self, url):
         return _url_re.match(url)
@@ -44,21 +51,38 @@ class NRK(Plugin):
     def _get_streams(self):
         # Get the stream type from the url (tv/radio).
         stream_type = _url_re.match(self.url).group(1).upper()
-        cookie = {
-            "NRK_PLAYER_SETTINGS_{0}".format(stream_type): COOKIE_PARAMS
-        }
 
-        # Construct API URL for this program.
-        baseurl = self.session.http.get(self.url, cookies=cookie, schema=_schema)
-        program_id = _id_re.search(self.url).group(1)
+        # Construct manifest URL for this program.
+        program_type, program_id = _id_re.search(self.url).groups()
+        if program_type == 'direkte':
+            manifest_type = 'channel'
+        elif program_type == 'serie':
+            manifest_type = 'program'
+        elif program_type == 'podkast':
+            manifest_type = 'podcast'
+        manifest_url = urljoin(self._psapi_url, "playback/manifest/{0}/{1}".format(manifest_type, program_id))
 
         # Extract media URL.
-        json_url = urljoin(baseurl, "mediaelement/{0}".format(program_id))
-        res = self.session.http.get(json_url, cookies=cookie)
-        media_element = self.session.http.json(res, schema=_mediaelement_schema)
-        media_url = media_element["mediaUrl"]
+        res = self.session.http.get(manifest_url)
+        manifest = self.session.http.json(res, schema=_playable_schema)
+        asset = manifest['playable']['assets'][0]
 
-        return HLSStream.parse_variant_playlist(self.session, media_url)
+        # Some streams such as podcasts are not HLS but plain files.
+        if asset['format'] == 'HLS':
+            return HLSStream.parse_variant_playlist(self.session, asset['url'])
+        else:
+            return [(self._get_title(manifest), HTTPStream(self.session, asset['url']))]
 
+    def _get_title(self, manifest):
+        statistics = manifest.get("statistics")
+        if not statistics:
+            return None
+        luna = statistics.get("luna")
+        if not luna:
+            return None
+        data = luna.get("data")
+        if not data:
+            return None
+        return data.get("title")
 
 __plugin__ = NRK

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -1,68 +1,74 @@
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 
-_id_re = re.compile(r"/(program|direkte|serie|podkast)(?:/.+)?/([^/]+)")
-_url_re = re.compile(r"https?://(tv|radio).nrk.no/")
 
-_mediaelement_schema = validate.Schema({
-    "mediaUrl": validate.url(
-        scheme="http",
-        path=validate.endswith(".m3u8")
-    )
-})
+class NRK(Plugin):
+    _psapi_url = 'https://psapi.nrk.no'
+    # Program type to manifest type mapping
+    _program_type_map = {
+        'direkte': 'channel',
+        'serie': 'program',
+        'podkast': 'podcast',
+    }
 
-_playable_schema = validate.Schema({
-    "playable": validate.all(
-        {
-            "assets": validate.all(
-                [{
+    _url_re = re.compile(r"https?://(?:tv|radio).nrk.no/(program|direkte|serie|podkast)(?:/.+)?/([^/]+)")
+
+    _playable_schema = validate.Schema({
+        "playable": validate.any(
+            None,
+            {
+                "assets": [{
                     "url": validate.url(
-                        scheme="http",
                         path=validate.any(
                             validate.endswith(".m3u8"),
                             validate.endswith(".mp3")
                         ),
                     ),
-                    "format": validate.all(validate.text),
-                }]
-            ),
-        }
-    ),
-    "statistics": {
-        "luna": {
-            "data": {
-                "title": validate.text,
+                    "format": str,
+                }],
             },
+        ),
+        "nonPlayable": validate.any(
+            None,
+            {
+                "reason": str,
+            },
+        ),
+        "statistics": {
+            validate.optional("luna"): validate.any(
+                None,
+                {
+                    "data": {
+                        "title": str,
+                    },
+                },
+            ),
         },
-    },
-})
-
-
-class NRK(Plugin):
-    _psapi_url = 'https://psapi.nrk.no'
+    })
 
     @classmethod
     def can_handle_url(self, url):
-        return _url_re.match(url)
+        return self._url_re.match(url)
 
     def _get_streams(self):
         # Construct manifest URL for this program.
-        program_type, program_id = _id_re.search(self.url).groups()
-        if program_type == 'direkte':
-            manifest_type = 'channel'
-        elif program_type == 'serie':
-            manifest_type = 'program'
-        elif program_type == 'podkast':
-            manifest_type = 'podcast'
-        manifest_url = urljoin(self._psapi_url, "playback/manifest/{0}/{1}".format(manifest_type, program_id))
+        program_type, program_id = self._url_re.search(self.url).groups()
+        manifest_type = self._program_type_map.get(program_type)
+        if manifest_type is None:
+            raise PluginError(f"Unknown program type '{program_type}'")
+        manifest_url = urljoin(self._psapi_url, f"playback/manifest/{manifest_type}/{program_id}")
 
         # Extract media URL.
         res = self.session.http.get(manifest_url)
-        manifest = self.session.http.json(res, schema=_playable_schema)
+        manifest = self.session.http.json(res, schema=self._playable_schema)
+        playable = manifest['playable']
+        if playable is None:
+            reason = manifest["nonPlayable"]["reason"]
+            raise PluginError(f"Not playable ({reason})")
         asset = manifest['playable']['assets'][0]
 
         # Some streams such as podcasts are not HLS but plain files.
@@ -72,16 +78,10 @@ class NRK(Plugin):
             return [(self._get_title(manifest), HTTPStream(self.session, asset['url']))]
 
     def _get_title(self, manifest):
-        statistics = manifest.get("statistics")
-        if not statistics:
-            return None
-        luna = statistics.get("luna")
+        luna = manifest.get("statistics").get("luna")
         if not luna:
             return None
-        data = luna.get("data")
-        if not data:
-            return None
-        return data.get("title")
+        return luna.get("data").get("title")
 
 
 __plugin__ = NRK

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -12,6 +12,7 @@ class NRK(Plugin):
     _program_type_map = {
         'direkte': 'channel',
         'serie': 'program',
+        'program': 'program',
         'podkast': 'podcast',
     }
 

--- a/tests/plugins/test_nrk.py
+++ b/tests/plugins/test_nrk.py
@@ -10,14 +10,24 @@ class TestPluginNRK(unittest.TestCase):
             'https://tv.nrk.no/direkte/nrk2',
             'https://tv.nrk.no/direkte/nrk3',
             'https://tv.nrk.no/direkte/nrksuper',
+
+            'https://tv.nrk.no/serie/nytt-paa-nytt/2020/MUHH43003020',
+            'https://tv.nrk.no/serie/kongelige-fotografer/sesong/1/episode/2/avspiller',
+
+            'https://tv.nrk.no/program/NNFA51102617',
+
             'https://radio.nrk.no/direkte/p1',
             'https://radio.nrk.no/direkte/p2',
+
+            'https://radio.nrk.no/podkast/oppdatert/l_5005d62a-7f4f-4581-85d6-2a7f4f2581f2',
         ]
         for url in should_match:
             self.assertTrue(NRK.can_handle_url(url))
 
     def test_can_handle_url_negative(self):
         should_not_match = [
+            'https://tv.nrk.no/',
+            'https://radio.nrk.no/',
             'https://nrk.no/',
         ]
         for url in should_not_match:


### PR DESCRIPTION
The TV and radio sites of nrk.no has been changed some time ago which
has left the NRK plugin broken. This change makes use of [PSAPI] to
bring both TV and radio back to working state, for both live and
on-demand shows.

[PSAPI]: https://psapi-we.nrk.no/documentation/