### PR TITLE
docs: add minimalist code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+Minimalist Code of Conduct
+====
+
+We believe that an elaborate code of conduct invites a lot of fighting over intricate details, much like law, and we do not have the resources to build up the equivalent of a legal system. Therefore we prefer keeping our rules as short as possible and filling the gaps with the mortar of human interaction: empathy.
+
+All we ask of members and contributors of this project is this:
+
+- Please treat each other with respect and understanding.
+- Please respect our wish to not serve as a stage for disputes about fairness or personal differences.
+
+If you can agree to these conditions, your contributions are welcome. If you can not, please don't spoil it for the rest of us.


### PR DESCRIPTION
Personally, I'm not a fan of Code of Conducts, as it's totally unnecessary to tell adults how to behave themselves :roll_eyes: :roll_eyes: :roll_eyes:, but unfortunately it's a requirement for being able to apply to the Netlify open source plan upgrade (see #3420).

That's why I'm proposing the "Minimalist Code of Conduct", which basically only tells the already implied and known rules of every community, "be nice and respectful", nothing more.

An alternative to the "Minimalist Code of Conduct" could be the "No Code of Conduct":
https://github.com/domgetter/NCoC/blob/master/CODE_OF_CONDUCT.md

Either way, I don't think there's any reason to fight or argue about adding a CoC of such kind. It doesn't change anything here, so if one doesn't like this, they can just ignore it.