### PR TITLE
session: replace usage of deprecated imp module

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -1,8 +1,5 @@
-import imp
 import logging
 import pkgutil
-import sys
-import traceback
 from collections import OrderedDict
 
 import requests
@@ -12,33 +9,13 @@ from streamlink.compat import is_win32
 from streamlink.exceptions import NoPluginError, PluginError
 from streamlink.logger import StreamlinkLogger
 from streamlink.options import Options
-from streamlink.plugin import api
-from streamlink.utils import memoize, update_scheme
+from streamlink.plugin import Plugin, api
+from streamlink.utils import load_module, memoize, update_scheme
 from streamlink.utils.l10n import Localization
 
 # Ensure that the Logger class returned is Streamslink's for using the API (for backwards compatibility)
 logging.setLoggerClass(StreamlinkLogger)
 log = logging.getLogger(__name__)
-
-
-def print_small_exception(start_after):
-    type, value, traceback_ = sys.exc_info()
-
-    tb = traceback.extract_tb(traceback_)
-    index = 0
-
-    for i, trace in enumerate(tb):
-        if trace[2] == start_after:
-            index = i + 1
-            break
-
-    lines = traceback.format_list(tb[index:])
-    lines += traceback.format_exception_only(type, value)
-
-    for line in lines:
-        sys.stderr.write(line)
-
-    sys.stderr.write("\n")
 
 
 class PythonDeprecatedWarning(UserWarning):
@@ -429,40 +406,23 @@ class Streamlink(object):
         :param path: full path to a directory where to look for plugins
 
         """
+        user_input_requester = self.get_option("user-input-requester")
         for loader, name, ispkg in pkgutil.iter_modules([path]):
-            file, pathname, desc = imp.find_module(name, [path])
             # set the full plugin module name
-            module_name = "streamlink.plugin.{0}".format(name)
-
+            module_name = f"streamlink.plugins.{name}"
             try:
-                self.load_plugin(module_name, file, pathname, desc)
-            except Exception:
-                sys.stderr.write("Failed to load plugin {0}:\n".format(name))
-                print_small_exception("load_plugin")
-
+                mod = load_module(module_name, path)
+            except ImportError:
+                log.exception(f"Failed to load plugin {name} from {path}\n")
                 continue
 
-    def load_plugin(self, name, file, pathname, desc):
-        # Set the global http session for this plugin
-        user_input_requester = self.get_option("user-input-requester")
-        api.http = self.http
-
-        module = imp.load_module(name, file, pathname, desc)
-
-        if hasattr(module, "__plugin__"):
-            module_name = getattr(module, "__name__")
-            plugin_name = module_name.split(".")[-1]  # get the plugin part of the module name
-
-            plugin = getattr(module, "__plugin__")
-            plugin.bind(self, plugin_name, user_input_requester)
-
+            if not hasattr(mod, "__plugin__") or not issubclass(mod.__plugin__, Plugin):
+                continue
+            plugin = mod.__plugin__
+            plugin.bind(self, name, user_input_requester)
             if plugin.module in self.plugins:
-                log.debug("Plugin {0} is being overridden by {1}".format(plugin.module, pathname))
-
+                log.debug(f"Plugin {plugin.module} is being overridden by {mod.__file__}")
             self.plugins[plugin.module] = plugin
-
-        if file:
-            file.close()
 
     @property
     def version(self):

--- a/tests/plugins/testplugin_invalid.py
+++ b/tests/plugins/testplugin_invalid.py
@@ -1,0 +1,6 @@
+class TestPluginInvalid:
+    pass
+
+
+# does not inherit from streamlink.plugin.plugin.Plugin
+__plugin__ = TestPluginInvalid

--- a/tests/plugins/testplugin_missing.py
+++ b/tests/plugins/testplugin_missing.py
@@ -1,0 +1,9 @@
+from streamlink.plugin.plugin import Plugin
+
+
+class TestPluginMissing(Plugin):
+    pass
+
+
+# does not export plugin via __plugin__
+# __plugin__ = TestPluginMissing

--- a/tests/plugins/testplugin_override.py
+++ b/tests/plugins/testplugin_override.py
@@ -1,0 +1,11 @@
+from tests.plugins.testplugin import __plugin__ as TestPlugin
+
+
+class TestPluginOverride(TestPlugin):
+    @classmethod
+    def bind(cls, *args, **kwargs):
+        super().bind(*args, **kwargs)
+        cls.module = "testplugin"
+
+
+__plugin__ = TestPluginOverride

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,4 +1,4 @@
-import imp
+import inspect
 import os.path
 import pkgutil
 import unittest
@@ -6,7 +6,7 @@ import unittest
 import six
 
 import streamlink.plugins
-from streamlink import Streamlink
+from streamlink.plugins import Plugin
 from streamlink.utils import load_module
 
 
@@ -15,27 +15,25 @@ class PluginTestMeta(type):
         plugin_path = os.path.dirname(streamlink.plugins.__file__)
         plugins = []
         for loader, pname, ispkg in pkgutil.iter_modules([plugin_path]):
-            module = load_module(pname, plugin_path)
+            module = load_module(f"streamlink.plugins.{pname}", plugin_path)
             if hasattr(module, "__plugin__"):
-                plugins.append((pname))
+                plugins.append((loader, pname))
 
-        session = Streamlink()
-
-        def gentest(pname):
+        def gentest(loader, pname):
             def load_plugin_test(self):
-                # Reset file variable to ensure it is still open when doing
-                # load_plugin else python might open the plugin source .py
-                # using ascii encoding instead of utf-8.
-                # See also open() call here: imp._HackedGetData.get_data
-                file, pathname, desc = imp.find_module(pname, [plugin_path])
-                session.load_plugin(pname, file, pathname, desc)
-                # validate that can_handle_url does not fail
-                session.plugins[pname].can_handle_url("http://test.com")
+                plugin = loader.find_module(pname).load_module(pname)
+                assert hasattr(plugin, "__plugin__"), "It exports __plugin__"
+                assert issubclass(plugin.__plugin__, Plugin), "__plugin__ is an instance of the Plugin class"
+
+                assert callable(plugin.__plugin__._get_streams), "The plugin implements _get_streams"
+                assert callable(plugin.__plugin__.can_handle_url), "The plugin implements can_handle_url"
+                sig = inspect.signature(plugin.__plugin__.can_handle_url)
+                assert str(sig) == "(url)", "can_handle_url only accepts the url arg"
 
             return load_plugin_test
 
-        for pname in plugins:
-            dict['test_{0}_load'.format(pname)] = gentest(pname)
+        for loader, pname in plugins:
+            dict[f"test_{pname}_load"] = gentest(loader, pname)
 
         return type.__new__(mcs, name, bases, dict)
 


### PR DESCRIPTION
Refactor `utils.load_module`:
- move it to the top and add it to `__all__`
- move imports and loader_details to the global scope

Refactor `session`:
- replace plugin imports via `imp` with `utils.load_module`
- fix incorrect plugin module names
  "streamlink.plugin.{name}" -> "streamlink.plugins.{name}"
- use `log.exception()` to print plugin load failures
- remove unused `print_small_exception`

Add / fix tests:
- remove session dependency from test_plugins
- add proper assertions for plugin modules, methods and their signatures
- add tests for invalid and for overridden plugins


----

Based on the changes of #2570

**Things to note**

- I've decided to keep the implementation of `importlib.machinery.FileFinder` in the `utils` module and use that for loading the plugins, as I had some issues with the module names while trying out the `pkgutils`-based imports of #2570, which led to plugins log calls not being recognized by the StreamlinkLogger, as their module names did not begin with `streamlink.`.
- `test_session` is really messy as it imports everything in `tests.plugins`, including all plugin test modules, which are irrelevant there. The actual `testplugin`s should be moved somewhere else. Mocking certain things is also impossible when everything is run in the test's `setUp`, and I couldn't mock the log call of the plugin override without patching the whole test class which would require adding an unused argument to every test method. That's why plugin load failures are also not tested.
- Why does `plugin.api.support_plugin` even exist? It's not being used and it looks totally unnecessary. This module is the reason why `utils.load_module` existed, but now it's being used by `session` as well.