### PR TITLE
stream.hls: remove --hls-segment-ignore-names command

### DIFF
--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -98,7 +98,7 @@ class SegmentedStreamWriter(Thread):
     and finally writing the data to the buffer.
     """
 
-    def __init__(self, reader, size=20, retries=None, threads=None, timeout=None, ignore_names=None):
+    def __init__(self, reader, size=20, retries=None, threads=None, timeout=None):
         self.closed = False
         self.reader = reader
         self.stream = reader.stream
@@ -115,7 +115,6 @@ class SegmentedStreamWriter(Thread):
 
         self.retries = retries
         self.timeout = timeout
-        self.ignore_names = ignore_names
         self.executor = CompatThreadPoolExecutor(max_workers=threads)
         self.futures = queue.Queue(size)
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -830,23 +830,6 @@ def build_parser():
         Default is 10.0.
         """)
     transport.add_argument(
-        "--hls-segment-ignore-names",
-        metavar="NAMES",
-        type=comma_list,
-        help="""
-        A comma-delimited list of segment names that will not be fetched.
-
-        Example: --hls-segment-ignore-names 000,001,002
-
-        This will ignore every segment that ends with 000.ts, 001.ts and 002.ts
-
-        Default is None.
-
-        Note: The --hls-timeout must be increased, to a time that is longer than
-        the ignored break.
-        """
-    )
-    transport.add_argument(
         "--hls-segment-key-uri",
         metavar="URI",
         type=str,

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -772,9 +772,6 @@ def setup_options():
     if args.hls_segment_timeout:
         streamlink.set_option("hls-segment-timeout", args.hls_segment_timeout)
 
-    if args.hls_segment_ignore_names:
-        streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
-
     if args.hls_segment_key_uri:
         streamlink.set_option("hls-segment-key-uri", args.hls_segment_key_uri)
 


### PR DESCRIPTION
It has some downsides such as `--hls-timeout`,
Plugin specified FilteredHLSStream should be used instead.

https://github.com/streamlink/streamlink/pull/3187

---

Afreeca Plugin as an Example

https://github.com/streamlink/streamlink/pull/3408

---

Revert https://github.com/streamlink/streamlink/pull/1432
