### PR TITLE
cli: move --stream-url to different args group

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -619,6 +619,13 @@ def build_parser():
         """
     )
     stream.add_argument(
+        "--stream-url",
+        action="store_true",
+        help="""
+        If possible, translate the resolved stream to a URL and print it.
+        """
+    )
+    stream.add_argument(
         "--retry-streams",
         metavar="DELAY",
         type=num(float, min=0),
@@ -1038,13 +1045,6 @@ def build_parser():
 
         Default is 60.0.
         """)
-    transport.add_argument(
-        "--stream-url",
-        action="store_true",
-        help="""
-        If possible, translate the stream to a URL and print it.
-        """
-    )
     transport.add_argument(
         "--subprocess-cmdline",
         action="store_true",


### PR DESCRIPTION
`--stream-url` is currently listed in the "Stream transport options" args group, which doesn't make sense, as it's CLI output related, and not stream transport related. This PR moves it to the "stream" args group, right under `--url` and `--default-stream`.

See the current latest CLI docs:
https://streamlink.github.io/latest/cli.html#cmdoption-stream-url