### PR TITLE
cli.main: use *_args, **_kwargs for create_http_server

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -104,7 +104,7 @@ def create_output(plugin):
             except OSError as err:
                 console.exit("Failed to create pipe: {0}", err)
         elif args.player_http:
-            http = create_http_server("127.0.0.1")
+            http = create_http_server()
 
         title = create_title(plugin)
 
@@ -122,7 +122,7 @@ def create_output(plugin):
     return out
 
 
-def create_http_server(host=None, port=0):
+def create_http_server(*_args, **_kwargs):
     """Creates a HTTP server listening on a given host and port.
 
     If host is empty, listen on all available interfaces, and if port is 0,
@@ -131,7 +131,7 @@ def create_http_server(host=None, port=0):
 
     try:
         http = HTTPServer()
-        http.bind(host=host, port=port)
+        http.bind(*_args, **_kwargs)
     except OSError as err:
         console.exit("Failed to create HTTP server: {0}", err)
 
@@ -178,7 +178,7 @@ def output_stream_http(plugin, initial_streams, external=False, port=0):
                          "executable with --player.")
 
         title = create_title(plugin)
-        server = create_http_server(host="127.0.0.1")
+        server = create_http_server()
         player = output = PlayerOutput(args.player, args=args.player_args,
                                        filename=server.url,
                                        quiet=not args.verbose_player,

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -104,7 +104,7 @@ def create_output(plugin):
             except OSError as err:
                 console.exit("Failed to create pipe: {0}", err)
         elif args.player_http:
-            http = create_http_server()
+            http = create_http_server("127.0.0.1")
 
         title = create_title(plugin)
 
@@ -178,7 +178,7 @@ def output_stream_http(plugin, initial_streams, external=False, port=0):
                          "executable with --player.")
 
         title = create_title(plugin)
-        server = create_http_server()
+        server = create_http_server(host="127.0.0.1")
         player = output = PlayerOutput(args.player, args=args.player_args,
                                        filename=server.url,
                                        quiet=not args.verbose_player,


### PR DESCRIPTION
closes https://github.com/streamlink/streamlink/issues/2622

use `127.0.0.1` for local `create_http_server()`
use `0.0.0.0` for external `create_http_server()`

`--player-http` = ***127.0.0.1***
https://streamlink.github.io/cli.html#cmdoption-player-http

`--player-continuous-http` = ***127.0.0.1***
https://streamlink.github.io/cli.html#cmdoption-player-continuous-http

`--player-external-http` = ***None*** / ***0.0.0.0***
https://streamlink.github.io/cli.html#cmdoption-player-external-http

---

we use `AF_INET` which is IPv4

https://github.com/streamlink/streamlink/blob/2.0.0/src/streamlink_cli/utils/http_server.py#L24

we don't use `AF_INET6` which is IPv6, so IPv6 support is unimportant.

Ref https://github.com/streamlink/streamlink/issues/2622#issuecomment-529408813

---

```
$ streamlink https://www.youtube.com/channel/UCSrZ3UV4jOidv8ppoVuvW9Q/live --player-http -l debug
...
[cli][info] Starting player: /usr/bin/mpv
[cli.output][debug] Opening subprocess: /usr/bin/mpv "--force-media-title=Euronews English Live" http://127.0.0.1:35085/
```

```
$ streamlink https://www.youtube.com/channel/UCSrZ3UV4jOidv8ppoVuvW9Q/live --player-continuous-http -l debug
...
[cli][info] Starting player: /usr/bin/mpv
[cli.output][debug] Opening subprocess: /usr/bin/mpv "--force-media-title=Euronews English Live" http://127.0.0.1:39099/
[cli][info] Got HTTP request from libmpv
```

```
$ streamlink https://www.youtube.com/channel/UCSrZ3UV4jOidv8ppoVuvW9Q/live --player-external-http --player-external-http-port 33333
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:33333/
[cli][info]  http://127.0.0.53:33333/
[cli][info]  http://127.0.1.1:33333/
[cli][info] Got HTTP request from Mozilla/5.0 ...
[cli][info] Opening stream: 720p (hls)
```
