### PR TITLE
utils/l10n: fix langs without alpha_2 in pycountry

### DIFF
--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -1,6 +1,5 @@
 import locale
 import logging
-import re
 
 
 try:
@@ -68,9 +67,19 @@ class Language:
     def get(cls, language):
         try:
             if PYCOUNTRY:
-                # lookup workaround for alpha_2 language codes
-                lang = languages.get(alpha_2=language) if re.match(r"^[a-z]{2}$", language) else languages.lookup(language)
-                return Language(lang.alpha_2, lang.alpha_3, lang.name, getattr(lang, "bibliographic", None))
+                lang = (languages.get(alpha_2=language)
+                        or languages.get(alpha_3=language)
+                        or languages.get(bibliographic=language)
+                        or languages.get(name=language))
+                if not lang:
+                    raise KeyError(language)
+                return Language(
+                    # some languages don't have an alpha_2 code
+                    getattr(lang, "alpha_2", ""),
+                    lang.alpha_3,
+                    lang.name,
+                    getattr(lang, "bibliographic", "")
+                )
             else:
                 lang = None
                 if len(language) == 2:

--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -109,6 +109,14 @@ class LocalizationTestsMixin:
         b = l10n.Language("AA", None, "Test")
         self.assertNotEqual(a, b)
 
+    # issue #3517: language lookups without alpha2 but with alpha3 codes should not raise
+    def test_language_a3_no_a2(self):
+        a = l10n.Localization.get_language("des")
+        self.assertEqual(a.alpha2, "")
+        self.assertEqual(a.alpha3, "des")
+        self.assertEqual(a.name, "Desano")
+        self.assertEqual(a.bibliographic, "")
+
 
 @unittest.skipIf(not ISO639, "iso639+iso3166 modules are required to test iso639+iso3166 Localization")
 class TestLocalization(LocalizationTestsMixin, unittest.TestCase):
@@ -131,3 +139,14 @@ class TestLocalizationPyCountry(LocalizationTestsMixin, unittest.TestCase):
 
     def test_pycountry(self):
         self.assertEqual(True, l10n.PYCOUNTRY)
+
+    # issue #3057: generic "en" lookups via pycountry yield the "En" language, but not "English"
+    def test_language_en(self):
+        english_a = l10n.Localization.get_language("en")
+        english_b = l10n.Localization.get_language("eng")
+        english_c = l10n.Localization.get_language("English")
+        for lang in [english_a, english_b, english_c]:
+            self.assertEqual(lang.alpha2, "en")
+            self.assertEqual(lang.alpha3, "eng")
+            self.assertEqual(lang.name, "English")
+            self.assertEqual(lang.bibliographic, "")


### PR DESCRIPTION
Fixes #3517

1. Replaces pycountry's generic `languages.lookup` call with several `languages.get(attr=language)` calls, where `attr` is `alpha_2`, `alpha_3`, `bibliographic` and `name`, in this order. Other attributes are probably not relevant for Streamlink. `.get` calls don't raise and just return `None` if the lookup fails. The order of attribute lookups prevents issue #3057, where `language.lookup("en")` would return the "En" language instead of "English".
2. To prevent the `AttributeError` from being raised when certain optional language attributes are missing, like `alpha_2` for example, those will be read via `getattr` with an empty string as fallback (instead of `None`), which matches the data representation of `iso639`. `alpha_3` and `name` attributes always exist.

```bash
curl -sSL 'https://raw.githubusercontent.com/flyingcircusio/pycountry/20.7.3/src/pycountry/databases/iso639-3.json' \
  | jq '.["639-3"][] | select(.alpha_3 == "des")'
```
```json
{
  "alpha_3": "des",
  "name": "Desano",
  "scope": "I",
  "type": "L"
}
```