### PR TITLE
stream.ffmpegmux: disable -start_at_zero for -copyts as default

### DIFF
--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -79,6 +79,8 @@ class Facebook(Plugin):
                 yield from DASHStream.parse_manifest(self.session, manifest).items()
 
     def _get_streams(self):
+        self.session.set_option("ffmpeg-start-at-zero", True)
+
         done = False
         res = self.session.http.get(self.url)
         for s in self._parse_streams(res):

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -59,7 +59,7 @@ class Streamlink:
             "ffmpeg-fout": None,
             "ffmpeg-video-transcode": None,
             "ffmpeg-audio-transcode": None,
-            "ffmpeg-start-at-zero": None,
+            "ffmpeg-start-at-zero": False,
             "mux-subtitles": False,
             "locale": None,
             "user-input-requester": None
@@ -196,6 +196,7 @@ class Streamlink:
 
         ffmpeg-start-at-zero     (bool) When used with ffmpeg and copyts,
                                  shift input timestamps so they start at zero
+                                 default: ``False``
 
         mux-subtitles            (bool) Mux available subtitles into the
                                  output stream.

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -99,10 +99,7 @@ class FFMPEGMuxer(StreamIO):
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
         copyts = options.pop("copyts", False)
-        if session.options.get("ffmpeg-start-at-zero") is not None:
-            start_at_zero = session.options.get("ffmpeg-start-at-zero")
-        else:
-            start_at_zero = options.pop("start_at_zero", True)
+        start_at_zero = session.options.get("ffmpeg-start-at-zero") or options.pop("start_at_zero", False)
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1137,11 +1137,10 @@ def build_parser():
         """
     )
     transport.add_argument(
-        "--ffmpeg-no-start-at-zero",
+        "--ffmpeg-start-at-zero",
         action="store_true",
         help="""
-        Disables the -start_at_zero ffmpeg option
-        when using copyts.
+        Enable the -start_at_zero ffmpeg option when using copyts.
         """
     )
     transport.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -849,8 +849,8 @@ def setup_options():
         streamlink.set_option("ffmpeg-video-transcode", args.ffmpeg_video_transcode)
     if args.ffmpeg_audio_transcode:
         streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
-    if args.ffmpeg_no_start_at_zero:
-        streamlink.set_option("ffmpeg-start-at-zero", False)
+    if args.ffmpeg_start_at_zero:
+        streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg_start_at_zero)
 
     if args.mux_subtitles:
         streamlink.set_option("mux-subtitles", args.mux_subtitles)

--- a/tests/streams/test_ffmpegmux.py
+++ b/tests/streams/test_ffmpegmux.py
@@ -59,13 +59,13 @@ def test_ffmpeg_open_copyts(session):
         with patch('subprocess.Popen') as popen:
             f.open()
             popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
-                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-start_at_zero', '-f', 'matroska', 'pipe:1'],
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-f', 'matroska', 'pipe:1'],
                                      stderr=ANY,
                                      stdout=ANY,
                                      stdin=ANY)
 
 
-def test_ffmpeg_open_copyts_disable(session):
+def test_ffmpeg_open_copyts_disable_session_start_at_zero(session):
     with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
         session.options.set("ffmpeg-start-at-zero", False)
         f = FFMPEGMuxer(session, copyts=True)
@@ -78,13 +78,38 @@ def test_ffmpeg_open_copyts_disable(session):
                                      stdin=ANY)
 
 
-def test_ffmpeg_open_copyts_no_start_at_zero(session):
+def test_ffmpeg_open_copyts_enable_session_start_at_zero(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        session.options.set("ffmpeg-start-at-zero", True)
+        f = FFMPEGMuxer(session, copyts=True)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-start_at_zero', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
+def test_ffmpeg_open_copyts_disable_start_at_zero(session):
     with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
         f = FFMPEGMuxer(session, copyts=True, start_at_zero=False)
         with patch('subprocess.Popen') as popen:
             f.open()
             popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
                                       FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-f', 'matroska', 'pipe:1'],
+                                     stderr=ANY,
+                                     stdout=ANY,
+                                     stdin=ANY)
+
+
+def test_ffmpeg_open_copyts_enable_start_at_zero(session):
+    with patch('streamlink.stream.ffmpegmux.which', return_value="ffmpeg"):
+        f = FFMPEGMuxer(session, copyts=True, start_at_zero=True)
+        with patch('subprocess.Popen') as popen:
+            f.open()
+            popen.assert_called_with(['ffmpeg', '-nostats', '-y', '-c:v', FFMPEGMuxer.DEFAULT_VIDEO_CODEC, '-c:a',
+                                      FFMPEGMuxer.DEFAULT_AUDIO_CODEC, '-copyts', '-start_at_zero', '-f', 'matroska', 'pipe:1'],
                                      stderr=ANY,
                                      stdout=ANY,
                                      stdin=ANY)


### PR DESCRIPTION
- don't use `-start_at_zero` as default for `-copyts`
- revert https://github.com/streamlink/streamlink/pull/2559

- change command `--ffmpeg-no-start-at-zero` to `--ffmpeg-start-at-zero`
  (there was no release in between this command)

- use `--ffmpeg-start-at-zero` for the facebook plugin,
  because the original fix was for it.
  https://github.com/streamlink/streamlink/issues/2488

---

as this might have some downsides

Might be helpful for https://github.com/streamlink/streamlink/pull/3404

