### PR TITLE
pluginsNicolive: login before getting wss api url

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -75,17 +75,16 @@ class NicoLive(Plugin):
         self.session.http.headers.update({
             "User-Agent": useragents.CHROME,
         })
+        
+        _log.debug("Attempting initial login")
+        self.niconico_web_login()
 
         if not self.get_wss_api_url():
-            _log.debug("Coundn't extract wss_api_url. Attempting login...")
-            if not self.niconico_web_login():
-                return None
-            if not self.get_wss_api_url():
-                _log.error("Failed to get wss_api_url.")
-                _log.error(
-                    "Please check if the URL is correct, "
-                    "and make sure your account has access to the video.")
-                return None
+            _log.error(
+                "Failed to get wss_api_url. "
+                "Please check if the URL is correct, "
+                "and make sure your account has access to the video.")
+            return None
 
         self.api_connect(self.wss_api_url)
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Some videos requiring login on Nicolive for the full video have a free section at the start. Without this fix, even if login credentials are provided, login may not be attempted since `get_wss_api_url()` will succeed, but once the 'locked section' is reached, it will download a blank 'error' screen (which is what you get if you attempt to view the locked section without logging in):

![image](https://user-images.githubusercontent.com/22608443/102941054-d8d62d00-4505-11eb-89e7-b3c6cd7b356e.png)

This fix will attempt an initial login to fix this issue.