### PR TITLE
plugins.dogan: fix/update

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -59,11 +59,11 @@ delfi                   - delfi.lt           --    Yes
                         - delfi.lv
 deutschewelle           dw.com               Yes   Yes
 dlive                   dlive.tv             Yes   Yes
-dogan                   - teve2.com.tr       Yes   Yes   VOD is supported for teve2 and kanald
-                        - kanald.com.tr
-                        - dreamtv.com.tr
-                        - cnnturk.com
+dogan                   - cnnturk.com        Yes   Yes
                         - dreamturk.com.tr
+                        - dreamtv.com.tr
+                        - kanald.com.tr
+                        - teve2.com.tr
 dogus                   - ntvspor.net        Yes   No
                         - kralmuzik.com.tr
                         - ntv.com.tr

--- a/tests/plugins/test_dogan.py
+++ b/tests/plugins/test_dogan.py
@@ -6,17 +6,39 @@ from streamlink.plugins.dogan import Dogan
 class TestPluginDogan(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
+            'https://www.cnnturk.com/action/embedvideo/',
+            'https://www.cnnturk.com/action/embedvideo/5fa56d065cf3b018a8dd0bbc',
             'https://www.cnnturk.com/canli-yayin',
+            'https://www.cnnturk.com/tv-cnn-turk/',
+            'https://www.cnnturk.com/tv-cnn-turk/belgeseller/bir-zamanlar/bir-zamanlar-90lar-belgeseli',
+            'https://www.cnnturk.com/video/',
+            'https://www.cnnturk.com/video/turkiye/polis-otomobiliyle-tur-atan-sahisla-ilgili-islem-baslatildi-video',
             'https://www.dreamturk.com.tr/canli',
-            'https://www.dreamtv.com.tr/canli-yayin',
+            'https://www.dreamturk.com.tr/canli-yayin-izle',
+            'https://www.dreamturk.com.tr/dream-turk-ozel/',
+            'https://www.dreamturk.com.tr/dream-turk-ozel/radyo-d/ilyas-yalcintas-radyo-dnin-konugu-oldu',
+            'https://www.dreamturk.com.tr/programlar/',
+            'https://www.dreamturk.com.tr/programlar/t-rap/bolumler/t-rap-keisan-ozel',
+            'https://www.dreamtv.com.tr/dream-ozel/',
+            'https://www.dreamtv.com.tr/dream-ozel/konserler/acik-sahne-dream-ozel',
             'https://www.kanald.com.tr/canli-yayin',
+            'https://www.kanald.com.tr/sadakatsiz/fragmanlar/sadakatsiz-10-bolum-fragmani',
             'https://www.teve2.com.tr/canli-yayin',
+            'https://www.teve2.com.tr/diziler/',
+            'https://www.teve2.com.tr/diziler/guncel/oyle-bir-gecer-zaman-ki/bolumler/oyle-bir-gecer-zaman-ki-1-bolum',
+            'https://www.teve2.com.tr/embed/',
+            'https://www.teve2.com.tr/embed/55f6d5b8402011f264ec7f64',
+            'https://www.teve2.com.tr/filmler/',
+            'https://www.teve2.com.tr/filmler/guncel/yasamak-guzel-sey',
+            'https://www.teve2.com.tr/programlar/',
+            'https://www.teve2.com.tr/programlar/guncel/kelime-oyunu/bolumler/kelime-oyunu-800-bolum-19-12-2020',
         ]
         for url in should_match:
             self.assertTrue(Dogan.can_handle_url(url))
 
     def test_can_handle_url_negative(self):
         should_not_match = [
+            'https://www.dreamtv.com.tr/canli-yayin',
             'https://example.com/index.html',
         ]
         for url in should_not_match:


### PR DESCRIPTION
- update/add schemas for new/old API responses
- update for dreamturk.com.tr and dreamtv.com.tr API path
- remove dreamtv.com.tr/canli-yayin (no live and redirect loop on old URL)
- add VOD support for cnnturk.com
- add /dream-turk-ozel/.* and /programlar/.* VOD paths for dreamturk.com.tr
- add /dream-turk-ozel/.* VOD path for dreamtv.com.tr
- add /diziler/.* and /embed/.* VOD paths for teve2.com.tr
- update URLs in plugin test
- update plugin matrix

~~No accounts needed, but streams are geo-restricted to Turkey.~~

closes  #3416
