### PR TITLE
cache: catch OverflowError in set()

### DIFF
--- a/src/streamlink/cache.py
+++ b/src/streamlink/cache.py
@@ -38,7 +38,7 @@ class Cache:
         pruned = []
 
         for key, value in self._cache.items():
-            expires = value.get("expires", time())
+            expires = value.get("expires", now)
             if expires <= now:
                 pruned.append(key)
 
@@ -69,10 +69,13 @@ class Cache:
         if self.key_prefix:
             key = "{0}:{1}".format(self.key_prefix, key)
 
-        expires += time()
-
-        if expires_at:
-            expires = mktime(expires_at.timetuple())
+        if expires_at is None:
+            expires += time()
+        else:
+            try:
+                expires = mktime(expires_at.timetuple())
+            except OverflowError:
+                expires = 0
 
         self._cache[key] = dict(value=value, expires=expires)
         self._save()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -55,6 +55,11 @@ class TestCache(unittest.TestCase):
         self.cache.set("value", 10, expires_at=datetime.datetime.now() + datetime.timedelta(seconds=20))
         self.assertEqual(10, self.cache.get("value"))
 
+    @patch("streamlink.cache.mktime", side_effect=OverflowError)
+    def test_expired_at_raise_overflowerror(self, mock):
+        self.cache.set("value", 10, expires_at=datetime.datetime.now())
+        self.assertEqual(None, self.cache.get("value"))
+
     def test_not_expired(self):
         self.cache.set("value", 10, expires=20)
         self.assertEqual(10, self.cache.get("value"))


### PR DESCRIPTION
This catches the `OverflowError` that's raised in `streamlink.cache.set` when unsupported timestamps are passed to `time.mktime()` and it sets `expires` to `0` in that case. Also some other minor improvements to the module.

Before merging, I'd first like to see a confirmation that this does indeed fix #3396 (can't test the plugin), because I think another plugin fix might be necessary if the expiration time is set to 0 on auth, as the cache module will clear the credentials immediately.