### PR TITLE
stream.ffmpegmux: only close FFMPEGMuxer once

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -153,6 +153,9 @@ class FFMPEGMuxer(StreamIO):
         return data
 
     def close(self):
+        if self.closed:
+            return
+
         log.debug("Closing ffmpeg thread")
         if self.process:
             # kill ffmpeg
@@ -161,10 +164,13 @@ class FFMPEGMuxer(StreamIO):
 
             # close the streams
             for stream in self.streams:
-                if hasattr(stream, "close"):
+                if hasattr(stream, "close") and callable(stream.close):
                     stream.close()
 
             log.debug("Closed all the substreams")
+
         if self.close_errorlog:
             self.errorlog.close()
             self.errorlog = None
+
+        super().close()


### PR DESCRIPTION
Fixes #3357 

See https://github.com/streamlink/streamlink/issues/3357#issuecomment-731819072

No tests, because the entire module is not tested yet and I didn't feel like writing a test just for checking whether close can be called twice or not.