### PR TITLE
plugins.twitch: fix access_token on invalid inputs

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -304,11 +304,17 @@ class TwitchAPI:
                 "playerType": "embed"
             }
         }
-        subschema = {
-            "value": str,
-            "signature": str,
-            "__typename": "PlaybackAccessToken"
-        }
+        subschema = validate.any(None, validate.all(
+            {
+                "value": str,
+                "signature": str,
+                "__typename": "PlaybackAccessToken"
+            },
+            validate.union((
+                validate.get("signature"),
+                validate.get("value")
+            ))
+        ))
         return self.call_gql(request, schema=validate.Schema(
             {"data": validate.any(
                 validate.all(
@@ -320,11 +326,7 @@ class TwitchAPI:
                     validate.get("videoPlaybackAccessToken")
                 )
             )},
-            validate.get("data"),
-            validate.union((
-                validate.get("signature"),
-                validate.get("value")
-            ))
+            validate.get("data")
         ))
 
     def parse_token(self, tokenstr):
@@ -561,11 +563,8 @@ class Twitch(Plugin):
     def _access_token(self, is_live, channel_or_vod):
         try:
             sig, token = self.api.access_token(is_live, channel_or_vod)
-        except PluginError as err:
-            if "404 Client Error" in str(err):
-                raise NoStreamsError(self.url)
-            else:
-                raise
+        except (PluginError, TypeError):
+            raise NoStreamsError(self.url)
 
         try:
             restricted_bitrates = self.api.parse_token(token)


### PR DESCRIPTION
**master**
```
$ streamlink -l debug twitch.tv/xrdtcfyvghutyfcvgyh best
[cli][debug] OS:         Linux-5.10.3-1-git-x86_64-with-glibc2.32
[cli][debug] Python:     3.9.1
[cli][debug] Streamlink: 2.0.0+9.g009bbd8
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.57.0)
[cli][info] Found matching plugin twitch for URL twitch.tv/xrdtcfyvghutyfcvgyh
[plugins.twitch][debug] Getting live HLS streams for xrdtcfyvghutyfcvgyh
error: Unable to validate JSON: Unable to validate key 'data': Unable to validate key 'streamPlaybackAccessToken': Type of None should be 'dict' but is 'NoneType' or Key 'videoPlaybackAccessToken' not found in {'streamPlaybackAccessToken': None}
```

**fix**
```
$ streamlink -l debug twitch.tv/xrdtcfyvghutyfcvgyh best
[cli][debug] OS:         Linux-5.10.3-1-git-x86_64-with-glibc2.32
[cli][debug] Python:     3.9.1
[cli][debug] Streamlink: 2.0.0+10.g916605b
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.57.0)
[cli][info] Found matching plugin twitch for URL twitch.tv/xrdtcfyvghutyfcvgyh
[plugins.twitch][debug] Getting live HLS streams for xrdtcfyvghutyfcvgyh
error: No playable streams found on this URL: twitch.tv/xrdtcfyvghutyfcvgyh
```