### PR TITLE
plugins.youtube: Fix 'ytInitialData' for channel pages

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -58,7 +58,7 @@ _config_schema = validate.Schema(
     }
 )
 
-_ytdata_re = re.compile(r'window\["ytInitialData"\]\s*=\s*({.*?});', re.DOTALL)
+_ytdata_re = re.compile(r'ytInitialData\s*=\s*({.*?});', re.DOTALL)
 _url_re = re.compile(r"""(?x)https?://(?:\w+\.)?youtube\.com
     (?:
         (?:


### PR DESCRIPTION
```
$ streamlink http://www.youtube.com/channel/UCj6PcyLvpnIRT_2W_mwa9Aw worst -l info
[cli][info] Found matching plugin youtube for URL http://www.youtube.com/channel/UCj6PcyLvpnIRT_2W_mwa9Aw
[cli][info] Available streams: 144p (worst), 240p, 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 144p (hls)
[cli][info] Starting player: /usr/bin/mpv
```

```
$ streamlink https://www.youtube.com/channel/UCFgk2Q2mVO1BklRQhSv6p0w worst -l info
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/channel/UCFgk2Q2mVO1BklRQhSv6p0w
[cli][info] Available streams: 144p (worst), 240p, 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 144p (hls)
[cli][info] Starting player: /usr/bin/mpv
```

closes https://github.com/streamlink/streamlink/issues/3426