### PR TITLE
add ffmpeg-copyts option

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -61,6 +61,7 @@ class Streamlink:
             "ffmpeg-video-transcode": None,
             "ffmpeg-audio-transcode": None,
             "ffmpeg-start-at-zero": False,
+            "ffmpeg-copyts": False,
             "mux-subtitles": False,
             "locale": None,
             "user-input-requester": None
@@ -202,6 +203,8 @@ class Streamlink:
         ffmpeg-start-at-zero     (bool) When used with ffmpeg and copyts,
                                  shift input timestamps so they start at zero
                                  default: ``False``
+
+        ffmpeg-copyts            (bool) When used with ffmpeg, do not shift input timestamps.
 
         mux-subtitles            (bool) Mux available subtitles into the
                                  output stream.

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -60,8 +60,8 @@ class Streamlink:
             "ffmpeg-fout": None,
             "ffmpeg-video-transcode": None,
             "ffmpeg-audio-transcode": None,
-            "ffmpeg-start-at-zero": False,
             "ffmpeg-copyts": False,
+            "ffmpeg-start-at-zero": False,
             "mux-subtitles": False,
             "locale": None,
             "user-input-requester": None
@@ -200,11 +200,11 @@ class Streamlink:
                                  audio when muxing with ffmpeg
                                  e.g. ``aac``
 
+        ffmpeg-copyts            (bool) When used with ffmpeg, do not shift input timestamps.
+
         ffmpeg-start-at-zero     (bool) When used with ffmpeg and copyts,
                                  shift input timestamps so they start at zero
                                  default: ``False``
-
-        ffmpeg-copyts            (bool) When used with ffmpeg, do not shift input timestamps.
 
         mux-subtitles            (bool) Mux available subtitles into the
                                  output stream.

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -98,8 +98,8 @@ class FFMPEGMuxer(StreamIO):
         audiocodec = session.options.get("ffmpeg-audio-transcode") or options.pop("acodec", self.DEFAULT_AUDIO_CODEC)
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
-        copyts = options.pop("copyts", False)
         start_at_zero = session.options.get("ffmpeg-start-at-zero") or options.pop("start_at_zero", False)
+        copyts = session.options.get("ffmpeg-copyts") or options.pop("copyts", False)
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -98,8 +98,8 @@ class FFMPEGMuxer(StreamIO):
         audiocodec = session.options.get("ffmpeg-audio-transcode") or options.pop("acodec", self.DEFAULT_AUDIO_CODEC)
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
-        start_at_zero = session.options.get("ffmpeg-start-at-zero") or options.pop("start_at_zero", False)
         copyts = session.options.get("ffmpeg-copyts") or options.pop("copyts", False)
+        start_at_zero = session.options.get("ffmpeg-start-at-zero") or options.pop("start_at_zero", False)
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1134,18 +1134,18 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--ffmpeg-start-at-zero",
-        action="store_true",
-        help="""
-        Enable the -start_at_zero ffmpeg option when using copyts.
-        """
-    )
-    transport.add_argument(
         "--ffmpeg-copyts",
         action="store_true",
         help="""
         Forces the -copyts ffmpeg option and does not remove
         the initial start time offset value.
+        """
+    )
+    transport.add_argument(
+        "--ffmpeg-start-at-zero",
+        action="store_true",
+        help="""
+        Enable the -start_at_zero ffmpeg option when using copyts.
         """
     )
     transport.add_argument(

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1141,6 +1141,14 @@ def build_parser():
         """
     )
     transport.add_argument(
+        "--ffmpeg-copyts",
+        action="store_true",
+        help="""
+        Forces the -copyts ffmpeg option and does not remove
+        the initial start time offset value.
+        """
+    )
+    transport.add_argument(
         "--mux-subtitles",
         action="store_true",
         help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -849,10 +849,10 @@ def setup_options():
         streamlink.set_option("ffmpeg-video-transcode", args.ffmpeg_video_transcode)
     if args.ffmpeg_audio_transcode:
         streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
-    if args.ffmpeg_start_at_zero:
-        streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg_start_at_zero)
     if args.ffmpeg_copyts:
         streamlink.set_option("ffmpeg-copyts", args.ffmpeg_copyts)
+    if args.ffmpeg_start_at_zero:
+        streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg_start_at_zero)
 
     if args.mux_subtitles:
         streamlink.set_option("mux-subtitles", args.mux_subtitles)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -851,6 +851,8 @@ def setup_options():
         streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
     if args.ffmpeg_start_at_zero:
         streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg_start_at_zero)
+    if args.ffmpeg_copyts:
+        streamlink.set_option("ffmpeg-copyts", args.ffmpeg_copyts)
 
     if args.mux_subtitles:
         streamlink.set_option("mux-subtitles", args.mux_subtitles)

--- a/tests/streams/test_ffmpegmux.py
+++ b/tests/streams/test_ffmpegmux.py
@@ -65,10 +65,37 @@ def test_ffmpeg_open_copyts(session):
                                      stdin=ANY)
 
 
+def test_ffmpeg_open_copyts_user_override(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        session.options.set("ffmpeg-copyts", True)
+        f = FFMPEGMuxer(session, copyts=False)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
 def test_ffmpeg_open_copyts_disable_session_start_at_zero(session):
     with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
         session.options.set("ffmpeg-start-at-zero", False)
         f = FFMPEGMuxer(session, copyts=True)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
+def test_ffmpeg_open_copyts_disable_session_start_at_zero_user_override(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        session.options.set("ffmpeg-copyts", True)
+        session.options.set("ffmpeg-start-at-zero", False)
+        f = FFMPEGMuxer(session, copyts=False)
         with patch('subprocess.Popen') as popen:
             f.open()
             popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
@@ -91,6 +118,20 @@ def test_ffmpeg_open_copyts_enable_session_start_at_zero(session):
                                      stdin=ANY)
 
 
+def test_ffmpeg_open_copyts_enable_session_start_at_zero_user_override(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        session.options.set("ffmpeg-copyts", True)
+        session.options.set("ffmpeg-start-at-zero", True)
+        f = FFMPEGMuxer(session, copyts=False)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-start_at_zero', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
 def test_ffmpeg_open_copyts_disable_start_at_zero(session):
     with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
         f = FFMPEGMuxer(session, copyts=True, start_at_zero=False)
@@ -103,9 +144,35 @@ def test_ffmpeg_open_copyts_disable_start_at_zero(session):
                                      stdin=ANY)
 
 
+def test_ffmpeg_open_copyts_disable_start_at_zero_user_override(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        session.options.set("ffmpeg-copyts", True)
+        f = FFMPEGMuxer(session, copyts=False, start_at_zero=False)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
 def test_ffmpeg_open_copyts_enable_start_at_zero(session):
     with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
         f = FFMPEGMuxer(session, copyts=True, start_at_zero=True)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-start_at_zero', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
+def test_ffmpeg_open_copyts_enable_start_at_zero_user_override(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        session.options.set("ffmpeg-copyts", True)
+        f = FFMPEGMuxer(session, copyts=False, start_at_zero=True)
         with patch('subprocess.Popen') as popen:
             f.open()
             popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',


### PR DESCRIPTION
`hls-multi` streams occasionally have an input offset between the audio and video streams and the sound is then out of sync. With `copyts`, the offset is not changed when outputting to the player so that the sound is in sync.