### PR TITLE
Fix race conditions in filtered HLSStreamWriter tests

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -19,10 +19,7 @@ class AfreecaHLSStreamReader(HLSStreamReader):
 
 
 class AfreecaHLSStream(HLSStream):
-    def open(self):
-        reader = AfreecaHLSStreamReader(self)
-        reader.open()
-        return reader
+    __reader__ = AfreecaHLSStreamReader
 
 
 class AfreecaTV(Plugin):

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -72,6 +72,7 @@ class FilmOnHLSStreamReader(HLSStreamReader):
 
 class FilmOnHLS(HLSStream):
     __shortname__ = "hls-filmon"
+    __reader__ = FilmOnHLSStreamReader
 
     def __init__(self, session_, channel=None, vod_id=None, quality="high", **args):
         super().__init__(session_, None, **args)
@@ -115,12 +116,6 @@ class FilmOnHLS(HLSStream):
         if expires < 0:
             raise TypeError("Stream has expired and cannot be converted to a URL")
         return url
-
-    def open(self):
-        reader = FilmOnHLSStreamReader(self)
-        reader.open()
-
-        return reader
 
 
 class FilmOnAPI:

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -91,11 +91,7 @@ class ShowroomHLSStreamReader(HLSStreamReader):
 
 
 class ShowroomHLSStream(HLSStream):
-    def open(self):
-        reader = ShowroomHLSStreamReader(self)
-        reader.open()
-
-        return reader
+    __reader__ = ShowroomHLSStreamReader
 
 
 class Showroom(Plugin):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -119,6 +119,8 @@ class TwitchHLSStreamReader(HLSStreamReader):
 
 
 class TwitchHLSStream(HLSStream):
+    __reader__ = TwitchHLSStreamReader
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.disable_ads = self.session.get_plugin_option("twitch", "disable-ads")
@@ -133,10 +135,7 @@ class TwitchHLSStream(HLSStream):
             self.session.options.set("hls-segment-stream-data", True)
             log.info("Low latency streaming (HLS live edge: {0})".format(live_edge))
 
-        reader = TwitchHLSStreamReader(self)
-        reader.open()
-
-        return reader
+        return super().open()
 
     @classmethod
     def _get_variant_playlist(cls, res):

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -405,6 +405,7 @@ class HLSStream(HTTPStream):
     """
 
     __shortname__ = "hls"
+    __reader__ = HLSStreamReader
 
     def __init__(self, session_, url, url_master=None, force_restart=False, start_offset=0, duration=None, **args):
         HTTPStream.__init__(self, session_, url, **args)
@@ -432,7 +433,7 @@ class HLSStream(HTTPStream):
         return self.url_master
 
     def open(self):
-        reader = HLSStreamReader(self)
+        reader = self.__reader__(self)
         reader.open()
 
         return reader

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -6,8 +6,8 @@ import requests_mock
 
 from streamlink import Streamlink
 from streamlink.plugin import PluginError
-from streamlink.plugins.twitch import Twitch, TwitchHLSStream
-from tests.mixins.stream_hls import Playlist, Segment as _Segment, Tag, TestMixinStreamHLS
+from streamlink.plugins.twitch import Twitch, TwitchHLSStream, TwitchHLSStreamReader, TwitchHLSStreamWriter
+from tests.mixins.stream_hls import EventedHLSStreamWriter, Playlist, Segment as _Segment, Tag, TestMixinStreamHLS
 
 
 DATETIME_BASE = datetime(2000, 1, 1, 0, 0, 0, 0)
@@ -44,6 +44,18 @@ class SegmentPrefetch(Segment):
         return "#EXT-X-TWITCH-PREFETCH:{0}".format(self.url(namespace))
 
 
+class _TwitchHLSStreamWriter(EventedHLSStreamWriter, TwitchHLSStreamWriter):
+    pass
+
+
+class _TwitchHLSStreamReader(TwitchHLSStreamReader):
+    __writer__ = _TwitchHLSStreamWriter
+
+
+class _TwitchHLSStream(TwitchHLSStream):
+    __reader__ = _TwitchHLSStreamReader
+
+
 class TestPluginTwitch(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
@@ -66,7 +78,7 @@ class TestPluginTwitch(unittest.TestCase):
 
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))
 class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
-    __stream__ = TwitchHLSStream
+    __stream__ = _TwitchHLSStream
 
     def get_session(self, options=None, disable_ads=False, low_latency=False):
         session = super().get_session(options)
@@ -82,6 +94,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True)
         ], disable_ads=True, low_latency=False)
 
+        self.await_write(2)
         self.assertEqual(self.await_read(read_all=True), self.content(segments), "Doesn't filter out segments")
         self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
 
@@ -91,6 +104,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True)
         ], disable_ads=True, low_latency=False)
 
+        self.await_write(2)
         self.assertEqual(self.await_read(read_all=True), segments[1].content, "Filters out ad segments")
         self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
 
@@ -100,6 +114,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True)
         ], disable_ads=True, low_latency=False)
 
+        self.await_write(2)
         self.assertEqual(self.await_read(read_all=True), segments[1].content, "Filters out ad segments")
         self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
 
@@ -109,6 +124,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True)
         ], disable_ads=True, low_latency=False)
 
+        self.await_write(2)
         self.assertEqual(self.await_read(read_all=True), segments[1].content, "Filters out ad segments")
         self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
 
@@ -121,6 +137,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(4, [Segment(4), Segment(5)], end=True)
         ], disable_ads=True, low_latency=False)
 
+        self.await_write(6)
         self.assertEqual(
             self.await_read(read_all=True),
             self.content(segments, cond=lambda s: s.num >= 4),
@@ -141,6 +158,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(4, [Segment(4), Segment(5)], end=True)
         ], disable_ads=True, low_latency=False)
 
+        self.await_write(6)
         self.assertEqual(
             self.await_read(read_all=True),
             self.content(segments, cond=lambda s: s.num != 2 and s.num != 3),
@@ -159,6 +177,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(2, [Segment(2), Segment(3)], end=True)
         ], disable_ads=False, low_latency=False)
 
+        self.await_write(4)
         self.assertEqual(
             self.await_read(read_all=True),
             self.content(segments),
@@ -177,6 +196,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         self.assertEqual(2, self.session.options.get("hls-live-edge"))
         self.assertEqual(True, self.session.options.get("hls-segment-stream-data"))
 
+        self.await_write(6)
         self.assertEqual(
             self.await_read(read_all=True),
             self.content(segments, cond=lambda s: s.num >= 4),
@@ -198,6 +218,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         self.assertEqual(4, self.session.options.get("hls-live-edge"))
         self.assertEqual(False, self.session.options.get("hls-segment-stream-data"))
 
+        self.await_write(8)
         self.assertEqual(
             self.await_read(read_all=True),
             self.content(segments, cond=lambda s: s.num < 8),
@@ -217,6 +238,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         self.assertTrue(self.session.get_plugin_option("twitch", "low-latency"))
         self.assertFalse(self.session.get_plugin_option("twitch", "disable-ads"))
 
+        self.await_write(6)
         self.await_read(read_all=True)
         self.assertEqual(mock_log.info.mock_calls, [
             call("Low latency streaming (HLS live edge: 2)"),
@@ -231,6 +253,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(4, [Segment(4), Segment(5), Segment(6), Segment(7), SegmentPrefetch(8), SegmentPrefetch(9)], end=True)
         ], disable_ads=False, low_latency=True)
 
+        self.await_write(8)
         self.assertEqual(
             self.await_read(read_all=True),
             self.content(segments, cond=lambda s: s.num > 1),
@@ -250,6 +273,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(4, [Segment(4), Segment(5), Segment(6), Segment(7), SegmentPrefetch(8), SegmentPrefetch(9)], end=True)
         ], disable_ads=True, low_latency=True)
 
+        self.await_write(8)
         self.await_read(read_all=True)
         self.assertEqual(mock_log.info.mock_calls, [
             call("Will skip ad segments"),
@@ -265,6 +289,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             Playlist(4, [Segment(4), Segment(5), Segment(6), Segment(7)], end=True)
         ], disable_ads=True, low_latency=True)
 
+        self.await_write(6)
         self.await_read(read_all=True)
         self.assertEqual(mock_log.info.mock_calls, [
             call("Will skip ad segments"),

--- a/tests/streams/test_hls_filtered.py
+++ b/tests/streams/test_hls_filtered.py
@@ -40,11 +40,7 @@ class _TestSubjectHLSReader(HLSStreamReader):
 
 
 class _TestSubjectHLSStream(HLSStream):
-    def open(self):
-        reader = _TestSubjectHLSReader(self)
-        reader.open()
-
-        return reader
+    __reader__ = _TestSubjectHLSReader
 
 
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))


### PR DESCRIPTION
Fixes #3451 

Changes are split into two commits:

1. Replace static reference to the `HLSStreamReader` in `HLSStream.open()`
2. Fix HLS writer race conditions (see commit message)
   This explicitly awaits all writer calls in filtered HLS tests, like the Twitch HLS tests for example.

I've been running all HLS tests in a loop for almost an hour now without any failures, so I think this should be good.

```bash
while pytest -q tests/plugins/test_twitch.py tests/streams/test_hls.py tests/streams/test_hls_filtered.py; do true; done
```