### PR TITLE
session: implement --interface, --ipv4 and --ipv6

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -303,6 +303,28 @@ def build_parser():
         Default is system locale.
         """
     )
+    general.add_argument(
+        "--interface",
+        type=str,
+        metavar="INTERFACE",
+        help="""
+        Set the network interface.
+        """
+    )
+    general.add_argument(
+        "-4", "--ipv4",
+        action="store_true",
+        help="""
+        Resolve address names to IPv4 only. This option overrides :option:`-6`.
+        """
+    )
+    general.add_argument(
+        "-6", "--ipv6",
+        action="store_true",
+        help="""
+        Resolve address names to IPv6 only. This option overrides :option:`-4`.
+        """
+    )
 
     player = parser.add_argument_group("Player options")
     player.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -751,6 +751,15 @@ def setup_streamlink():
 
 def setup_options():
     """Sets Streamlink options."""
+    if args.interface:
+        streamlink.set_option("interface", args.interface)
+
+    if args.ipv4:
+        streamlink.set_option("ipv4", args.ipv4)
+
+    if args.ipv6:
+        streamlink.set_option("ipv6", args.ipv6)
+
     if args.hls_live_edge:
         streamlink.set_option("hls-live-edge", args.hls_live_edge)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,9 @@
 import os
 import unittest
-from unittest.mock import call, patch
+from socket import AF_INET, AF_INET6
+from unittest.mock import Mock, call, patch
+
+from requests.packages.urllib3.util.connection import allowed_gai_family
 
 from streamlink import NoPluginError, Streamlink
 from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY
@@ -191,6 +194,66 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session.localization.country.alpha2, "US")
         self.assertEqual(session.localization.language.alpha2, "en")
         self.assertEqual(session.localization.language_code, "en_US")
+
+    @patch("streamlink.session.api")
+    def test_interface(self, mock_api):
+        adapter_http = Mock(poolmanager=Mock(connection_pool_kw={}))
+        adapter_https = Mock(poolmanager=Mock(connection_pool_kw={}))
+        adapter_foo = Mock(poolmanager=Mock(connection_pool_kw={}))
+        mock_api.HTTPSession.return_value = Mock(adapters={
+            "http://": adapter_http,
+            "https://": adapter_https,
+            "foo://": adapter_foo
+        })
+        session = self.subject(load_plugins=False)
+        self.assertEqual(session.get_option("interface"), None)
+
+        session.set_option("interface", "my-interface")
+        self.assertEqual(adapter_http.poolmanager.connection_pool_kw, {"source_address": ("my-interface", 0)})
+        self.assertEqual(adapter_https.poolmanager.connection_pool_kw, {"source_address": ("my-interface", 0)})
+        self.assertEqual(adapter_foo.poolmanager.connection_pool_kw, {})
+        self.assertEqual(session.get_option("interface"), "my-interface")
+
+        session.set_option("interface", None)
+        self.assertEqual(adapter_http.poolmanager.connection_pool_kw, {})
+        self.assertEqual(adapter_https.poolmanager.connection_pool_kw, {})
+        self.assertEqual(adapter_foo.poolmanager.connection_pool_kw, {})
+        self.assertEqual(session.get_option("interface"), None)
+
+    @patch("streamlink.session.urllib3_connection", allowed_gai_family=allowed_gai_family)
+    def test_ipv4_ipv6(self, mock_urllib3_connection):
+        session = self.subject(load_plugins=False)
+        self.assertEqual(session.get_option("ipv4"), False)
+        self.assertEqual(session.get_option("ipv6"), False)
+        self.assertEqual(mock_urllib3_connection.allowed_gai_family, allowed_gai_family)
+
+        session.set_option("ipv4", True)
+        self.assertEqual(session.get_option("ipv4"), True)
+        self.assertEqual(session.get_option("ipv6"), False)
+        self.assertNotEqual(mock_urllib3_connection.allowed_gai_family, allowed_gai_family)
+        self.assertEqual(mock_urllib3_connection.allowed_gai_family(), AF_INET)
+
+        session.set_option("ipv4", False)
+        self.assertEqual(session.get_option("ipv4"), False)
+        self.assertEqual(session.get_option("ipv6"), False)
+        self.assertEqual(mock_urllib3_connection.allowed_gai_family, allowed_gai_family)
+
+        session.set_option("ipv6", True)
+        self.assertEqual(session.get_option("ipv4"), False)
+        self.assertEqual(session.get_option("ipv6"), True)
+        self.assertNotEqual(mock_urllib3_connection.allowed_gai_family, allowed_gai_family)
+        self.assertEqual(mock_urllib3_connection.allowed_gai_family(), AF_INET6)
+
+        session.set_option("ipv6", False)
+        self.assertEqual(session.get_option("ipv4"), False)
+        self.assertEqual(session.get_option("ipv6"), False)
+        self.assertEqual(mock_urllib3_connection.allowed_gai_family, allowed_gai_family)
+
+        session.set_option("ipv4", True)
+        session.set_option("ipv6", False)
+        self.assertEqual(session.get_option("ipv4"), True)
+        self.assertEqual(session.get_option("ipv6"), False)
+        self.assertEqual(mock_urllib3_connection.allowed_gai_family, allowed_gai_family)
 
     def test_https_proxy_default(self):
         session = self.subject(load_plugins=False)


### PR DESCRIPTION
Resolves #3474 
Resolves #2192

Implements `--interface`, `-4`/`--ipv4` and `-6`/`--ipv6`, similar to curl.

**Concerns**
- What I don't like about this implementation is that it overrides the address family resolving in `requests.packages.urllib3.util.connection` globally, as it's not session based. This means that when someone creates two sessions from the API and sets the `ipv4` or `ipv6` option, all other sessions will be affected as well.
- This does only affect HTTP/HTTPS connections. Web sockets for example are currently all managed individually in certain plugins. The implementation of a common WSSession similar to the HTTPSession would fix this.
- Not sure if the "general" arguments group is the correct choice. Technically it could also go into the "transport" arguments group.

----

**Examples**

Default interface:
```bash
$ streamlink -l none -o /dev/null twitch.tv/gamesdonequick best &
$ ss -npt | awk '/streamlink/ {print $4; exit}'
192.168.178.99:33253
```

Second interface:
```bash
$ streamlink -l none -o /dev/null twitch.tv/gamesdonequick best --interface 192.168.100.1 &
$ ss -npt | awk '/streamlink/ {print $4; exit}'
192.168.100.1:43101
```

Invalid interface:
```bash
$ streamlink -l none -o /dev/null twitch.tv/gamesdonequick best --interface 1.2.3.4
error: No playable streams found on this URL: twitch.tv/gamesdonequick
```

Automatic address family resolving:
```bash
$ streamlink -l none -o /dev/null 'youtube.com/watch?v=xcJtL7QggTI' best &
$ ss -npt | awk '/streamlink/ {print $5; exit}'
[2a00:1450:4001:819::200e]:443
```

IPv4 resolving:
```bash
$ streamlink -l none -o /dev/null 'youtube.com/watch?v=xcJtL7QggTI' best --ipv4 &
$ ss -npt | awk '/streamlink/ {print $5; exit}'
74.125.126.91:443
```

IPv6 resolving (IPv4-only example):
```bash
$ streamlink -l none -o /dev/null twitch.tv/gamesdonequick best --ipv6
error: No playable streams found on this URL: twitch.tv/gamesdonequick
```