### PR TITLE
docs: bump furo docs req to 2020.12.28.beta23

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,3 @@
 sphinx>=3.0
-furo==2020.12.09.beta21
+furo==2020.12.28.beta23
 recommonmark>=0.5.0


### PR DESCRIPTION
No big changes here.
https://github.com/pradyunsg/furo/blob/2020.12.28.beta23/docs/changelog.md

I'm just using this one to test the netlify integration, as it changes the `docs-requirements.txt` file which should trigger a docs preview build.