### PR TITLE
installer: fix + rewrite streamlinkrc config file

### DIFF
--- a/win32/streamlinkrc
+++ b/win32/streamlinkrc
@@ -1,15 +1,20 @@
-# Format is option=value. Lines starting with a # is considered comments
-# and are ignored.
+# The format is option=value
+# Lines starting with a # are considered comments and are ignored.
 
-# By default streamlink will attempt to locate VLC on your system
-# and use that, but you can also specify the location of a player
-# yourself.
+# Please see the Streamlink CLI documentation for all available options
+# and their descriptions. All leading dashes need to be ignored,
+# e.g. --default-stream=STREAM becomes default-stream=STREAM
+# https://streamlink.github.io/cli.html#command-line-usage
 
-# Important: You must use a quoted path if there are spaces in the path. This
-# is because the player command is parsed like a shell command to allow
-# parameters to be passed to the player.
 
-# Here is a few examples of players:
+# By default, Streamlink will attempt to locate VLC on your system
+# and use that, but you can also specify the location of a player yourself.
+
+# Important: You must use a quoted path if there are spaces in it. This
+# is because the player command is parsed like a shell command, to allow
+# parameters to be passed to the player when not using the player-args option.
+
+# Here are a couple of player examples:
 
 # VLC
 #player="C:\Program Files (x86)\VideoLAN\VLC\vlc.exe"
@@ -22,33 +27,58 @@
 #player="C:\Program Files (x86)\MPC-HC\mpc-hc.exe"
 #player="C:\Program Files\MPC-HC\mpc-hc64.exe"
 
+# MPV
+#player="C:\Program Files\mpv-x86_64\mpv.exe"
+
+# Alternatively, player arguments can also be set via the player-args option.
+# Please see the documentation of the used player for its available arguments.
+
+# VLC
+#player-args=--no-one-instance --play-and-exit
+#player-args=--qt-minimal-view
+#player-args=--file-caching=5000
+
+# MPC-HC
+#player-args=/new /play /close
+
+# MPV
+#player-args=--keep-open=no --force-window=yes
+#player-args=--no-border
+#player-args=--cache=yes --demuxer-max-bytes=2M
+
+
+# Custom player window titles can automatically be set when a supported player
+# and plugin are used. The title option has several variables available, which
+# can show the stream's author, category/game, title, URL, etc.
+#title={author} - {category} - {title}
+
 
 # Use this if you want to transport the stream to the player via a named pipe.
 #player-fifo
 
-# Use this if you want to transport the stream to the player via HTTP.
+# Use one of these if you want to transport the stream to the player via HTTP.
+# The continuous option will allow the player to stop and resume the output.
 #player-http
+#player-continuous-http
 
-# Use this if you want streamlink to only pass a URL to your player and
-# let it handle the transport of the stream itself.
+# Use player-passthrough if you want Streamlink to only pass the resolved URL
+# to your player and let it handle the transport of the stream itself.
+# Please note that the player needs to support the streaming protocol
+# and that custom stream implementations in plugins will become unavailable,
+# same as buffering options and those which change the network behavior.
 #player-passthrough=http,hls,rtmp
 
-# By default streamlink will close the player when stream is over.
+# By default, Streamlink will close the player when the stream is over.
 # Use this option to let the player stay or close itself instead.
 #player-no-close
 
-# Use this option if you want streamlink to keep trying to access
-# the stream even if it goes offline or disconnects. Your player must
-# support HTTP and its playlist should be set to repeat mode.
-#player-continuous-http
-
-# Show console output from the video player
+# Show the player's console output
 #verbose-player
 
-# RTMP streams are downloaded using rtmpdump. Full path or relative path
+# RTMP streams are downloaded using rtmpdump. A full or relative path
 # to the rtmpdump exe should be specified here.
-#rtmpdump=C:\Program Files (x86)\Streamlink\rtmpdump\rtmpdump.exe
-rtmpdump=rtmpdump.exe
+#rtmp-rtmpdump=C:\Program Files (x86)\Streamlink\rtmpdump\rtmpdump.exe
+rtmp-rtmpdump=rtmpdump.exe
 
 # FFMPEG is used to mux separate video and audio streams in to a single
 # stream so that they can be played. The full or relative path to ffmpeg


### PR DESCRIPTION
As mentioned in #3349, the streamlinkrc config file still sets the old `--rtmpdump` argument which needs to be changed.

This PR also rewrites most of the rather poor descriptions and adds a couple of things.

Further suggestions/improvements are welcome...