### PR TITLE
build: include man page in sdist tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,5 +11,7 @@ recursive-include examples *
 recursive-include tests *
 
 prune docs/_build
+include docs/_build/man/*
+
 prune */__pycache__
 global-exclude *.pyc *~ *.bak *.swp *.pyo


### PR DESCRIPTION
Resolves #3507 

This adds the man page to the sdist tarballs by white-listing the man page build path. It can be found here now:
`docs/_build/man/streamlink.1`

Due to the white-listing, the man page gets included twice (same path though), first by the `recursive-include docs *` pattern in the manifest, and second by the `data_files` field in `setup.py` (which was added by #3459 for the `bdist` target).

I would have preferred having the man page in the tarball's root directory or in `share/man/man.1/`, like the wheels, but that would have required copying the file via `script/build-and-sign.sh` first and deleting it again afterwards. Unfortunately, the `data_files` field which moves the man page to `share/man/man.1/` in the wheels doesn't work with distutil's `sdist` command, and it simply ignores the path override, as you can see here:
https://github.com/python/cpython/blob/v3.9.1/Lib/distutils/command/sdist.py#L304-L307

```bash
$ python setup.py sdist
$ tar -tzf dist/streamlink-2.0.0+25.g815262d.tar.gz | grep 'streamlink.1'
streamlink-2.0.0+25.g815262d/docs/_build/man/streamlink.1
```

On the CI side, everything is already in place from the bdist-manpage PR:
- https://github.com/streamlink/streamlink/blob/c5791f75c3f38cdd90090eb88b3ce66de0c56ae5/.github/workflows/main.yml#L155-L156
- https://github.com/streamlink/streamlink/blob/c5791f75c3f38cdd90090eb88b3ce66de0c56ae5/.github/workflows/main.yml#L165-L168