### PR TITLE
ci: add netlify docs preview deploy config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 max_line_length = 128
 trim_trailing_whitespace = true
 
-[*.{cfg,svg,yml}]
+[*.{cfg,svg,toml,yml}]
 indent_size = 2
 
 [*.{md,markdown}]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,27 @@
+# Streamlink documentation preview config for pull requests via netlify.com
+# Some settings like PR statuses for example can only be configured via the netlify website
+
+# https://docs.netlify.com/configure-builds/file-based-configuration/#build-settings
+[build]
+  command = "pip install -U pip setuptools && pip install -e . && pip install -U -r docs-requirements.txt && make --directory=docs clean html"
+  publish = "docs/_build/html"
+  # Since production builds can't be disabled without disabling PRs as well, pushes to the master branch need to be ignored.
+  # Also ignore pull requests which don't include any changes that would alter the docs:
+  # - docs/
+  # - docs-requirements.txt
+  # - src/streamlink_cli/argparser.py
+  # https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds
+  ignore = "[ $(git rev-parse --abbrev-ref HEAD) = master ] || git diff --quiet master HEAD docs/ docs-requirements.txt src/streamlink_cli/argparser.py"
+
+[build.environment]
+  # Set the latest natively available Python version in the Ubuntu env (currently 16.04 / Xenial)
+  # https://docs.netlify.com/configure-builds/manage-dependencies/#python
+  # https://github.com/netlify/build-image/blob/xenial/included_software.md
+  PYTHON_VERSION = "3.7"
+
+# Builds on untagged commits are always "latest", but since it's built on the root docs dir, actual "latest" links will cause 404 errors
+# https://docs.netlify.com/configure-builds/file-based-configuration/#redirects
+[[redirects]]
+  from = "/latest/*"
+  to = "/:splat"
+  status = 301


### PR DESCRIPTION
As discussed in https://github.com/streamlink/streamlink/pull/3335#issuecomment-742131264, here's a config for docs previews in PRs via netlify.com. This will make reviewing docs changes way more easy.

This config will be required before enabling the repo integration, otherwise it'd create production builds on pushes to the master branch, which is not what we want. I've added comments to the config, so that it's clear what everything's for.

----

So far, I haven't received a response from them yet regarding the upgrade to their "open source" plan. If they are so kind and update the account from the free "starter" plan, that would enable us having multiple account maintainers and an increased build time (which doesn't matter so much).

Since I feel like they probably won't answer my message, as I had to send it on a different contact form, I will try this again via their community forums, which is the only contact method that's supported for starter accounts, as I've already mentioned. There's a post on their forums though where you can discuss stuff in private after asking first. I will try that later today.

The upgrade would probably require us adding a CoC and a link to their site in the docs. I've already explained in my contact message that I don't know whether these are hard requirements for being able to apply to the open source plan. If they are, then we'll have to figure something out or keep the free account, which is fine, too. Personally, I'm fine with adding a **very** simple CoC and adding a "thank you" note/link to the index page or even adding a new "thank you" page and listing them there.

----

Please don't merge until the account stuff is resolved.

This is how the PR status checks look like:
https://github.com/bastimeyer-test/streamlink-test/pull/8