### PR TITLE
Examples: use python3 interpreter instead of python

### DIFF
--- a/examples/gst-player.py
+++ b/examples/gst-player.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 


### PR DESCRIPTION
Change python interpreter of `gst-player.py` to python3 as now only python 3 is supported, and to match the other example `opencv-face.py`. 