### PR TITLE
stream.dash: allow '_alt' streams with the same resolution

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -258,7 +258,7 @@ class DASHStream(Stream):
                 elif n == 1:
                     ret_new[f'{q}_alt'] = items[n]
                 else:
-                    ret_new[f'{q}_alt_{n}'] = items[n]
+                    ret_new[f'{q}_alt{n}'] = items[n]
         return ret_new
 
     def open(self):

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -3,6 +3,7 @@ import datetime
 import itertools
 import logging
 import os.path
+from collections import defaultdict
 from urllib.parse import urlparse, urlunparse
 
 import requests
@@ -174,7 +175,6 @@ class DASHStream(Stream):
         :param url_or_manifest: URL of the manifest file or an XML manifest string
         :return: a dict of name -> DASHStream instances
         """
-        ret = {}
 
         if url_or_manifest.startswith('<?xml'):
             mpd = MPD(parse_xml(url_or_manifest, ignore_ns=True))
@@ -233,6 +233,7 @@ class DASHStream(Stream):
         if len(available_languages) > 1:
             audio = list(filter(lambda a: a.lang is None or a.lang == lang, audio))
 
+        ret = []
         for vid, aud in itertools.product(video, audio):
             stream = DASHStream(session, mpd, vid, aud, **args)
             stream_name = []
@@ -241,8 +242,24 @@ class DASHStream(Stream):
                 stream_name.append("{:0.0f}{}".format(vid.height or vid.bandwidth_rounded, "p" if vid.height else "k"))
             if audio and len(audio) > 1:
                 stream_name.append("a{:0.0f}k".format(aud.bandwidth))
-            ret['+'.join(stream_name)] = stream
-        return ret
+            ret.append(('+'.join(stream_name), stream))
+
+        # rename duplicate streams
+        dict_value_list = defaultdict(list)
+        for k, v in ret:
+            dict_value_list[k].append(v)
+
+        ret_new = {}
+        for q in dict_value_list:
+            items = dict_value_list[q]
+            for n in range(len(items)):
+                if n == 0:
+                    ret_new[q] = items[n]
+                elif n == 1:
+                    ret_new[f'{q}_alt'] = items[n]
+                else:
+                    ret_new[f'{q}_alt_{n}'] = items[n]
+        return ret_new
 
     def open(self):
         if self.video_representation:

--- a/tests/resources/dash/test_10.mpd
+++ b/tests/resources/dash/test_10.mpd
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="urn:mpeg:dash:schema:mpd:2011"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+	profiles="urn:mpeg:dash:profile:isoff-live:2011"
+	type="dynamic"
+	minimumUpdatePeriod="PT500S"
+	suggestedPresentationDelay="PT6S"
+	availabilityStartTime="2020-11-26T00:56:27.795Z"
+	publishTime="2020-11-26T00:57:33.023Z"
+	timeShiftBufferDepth="PT48.0S"
+	maxSegmentDuration="PT6.0S"
+	minBufferTime="PT12.0S">
+	<ProgramInformation>
+	</ProgramInformation>
+	<ServiceDescription id="0">
+	</ServiceDescription>
+	<Period id="0" start="PT0.0S">
+		<AdaptationSet id="0" contentType="video" startWithSAP="1" segmentAlignment="true" bitstreamSwitching="true" frameRate="24000/1001" maxWidth="1920" maxHeight="804" par="160:67">
+			<Representation id="0" mimeType="video/mp4" codecs="hvc1" bandwidth="10000000" width="1920" height="804" scanType="unknown" sar="1:1">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="2" mimeType="video/mp4" codecs="avc1.640029" bandwidth="8000000" width="1920" height="804" sar="1:1">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="3" mimeType="video/mp4" codecs="avc1.640029" bandwidth="6000000" width="1792" height="750" sar="1875:1876">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="4" mimeType="video/mp4" codecs="avc1.64081f" bandwidth="3000000" width="1280" height="536" sar="1:1">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="5" mimeType="video/mp4" codecs="avc1.64081f" bandwidth="2000000" width="1024" height="428" sar="535:536">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="6" mimeType="video/mp4" codecs="avc1.64081e" bandwidth="1000000" width="768" height="322" sar="805:804">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+			<Representation id="7" mimeType="video/mp4" codecs="avc1.640815" bandwidth="600000" width="512" height="214" sar="535:536">
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+		<AdaptationSet id="1" contentType="audio" startWithSAP="1" segmentAlignment="true" bitstreamSwitching="true">
+			<Representation id="1" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="192000" audioSamplingRate="48000">
+				<AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
+				<SegmentTemplate timescale="1000000" duration="6006000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
+				</SegmentTemplate>
+			</Representation>
+		</AdaptationSet>
+	</Period>
+	<UTCTiming schemeIdUri="urn:mpeg:dash:utc:http-xsdate:2014" value="https://localhost"/>
+</MPD>

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -252,6 +252,30 @@ class TestDASHStream(unittest.TestCase):
 
             self.assertSequenceEqual(list(streams.keys()), ['2500k'])
 
+    @patch('streamlink.stream.dash.MPD')
+    def test_parse_manifest_with_duplicated_resolutions(self, mpdClass):
+        """
+            Verify the fix for https://github.com/streamlink/streamlink/issues/3365
+        """
+        mpdClass.return_value = Mock(periods=[
+            Mock(adaptationSets=[
+                Mock(contentProtection=None,
+                     representations=[
+                         Mock(id=1, mimeType="video/mp4", height=1080, bandwidth=128.0),
+                         Mock(id=2, mimeType="video/mp4", height=1080, bandwidth=64.0),
+                         Mock(id=3, mimeType="video/mp4", height=720),
+                     ])
+            ])
+        ])
+
+        streams = DASHStream.parse_manifest(self.session, self.test_url)
+        mpdClass.assert_called_with(ANY, base_url="http://test.bar", url="http://test.bar/foo.mpd")
+
+        self.assertSequenceEqual(
+            sorted(list(streams.keys())),
+            sorted(["720p", "1080p", "1080p_alt"])
+        )
+
 
 class TestDASHStreamWorker(unittest.TestCase):
     @patch("streamlink.stream.dash_manifest.time.sleep")

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -263,7 +263,8 @@ class TestDASHStream(unittest.TestCase):
                      representations=[
                          Mock(id=1, mimeType="video/mp4", height=1080, bandwidth=128.0),
                          Mock(id=2, mimeType="video/mp4", height=1080, bandwidth=64.0),
-                         Mock(id=3, mimeType="video/mp4", height=720),
+                         Mock(id=3, mimeType="video/mp4", height=1080, bandwidth=32.0),
+                         Mock(id=4, mimeType="video/mp4", height=720),
                      ])
             ])
         ])
@@ -273,7 +274,7 @@ class TestDASHStream(unittest.TestCase):
 
         self.assertSequenceEqual(
             sorted(list(streams.keys())),
-            sorted(["720p", "1080p", "1080p_alt"])
+            sorted(["720p", "1080p", "1080p_alt", "1080p_alt2"])
         )
 
 

--- a/tests/streams/test_dash_parser.py
+++ b/tests/streams/test_dash_parser.py
@@ -235,3 +235,17 @@ class TestMPDParser(unittest.TestCase):
         self.assertEqual(mock_rep(45.6 * 1000.0).bandwidth_rounded, 46.0)
         self.assertEqual(mock_rep(134.0 * 1000.0).bandwidth_rounded, 130.0)
         self.assertEqual(mock_rep(1324.0 * 1000.0).bandwidth_rounded, 1300.0)
+
+    def test_duplicated_resolutions(self):
+        """
+            Verify the fix for https://github.com/streamlink/streamlink/issues/3365
+        """
+        with xml("dash/test_10.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")
+
+            representations_0 = mpd.periods[0].adaptationSets[0].representations[0]
+            self.assertEqual(representations_0.height, 804)
+            self.assertEqual(representations_0.bandwidth, 10000.0)
+            representations_1 = mpd.periods[0].adaptationSets[0].representations[1]
+            self.assertEqual(representations_1.height, 804)
+            self.assertEqual(representations_1.bandwidth, 8000.0)


### PR DESCRIPTION
- create a list of stream_names and rename streams with the same resolution
- `defaultdict` seems the easy way without changing a lot of tests
- added `test_10.mpd`, so we have an actual test file for future updates

closes https://github.com/streamlink/streamlink/issues/3365