### PR TITLE
docs: fix mpv property-list link in --title description

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -468,7 +468,7 @@ def build_parser():
             inserted inside your --title string.
 
             A full list of the format codes mpv uses is available here:
-            https://mpv.io/manual/stable/#property-expansion
+            https://mpv.io/manual/master/#property-list
 
         Formatting variables available to use in --title:
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -468,7 +468,7 @@ def build_parser():
             inserted inside your --title string.
 
             A full list of the format codes mpv uses is available here:
-            https://mpv.io/stable/master/#property-list
+            https://mpv.io/manual/stable/#property-list
 
         Formatting variables available to use in --title:
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -468,7 +468,7 @@ def build_parser():
             inserted inside your --title string.
 
             A full list of the format codes mpv uses is available here:
-            https://mpv.io/manual/master/#property-list
+            https://mpv.io/stable/master/#property-list
 
         Formatting variables available to use in --title:
 


### PR DESCRIPTION
Fixed URL pointing to list of mpv format codes

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
