### PR TITLE
chore: remove old rtmpdump/subprocess CLI args

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -246,16 +246,6 @@ class Streamlink(object):
 
         """
 
-        # Backwards compatibility
-        if key == "rtmpdump":
-            key = "rtmp-rtmpdump"
-        elif key == "rtmpdump-proxy":
-            key = "rtmp-proxy"
-        elif key == "errorlog":
-            key = "subprocess-errorlog"
-        elif key == "errorlog-path":
-            key = "subprocess-errorlog-path"
-
         if key == "http-proxy":
             self.http.proxies["http"] = update_scheme("http://", value)
             if "https" not in self.http.proxies:
@@ -304,13 +294,6 @@ class Streamlink(object):
         :param key: key of the option
 
         """
-        # Backwards compatibility
-        if key == "rtmpdump":
-            key = "rtmp-rtmpdump"
-        elif key == "rtmpdump-proxy":
-            key = "rtmp-proxy"
-        elif key == "errorlog":
-            key = "subprocess-errorlog"
 
         if key == "http-proxy":
             return self.http.proxies.get("http")

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -932,7 +932,7 @@ def build_parser():
         processing (such as HDS) to avoid unnecessary background processing.
         """)
     transport.add_argument(
-        "--rtmp-proxy", "--rtmpdump-proxy",
+        "--rtmp-proxy",
         metavar="PROXY",
         help="""
         A SOCKS proxy that RTMP streams will use.
@@ -941,7 +941,7 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--rtmp-rtmpdump", "--rtmpdump",
+        "--rtmp-rtmpdump",
         metavar="FILENAME",
         help="""
         RTMPDump is used to access RTMP streams. You can specify the
@@ -950,6 +950,7 @@ def build_parser():
         Example: "/usr/local/bin/rtmpdump"
         """
     )
+    transport.add_argument("--rtmpdump", help=argparse.SUPPRESS)
     transport.add_argument(
         "--rtmp-timeout",
         type=num(float, min=0),
@@ -1020,7 +1021,7 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--subprocess-cmdline", "--cmdline", "-c",
+        "--subprocess-cmdline",
         action="store_true",
         help="""
         Print the command-line used internally to play the stream.
@@ -1029,7 +1030,7 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--subprocess-errorlog", "--errorlog", "-e",
+        "--subprocess-errorlog",
         action="store_true",
         help="""
         Log possible errors from internal subprocesses to a temporary file. The
@@ -1039,7 +1040,7 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--subprocess-errorlog-path", "--errorlog-path",
+        "--subprocess-errorlog-path",
         type=str,
         metavar="PATH",
         help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -819,6 +819,8 @@ def setup_options():
 
     if args.rtmp_rtmpdump:
         streamlink.set_option("rtmp-rtmpdump", args.rtmp_rtmpdump)
+    elif args.rtmpdump:
+        streamlink.set_option("rtmp-rtmpdump", args.rtmpdump)
 
     if args.rtmp_timeout:
         streamlink.set_option("rtmp-timeout", args.rtmp_timeout)


### PR DESCRIPTION
and remove compat key name translations in the Session options.

Removes the following CLI arguments:
- `--rtmpdump-proxy` (use `--rtmp-proxy` instead)
- `-c` / `--cmdline` (use `--subprocess-cmdline` instead)
- `-e` / `--errorlog` (use `--subprocess-errorlog` instead)
- `--erorlog-path` (use `--subprocess-errorlog-path` instead)

Keeps `--rtmpdump` as a fallback for `--rtmp-rtmpdump`, as the default
streamlinkrc config file of the Windows installer is still using the
old parameter name.

----

https://github.com/streamlink/streamlink/issues/3235#issuecomment-730251337
