### PR TITLE
installer: upgrade to Python 3.9.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
-          python -m pip install pynsist
+          python -m pip install git+https://github.com/takluyver/pynsist.git@ba9d161370c1b04dec82f72d30a28851c5eef884
           sudo apt update
           sudo apt install -y nsis imagemagick inkscape
       - name: Installer file name

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -33,7 +33,7 @@ cd "${ROOT}"
 STREAMLINK_VERSION=$(python setup.py --version)
 STREAMLINK_VERSION_PLAIN="${STREAMLINK_VERSION%%+*}"
 STREAMLINK_INSTALLER="${1:-"streamlink-${STREAMLINK_VERSION/\+/_}"}"
-STREAMLINK_PYTHON_VERSION=3.6.6
+STREAMLINK_PYTHON_VERSION=3.9.0
 STREAMLINK_ASSETS_REPO="${STREAMLINK_ASSETS_REPO:-streamlink/streamlink-assets}"
 STREAMLINK_ASSETS_RELEASE="${STREAMLINK_ASSETS_RELEASE:-latest}"
 
@@ -118,7 +118,7 @@ packages=pkg_resources
          socks
          sockshandler
          isodate
-pypi_wheels=pycryptodome==3.6.4
+pypi_wheels=pycryptodome==3.9.9
 
 files=${ROOT}/win32/THIRD-PARTY.txt > \$INSTDIR
       ${ROOT}/build/lib/streamlink > \$INSTDIR\pkgs


### PR DESCRIPTION
- Install fixed pynsist pre-release version from git. This is necessary
  when trying to install wheels with an included Python ABI tag in their
  file name, as the tag naming scheme has been changed in Python 3.8.0.
- Bump the installer's Python version to 3.9.0
- Bump pycryptodome dependency to 3.9.9

takluyver/pynsist#210

Yes, I know that we've just switched back to downloading pynsist from PyPI instead of a specific commit from the git repo, but I don't want to wait until its next release, even though the maintainer said he intends to publish the next one this weekend. If he indeed does, we can switch back to installing the latest version from PyPI. At least the issue of the old Python version in the Windows installer is resolved for now.