### PR TITLE
plugins.bfmtv : fix rmcstory and rmcdecouverte

### DIFF
--- a/src/streamlink/plugins/bfmtv.py
+++ b/src/streamlink/plugins/bfmtv.py
@@ -14,6 +14,10 @@ class BFMTV(Plugin):
         r'accountid="(?P<account_id>[0-9]+).*?videoid="(?P<video_id>[0-9]+)"',
         re.DOTALL
     )
+    _brightcove_video_alt_re = re.compile(
+        r'data-account="(?P<account_id>[0-9]+).*?data-video-id="(?P<video_id>[0-9]+)"',
+        re.DOTALL
+    )
     _embed_video_id_re = re.compile(
         r'<iframe.*?src=".*?/(?P<video_id>\w+)"',
         re.DOTALL
@@ -26,7 +30,7 @@ class BFMTV(Plugin):
     def _get_streams(self):
         # Retrieve URL page and search for Brightcove video data
         res = self.session.http.get(self.url)
-        match = self._brightcove_video_re.search(res.text)
+        match = self._brightcove_video_re.search(res.text) or self._brightcove_video_alt_re.search(res.text)
         if match is not None:
             account_id = match.group('account_id')
             log.debug(f'Account ID: {account_id}')


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

[RmcStory](https://rmcstory.bfmtv.com/mediaplayer-direct/) and RmcDecouverte were not working for me.

Looks like it is coming for this modification : https://github.com/streamlink/streamlink/pull/3290

I just added back the second regex for getting the brightcove player id. 

