### PR TITLE
plugins.twitch: move access_token request to GQL

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -285,36 +285,6 @@ class TwitchAPI(object):
             validate.get("stream")
         ))
 
-    # Private API calls
-
-    def access_token(self, endpoint, asset):
-        return self.call("/api/{0}/{1}/access_token".format(endpoint, asset), private=True, schema=validate.Schema(
-            {
-                "token": validate.text,
-                "sig": validate.text
-            },
-            validate.union((
-                validate.get("sig"),
-                validate.get("token")
-            ))
-        ))
-
-    def token(self, tokenstr):
-        return parse_json(tokenstr, schema=validate.Schema(
-            {
-                "chansub": {
-                    "restricted_bitrates": validate.all(
-                        [validate.text],
-                        validate.filter(
-                            lambda n: not re.match(r"(.+_)?archives|live|chunked", n)
-                        )
-                    )
-                }
-            },
-            validate.get("chansub"),
-            validate.get("restricted_bitrates")
-        ))
-
     def hosted_channel(self, channel_id):
         return self.call("/hosts", subdomain="tmi", include_logins=1, host=channel_id, schema=validate.Schema(
             {
@@ -336,6 +306,62 @@ class TwitchAPI(object):
         ))
 
     # GraphQL API calls
+
+    def access_token(self, is_live, channel_or_vod):
+        request = {
+            "operationName": "PlaybackAccessToken",
+            "extensions": {
+                "persistedQuery": {
+                    "version": 1,
+                    "sha256Hash": "0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712"
+                }
+            },
+            "variables": {
+                "isLive": is_live,
+                "login": channel_or_vod if is_live else "",
+                "isVod": not is_live,
+                "vodID": channel_or_vod if not is_live else "",
+                "playerType": "site"
+            }
+        }
+        subschema = {
+            "value": str,
+            "signature": str,
+            "__typename": "PlaybackAccessToken"
+        }
+        return self.call_gql(request, schema=validate.Schema(
+            {"data": validate.any(
+                validate.all(
+                    {"streamPlaybackAccessToken": subschema},
+                    validate.get("streamPlaybackAccessToken")
+                ),
+                validate.all(
+                    {"videoPlaybackAccessToken": subschema},
+                    validate.get("videoPlaybackAccessToken")
+                )
+            )},
+            validate.get("data"),
+            validate.union((
+                validate.get("signature"),
+                validate.get("value")
+            ))
+        ))
+
+    def parse_token(self, tokenstr):
+        return parse_json(tokenstr, schema=validate.Schema(
+            {
+                "chansub": {
+                    "restricted_bitrates": validate.all(
+                        [str],
+                        validate.filter(
+                            lambda n: not re.match(r"(.+_)?archives|live|chunked", n)
+                        )
+                    )
+                }
+            },
+            validate.get("chansub"),
+            validate.get("restricted_bitrates")
+        ))
 
     def clips(self, clipname):
         query = """{{
@@ -523,9 +549,9 @@ class Twitch(Plugin):
         except PluginError:
             raise PluginError("Unable to find channel: {0}".format(channel))
 
-    def _access_token(self, endpoint, asset):
+    def _access_token(self, is_live, channel_or_vod):
         try:
-            sig, token = self.api.access_token(endpoint, asset)
+            sig, token = self.api.access_token(is_live, channel_or_vod)
         except PluginError as err:
             if "404 Client Error" in str(err):
                 raise NoStreamsError(self.url)
@@ -533,7 +559,7 @@ class Twitch(Plugin):
                 raise
 
         try:
-            restricted_bitrates = self.api.token(token)
+            restricted_bitrates = self.api.parse_token(token)
         except PluginError:
             restricted_bitrates = []
 
@@ -586,14 +612,14 @@ class Twitch(Plugin):
 
         # only get the token once the channel has been resolved
         log.debug("Getting live HLS streams for {0}".format(self.channel))
-        sig, token, restricted_bitrates = self._access_token("channels", self.channel)
+        sig, token, restricted_bitrates = self._access_token(True, self.channel)
         url = self.usher.channel(self.channel, sig=sig, token=token, fast_bread=True)
 
         return self._get_hls_streams(url, restricted_bitrates)
 
     def _get_hls_streams_video(self):
         log.debug("Getting video HLS streams for {0}".format(self.channel))
-        sig, token, restricted_bitrates = self._access_token("vods", self.video_id)
+        sig, token, restricted_bitrates = self._access_token(False, self.video_id)
         url = self.usher.video(self.video_id, nauthsig=sig, nauth=token)
 
         # If the stream is a VOD that is still being recorded, the stream should start at the beginning of the recording


### PR DESCRIPTION
Resolves #3341

Twitch's old private API namespace `/api` has already been deprecated and replaced by their new private GraphQL API when they redesigned their website several years ago. The only exception until yesterday were the access_token requests, which have now fully migrated after a couple of weeks of testing from what it looked like.

Since it is unknown how long the old API namespace will stay available, we'll have to move the access_token request at some point.

This commit switches the access_token API request to the GQL API and uses the `PlaybackAccessToken` query with the persistedQuery sha256 hash of `0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712`. This is the checksum of the actual GraphQL query for server-caching purposes and for Streamlink, this simply means that the query doesn't have to be defined here.

Tested with live streams and vods:
```
$ streamlink -l debug twitch.tv/shroud
[cli][debug] OS:         Linux-5.10.0-rc4-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.6
[cli][debug] Streamlink: 1.7.0+66.ga98872e
[cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin twitch for URL twitch.tv/shroud
[plugin.twitch][debug] Getting live HLS streams for shroud
[utils.l10n][debug] Language code: en_US
Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 936p60 (best)

$ streamlink -l debug https://www.twitch.tv/videos/807481367
[cli][debug] OS:         Linux-5.10.0-rc4-1-git-x86_64-with-glibc2.2.5
[cli][debug] Python:     3.8.6
[cli][debug] Streamlink: 1.7.0+66.ga98872e
[cli][debug] Requests(2.24.0), Socks(1.7.1), Websocket(0.56.0)
[cli][info] Found matching plugin twitch for URL https://www.twitch.tv/videos/807481367
[plugin.twitch][debug] Getting video HLS streams for shroud
[utils.l10n][debug] Language code: en_US
Available streams: audio, 160p (worst), 360p, 480p, 720p, 720p60, 936p60 (best)
```
