### PR TITLE
docs: add thank-you section to index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,16 @@ User guide
 Streamlink is made up of two parts, a :ref:`cli <cli:Command-Line Interface>` and a library :ref:`API <api:API Reference>`.
 See their respective sections for more information on how to use them.
 
+Thank you
+---------
+
+- `Github <https://github.com/>`_, for hosting the git repo, docs, release assets and providing CI tools
+- `Netlify <https://netlify.com/>`_, for hosting docs preview builds
+
+
+Table of contents
+-----------------
+
 .. toctree::
     :maxdepth: 2
 


### PR DESCRIPTION
As mentioned in #3420, a link to netlify.com on the index page is required for being able to apply to their "open source" plan, which enables us having multiple maintainer accounts. The other benefits of this plan-upgrade are not really relevant to us.
https://www.netlify.com/legal/open-source-policy/

If there's more to add here or if you think that this should be reworded, please post a suggestion.