### PR TITLE
chore: remove HLS variant playlist compat params

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -336,7 +336,7 @@ class YouTube(Plugin):
         if hls_manifest:
             try:
                 hls_streams = HLSStream.parse_variant_playlist(
-                    self.session, hls_manifest, namekey="pixels"
+                    self.session, hls_manifest, name_key="pixels"
                 )
                 streams.update(hls_streams)
             except IOError as err:

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -425,9 +425,6 @@ class HLSStream(HTTPStream):
                          name, pixels, bitrate.
         """
         locale = session_.localization
-        # Backwards compatibility with "namekey" and "nameprefix" params.
-        name_key = request_params.pop("namekey", name_key)
-        name_prefix = request_params.pop("nameprefix", name_prefix)
         audio_select = session_.options.get("hls-audio-select") or []
 
         res = session_.http.get(url, exception=IOError, **request_params)


### PR DESCRIPTION
This removes old compat parameters from `HLSStream.parse_variant_playlist`.
Looks like the old params were only used in the youtube plugin.

Still a breaking change for all applications using Streamlink's API.