### PR TITLE
build: include man page in wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,10 @@ jobs:
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
+          python -m pip install -r docs-requirements.txt
           python -m pip install --upgrade wheel twine
+      - name: Build man page
+        run: make --directory=docs man
       - name: Installer file name
         id: installer
         run: echo ::set-output name=filename::streamlink-$(python setup.py --version | sed 's/+/_/')

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from setuptools import find_packages, setup
 import versioneer
 
 
+data_files = []
 deps = [
     "requests>=2.21.0,<3.0",
     "isodate",
@@ -63,6 +64,19 @@ if is_wheel_for_windows():
     entry_points["gui_scripts"] = ["streamlinkw=streamlink_cli.main:main"]
 
 
+additional_files = [
+    ("share/man/man1", ["docs/_build/man/streamlink.1"])
+]
+
+for destdir, srcfiles in additional_files:
+    files = []
+    for srcfile in srcfiles:
+        if path.exists(srcfile):
+            files.append(srcfile)
+    if files:
+        data_files.append((destdir, files))
+
+
 setup(name="streamlink",
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
@@ -85,6 +99,7 @@ setup(name="streamlink",
       packages=find_packages("src"),
       package_dir={"": "src"},
       entry_points=entry_points,
+      data_files=data_files,
       install_requires=deps,
       test_suite="tests",
       python_requires=">=3.6, <4",


### PR DESCRIPTION
Resolves #1753 

This adds the man page, if it exists, to wheels via the `data_files` keyword:
https://setuptools.readthedocs.io/en/latest/references/keywords.html

The `data_files` keyword is marked as deprecated, but there doesn't seem to be another way of mapping files from one path to another in the distribution file. What it says about not being supported by wheels is wrong. `package_data` doesn't seem to work here without changing build scripts. At least I wasn't able to make it work.

`sdist` does not include any `data_files`.

Regarding the manpages themselves, it might be necessary on some systems to extend the `MANPATH` env var with `MANPATH="${XDG_DATA_HOME:-$HOME/.local/share}/man:$MANPATH"` so that it looks up man pages in `$XDG_DATA_HOME/man` (which defaults to `$HOME/.local/share/man`) too.

To validate the changes:
```
$ make --directory=docs clean
$ python setuptools.py bdist_wheel
$ unzip -l dist/streamlink-2.0.0+10.gc6a1806-py3-none-any.whl | grep share/man/man1/streamlink.1

$ make --directory=docs clean man
$ python setuptools.py bdist_wheel
$ unzip -l dist/streamlink-2.0.0+10.gc6a1806-py3-none-any.whl | grep share/man/man1/streamlink.1
    49409  2020-12-28 12:05   streamlink-2.0.0+10.gc6a1806.data/data/share/man/man1/streamlink.1
$ pip install ./dist/streamlink-2.0.0+10.gc6a1806-py3-none-any.whl
$ ls ~/.local/share/man/man1/streamlink.1 
/home/basti/.local/share/man/man1/streamlink.1
```