### PR TITLE
plugins.huya: use FLV stream with multiple mirrors

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -97,7 +97,7 @@ hitbox                  - hitbox.tv          Yes   Yes
 huajiao                 huajiao.com          Yes   No
 huomao                  - huomao.com         Yes   Yes
                         - huomao.tv
-huya                    huya.com             Yes   No    Temporarily only HLS streams available.
+huya                    huya.com             Yes   No
 idf1                    idf1.fr              Yes   Yes
 ine                     ine.com              ---   Yes
 invintus                player.invintus.com  Yes   Yes

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -1,37 +1,76 @@
+import base64
+import logging
 import re
+from html import unescape as html_unescape
 
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
+from streamlink.plugin.api import validate
+from streamlink.stream import HTTPStream
+from streamlink.utils import parse_json
 
-HUYA_URL = "http://m.huya.com/%s"
-
-_url_re = re.compile(r'https?://(www\.)?huya.com/(?P<channel>[^/]+)')
-_hls_re = re.compile(r'liveLineUrl\s*=\s*"(?P<url>[^"]+)"')
-
-_hls_schema = validate.Schema(
-    validate.transform(_hls_re.search),
-    validate.any(None, validate.get("url")),
-    validate.transform(lambda v: update_scheme("http://", v)),
-    validate.url()
-)
+log = logging.getLogger(__name__)
 
 
 class Huya(Plugin):
+    _re_url = re.compile(r'https?://(?:www\.)?huya\.com/(?P<channel>[^/]+)')
+    _re_stream = re.compile(r'"stream"\s?:\s?"([^"]+)"')
+    _schema_data = validate.Schema(
+        {
+            # 'status': int,
+            # 'msg': validate.any(None, str),
+            'data': [{
+                'gameStreamInfoList': [{
+                    'sCdnType': str,
+                    'sStreamName': str,
+                    'sFlvUrl': str,
+                    'sFlvUrlSuffix': str,
+                    'sFlvAntiCode': validate.all(str, validate.transform(lambda v: html_unescape(v))),
+                    # 'sHlsUrl': str,
+                    # 'sHlsUrlSuffix': str,
+                    # 'sHlsAntiCode': validate.all(str, validate.transform(lambda v: html_unescape(v))),
+                    validate.optional('iIsMultiStream'): int,
+                    'iPCPriorityRate': int,
+                }]
+            }],
+            # 'vMultiStreamInfo': [{
+            #    'sDisplayName': str,
+            #    'iBitRate': int,
+            # }],
+        },
+        validate.get('data'),
+        validate.get(0),
+        validate.get('gameStreamInfoList'),
+    )
+    QUALITY_WEIGHTS = {}
+
     @classmethod
-    def can_handle_url(self, url):
-        return _url_re.match(url)
+    def can_handle_url(cls, url):
+        return cls._re_url.match(url) is not None
+
+    @classmethod
+    def stream_weight(cls, key):
+        weight = cls.QUALITY_WEIGHTS.get(key)
+        if weight:
+            return weight, 'huya'
+
+        return Plugin.stream_weight(key)
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        channel = match.group("channel")
+        res = self.session.http.get(self.url)
+        data = self._re_stream.search(res.text)
 
-        self.session.http.headers.update({"User-Agent": useragents.IPAD})
-        # Some problem with SSL on huya.com now, do not use https
+        if not data:
+            return
 
-        hls_url = self.session.http.get(HUYA_URL % channel, schema=_hls_schema)
-        yield "live", HLSStream(self.session, hls_url)
+        data = parse_json(base64.b64decode(data.group(1)), schema=self._schema_data)
+        for info in data:
+            log.trace(f'{info!r}')
+            flv_url = f'{info["sFlvUrl"]}/{info["sStreamName"]}.{info["sFlvUrlSuffix"]}?{info["sFlvAntiCode"]}'
+            name = f'source_{info["sCdnType"].lower()}'
+            self.QUALITY_WEIGHTS[name] = info['iPCPriorityRate']
+            yield name, HTTPStream(self.session, flv_url)
+
+        log.debug(f'QUALITY_WEIGHTS: {self.QUALITY_WEIGHTS!r}')
 
 
 __plugin__ = Huya

--- a/tests/plugins/test_huya.py
+++ b/tests/plugins/test_huya.py
@@ -11,11 +11,11 @@ class TestPluginHuya(unittest.TestCase):
             'https://www.huya.com/123123123',
         ]
         for url in should_match:
-            self.assertTrue(Huya.can_handle_url(url))
+            self.assertTrue(Huya.can_handle_url(url), url)
 
     def test_can_handle_url_negative(self):
         should_not_match = [
             'http://www.huya.com',
         ]
         for url in should_not_match:
-            self.assertFalse(Huya.can_handle_url(url))
+            self.assertFalse(Huya.can_handle_url(url), url)


### PR DESCRIPTION
Not every mirror works good for every user location,
the users must select the mirror which works for them.

```
$ streamlink https://www.huya.com/kpl -l info
[cli][info] Found matching plugin huya for URL https://www.huya.com/kpl
[cli][info] Available streams: source_al13, source_al (worst), source_tx, source_bd, source_tx15 (best)
[cli][info] Opening stream: source_tx15 (http)
```
closes https://github.com/streamlink/streamlink/issues/3317