### PR TITLE
plugins.youtube: quickfix for "/live" URL

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -249,7 +249,7 @@ class YouTube(Plugin):
                             log.debug("Video ID from videoRenderer (live)")
                             return x["videoId"]
 
-        if "/embed/live_stream" in url:
+        if urlparse(url).path.endswith(("/embed/live_stream", "/live")):
             for link in itertags(res.text, "link"):
                 if link.attributes.get("rel") == "canonical":
                     canon_link = link.attributes.get("href")


### PR DESCRIPTION
before

```
$ streamlink https://www.youtube.com/user/deutschewelleenglish/live -l info
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/user/deutschewelleenglish/live
error: Could not find a video on this page
```

after

```
$ streamlink https://www.youtube.com/user/deutschewelleenglish/live worst -l info
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/user/deutschewelleenglish/live
[cli][info] Available streams: 144p (worst), 240p, 360p, 480p, 720p (best)
[cli][info] Opening stream: 144p (hls)
```