### PR TITLE
plugins.twitcasting: add support for private/password-protected streams

### DIFF
--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -1,5 +1,5 @@
-import logging
 import hashlib
+import logging
 import re
 from threading import Event, Thread
 from urllib.parse import unquote_plus, urlparse

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -12,6 +12,8 @@ from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginErr
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream.stream import Stream
 from streamlink.stream.stream import StreamIO
+from streamlink.utils.url import update_qsd
+
 
 log = logging.getLogger(__name__)
 
@@ -19,8 +21,9 @@ log = logging.getLogger(__name__)
 class TwitCasting(Plugin):
     arguments = PluginArguments(
         PluginArgument(
-            "twitcasting-password",
-            argument_name="twitcasting-password",
+            "password",
+            sensitive=True,
+            metavar="PASSWORD",
             help="Password for private Twitcasting streams."
         )
     )
@@ -75,11 +78,10 @@ class TwitCasting(Plugin):
 
         real_stream_url = self._STREAM_REAL_URL.format(proto=proto, host=host, movie_id=movie_id, mode=mode)
 
-        if self.options.get("twitcasting-password"):
-            password = self.options.get("twitcasting-password")
-            encrypted_password = hashlib.md5(password.encode()).hexdigest()
-
-            real_stream_url = real_stream_url + "&word=" + encrypted_password
+        password = self.options.get("password")
+        if password is not None:
+            password_hash = hashlib.md5(password.encode()).hexdigest()
+            real_stream_url = update_qsd(real_stream_url, {"word": password_hash})
 
         log.debug("Real stream url: {}".format(real_stream_url))
 


### PR DESCRIPTION
### Description
Add a `--twitcasting-password` option to the TwitCasting plugin, supporting private (password-protected) TwitCasting streams.

closes #3504

### How it works
If the command line option is used, then we append `&word={md5_encrypted_password}` to `real_stream_url`.

### How to test
You can easily start a livestream from Twitcasting by hovering the blue "Broadcast" button at the top right of the site then clicking "Web broadcasting". Scroll down to set a password then back up to start an audio-only livestream. If you do not have an account, you can quickly login with a Twitter or Facebook account if you have one.

This is my first ever pull request, in a language I have essentially no experience with. I hope everything is OK.