### PR TITLE
chore: add issue template config with more links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: "Help"
+    about: "The issue tracker is only meant for bug reports, feature/plugin requests and plugin issues. Please ask your questions on the discussions forum and look for already existing answers."
+    url: https://github.com/streamlink/streamlink/discussions
+  - name: "Documentation"
+    about: "Please refer to Streamlink's documentation first before opening new issues or asking questions."
+    url: https://streamlink.github.io/
+  - name: "Gitter channel"
+    about: "Get in touch with other Streamlink users."
+    url: https://gitter.im/streamlink/streamlink


### PR DESCRIPTION
Closes #3171 

This adds three links to the issue template chooser:
1. Help -> discussions forum
2. Documentation
3. Gitter 

Not sure if everyone will be happy with this. If not, please make a suggestion. I've tried to put the important stuff first and keep it as short as possible.

I've also pushed the PR branch onto the master branch of my streamlink-test repo, so you can see what it looks like:
https://github.com/bastimeyer-test/streamlink-test/issues/new/choose

----

Btw, I think the default "Ideas" and "Show and tell" categories can be deleted from the discussions. "Ideas" are feature requests anyway and "Show and tell" can be posted into "General".