### PR TITLE
plugins.twitch: remove player_type parameter

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -297,7 +297,7 @@ class TwitchAPI(object):
                 validate.get("sig"),
                 validate.get("token")
             ))
-        ), player_type="frontpage")
+        ))
 
     def token(self, tokenstr):
         return parse_json(tokenstr, schema=validate.Schema(


### PR DESCRIPTION
As mentioned in #3210, the `player_type` access token request parameter workaround stopped working and it's pointless to keep (the cycle continues).
Added in #3301.
