### PR TITLE
cli.output: replace MPV player title parameter

### DIFF
--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -199,7 +199,7 @@ class PlayerOutput(Output):
             if self.player_name == "mpv":
                 # see https://mpv.io/manual/stable/#property-expansion, allow escaping with \$, respect mpv's $>
                 self.title = self._mpv_title_escape(self.title)
-                extra_args.append(f"--title={self.title}")
+                extra_args.append(f"--force-media-title={self.title}")
 
             # potplayer
             if self.player_name == "potplayer":

--- a/tests/test_cli_playerout.py
+++ b/tests/test_cli_playerout.py
@@ -13,7 +13,7 @@ def test_output_mpv_unicode_title_posix(popen):
     po = PlayerOutput("mpv", title=UNICODE_TITLE)
     popen().poll.side_effect = lambda: None
     po.open()
-    popen.assert_called_with(["mpv", f"--title={UNICODE_TITLE}", "-"],
+    popen.assert_called_with(["mpv", f"--force-media-title={UNICODE_TITLE}", "-"],
                              bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
 
 
@@ -35,7 +35,7 @@ def test_output_mpv_unicode_title_windows_py3(popen):
     po = PlayerOutput("mpv.exe", title=UNICODE_TITLE)
     popen().poll.side_effect = lambda: None
     po.open()
-    popen.assert_called_with(f"mpv.exe \"--title={UNICODE_TITLE}\" -",
+    popen.assert_called_with(f"mpv.exe \"--force-media-title={UNICODE_TITLE}\" -",
                              bufsize=ANY, stderr=ANY, stdout=ANY, stdin=ANY)
 
 

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -24,11 +24,11 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
 
     def test_open_player_with_title_mpv(self):
         self._test_args(["streamlink", "-p", "/usr/bin/mpv", "--title", "{title}", "http://test.se", "test"],
-                        ["/usr/bin/mpv", "--title=Test Title", "-"])
+                        ["/usr/bin/mpv", "--force-media-title=Test Title", "-"])
 
     def test_unicode_title_2444(self):
-        self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
-                        ["mpv", "--title=\u2605", "-"])
+        self._test_args(["streamlink", "-p", "mpv", "-t", "★ ★ ★", "http://test.se", "test"],
+                        ["mpv", "--force-media-title=★ ★ ★", "-"])
 
 
 @unittest.skipIf(not is_win32, "test only applicable on Windows")
@@ -87,5 +87,5 @@ class TestCommandLineWithTitleWindows(CommandLineTestCase):
         )
 
     def test_unicode_title_2444_py3(self):
-        self._test_args(["streamlink", "-p", "mpv", "-t", "★", "http://test.se", "test"],
-                        "mpv --title=★ -")
+        self._test_args(["streamlink", "-p", "mpv", "-t", "★ ★ ★", "http://test.se", "test"],
+                        "mpv \"--force-media-title=★ ★ ★\" -")


### PR DESCRIPTION
Replace MPV's `--title` parameter with `--force-media-title`, as it also
changes the name of the playlist item and not just the window title.

----

See https://github.com/streamlink/streamlink/issues/3231#issuecomment-741636677

Also changed the content of some test assertions in one go, as they were not testing the entire player argument logic (`subprocess.list2cmdline` on Windows).