### PR TITLE
add --niconico-timeshift-offset option to the nicolive plugin

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -11,6 +11,7 @@ from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils.times import hours_minutes_seconds
+from streamlink.utils.url import update_qsd
 
 _log = logging.getLogger(__name__)
 
@@ -252,12 +253,8 @@ class NicoLive(Plugin):
             self.hls_stream_url = data["uri"]
             # load in the offset for timeshift live videos
             offset = self.get_option("timeshift-offset")
-            if offset:
-                if 'timeshift' in self.wss_api_url:
-                    self.hls_stream_url += '&start={0}'.format(offset)
-                    _log.debug("Timeshift offset stream URL is now {0}".format(self.hls_stream_url))
-                else:
-                    _log.debug("Not a timeshift video, ignoring offset")
+            if offset and 'timeshift' in self.wss_api_url:
+                self.hls_stream_url = update_qsd(self.hls_stream_url, {"start": offset})
             self.is_stream_ready = True
 
         if message_parsed["type"] == "watch":

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -10,6 +10,7 @@ import websocket
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
+from streamlink.utils.times import hours_minutes_seconds
 
 _log = logging.getLogger(__name__)
 
@@ -45,7 +46,15 @@ class NicoLive(Plugin):
             sensitive=True,
             metavar="VALUE",
             help="Value of the user-session token \n(can be used in "
-                 "case you do not want to put your password here)"))
+                 "case you do not want to put your password here)"),
+        PluginArgument(
+            "timeshift-offset",
+            type=hours_minutes_seconds,
+            argument_name="niconico-timeshift-offset",
+            metavar="[HH:]MM:SS",
+            default=None,
+            help="Amount of time to skip from the beginning of a stream. "
+                 "Default is 00:00:00."))
 
     is_stream_ready = False
     is_stream_ended = False
@@ -241,6 +250,14 @@ class NicoLive(Plugin):
         if message_parsed["type"] == "stream":
             data = message_parsed["data"]
             self.hls_stream_url = data["uri"]
+            # load in the offset for timeshift live videos
+            offset = self.get_option("timeshift-offset")
+            if offset:
+                if 'timeshift' in self.wss_api_url:
+                    self.hls_stream_url += '&start={0}'.format(offset)
+                    _log.debug("Timeshift offset stream URL is now {0}".format(self.hls_stream_url))
+                else:
+                    _log.debug("Not a timeshift video, ignoring offset")
             self.is_stream_ready = True
 
         if message_parsed["type"] == "watch":


### PR DESCRIPTION
`--niconico-timeshift-offset` allows the nicolive Streamlink plugin to start at a particular timestamp in the HLS stream for [timeshift streams](http://help.nicovideo.jp/live_en/2013/06/305what-is-a-timeshiftwatch-period.html).

This proves particularly useful because some broadcasts' HLS streams start with a long "waiting room" during a live broadcast that the web player skips past by default.