### PR TITLE
stream.dash: Fix static playlist - refresh_wait - Pipe copy aborted - Read timeout

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -91,6 +91,10 @@ class DASHStreamWorker(SegmentedStreamWorker):
             representation = self.get_representation(self.mpd, self.reader.representation_id, self.reader.mime_type)
             refresh_wait = max(self.mpd.minimumUpdatePeriod.total_seconds(),
                                self.mpd.periods[0].duration.total_seconds()) or 5
+
+            if self.mpd.type == "static":
+                refresh_wait = 5
+
             with sleeper(refresh_wait * back_off_factor):
                 if representation:
                     for segment in representation.segments(init=init):

--- a/tests/resources/dash/test_11_static.mpd
+++ b/tests/resources/dash/test_11_static.mpd
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-live:2011" type="static" mediaPresentationDuration="PT3M24.320S" minBufferTime="PT6.000S">
+    <BaseURL>../</BaseURL>
+    <Period start="PT0.000S" duration="PT3M24.320S">
+        <AdaptationSet bitstreamSwitching="true">
+            <ContentComponent contentType="video"></ContentComponent>
+            <Representation id="video-574992933" codecs="avc1.64001F" mimeType="video/mp4" width="960" height="540" frameRate="25" startWithSAP="1" bandwidth="1483000">
+                <SegmentTemplate timescale="48000" media="574992933/chop/segment-$Number$.m4s" initialization="574992933/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="288000" r="32"></S>
+                        <S t="9504000" d="303360"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+            <Representation id="video-1309483008" codecs="avc1.640815" mimeType="video/mp4" width="426" height="240" frameRate="25" startWithSAP="1" bandwidth="338000">
+                <SegmentTemplate timescale="24000" media="1309483008/chop/segment-$Number$.m4s" initialization="1309483008/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="145920" r="32"></S>
+                        <S t="4815360" d="88320"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+            <Representation id="video-574992928" codecs="avc1.4D401E" mimeType="video/mp4" width="640" height="360" frameRate="25" startWithSAP="1" bandwidth="542000">
+                <SegmentTemplate timescale="48000" media="574992928/chop/segment-$Number$.m4s" initialization="574992928/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="288000" r="32"></S>
+                        <S t="9504000" d="303360"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+            <Representation id="video-574992937" codecs="avc1.640028" mimeType="video/mp4" width="1920" height="1080" frameRate="25" startWithSAP="1" bandwidth="5002000">
+                <SegmentTemplate timescale="48000" media="574992937/chop/segment-$Number$.m4s" initialization="574992937/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="288000" r="32"></S>
+                        <S t="9504000" d="303360"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+            <Representation id="video-574992932" codecs="avc1.640020" mimeType="video/mp4" width="1280" height="720" frameRate="25" startWithSAP="1" bandwidth="2355000">
+                <SegmentTemplate timescale="48000" media="574992932/chop/segment-$Number$.m4s" initialization="574992932/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="288000" r="32"></S>
+                        <S t="9504000" d="303360"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+        <AdaptationSet>
+            <ContentComponent contentType="audio"></ContentComponent>
+            <Representation id="audio-1309483008" codecs="mp4a.40.2" mimeType="audio/mp4" startWithSAP="1" bandwidth="52000" audioSamplingRate="24000">
+                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="1"></AudioChannelConfiguration>
+                <SegmentTemplate timescale="24000" media="../audio/1309483008/chop/segment-$Number$.m4s" initialization="../audio/1309483008/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="146432"></S>
+                        <S t="146432" d="145408"></S>
+                        <S t="291840" d="146432"></S>
+                        <S t="438272" d="145408"></S>
+                        <S t="583680" d="146432"></S>
+                        <S t="730112" d="145408"></S>
+                        <S t="875520" d="146432"></S>
+                        <S t="1021952" d="145408"></S>
+                        <S t="1167360" d="146432"></S>
+                        <S t="1313792" d="145408"></S>
+                        <S t="1459200" d="146432"></S>
+                        <S t="1605632" d="145408"></S>
+                        <S t="1751040" d="146432"></S>
+                        <S t="1897472" d="145408"></S>
+                        <S t="2042880" d="146432"></S>
+                        <S t="2189312" d="145408"></S>
+                        <S t="2334720" d="146432"></S>
+                        <S t="2481152" d="145408"></S>
+                        <S t="2626560" d="146432"></S>
+                        <S t="2772992" d="145408"></S>
+                        <S t="2918400" d="146432"></S>
+                        <S t="3064832" d="145408"></S>
+                        <S t="3210240" d="146432"></S>
+                        <S t="3356672" d="145408"></S>
+                        <S t="3502080" d="146432"></S>
+                        <S t="3648512" d="145408"></S>
+                        <S t="3793920" d="146432"></S>
+                        <S t="3940352" d="145408"></S>
+                        <S t="4085760" d="146432"></S>
+                        <S t="4232192" d="145408"></S>
+                        <S t="4377600" d="146432"></S>
+                        <S t="4524032" d="145408"></S>
+                        <S t="4669440" d="146432"></S>
+                        <S t="4815872" d="89088"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+            <Representation id="audio-574992933" codecs="mp4a.40.2" mimeType="audio/mp4" startWithSAP="1" bandwidth="237000" audioSamplingRate="48000">
+                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+                <SegmentTemplate timescale="48000" media="../audio/574992933/chop/segment-$Number$.m4s" initialization="../audio/574992933/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="287744"></S>
+                        <S t="287744" d="288768"></S>
+                        <S t="576512" d="287744" r="2"></S>
+                        <S t="1439744" d="288768"></S>
+                        <S t="1728512" d="287744" r="2"></S>
+                        <S t="2591744" d="288768"></S>
+                        <S t="2880512" d="287744" r="2"></S>
+                        <S t="3743744" d="288768"></S>
+                        <S t="4032512" d="287744" r="2"></S>
+                        <S t="4895744" d="288768"></S>
+                        <S t="5184512" d="287744" r="2"></S>
+                        <S t="6047744" d="288768"></S>
+                        <S t="6336512" d="287744" r="2"></S>
+                        <S t="7199744" d="288768"></S>
+                        <S t="7488512" d="287744" r="2"></S>
+                        <S t="8351744" d="288768"></S>
+                        <S t="8640512" d="287744" r="2"></S>
+                        <S t="9503744" d="307200"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+            <Representation id="audio-574992928" codecs="mp4a.40.2" mimeType="audio/mp4" startWithSAP="1" bandwidth="120000" audioSamplingRate="48000">
+                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2"></AudioChannelConfiguration>
+                <SegmentTemplate timescale="48000" media="../audio/574992928/chop/segment-$Number$.m4s" initialization="../audio/574992928/chop/segment-0.mp4">
+                    <SegmentTimeline>
+                        <S t="0" d="287744"></S>
+                        <S t="287744" d="288768"></S>
+                        <S t="576512" d="287744" r="2"></S>
+                        <S t="1439744" d="288768"></S>
+                        <S t="1728512" d="287744" r="2"></S>
+                        <S t="2591744" d="288768"></S>
+                        <S t="2880512" d="287744" r="2"></S>
+                        <S t="3743744" d="288768"></S>
+                        <S t="4032512" d="287744" r="2"></S>
+                        <S t="4895744" d="288768"></S>
+                        <S t="5184512" d="287744" r="2"></S>
+                        <S t="6047744" d="288768"></S>
+                        <S t="6336512" d="287744" r="2"></S>
+                        <S t="7199744" d="288768"></S>
+                        <S t="7488512" d="287744" r="2"></S>
+                        <S t="8351744" d="288768"></S>
+                        <S t="8640512" d="287744" r="2"></S>
+                        <S t="9503744" d="307200"></S>
+                    </SegmentTimeline>
+                </SegmentTemplate>
+            </Representation>
+        </AdaptationSet>
+    </Period>
+</MPD>

--- a/tests/streams/test_dash_parser.py
+++ b/tests/streams/test_dash_parser.py
@@ -249,3 +249,12 @@ class TestMPDParser(unittest.TestCase):
             representations_1 = mpd.periods[0].adaptationSets[0].representations[1]
             self.assertEqual(representations_1.height, 804)
             self.assertEqual(representations_1.bandwidth, 8000.0)
+
+    def test_segments_static_periods_duration(self):
+        """
+            Verify the fix for https://github.com/streamlink/streamlink/issues/2873
+        """
+        with xml("dash/test_11_static.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")
+            duration = mpd.periods[0].duration.total_seconds()
+            self.assertEqual(duration, 204.32)


### PR DESCRIPTION
closes https://github.com/streamlink/streamlink/issues/2873

- set `refresh_wait` for static playlists to default 5 seconds
  for this example the `refresh_wait` time was set to 204.32 seconds
  which would result in some unexpected behavior.
- Fix for not correct closing streamlink process
- Fix for Pipe copy aborted - Read timeout

`--player-no-close` must be used now

https://streamlink.github.io/cli.html#cmdoption-player-no-close

```
$ streamlink https://vimeo.com/176894130 --stream-type dash -o test.mp4 -l debug
[cli][info] Found matching plugin vimeo for URL https://vimeo.com/176894130
[stream.dash][debug] Opening DASH reader for: video-574992937 (video/mp4)
[stream.dash][debug] Opening DASH reader for: audio-574992933 (audio/mp4)
[stream.dash_manifest][debug] Generating segment timeline for static playlist (id=video-574992937))
[stream.dash_manifest][debug] Generating segment timeline for static playlist (id=audio-574992933))
[stream.ffmpegmux][debug] ffmpeg command: /usr/bin/ffmpeg -nostats -y -i /tmp/ffmpeg-114055-652 -i /tmp/ffmpeg-114055-914 -c:v copy -c:a copy -copyts -f matroska pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/ffmpeg-114055-652
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/ffmpeg-114055-914
[cli][debug] Pre-buffering 8192 bytes
[stream.dash][debug] Download of segment: segment-0.mp4 complete
[stream.dash][debug] Download of segment: segment-0.mp4 complete
[cli][debug] Checking file output
[cli][debug] Writing stream to output
[download][test.mp4] Written 72.6 MB
[stream.dash][debug] Download of segment: segment-34.m4s complete
[stream.dash][debug] Download of segment: segment-34.m4s complete
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/ffmpeg-114055-914
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/ffmpeg-114055-652
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```
