### PR TITLE
plugins.plugin: use the same cls.logger 'plugins'

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -202,7 +202,7 @@ class Plugin:
     def bind(cls, session, module, user_input_requester=None):
         cls.cache = Cache(filename="plugin-cache.json",
                           key_prefix=module)
-        cls.logger = logging.getLogger("streamlink.plugin." + module)
+        cls.logger = logging.getLogger("streamlink.plugins." + module)
         cls.module = module
         cls.session = session
         if user_input_requester is not None:


### PR DESCRIPTION
since https://github.com/streamlink/streamlink/pull/3366
https://github.com/streamlink/streamlink/blob/5e7a04b006d0e4d7a884b13bf2aa8047791b837b/src/streamlink/session.py#L412
the logger is `[plugins.afreeca]` which was `[plugin.afreeca]` before

update the cls.logger so it will be `[plugins.afreeca]` also

after this PR

```
[plugins.afreeca][debug] Restored cookies: ...
...
[plugins.afreeca][debug] Attempting to authenticate using cached cookies
```
