### PR TITLE
utils: remove custom memoize decorator

### DIFF
--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -1,13 +1,13 @@
 import json
 import logging
 import re
+from functools import lru_cache
 from urllib.parse import parse_qsl, urlparse
 
 from streamlink import PluginError
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
-from streamlink.utils import memoize
 from streamlink.utils.times import seconds_to_hhmmss
 
 log = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ class WWENetwork(Plugin):
         return self.auth_token
 
     @property
-    @memoize
+    @lru_cache(maxsize=128)
     def item_config(self):
         log.debug("Loading page config")
         p = urlparse(self.url)

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -1,6 +1,7 @@
 import logging
 import pkgutil
 from collections import OrderedDict
+from functools import lru_cache
 
 import requests
 
@@ -10,7 +11,7 @@ from streamlink.exceptions import NoPluginError, PluginError
 from streamlink.logger import StreamlinkLogger
 from streamlink.options import Options
 from streamlink.plugin import Plugin, api
-from streamlink.utils import load_module, memoize, update_scheme
+from streamlink.utils import load_module, update_scheme
 from streamlink.utils.l10n import Localization
 
 # Ensure that the Logger class returned is Streamslink's for using the API (for backwards compatibility)
@@ -337,7 +338,7 @@ class Streamlink:
             plugin = self.plugins[plugin]
             return plugin.get_option(key)
 
-    @memoize
+    @lru_cache(maxsize=128)
     def resolve_url(self, url, follow_redirect=True):
         """Attempts to find a plugin that can use this URL.
 

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -1,4 +1,3 @@
-import functools
 import json
 import re
 import xml.etree.ElementTree as ET
@@ -149,18 +148,6 @@ def rtmpparse(url):
                                                app=app)
 
     return tcurl, playpath
-
-
-def memoize(obj):
-    cache = obj.cache = {}
-
-    @functools.wraps(obj)
-    def memoizer(*args, **kwargs):
-        key = str(args) + str(kwargs)
-        if key not in cache:
-            cache[key] = obj(*args, **kwargs)
-        return cache[key]
-    return memoizer
 
 
 def search_dict(data, key):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -68,6 +68,7 @@ class TestSession(unittest.TestCase):
         plugin = session.resolve_url("http://test.se/channel")
         self.assertTrue(isinstance(plugin, Plugin))
         self.assertTrue(isinstance(plugin, plugins["testplugin"]))
+        self.assertTrue(hasattr(session.resolve_url, "cache_info"), "resolve_url has a lookup cache")
 
     def test_resolve_url_priority(self):
         from tests.plugin.testplugin import TestPlugin


### PR DESCRIPTION
This replaces the custom `memoize` decorator in favor of the native [`functools.lru_cache`](https://docs.python.org/3/library/functools.html#functools.lru_cache) decorator (available since py 3.2).

Since I didn't set `maxsize=None`, this also changes the cache size of each decorated method, which was infinite prior to these changes and is now set to 128 with the LRU algorithm.

Not sure why I had to force-push and explicitly set `maxsize=128` on py `<3.8`, as it's the default there as well:
https://github.com/python/cpython/blob/3.7/Lib/functools.py#L458
https://github.com/python/cpython/blob/3.8/Lib/functools.py#L487