### PR TITLE
docs: split CLI args in HTML output into rows

### DIFF
--- a/docs/_themes/sphinx_rtd_theme_violet/static/css/theme.css
+++ b/docs/_themes/sphinx_rtd_theme_violet/static/css/theme.css
@@ -4827,6 +4827,21 @@ table.table-custom-layout tbody tr td {
   white-space: unset;
 }
 
+/* fix CLI arguments */
+.rst-content dl.option:not(.docutils) > dt {
+  float: left;
+}
+.rst-content dl.option:not(.docutils) > dt,
+.rst-content dl.option:not(.docutils) > dd {
+  clear: left;
+}
+.rst-content dl.option:not(.docutils) > dt + dt {
+  margin-top: 0;
+}
+.rst-content dl.option:not(.docutils) > dt > code.descclassname:empty {
+  display: none;
+}
+
 /* github avatar pictures on the donate page */
 .github-avatar {
   float: left;

--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -108,7 +108,9 @@ class ArgparseDirective(Directive):
             else:
                 options += action.option_strings
 
-            yield f".. option:: {', '.join(options)}"
+            directive = ".. option:: "
+            options = f"\n{' ' * len(directive)}".join(options)
+            yield f"{directive}{options}"
             yield ""
             for line in self.process_help(action.help).split("\n"):
                 yield line


### PR DESCRIPTION
instead of separating them with a comma, so that it adds anchors to
secondary arguments. The rendered manpage already splits arguments into
multiple rows if there are multiple arguments for a specific command.

Fix CSS of the rtd_theme_violet theme and hide empty argument values.