### PR TITLE
plugins.facebook: Add 'Log into Facebook' error message.

### DIFF
--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -80,9 +80,16 @@ class Facebook(Plugin):
 
     def _get_streams(self):
         self.session.set_option("ffmpeg-start-at-zero", True)
+        self.session.http.headers.update({"Accept-Language": "en-US"})
 
         done = False
         res = self.session.http.get(self.url)
+        log.trace(f"{res.url}")
+        for title in itertags(res.text, "title"):
+            if title.text.startswith("Log into Facebook"):
+                log.error("Video is not available, You must log in to continue.")
+                return
+
         for s in self._parse_streams(res):
             done = True
             yield s


### PR DESCRIPTION
```
$ streamlink https://www.facebook.com/FranceRugby/posts/3017597365007921
[cli][info] Found matching plugin facebook for URL https://www.facebook.com/FranceRugby/posts/3017597365007921
[plugins.facebook][error] Video is not available, You must log in to continue.
error: No playable streams found on this URL: https://www.facebook.com/FranceRugby/posts/3017597365007921
```

closes https://github.com/streamlink/streamlink/issues/3480