### PR TITLE
plugins: turn mux-subtitles into a global argument

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -52,7 +52,7 @@ class Argument(object):
 
     """
     def __init__(self, name, required=False, requires=None, prompt=None, sensitive=False, argument_name=None,
-                 dest=None, **options):
+                 dest=None, is_global=False, **options):
         """
         :param name: name of the argument, without -- or plugin name prefixes, eg. ``"password"``, ``"mux-subtitles"``, etc.
         :param required (bool): if the argument is required for the plugin
@@ -73,12 +73,13 @@ class Argument(object):
         self.prompt = prompt
         self.sensitive = sensitive
         self._default = options.get("default")
+        self.is_global = is_global
 
     def _name(self, plugin):
         return self._argument_name or _normalise_argument_name("{0}-{1}".format(plugin, self.name))
 
     def argument_name(self, plugin):
-        return "--" + self._name(plugin)
+        return f"--{self.name if self.is_global else self._name(plugin)}"
 
     def namespace_dest(self, plugin):
         return _normalise_option_name(self._name(plugin))

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -176,15 +176,7 @@ class FunimationNow(Plugin):
             Default is "english".
             """
         ),
-        PluginArgument(
-            "mux-subtitles",
-            argument_name="funimation-mux-subtitles",
-            action="store_true",
-            help="""
-            Enable automatically including available subtitles in to the output
-            stream.
-            """
-        )
+        PluginArgument("mux-subtitles", is_global=True)
     )
 
     url_re = re.compile(r"""

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -85,13 +85,7 @@ class Pluzz(Plugin):
     _player_schema = validate.Schema({'result': validate.url()})
 
     arguments = PluginArguments(
-        PluginArgument(
-            "mux-subtitles",
-            action="store_true",
-            help="""
-        Automatically mux available subtitles in to the output stream.
-        """
-        )
+        PluginArgument("mux-subtitles", is_global=True)
     )
 
     @classmethod

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -94,14 +94,9 @@ class Rtve(Plugin):
         validate.get("page"),
         validate.get("items"),
         validate.get(0))
+
     arguments = PluginArguments(
-        PluginArgument(
-            "mux-subtitles",
-            action="store_true",
-            help="""
-        Automatically mux available subtitles in to the output stream.
-        """
-        )
+        PluginArgument("mux-subtitles", is_global=True)
     )
 
     @classmethod

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -47,11 +47,7 @@ class SVTPlay(Plugin):
     })
 
     arguments = PluginArguments(
-        PluginArgument(
-            'mux-subtitles',
-            action='store_true',
-            help="Automatically mux available subtitles in to the output stream.",
-        ),
+        PluginArgument("mux-subtitles", is_global=True)
     )
 
     @classmethod

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -51,11 +51,7 @@ class Vimeo(Plugin):
     )
 
     arguments = PluginArguments(
-        PluginArgument(
-            "mux-subtitles",
-            action="store_true",
-            help="Automatically mux available subtitles in to the output stream.",
-        )
+        PluginArgument("mux-subtitles", is_global=True)
     )
 
     @classmethod

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -81,6 +81,7 @@ class Streamlink(object):
             "ffmpeg-ffmpeg": None,
             "ffmpeg-video-transcode": "copy",
             "ffmpeg-audio-transcode": "copy",
+            "mux-subtitles": False,
             "locale": None,
             "user-input-requester": None
         })
@@ -209,6 +210,9 @@ class Streamlink(object):
         ffmpeg-audio-transcode   (str) The codec to use if transcoding
                                  audio when muxing with ffmpeg
                                  e.g. ``aac``
+
+        mux-subtitles            (bool) Mux available subtitles into the
+                                 output stream.
 
         stream-segment-attempts  (int) How many attempts should be done
                                  to download each segment, default: ``3``.

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1097,6 +1097,15 @@ def build_parser():
         Example: "aac"
         """
     )
+    transport.add_argument(
+        "--mux-subtitles",
+        action="store_true",
+        help="""
+        Automatically mux available subtitles into the output stream.
+
+        Needs to be supported by the used plugin.
+        """
+    )
 
     http = parser.add_argument_group("HTTP options")
     http.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -846,6 +846,9 @@ def setup_options():
     if args.ffmpeg_audio_transcode:
         streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
 
+    if args.mux_subtitles:
+        streamlink.set_option("mux-subtitles", args.mux_subtitles)
+
     streamlink.set_option("subprocess-errorlog", args.subprocess_errorlog)
     streamlink.set_option("subprocess-errorlog-path", args.subprocess_errorlog_path)
     streamlink.set_option("locale", args.locale)

--- a/tests/plugins/test_funimationnow.py
+++ b/tests/plugins/test_funimationnow.py
@@ -34,10 +34,11 @@ class TestPluginFunimationNow(unittest.TestCase):
         }
 
         setup_plugin_args(session, parser)
-        self.assertSequenceEqual(plugin_parser.add_argument.mock_calls,
-                                 [call('--funimation-email', help=ANY),
-                                  call('--funimation-password', help=ANY),
-                                  call('--funimation-language',
-                                       choices=["en", "ja", "english", "japanese"],
-                                       default="english", help=ANY),
-                                  call('--funimation-mux-subtitles', action="store_true", help=ANY)])
+        self.assertSequenceEqual(
+            plugin_parser.add_argument.mock_calls,
+            [
+                call('--funimation-email', help=ANY),
+                call('--funimation-password', help=ANY),
+                call('--funimation-language', choices=["en", "ja", "english", "japanese"], default="english", help=ANY)
+            ]
+        )

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,8 +1,9 @@
+import argparse
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from streamlink.options import Argument, Arguments, Options
-from streamlink_cli.main import setup_plugin_args
+from streamlink_cli.main import setup_plugin_args, setup_plugin_options
 
 
 class TestOptions(unittest.TestCase):
@@ -112,13 +113,16 @@ class TestArguments(unittest.TestCase):
 
 
 class TestSetupOptions(unittest.TestCase):
-    def test_set_defaults(self):
+    def test_setup_plugin_args(self):
         session = Mock()
         plugin = Mock()
-        parser = Mock()
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--global-arg1", default=123)
+        parser.add_argument("--global-arg2", default=456)
 
         session.plugins = {"mock": plugin}
         plugin.arguments = Arguments(
+            Argument("global-arg1", is_global=True),
             Argument("test1", default="default1"),
             Argument("test2", default="default2"),
             Argument("test3")
@@ -126,6 +130,45 @@ class TestSetupOptions(unittest.TestCase):
 
         setup_plugin_args(session, parser)
 
+        group = next((group for group in parser._action_groups if group.title == "Plugin options"), None)
+        self.assertIsNotNone(group, "Adds the 'Plugin options' arguments group")
+        self.assertEqual(
+            [item for action in group._group_actions for item in action.option_strings],
+            ["--mock-test1", "--mock-test2", "--mock-test3"],
+            "Only adds plugin arguments and ignores global argument references"
+        )
+
+        self.assertEqual(plugin.options.get("global-arg1"), 123)
+        self.assertEqual(plugin.options.get("global-arg2"), None)
         self.assertEqual(plugin.options.get("test1"), "default1")
         self.assertEqual(plugin.options.get("test2"), "default2")
         self.assertEqual(plugin.options.get("test3"), None)
+
+    def test_setup_plugin_options(self):
+        session = Mock()
+        plugin = Mock(module="plugin")
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--foo-foo", default=123)
+
+        session.plugins = {"plugin": plugin}
+        session.set_plugin_option = lambda name, key, value: session.plugins[name].options.update({key: value})
+        plugin.arguments = Arguments(
+            Argument("foo-foo", is_global=True),
+            Argument("bar-bar", default=456),
+            Argument("baz-baz", default=789, help=argparse.SUPPRESS)
+        )
+
+        with patch("streamlink_cli.main.args") as args:
+            args.foo_foo = 321
+            args.plugin_bar_bar = 654
+            args.plugin_baz_baz = 987  # this wouldn't be set by the parser if the argument is suppressed
+
+            setup_plugin_args(session, parser)
+            self.assertEqual(plugin.options.get("foo_foo"), 123, "Sets the global-argument's default value")
+            self.assertEqual(plugin.options.get("bar_bar"), 456, "Sets the plugin-argument's default value")
+            self.assertEqual(plugin.options.get("baz_baz"), 789, "Sets the suppressed plugin-argument's default value")
+
+            setup_plugin_options(session, plugin)
+            self.assertEqual(plugin.options.get("foo_foo"), 321, "Sets the provided global-argument value")
+            self.assertEqual(plugin.options.get("bar_bar"), 654, "Sets the provided plugin-argument value")
+            self.assertEqual(plugin.options.get("baz_baz"), 789, "Doesn't set values of suppressed plugin-arguments")

--- a/tests/test_plugins_meta.py
+++ b/tests/test_plugins_meta.py
@@ -58,3 +58,13 @@ class TestPluginMeta(unittest.TestCase):
             if pname not in self.built_in_plugins:
                 self.assertIn(pname, self.session.plugins.keys(),
                               "{0} is not a plugin but has tests".format(pname))
+
+    def test_plugin_has_valid_global_args(self):
+        from streamlink_cli.argparser import build_parser
+        parser = build_parser()
+        global_arg_dests = [action.dest for action in parser._actions]
+        for pname, plugin in self.session.plugins.items():
+            for parg in plugin.arguments:
+                if parg.is_global:
+                    self.assertIn(parg.dest, global_arg_dests,
+                                  f"{parg.name} from plugins.{pname} is not a valid global argument")


### PR DESCRIPTION
Closes #3282 

Split into two commits. See the commit messages for the descriptions.

----

Since the argparse docs extension had to be refactored, here's a demonstration of the overall CLI docs changes, to make sure that nothing else changed:

```bash
diff <(curl -s https://streamlink.github.io/latest/cli.html) <(cat ./docs/_build/html/cli.html)
```

```diff
10c10
<   <title>Command-Line Interface &mdash; Streamlink 1.7.0+52.gf0b35b6 documentation</title>
---
>   <title>Command-Line Interface &mdash; Streamlink 1.7.0+54.g49ce436 documentation</title>
31c31
<     <link rel="top" title="Streamlink 1.7.0+52.gf0b35b6 documentation" href="index.html"/>
---
>     <link rel="top" title="Streamlink 1.7.0+54.g49ce436 documentation" href="index.html"/>
56c56
<   <span class="wy-side-nav-versions-current"><i class="fa fa-book"></i>1.7.0+52.gf0b35b6</span>
---
>   <span class="wy-side-nav-versions-current"><i class="fa fa-book"></i>1.7.0+54.g49ce436</span>
1382a1383,1390
> <dl class="option">
> <dt id="cmdoption-mux-subtitles">
> <code class="descname">--mux-subtitles</code><code class="descclassname"></code><a class="headerlink" href="#cmdoption-mux-subtitles" title="Permalink to this definition">¶</a></dt>
> <dd><p>Automatically mux available subtitles into the output stream.</p>
> <p>Needs to be supported by the used plugin.</p>
> <p><strong>Supported plugins:</strong> funimationnow, pluzz, rtve, svtplay, vimeo</p>
> </dd></dl>
> 
1610,1616d1617
< <dt id="cmdoption-funimation-mux-subtitles">
< <code class="descname">--funimation-mux-subtitles</code><code class="descclassname"></code><a class="headerlink" href="#cmdoption-funimation-mux-subtitles" title="Permalink to this definition">¶</a></dt>
< <dd><p>Enable automatically including available subtitles in to the output
< stream.</p>
< </dd></dl>
< 
< <dl class="option">
1688,1699d1688
< <dt id="cmdoption-pluzz-mux-subtitles">
< <code class="descname">--pluzz-mux-subtitles</code><code class="descclassname"></code><a class="headerlink" href="#cmdoption-pluzz-mux-subtitles" title="Permalink to this definition">¶</a></dt>
< <dd><p>Automatically mux available subtitles in to the output stream.</p>
< </dd></dl>
< 
< <dl class="option">
< <dt id="cmdoption-rtve-mux-subtitles">
< <code class="descname">--rtve-mux-subtitles</code><code class="descclassname"></code><a class="headerlink" href="#cmdoption-rtve-mux-subtitles" title="Permalink to this definition">¶</a></dt>
< <dd><p>Automatically mux available subtitles in to the output stream.</p>
< </dd></dl>
< 
< <dl class="option">
1742,1747d1730
< <dt id="cmdoption-svtplay-mux-subtitles">
< <code class="descname">--svtplay-mux-subtitles</code><code class="descclassname"></code><a class="headerlink" href="#cmdoption-svtplay-mux-subtitles" title="Permalink to this definition">¶</a></dt>
< <dd><p>Automatically mux available subtitles in to the output stream.</p>
< </dd></dl>
< 
< <dl class="option">
1813,1818d1795
< <dt id="cmdoption-vimeo-mux-subtitles">
< <code class="descname">--vimeo-mux-subtitles</code><code class="descclassname"></code><a class="headerlink" href="#cmdoption-vimeo-mux-subtitles" title="Permalink to this definition">¶</a></dt>
< <dd><p>Automatically mux available subtitles in to the output stream.</p>
< </dd></dl>
< 
< <dl class="option">
1925c1902
<             VERSION:'1.7.0+52.gf0b35b6',
---
>             VERSION:'1.7.0+54.g49ce436',
```
