### PR TITLE
docs: fix links

### DIFF
--- a/docs/_applications.rst
+++ b/docs/_applications.rst
@@ -1,5 +1,3 @@
-.. _applications:
-
 :orphan:
 
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,5 +1,3 @@
-.. _api:
-
 API Reference
 =============
 
@@ -45,8 +43,6 @@ All streams inherit from the :class:`Stream` class.
 .. autoclass:: Stream
     :members:
 
-
-.. _api-stream-subclasses:
 
 Stream subclasses
 ^^^^^^^^^^^^^^^^^

--- a/docs/api_guide.rst
+++ b/docs/api_guide.rst
@@ -13,7 +13,7 @@ The simplest use of the Streamlink API looks like this:
 .. code-block:: python
 
     >>> import streamlink
-    >>> streams = streamlink.streams("http://twitch.tv/day9tv")
+    >>> streams = streamlink.streams("https://twitch.tv/day9tv")
 
 This simply attempts to find a plugin and use it to extract streams from
 the URL. This works great in simple cases but if you want more
@@ -24,13 +24,13 @@ The returned value is a dict containing :class:`Stream <stream.Stream>` objects:
 .. code-block:: python
 
     >>> streams
-    {'best': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>,
-     'high': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>,
-     'low': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>,
-     'medium': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>,
-     'mobile': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>,
-     'source': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>,
-     'worst': <HLSStream('http://video11.fra01.hls.twitch.tv/ ...')>}
+    {'best': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>,
+     'high': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>,
+     'low': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>,
+     'medium': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>,
+     'mobile': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>,
+     'source': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>,
+     'worst': <HLSStream('https://video11.fra01.hls.twitch.tv/ ...')>}
 
 
 If no plugin for the URL is found, a :exc:`NoPluginError` will be raised.
@@ -68,7 +68,7 @@ contains a `url` attribute.
 .. code-block:: python
 
     >>> stream.url
-    'http://video38.ams01.hls.twitch.tv/hls11/ ...'
+    'https://video38.ams01.hls.twitch.tv/hls11/ ...'
 
 
 Session object
@@ -87,7 +87,7 @@ You can then extract streams like this:
 
 .. code-block:: python
 
-    >>> streams = session.streams("http://twitch.tv/day9tv")
+    >>> streams = session.streams("https://twitch.tv/day9tv")
 
 or set options like this:
 
@@ -109,6 +109,6 @@ This example uses the `PyGObject`_ module to playback a stream using the
 `GStreamer`_ framework.
 
 .. _PyGObject: https://wiki.gnome.org/action/show/Projects/PyGObject
-.. _GStreamer: http://gstreamer.freedesktop.org/
+.. _GStreamer: https://gstreamer.freedesktop.org/
 
 .. literalinclude:: ../examples/gst-player.py

--- a/docs/api_guide.rst
+++ b/docs/api_guide.rst
@@ -1,9 +1,7 @@
-.. _api_guide:
-
 API Guide
 =========
 
-This API is what powers the :ref:`cli` but is also available to developers that wish
+This API is what powers the :ref:`cli <cli:Command-Line Interface>` but is also available to developers that wish
 to make use of the data Streamlink can retrieve in their own application.
 
 
@@ -60,8 +58,8 @@ If an error occurs while opening a stream, a :exc:`StreamError` will be raised.
 Inspecting streams
 ------------------
 
-It's also possible to inspect streams internal parameters, see
-:ref:`api-stream-subclasses` to see what attributes are available
+It's also possible to inspect streams internal parameters, go to
+:ref:`Stream subclasses <api:Stream subclasses>` to see what attributes are available
 for inspection for each stream type.
 
 For example this is a :class:`HLSStream <stream.HLSStream>` object which

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -6,7 +6,7 @@ Tutorial
 
 Streamlink is a command-line application, which means that the commands described
 here should be typed into a terminal. On Windows, you have to open either the
-`command prompt`_ or the `PowerShell`_, on macOS open the `Terminal`_ app
+`Command Prompt`_, `PowerShell`_ or `Windows Terminal`_, on macOS open the `Terminal <macOS-Terminal>`_ app,
 and if you're on Linux or BSD you probably already know the drill.
 
 The way Streamlink works is that it's only a means to extract and transport
@@ -73,11 +73,12 @@ into customizing it to your own needs, such as:
   before playing the stream to help avoiding buffering issues
 
 
-.. _command prompt: http://windows.microsoft.com/en-us/windows/command-prompt-faq#1TC=windows-8
-.. _PowerShell: http://www.microsoft.com/powershell
-.. _Terminal: http://en.wikipedia.org/wiki/Terminal_(OS_X)
-.. _VLC: http://videolan.org/
-.. _mpv: http://mpv.io/
+.. _Command Prompt: https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/windows-commands
+.. _PowerShell: https://docs.microsoft.com/en-us/powershell/
+.. _Windows Terminal: https://docs.microsoft.com/en-us/windows/terminal/get-started
+.. _macOS Terminal: https://support.apple.com/guide/terminal/welcome/mac
+.. _VLC: https://videolan.org/
+.. _mpv: https://mpv.io/
 
 
 Configuration file
@@ -180,7 +181,7 @@ You can login like this:
 
 .. sourcecode:: console
 
-    $ streamlink --crunchyroll-username=xxxx --crunchyroll-password=xxx http://crunchyroll.com/a-crunchyroll-episode-link
+    $ streamlink --crunchyroll-username=xxxx --crunchyroll-password=xxx https://crunchyroll.com/a-crunchyroll-episode-link
 
 .. note::
 
@@ -233,7 +234,7 @@ For example:
     There are multiple ways to retrieve the required cookie.  For more
     information on browser cookies, please consult the following:
 
-    - `What are cookies? <http://www.whatarecookies.com/view.asp>`_
+    - `What are cookies? <https://en.wikipedia.org/wiki/HTTP_cookie>`_
 
 Sideloading plugins
 -------------------

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,5 +1,3 @@
-.. _cli:
-
 Command-Line Interface
 ======================
 
@@ -14,7 +12,7 @@ and if you're on Linux or BSD you probably already know the drill.
 The way Streamlink works is that it's only a means to extract and transport
 the streams, and the playback is done by an external video player. Streamlink
 works best with `VLC`_ or `mpv`_, which are also cross-platform, but other players
-may be compatible too, see the :ref:`Players` page for a complete overview.
+may be compatible too, see the :ref:`Players <players:Players>` page for a complete overview.
 
 Now to get into actually using Streamlink, let's say you want to watch the
 stream located on twitch.tv/day9tv, you start off by telling Streamlink
@@ -69,9 +67,9 @@ specify ``worst`` to get the lowest quality.
 Now that you have a basic grasp of how Streamlink works, you may want to look
 into customizing it to your own needs, such as:
 
-- Creating a :ref:`configuration file <cli-streamlinkrc>` of options you
+- Creating a :ref:`configuration file <cli:Configuration file>` of options you
   want to use
-- Setting up your player to :ref:`cache some data <issues-player_caching>`
+- Setting up your player to :ref:`cache some data <issues:Streams are buffering/lagging>`
   before playing the stream to help avoiding buffering issues
 
 
@@ -81,8 +79,6 @@ into customizing it to your own needs, such as:
 .. _VLC: http://videolan.org/
 .. _mpv: http://mpv.io/
 
-
-.. _cli-streamlinkrc:
 
 Configuration file
 ------------------
@@ -118,7 +114,7 @@ Syntax
 ^^^^^^
 
 The config file is a simple text file and should contain one
-:ref:`command-line option <cli-options>` (omitting the dashes) per
+:ref:`command-line option <cli:Command-line usage>` (omitting the dashes) per
 line in the format::
 
   option=value
@@ -166,7 +162,7 @@ Unix-like (POSIX) - $XDG_CONFIG_HOME/streamlink/config\ **.twitch**
 Windows           %APPDATA%\\streamlink\\streamlinkrc\ **.youtube**
 ================= ====================================================
 
-Have a look at the :ref:`list of plugins <plugin_matrix>` to see
+Have a look at the :ref:`list of plugins <plugin_matrix:Plugins>` to see
 the name of each built-in plugin.
 
 
@@ -195,7 +191,7 @@ asking your username and password again.
 
 Nevertheless, these credentials are valid for a limited amount of time, so it
 might be a good idea to save your username and password in your
-:ref:`configuration file <cli-streamlinkrc>` anyway.
+:ref:`configuration file <cli:Configuration file>` anyway.
 
 .. warning::
 
@@ -219,8 +215,6 @@ you're in that region.
 For this, the plugin provides the :option:`--crunchyroll-purge-credentials`
 option, which removes your saved session and credentials and tries to log
 in again using your username and password.
-
-.. _cli-funimationnow:
 
 Authenticating with FunimationNow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -324,7 +318,6 @@ Progressive HTTP, HTTPS, etc   httpstream:// [1]_
 
 .. [1] supports local files using the file:// protocol
 .. [2] Dynamic Adaptive Streaming over HTTP
-.. _cli-options:
 
 Proxy Support
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,16 @@ sys.path.insert(0, os.path.abspath('.'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'ext_argparse', 'ext_github', 'ext_releaseref', 'recommonmark']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
+    'ext_argparse',
+    'ext_github',
+    'ext_releaseref',
+    'recommonmark'
+]
+
+autosectionlabel_prefix_document = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,11 +1,11 @@
 Overview
 --------
 
-Streamlink is a :ref:`command-line utility <cli>` which pipes video streams
+Streamlink is a :ref:`command-line utility <cli:Command-Line Interface>` which pipes video streams
 from various services into a video player, such as `VLC`_.
 The main purpose of Streamlink is to avoid resource-heavy and unoptimized websites,
 while still allowing the user to enjoy various streamed content.
-There is also an :ref:`API <api_guide>` available for developers who want access
+There is also an :ref:`API <api_guide:API Guide>` available for developers who want access
 to the stream data.
 
 This project was forked from Livestreamer, which is no longer maintained.
@@ -33,7 +33,7 @@ to be easily added. Most of the big streaming services are supported, such as:
 - `Dailymotion.com <https://www.dailymotion.com/live>`_
 
 ... and many more. A full list of plugins currently included can be found
-on the :ref:`plugin_matrix` page.
+on the :ref:`Plugins <plugin_matrix:Plugins>` page.
 
 Quickstart
 ----------
@@ -53,7 +53,7 @@ For more in-depth usage and install instructions, please refer to the `User guid
 User guide
 ----------
 
-Streamlink is made up of two parts, a :ref:`cli` and a library :ref:`API <api>`.
+Streamlink is made up of two parts, a :ref:`cli <cli:Command-Line Interface>` and a library :ref:`API <api:API Reference>`.
 See their respective sections for more information on how to use them.
 
 .. toctree::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -138,9 +138,9 @@ Distribution                         Installing
 .. _Debian (stable): https://packages.debian.org/unstable/streamlink
 .. _Fedora: https://apps.fedoraproject.org/packages/python-streamlink
 .. _Gentoo Linux: https://packages.gentoo.org/package/net-misc/streamlink
-.. _NetBSD (pkgsrc): http://pkgsrc.se/multimedia/streamlink
+.. _NetBSD (pkgsrc): https://pkgsrc.se/multimedia/streamlink
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
-.. _OpenBSD: http://openports.se/multimedia/streamlink
+.. _OpenBSD: https://openports.se/multimedia/streamlink
 .. _Solus: https://dev.solus-project.com/source/streamlink/
 .. _Ubuntu: http://ppa.launchpad.net/nilarimogard/webupd8/ubuntu/pool/main/s/streamlink/
 .. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
@@ -326,8 +326,8 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 
 .. _Python: https://www.python.org/
 .. _python-setuptools: https://pypi.org/project/setuptools/
-.. _python-requests: http://python-requests.org/
-.. _RTMPDump: http://rtmpdump.mplayerhq.hu/
+.. _python-requests: https://requests.readthedocs.io/en/master/
+.. _RTMPDump: https://rtmpdump.mplayerhq.hu/
 .. _pycountry: https://pypi.org/project/pycountry/
 .. _pycrypto: https://www.dlitz.net/software/pycrypto/
 .. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,5 +1,3 @@
-.. _install:
-
 .. |br| raw:: html
 
   <br />
@@ -177,7 +175,6 @@ Windows port. version                RosadinTV <RosadinTV at outlook.com> |br|
                                      beardypig <beardypig at protonmail.com>
 ==================================== ===========================================
 
-.. _PyPI package and source code:
 
 PyPI package and source code
 ----------------------------
@@ -286,8 +283,6 @@ using `virtualenv`_, which creates a user owned Python environment instead.
 
 .. _virtualenv: https://virtualenv.readthedocs.io/en/latest/
 
-.. _Dependencies:
-
 Dependencies
 ^^^^^^^^^^^^
 
@@ -368,8 +363,8 @@ Release                              Notes
     Be aware that the packages for `Chocolatey`_ and the `Windows Package Manager`_ are just wrappers
     around the stable installer and thus depend on Windows 7+ as well.
 
-    Alternatively, :ref:`Streamlink can be installed via python-pip<PyPI package and source code>`
-    in a :ref:`compatible<Dependencies>` Python environment.
+    Alternatively, :ref:`Streamlink can be installed via python-pip <install:PyPI package and source code>`
+    in a :ref:`compatible <install:Dependencies>` Python environment.
 
 .. _Stable release:
 .. _GitHub releases page: https://github.com/streamlink/streamlink/releases/latest

--- a/docs/issues.rst
+++ b/docs/issues.rst
@@ -1,9 +1,5 @@
-.. _issues:
-
 Common issues
 =============
-
-.. _issues-player_caching:
 
 Streams are buffering/lagging
 -----------------------------

--- a/docs/players.rst
+++ b/docs/players.rst
@@ -1,6 +1,3 @@
-.. _players:
-
-
 Players
 =======
 

--- a/docs/players.rst
+++ b/docs/players.rst
@@ -26,13 +26,13 @@ modes.
 ===================================================== ========== ========== ====
 Name                                                  Stdin Pipe Named Pipe HTTP
 ===================================================== ========== ========== ====
-`Daum Pot Player <http://potplayer.daum.net>`_        Yes        No         Yes [1]_
-`MPC-HC <http://mpc-hc.org/>`_                        Yes [2]_   No         Yes [1]_
-`MPlayer <http://mplayerhq.hu>`_                      Yes        Yes        Yes
-`mpv <http://mpv.io>`_                                Yes        Yes        Yes
-`QuickTime <http://apple.com/quicktime>`_             No         No         No
-`VLC media player <http://videolan.org>`_             Yes [3]_   Yes        Yes
-OMXPlayer                                             No         Yes        Yes [4]_
+`Daum Pot Player`_                                    Yes        No         Yes [1]_
+`MPC-HC`_                                             Yes [2]_   No         Yes [1]_
+`MPlayer`_                                            Yes        Yes        Yes
+`mpv`_                                                Yes        Yes        Yes
+`OMXPlayer`_                                          No         Yes        Yes [4]_
+`QuickTime`_                                          No         No         No
+`VLC media player`_                                   Yes [3]_   Yes        Yes
 ===================================================== ========== ========== ====
 
 .. [1] :option:`--player-continuous-http` must be used.
@@ -54,6 +54,14 @@ OMXPlayer                                             No         Yes        Yes 
        (see `When using OMXPlayer the stream stops unexpectedly`_.)
        Other stream types may not work as expected, it is recommended that
        :option:`--player-fifo` be used.
+
+.. _Daum Pot Player: https://potplayer.daum.net
+.. _MPC-HC: https://mpc-hc.org/
+.. _MPlayer: https://mplayerhq.hu
+.. _mpv: https://mpv.io
+.. _OMXPlayer: https://www.raspberrypi.org/documentation/raspbian/applications/omxplayer.md
+.. _QuickTime: https://apple.com/quicktime
+.. _VLC media player: https://videolan.org
 
 
 Known issues and workarounds
@@ -78,7 +86,7 @@ reported to work.
 
 MPlayer tries to play Twitch streams at the wrong FPS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This is a bug in MPlayer, using the MPlayer fork `mpv <http://mpv.io>`_ instead
+This is a bug in MPlayer, using the MPlayer fork `mpv`_ instead
 is recommended.
 
 VLC hangs when buffering and no playback starts

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -1,6 +1,3 @@
-.. _plugin_matrix:
-
-
 Plugins
 =======
 
@@ -82,7 +79,7 @@ euronews                euronews.com         Yes   No
 facebook                facebook.com         Yes   Yes
 filmon                  filmon.com           Yes   Yes   Only SD quality streams.
 foxtr                   fox.com.tr           Yes   No
-funimationnow           - funimation.com     --    Yes   :ref:`Requires session cookies <cli-funimationnow>`
+funimationnow           - funimation.com     --    Yes   :ref:`Requires session cookies <cli:Authenticating with FunimationNow>`
                         - funimationnow.uk
 galatasaraytv           galatasaray.com      Yes   No
 gardenersworld          gardenersworld.com   --    Yes


### PR DESCRIPTION
**First commit:**
- adds `autosectionlabel` Sphinx extension, so that headlines don't need to be labelled manually
  see https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html
- sets `autosectionlabel_prefix_document` to True, so that no duplicates exist
- removes custom headline labels
- fixes all `:ref:` links with properly prefixed references

**Second commit:**
- replaces all `http://` links with `https://` where possible
  Debian repos and Ubuntu PPAs are all non-TLS, so those are the last remaining http links
- sets new/proper links where the site was either outdated, unofficial or offline
  - "What are cookies" replaced with Wikipedia HTTP-Cookies page
  - MS doesn't document its old Windows command prompt, link should probably be removed, as it's documenting the available commands/utilities
  - Added Windows Terminal docs link
  - Switched from Wikipedia to Apple's Terminal app guide page
- re-orders players table, moves its links to the section footer and adds OMXPlayer link