### PR TITLE
docs: remove CLI tutorial from man page

### DIFF
--- a/docs/_man.rst
+++ b/docs/_man.rst
@@ -1,0 +1,29 @@
+:orphan:
+
+
+Streamlink
+==========
+
+Synopsis
+--------
+
+.. code-block:: console
+
+   streamlink [OPTIONS] <URL> [STREAM]
+
+   streamlink --loglevel debug youtu.be/VIDEO-ID best
+   streamlink --player mpv --player-args '--no-border --no-keepaspect-window' twitch.tv/CHANNEL 1080p60
+   streamlink --player-external-http --player-external-http-port 8888 URL STREAM
+   streamlink --output /path/to/file --http-timeout 60 URL STREAM
+   streamlink --stdout URL STREAM | ffmpeg -i pipe:0 ...
+   streamlink --http-header 'Authorization=OAuth TOKEN' --http-header 'Referer=URL' URL STREAM
+   streamlink --hls-live-edge 5 --hls-segment-threads 5 'hls://https://host/playlist.m3u8' best
+   streamlink --twitch-low-latency -p mpv -a '--cache=yes --demuxer-max-bytes=750k' twitch.tv/CHANNEL best
+
+
+Options
+=======
+
+.. argparse::
+    :module: streamlink_cli.main
+    :attr: parser_helper

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,7 +182,7 @@ htmlhelp_basename = 'streamlinkdoc'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('cli', 'streamlink', 'extracts streams from various services and pipes them into a video player of choice', ['Streamlink Contributors'], 1)
+    ('_man', 'streamlink', 'extracts streams from various services and pipes them into a video player of choice', ['Streamlink Contributors'], 1)
 ]
 
 # If true, show URL addresses after external links.


### PR DESCRIPTION
and add synopsis with examples

----

I'd like to embed some sections from the CLI page in the man page, but that would require rewriting the CLI page and making it modular, so that the sections can be included without duplicating them. At least the tutorial does not get included with this PR.

The examples could probably be improved, so if you have suggestions, please tell.


```
$ make --directory=docs clean man
$ man ./docs/_build/man/streamlink.1
```