### PR TITLE
tests.plugins: parametrize can_handle_url tests 

### DIFF
--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -10,7 +10,7 @@ from streamlink.utils import parse_json, verifyjson
 log = logging.getLogger(__name__)
 
 
-class ard_live(Plugin):
+class ARDLive(Plugin):
     _url_re = re.compile(r"https?://((www|live)\.)?daserste\.de/")
     _player_re = re.compile(r'''data-ctrl-player\s*=\s*"(?P<jsondata>.*?)"''')
     _player_url_schema = validate.Schema(
@@ -78,4 +78,4 @@ class ard_live(Plugin):
                         log.error("Unexpected stream type: '{0}'".format(stream_))
 
 
-__plugin__ = ard_live
+__plugin__ = ARDLive

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -31,7 +31,7 @@ _media_schema = validate.Schema({
 log = logging.getLogger(__name__)
 
 
-class ard_mediathek(Plugin):
+class ARDMediathek(Plugin):
     @classmethod
     def can_handle_url(cls, url):
         return _url_re.match(url) is not None
@@ -86,4 +86,4 @@ class ard_mediathek(Plugin):
                     log.error("Failed to extract {0} streams: {1}".format(parser_name, err))
 
 
-__plugin__ = ard_mediathek
+__plugin__ = ARDMediathek

--- a/src/streamlink/plugins/rtlxl.py
+++ b/src/streamlink/plugins/rtlxl.py
@@ -7,7 +7,7 @@ from streamlink.stream import HLSStream
 _url_re = re.compile(r"http(?:s)?://(?:\w+\.)?rtl.nl/video/(?P<uuid>.*?)\Z", re.IGNORECASE)
 
 
-class rtlxl(Plugin):
+class RTLxl(Plugin):
     @classmethod
     def can_handle_url(cls, url):
         return _url_re.match(url)
@@ -25,4 +25,4 @@ class rtlxl(Plugin):
         return HLSStream.parse_variant_playlist(self.session, playlist_url)
 
 
-__plugin__ = rtlxl
+__plugin__ = RTLxl

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -83,7 +83,7 @@ _schema = validate.Schema(
 )
 
 
-class zdf_mediathek(Plugin):
+class ZDFMediathek(Plugin):
     @classmethod
     def can_handle_url(cls, url):
         return _url_re.match(url)
@@ -157,4 +157,4 @@ class zdf_mediathek(Plugin):
         return streams
 
 
-__plugin__ = zdf_mediathek
+__plugin__ = ZDFMediathek

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,0 +1,27 @@
+from streamlink.plugin import Plugin
+
+
+generic_negative_matches = [
+    "http://example.com/",
+    "https://example.com/",
+    "https://example.com/index.html",
+]
+
+
+class PluginCanHandleUrl:
+    __plugin__ = None
+
+    should_match = []
+    should_not_match = []
+
+    def test_class_setup(self):
+        assert issubclass(self.__plugin__, Plugin), "Test has a __plugin__ that is a subclass of streamlink.plugin.Plugin"
+        assert len(self.should_match) > 0, "Test has at least one positive URL"
+
+    # parametrized dynamically via conftest.py
+    def test_can_handle_url_positive(self, url):
+        assert self.__plugin__.can_handle_url(url), "URL matches"
+
+    # parametrized dynamically via conftest.py
+    def test_can_handle_url_negative(self, url):
+        assert not self.__plugin__.can_handle_url(url), "URL does not match"

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,0 +1,9 @@
+from tests.plugins import PluginCanHandleUrl, generic_negative_matches
+
+
+def pytest_generate_tests(metafunc):
+    if issubclass(metafunc.cls, PluginCanHandleUrl):  # pragma: no branch
+        if metafunc.function.__name__ == "test_can_handle_url_positive":
+            metafunc.parametrize("url", metafunc.cls.should_match)
+        elif metafunc.function.__name__ == "test_can_handle_url_negative":
+            metafunc.parametrize("url", metafunc.cls.should_not_match + generic_negative_matches)

--- a/tests/plugins/test_abematv.py
+++ b/tests/plugins/test_abematv.py
@@ -1,30 +1,26 @@
-import unittest
-
 from streamlink.plugins.abematv import AbemaTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginAbemaTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://abema.tv/now-on-air/abema-news',
-            'https://abema.tv/video/episode/90-1053_s99_p12',
-            'https://abema.tv/channels/everybody-anime/slots/FJcUsdYjTk1rAb',
-            'https://abema.tv/now-on-air/abema-news?a=b&c=d',
-            'https://abema.tv/video/episode/90-1053_s99_p12?a=b&c=d',
-            'https://abema.tv/channels/abema-anime/slots/9rTULtcJFiFmM9?a=b'
-        ]
-        for url in should_match:
-            self.assertTrue(AbemaTV.can_handle_url(url))
+class TestPluginCanHandleUrlAbemaTV(PluginCanHandleUrl):
+    __plugin__ = AbemaTV
 
-        should_not_match = [
-            'http://abema.tv/now-on-air/abema-news',
-            'http://www.abema.tv/now-on-air/abema-news',
-            'https://www.abema.tv/now-on-air/abema-news',
-            'https://www.abema.tv/now-on-air/',
-            'https://abema.tv/timetable',
-            'https://abema.tv/video',
-            'https://abema.tv/video/title/13-47',
-            'https://abema.tv/video/title/13-47?a=b'
-        ]
-        for url in should_not_match:
-            self.assertFalse(AbemaTV.can_handle_url(url))
+    should_match = [
+        'https://abema.tv/now-on-air/abema-news',
+        'https://abema.tv/video/episode/90-1053_s99_p12',
+        'https://abema.tv/channels/everybody-anime/slots/FJcUsdYjTk1rAb',
+        'https://abema.tv/now-on-air/abema-news?a=b&c=d',
+        'https://abema.tv/video/episode/90-1053_s99_p12?a=b&c=d',
+        'https://abema.tv/channels/abema-anime/slots/9rTULtcJFiFmM9?a=b'
+    ]
+
+    should_not_match = [
+        'http://abema.tv/now-on-air/abema-news',
+        'http://www.abema.tv/now-on-air/abema-news',
+        'https://www.abema.tv/now-on-air/abema-news',
+        'https://www.abema.tv/now-on-air/',
+        'https://abema.tv/timetable',
+        'https://abema.tv/video',
+        'https://abema.tv/video/title/13-47',
+        'https://abema.tv/video/title/13-47?a=b'
+    ]

--- a/tests/plugins/test_abweb.py
+++ b/tests/plugins/test_abweb.py
@@ -1,22 +1,17 @@
-import unittest
-
 from streamlink.plugins.abweb import ABweb
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginABweb(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.abweb.com/bis-tv-online/bistvo-tele-universal.aspx?chn=ab1',
-            'http://www.abweb.com/BIS-TV-Online/bistvo-tele-universal.aspx?chn=ab1',
-            'http://www.abweb.com/BIS-TV-Online/bistvo-tele-universal.aspx?chn=luckyjack',
-            'https://www.abweb.com/BIS-TV-Online/bistvo-tele-universal.aspx?chn=action',
-        ]
-        for url in should_match:
-            self.assertTrue(ABweb.can_handle_url(url), url)
+class TestPluginCanHandleUrlABweb(PluginCanHandleUrl):
+    __plugin__ = ABweb
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.abweb.com',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ABweb.can_handle_url(url), url)
+    should_match = [
+        'http://www.abweb.com/bis-tv-online/bistvo-tele-universal.aspx?chn=ab1',
+        'http://www.abweb.com/BIS-TV-Online/bistvo-tele-universal.aspx?chn=ab1',
+        'http://www.abweb.com/BIS-TV-Online/bistvo-tele-universal.aspx?chn=luckyjack',
+        'https://www.abweb.com/BIS-TV-Online/bistvo-tele-universal.aspx?chn=action',
+    ]
+
+    should_not_match = [
+        'http://www.abweb.com',
+    ]

--- a/tests/plugins/test_adultswim.py
+++ b/tests/plugins/test_adultswim.py
@@ -1,24 +1,15 @@
-import unittest
-
 from streamlink.plugins.adultswim import AdultSwim
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginAdultSwim(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.adultswim.com/streams",
-            "http://www.adultswim.com/streams/",
-            "https://www.adultswim.com/streams/infomercials",
-            "https://www.adultswim.com/streams/last-stream-on-the-left-channel/",
-            "https://www.adultswim.com/videos/as-seen-on-adult-swim/wednesday-march-18th-2020",
-            "https://www.adultswim.com/videos/fishcenter-live/wednesday-april-29th-2020/"
-        ]
-        for url in should_match:
-            self.assertTrue(AdultSwim.can_handle_url(url))
+class TestPluginCanHandleUrlAdultSwim(PluginCanHandleUrl):
+    __plugin__ = AdultSwim
 
-        should_not_match = [
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(AdultSwim.can_handle_url(url))
+    should_match = [
+        "http://www.adultswim.com/streams",
+        "http://www.adultswim.com/streams/",
+        "https://www.adultswim.com/streams/infomercials",
+        "https://www.adultswim.com/streams/last-stream-on-the-left-channel/",
+        "https://www.adultswim.com/videos/as-seen-on-adult-swim/wednesday-march-18th-2020",
+        "https://www.adultswim.com/videos/fishcenter-live/wednesday-april-29th-2020/"
+    ]

--- a/tests/plugins/test_afreeca.py
+++ b/tests/plugins/test_afreeca.py
@@ -1,25 +1,21 @@
-import unittest
-
 from streamlink.plugins.afreeca import AfreecaTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginAfreecaTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://play.afreecatv.com/exampleuser",
-            "http://play.afreecatv.com/exampleuser/123123123",
-            "https://play.afreecatv.com/exampleuser",
-        ]
-        for url in should_match:
-            self.assertTrue(AfreecaTV.can_handle_url(url))
+class TestPluginCanHandleUrlAfreecaTV(PluginCanHandleUrl):
+    __plugin__ = AfreecaTV
 
-        should_not_match = [
-            "http://afreeca.com/exampleuser",
-            "http://afreeca.com/exampleuser/123123123",
-            "http://afreecatv.com/exampleuser",
-            "http://afreecatv.com/exampleuser/123123123",
-            "http://www.afreecatv.com.tw",
-            "http://www.afreecatv.jp",
-        ]
-        for url in should_not_match:
-            self.assertFalse(AfreecaTV.can_handle_url(url))
+    should_match = [
+        "http://play.afreecatv.com/exampleuser",
+        "http://play.afreecatv.com/exampleuser/123123123",
+        "https://play.afreecatv.com/exampleuser",
+    ]
+
+    should_not_match = [
+        "http://afreeca.com/exampleuser",
+        "http://afreeca.com/exampleuser/123123123",
+        "http://afreecatv.com/exampleuser",
+        "http://afreecatv.com/exampleuser/123123123",
+        "http://www.afreecatv.com.tw",
+        "http://www.afreecatv.jp",
+    ]

--- a/tests/plugins/test_albavision.py
+++ b/tests/plugins/test_albavision.py
@@ -1,32 +1,26 @@
-import unittest  # noqa: F401
-
-import pytest
+import unittest
 
 from streamlink.plugins.albavision import Albavision
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginAlbavision:
-    valid_urls = [
-        ("https://www.elnueve.com.ar/en-vivo",),
-        ("http://www.rts.com.ec/envivo",),
-        ("https://www.tvc.com.ec/envivo",),
-        ("http://www.atv.pe/envivo/ATV",),
-        ("http://www.atv.pe/envivo/ATVMas",),
+class TestPluginCanHandleUrlAlbavision(PluginCanHandleUrl):
+    __plugin__ = Albavision
+
+    should_match = [
+        "https://www.elnueve.com.ar/en-vivo",
+        "http://www.rts.com.ec/envivo",
+        "https://www.tvc.com.ec/envivo",
+        "http://www.atv.pe/envivo/ATV",
+        "http://www.atv.pe/envivo/ATVMas",
     ]
-    invalid_urls = [
-        ("https://news.now.com/home/local",),
-        ("http://media.now.com.hk/",),
-        ("https://www.youtube.com",)
+    should_not_match = [
+        "https://news.now.com/home/local",
+        "http://media.now.com.hk/",
     ]
 
-    @pytest.mark.parametrize(["url"], valid_urls)
-    def test_can_handle_url(self, url):
-        assert Albavision.can_handle_url(url), "url should be handled"
 
-    @pytest.mark.parametrize(["url"], invalid_urls)
-    def test_can_handle_url_negative(self, url):
-        assert not Albavision.can_handle_url(url), "url should not be handled"
-
+class TestPluginAlbavision(unittest.TestCase):
     def test_transform(self):
         token = Albavision.transform_token("6b425761cc8a86569b1a05a9bf1870c95fca717dOK", 436171)
         assert token == "6b425761cc8a86569b1a05a9bf1870c95fca717d"

--- a/tests/plugins/test_animelab.py
+++ b/tests/plugins/test_animelab.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.animelab import AnimeLab
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginAnimeLab(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.animelab.com/player/123',
-            'https://animelab.com/player/123',
-        ]
-        for url in should_match:
-            self.assertTrue(AnimeLab.can_handle_url(url))
+class TestPluginCanHandleUrlAnimeLab(PluginCanHandleUrl):
+    __plugin__ = AnimeLab
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(AnimeLab.can_handle_url(url))
+    should_match = [
+        'https://www.animelab.com/player/123',
+        'https://animelab.com/player/123',
+    ]

--- a/tests/plugins/test_app17.py
+++ b/tests/plugins/test_app17.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.app17 import App17
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginApp17(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://17.live/live/123123',
-        ]
-        for url in should_match:
-            self.assertTrue(App17.can_handle_url(url))
+class TestPluginCanHandleUrlApp17(PluginCanHandleUrl):
+    __plugin__ = App17
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(App17.can_handle_url(url))
+    should_match = [
+        'https://17.live/live/123123',
+    ]

--- a/tests/plugins/test_ard_live.py
+++ b/tests/plugins/test_ard_live.py
@@ -1,20 +1,15 @@
-import unittest
-
 from streamlink.plugins.ard_live import ARDLive
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginARDLive(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://daserste.de/live/index.html',
-            'https://www.daserste.de/live/index.html',
-        ]
-        for url in should_match:
-            self.assertTrue(ARDLive.can_handle_url(url))
+class TestPluginCanHandleUrlARDLive(PluginCanHandleUrl):
+    __plugin__ = ARDLive
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://mediathek.daserste.de/live',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ARDLive.can_handle_url(url))
+    should_match = [
+        'https://daserste.de/live/index.html',
+        'https://www.daserste.de/live/index.html',
+    ]
+
+    should_not_match = [
+        'http://mediathek.daserste.de/live',
+    ]

--- a/tests/plugins/test_ard_live.py
+++ b/tests/plugins/test_ard_live.py
@@ -1,20 +1,20 @@
 import unittest
 
-from streamlink.plugins.ard_live import ard_live
+from streamlink.plugins.ard_live import ARDLive
 
 
-class TestPluginard_live(unittest.TestCase):
+class TestPluginARDLive(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
             'https://daserste.de/live/index.html',
             'https://www.daserste.de/live/index.html',
         ]
         for url in should_match:
-            self.assertTrue(ard_live.can_handle_url(url))
+            self.assertTrue(ARDLive.can_handle_url(url))
 
     def test_can_handle_url_negative(self):
         should_not_match = [
             'http://mediathek.daserste.de/live',
         ]
         for url in should_not_match:
-            self.assertFalse(ard_live.can_handle_url(url))
+            self.assertFalse(ARDLive.can_handle_url(url))

--- a/tests/plugins/test_ard_mediathek.py
+++ b/tests/plugins/test_ard_mediathek.py
@@ -1,16 +1,16 @@
 import unittest
 
-from streamlink.plugins.ard_mediathek import ard_mediathek
+from streamlink.plugins.ard_mediathek import ARDMediathek
 
 
-class TestPluginard_mediathek(unittest.TestCase):
+class TestPluginARDMediathek(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
             'http://mediathek.daserste.de/live',
             'http://www.ardmediathek.de/tv/Sportschau/'
         ]
         for url in should_match:
-            self.assertTrue(ard_mediathek.can_handle_url(url))
+            self.assertTrue(ARDMediathek.can_handle_url(url))
 
     def test_can_handle_url_negative(self):
         should_not_match = [
@@ -18,4 +18,4 @@ class TestPluginard_mediathek(unittest.TestCase):
             'https://www.daserste.de/live/index.html',
         ]
         for url in should_not_match:
-            self.assertFalse(ard_mediathek.can_handle_url(url))
+            self.assertFalse(ARDMediathek.can_handle_url(url))

--- a/tests/plugins/test_ard_mediathek.py
+++ b/tests/plugins/test_ard_mediathek.py
@@ -1,21 +1,16 @@
-import unittest
-
 from streamlink.plugins.ard_mediathek import ARDMediathek
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginARDMediathek(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://mediathek.daserste.de/live',
-            'http://www.ardmediathek.de/tv/Sportschau/'
-        ]
-        for url in should_match:
-            self.assertTrue(ARDMediathek.can_handle_url(url))
+class TestPluginCanHandleUrlARDMediathek(PluginCanHandleUrl):
+    __plugin__ = ARDMediathek
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://daserste.de/live/index.html',
-            'https://www.daserste.de/live/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ARDMediathek.can_handle_url(url))
+    should_match = [
+        'http://mediathek.daserste.de/live',
+        'http://www.ardmediathek.de/tv/Sportschau/'
+    ]
+
+    should_not_match = [
+        'https://daserste.de/live/index.html',
+        'https://www.daserste.de/live/index.html',
+    ]

--- a/tests/plugins/test_artetv.py
+++ b/tests/plugins/test_artetv.py
@@ -1,32 +1,34 @@
-import unittest
-
 from streamlink.plugins.artetv import ArteTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginArteTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
+class TestPluginCanHandleUrlArteTV(PluginCanHandleUrl):
+    __plugin__ = ArteTV
+
+    should_match = [
         # new url
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/fr/direct/"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/de/live/"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/de/videos/074633-001-A/gesprach-mit-raoul-peck"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/en/videos/071437-010-A/sunday-soldiers"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/fr/videos/074633-001-A/entretien-avec-raoul-peck"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/pl/videos/069873-000-A/supermama-i-businesswoman"))
+        "http://www.arte.tv/fr/direct/",
+        "http://www.arte.tv/de/live/",
+        "http://www.arte.tv/de/videos/074633-001-A/gesprach-mit-raoul-peck",
+        "http://www.arte.tv/en/videos/071437-010-A/sunday-soldiers",
+        "http://www.arte.tv/fr/videos/074633-001-A/entretien-avec-raoul-peck",
+        "http://www.arte.tv/pl/videos/069873-000-A/supermama-i-businesswoman",
 
-        # should match
         # old url - some of them get redirected and some are 404
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/fr/direct"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/de/live"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/fr/024031-000-A/le-testament-du-docteur-mabuse"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/de/024031-000-A/das-testament-des-dr-mabuse"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/en/072544-002-A/christmas-carols-from-cork"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/es/068380-000-A/una-noche-en-florencia"))
-        self.assertTrue(ArteTV.can_handle_url("http://www.arte.tv/guide/pl/068916-006-A/belle-and-sebastian-route-du-rock"))
+        "http://www.arte.tv/guide/fr/direct",
+        "http://www.arte.tv/guide/de/live",
+        "http://www.arte.tv/guide/fr/024031-000-A/le-testament-du-docteur-mabuse",
+        "http://www.arte.tv/guide/de/024031-000-A/das-testament-des-dr-mabuse",
+        "http://www.arte.tv/guide/en/072544-002-A/christmas-carols-from-cork",
+        "http://www.arte.tv/guide/es/068380-000-A/una-noche-en-florencia",
+        "http://www.arte.tv/guide/pl/068916-006-A/belle-and-sebastian-route-du-rock",
+    ]
 
+    should_not_match = [
         # shouldn't match
-        self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/guide/fr/plus7/"))
-        self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/guide/de/plus7/"))
+        "http://www.arte.tv/guide/fr/plus7/",
+        "http://www.arte.tv/guide/de/plus7/",
         # shouldn't match - playlists without video ids in url
-        self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/en/videos/RC-014457/the-power-of-forests/"))
-        self.assertFalse(ArteTV.can_handle_url("http://www.arte.tv/en/videos/RC-013118/street-art/"))
+        "http://www.arte.tv/en/videos/RC-014457/the-power-of-forests/",
+        "http://www.arte.tv/en/videos/RC-013118/street-art/",
+    ]

--- a/tests/plugins/test_atresplayer.py
+++ b/tests/plugins/test_atresplayer.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.atresplayer import AtresPlayer
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginAtresPlayer(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.atresplayer.com/directos/antena3/',
-            'http://www.atresplayer.com/directos/lasexta/',
-            'https://www.atresplayer.com/directos/antena3/',
-            'https://www.atresplayer.com/flooxer/programas/unas/temporada-1/dario-eme-hache-sindy-takanashi-entrevista_123/',
-        ]
-        for url in should_match:
-            self.assertTrue(AtresPlayer.can_handle_url(url))
+class TestPluginCanHandleUrlAtresPlayer(PluginCanHandleUrl):
+    __plugin__ = AtresPlayer
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.example.com/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(AtresPlayer.can_handle_url(url))
+    should_match = [
+        'http://www.atresplayer.com/directos/antena3/',
+        'http://www.atresplayer.com/directos/lasexta/',
+        'https://www.atresplayer.com/directos/antena3/',
+        'https://www.atresplayer.com/flooxer/programas/unas/temporada-1/dario-eme-hache-sindy-takanashi-entrevista_123/',
+    ]

--- a/tests/plugins/test_bbciplayer.py
+++ b/tests/plugins/test_bbciplayer.py
@@ -1,20 +1,23 @@
 import unittest
 
 from streamlink.plugins.bbciplayer import BBCiPlayer
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlBBCiPlayer(PluginCanHandleUrl):
+    __plugin__ = BBCiPlayer
+
+    should_match = [
+        "http://www.bbc.co.uk/iplayer/episode/b00ymh67/madagascar-1-island-of-marvels",
+        "http://www.bbc.co.uk/iplayer/live/bbcone",
+    ]
+
+    should_not_match = [
+        "http://www.bbc.co.uk/iplayer/",
+    ]
 
 
 class TestPluginBBCiPlayer(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(
-            BBCiPlayer.can_handle_url("http://www.bbc.co.uk/iplayer/episode/b00ymh67/madagascar-1-island-of-marvels"))
-        self.assertTrue(BBCiPlayer.can_handle_url("http://www.bbc.co.uk/iplayer/live/bbcone"))
-
-        # shouldn't match
-        self.assertFalse(BBCiPlayer.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(BBCiPlayer.can_handle_url("http://www.sportal.bg/sportal_live_tv.php?str=15"))
-        self.assertFalse(BBCiPlayer.can_handle_url("http://www.bbc.co.uk/iplayer/"))
-
     def test_vpid_hash(self):
         self.assertEqual(
             "71c345435589c6ddeea70d6f252e2a52281ecbf3",

--- a/tests/plugins/test_bfmtv.py
+++ b/tests/plugins/test_bfmtv.py
@@ -1,32 +1,23 @@
-import unittest
-
 from streamlink.plugins.bfmtv import BFMTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBFMTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.bfmtv.com/mediaplayer/live-video/",
-            "https://bfmbusiness.bfmtv.com/mediaplayer/live-video/",
-            "https://www.bfmtv.com/mediaplayer/live-bfm-paris/",
-            "https://rmc.bfmtv.com/mediaplayer/live-audio/",
-            "https://rmcsport.bfmtv.com/mediaplayer/live-bfm-sport/",
-            "https://rmcdecouverte.bfmtv.com/mediaplayer-direct/",
-            "https://www.bfmtv.com/mediaplayer/replay/premiere-edition/",
-            "https://bfmbusiness.bfmtv.com/mediaplayer/replay/good-morning-business/",
-            "https://rmc.bfmtv.com/mediaplayer/replay/les-grandes-gueules/",
-            "https://rmc.bfmtv.com/mediaplayer/replay/after-foot/",
-            "https://www.01net.com/mediaplayer/replay/jtech/",
-            "https://www.bfmtv.com/politique/macron-et-le-pen-talonnes-par-fillon-et-melenchon-a-l-approche"
-            + "-du-premier-tour-1142070.html",
-            "https://rmcdecouverte.bfmtv.com/mediaplayer-replay/?id=6714&title=TOP%20GEAR%20:PASSION%20VINTAGE"
-        ]
-        for url in should_match:
-            self.assertTrue(BFMTV.can_handle_url(url))
+class TestPluginCanHandleUrlBFMTV(PluginCanHandleUrl):
+    __plugin__ = BFMTV
 
-        should_not_match = [
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(BFMTV.can_handle_url(url))
+    should_match = [
+        "https://www.bfmtv.com/mediaplayer/live-video/",
+        "https://bfmbusiness.bfmtv.com/mediaplayer/live-video/",
+        "https://www.bfmtv.com/mediaplayer/live-bfm-paris/",
+        "https://rmc.bfmtv.com/mediaplayer/live-audio/",
+        "https://rmcsport.bfmtv.com/mediaplayer/live-bfm-sport/",
+        "https://rmcdecouverte.bfmtv.com/mediaplayer-direct/",
+        "https://www.bfmtv.com/mediaplayer/replay/premiere-edition/",
+        "https://bfmbusiness.bfmtv.com/mediaplayer/replay/good-morning-business/",
+        "https://rmc.bfmtv.com/mediaplayer/replay/les-grandes-gueules/",
+        "https://rmc.bfmtv.com/mediaplayer/replay/after-foot/",
+        "https://www.01net.com/mediaplayer/replay/jtech/",
+        "https://www.bfmtv.com/politique/macron-et-le-pen-talonnes-par-fillon-et-melenchon-a-l-approche"
+        + "-du-premier-tour-1142070.html",
+        "https://rmcdecouverte.bfmtv.com/mediaplayer-replay/?id=6714&title=TOP%20GEAR%20:PASSION%20VINTAGE"
+    ]

--- a/tests/plugins/test_bigo.py
+++ b/tests/plugins/test_bigo.py
@@ -1,37 +1,32 @@
-import unittest
-
 from streamlink.plugins.bigo import Bigo
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBigo(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://bigo.tv/00000000",
-            "https://bigo.tv/00000000",
-            "https://www.bigo.tv/00000000",
-            "http://www.bigo.tv/00000000",
-            "http://www.bigo.tv/fancy1234",
-            "http://www.bigo.tv/abc.123",
-            "http://www.bigo.tv/000000.00"
-        ]
-        for url in should_match:
-            self.assertTrue(Bigo.can_handle_url(url), url)
+class TestPluginCanHandleUrlBigo(PluginCanHandleUrl):
+    __plugin__ = Bigo
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            # Old URLs don't work anymore
-            "http://live.bigo.tv/00000000",
-            "https://live.bigo.tv/00000000",
-            "http://www.bigoweb.co/show/00000000",
-            "https://www.bigoweb.co/show/00000000",
-            "http://bigoweb.co/show/00000000",
-            "https://bigoweb.co/show/00000000"
+    should_match = [
+        "http://bigo.tv/00000000",
+        "https://bigo.tv/00000000",
+        "https://www.bigo.tv/00000000",
+        "http://www.bigo.tv/00000000",
+        "http://www.bigo.tv/fancy1234",
+        "http://www.bigo.tv/abc.123",
+        "http://www.bigo.tv/000000.00"
+    ]
 
-            # Wrong URL structure
-            "https://www.bigo.tv/show/00000000",
-            "http://www.bigo.tv/show/00000000",
-            "http://bigo.tv/show/00000000",
-            "https://bigo.tv/show/00000000"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Bigo.can_handle_url(url), url)
+    should_not_match = [
+        # Old URLs don't work anymore
+        "http://live.bigo.tv/00000000",
+        "https://live.bigo.tv/00000000",
+        "http://www.bigoweb.co/show/00000000",
+        "https://www.bigoweb.co/show/00000000",
+        "http://bigoweb.co/show/00000000",
+        "https://bigoweb.co/show/00000000"
+
+        # Wrong URL structure
+        "https://www.bigo.tv/show/00000000",
+        "http://www.bigo.tv/show/00000000",
+        "http://bigo.tv/show/00000000",
+        "https://bigo.tv/show/00000000"
+    ]

--- a/tests/plugins/test_bilibili.py
+++ b/tests/plugins/test_bilibili.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.bilibili import Bilibili
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBilibili(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://live.bilibili.com/123123123',
-        ]
-        for url in should_match:
-            self.assertTrue(Bilibili.can_handle_url(url))
+class TestPluginCanHandleUrlBilibili(PluginCanHandleUrl):
+    __plugin__ = Bilibili
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Bilibili.can_handle_url(url))
+    should_match = [
+        'https://live.bilibili.com/123123123',
+    ]

--- a/tests/plugins/test_bloomberg.py
+++ b/tests/plugins/test_bloomberg.py
@@ -1,29 +1,22 @@
-import unittest
-
 from streamlink.plugins.bloomberg import Bloomberg
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBloomberg(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.bloomberg.com/live/us",
-            "https://www.bloomberg.com/live/europe",
-            "https://www.bloomberg.com/live/asia",
-            "https://www.bloomberg.com/live/stream",
-            "https://www.bloomberg.com/live/emea",
-            "https://www.bloomberg.com/live/asia_stream",
-            "https://www.bloomberg.com/news/videos/2017-04-17/wozniak-science-fiction-finally-becoming-reality-video",
-            "http://www.bloomberg.com/news/videos/2017-04-17/russia-s-stake-in-a-u-s-north-korea-conflict-video"
-        ]
-        for url in should_match:
-            self.assertTrue(Bloomberg.can_handle_url(url))
+class TestPluginCanHandleUrlBloomberg(PluginCanHandleUrl):
+    __plugin__ = Bloomberg
 
-        should_not_match = [
-            "https://www.bloomberg.com/live/",
-            "https://www.bloomberg.com/politics/articles/2017-04-17/french-race-up-for-grabs-days-before-voters-cast"
-            + "-first-ballots",
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Bloomberg.can_handle_url(url))
+    should_match = [
+        "https://www.bloomberg.com/live/us",
+        "https://www.bloomberg.com/live/europe",
+        "https://www.bloomberg.com/live/asia",
+        "https://www.bloomberg.com/live/stream",
+        "https://www.bloomberg.com/live/emea",
+        "https://www.bloomberg.com/live/asia_stream",
+        "https://www.bloomberg.com/news/videos/2017-04-17/wozniak-science-fiction-finally-becoming-reality-video",
+        "http://www.bloomberg.com/news/videos/2017-04-17/russia-s-stake-in-a-u-s-north-korea-conflict-video"
+    ]
+
+    should_not_match = [
+        "https://www.bloomberg.com/live/",
+        "https://www.bloomberg.com/politics/articles/2017-04-17/french-race-up-for-grabs-days-before-voters-cast-first-ballots",
+    ]

--- a/tests/plugins/test_brightcove.py
+++ b/tests/plugins/test_brightcove.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.brightcove import Brightcove
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBrightcove(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://players.brightcove.net/123/default_default/index.html?videoId=456',
-            'http://players.brightcove.net/456/default_default/index.html?videoId=789',
-        ]
-        for url in should_match:
-            self.assertTrue(Brightcove.can_handle_url(url))
+class TestPluginCanHandleUrlBrightcove(PluginCanHandleUrl):
+    __plugin__ = Brightcove
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Brightcove.can_handle_url(url))
+    should_match = [
+        'http://players.brightcove.net/123/default_default/index.html?videoId=456',
+        'http://players.brightcove.net/456/default_default/index.html?videoId=789',
+    ]

--- a/tests/plugins/test_btsports.py
+++ b/tests/plugins/test_btsports.py
@@ -1,16 +1,16 @@
-import unittest
-
 from streamlink.plugins.btsports import BTSports
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBTSports(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(BTSports.can_handle_url("https://sport.bt.com/btsportsplayer/football-match-1"))
-        self.assertTrue(BTSports.can_handle_url("https://sport.bt.com/ss/Satellite/btsportsplayer/football-match-1"))
+class TestPluginCanHandleUrlBTSports(PluginCanHandleUrl):
+    __plugin__ = BTSports
 
-        # shouldn't match
-        self.assertFalse(BTSports.can_handle_url("http://www.bt.com/"))
-        self.assertFalse(BTSports.can_handle_url("http://bt.com/"))
-        self.assertFalse(BTSports.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(BTSports.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://sport.bt.com/btsportsplayer/football-match-1",
+        "https://sport.bt.com/ss/Satellite/btsportsplayer/football-match-1",
+    ]
+
+    should_not_match = [
+        "http://www.bt.com/",
+        "http://bt.com/",
+    ]

--- a/tests/plugins/test_btv.py
+++ b/tests/plugins/test_btv.py
@@ -1,15 +1,12 @@
-import unittest
-
 from streamlink.plugins.btv import BTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginBTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(BTV.can_handle_url("http://btvplus.bg/live"))
-        self.assertTrue(BTV.can_handle_url("http://btvplus.bg/live/"))
-        self.assertTrue(BTV.can_handle_url("http://www.btvplus.bg/live/"))
+class TestPluginCanHandleUrlBTV(PluginCanHandleUrl):
+    __plugin__ = BTV
 
-        # shouldn't match
-        self.assertFalse(BTV.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(BTV.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://btvplus.bg/live",
+        "http://btvplus.bg/live/",
+        "http://www.btvplus.bg/live/",
+    ]

--- a/tests/plugins/test_canalplus.py
+++ b/tests/plugins/test_canalplus.py
@@ -1,31 +1,25 @@
-import unittest
-
 from streamlink.plugins.canalplus import CanalPlus
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginCanalPlus(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.mycanal.fr/docus-infos/l-info-du-vrai-du-13-12-politique-les-affaires-reprennent/p/1473830",
-            "https://www.mycanal.fr/sport/infosport-laurey-et-claudia/p/1473752",
-            "https://www.mycanal.fr/docus-infos/ses-debuts-a-madrid-extrait-le-k-benzema/p/1469050",
-            "https://www.mycanal.fr/d8-docs-mags/au-revoir-johnny-hallyday-le-doc/p/1473054"
-        ]
-        for url in should_match:
-            self.assertTrue(CanalPlus.can_handle_url(url))
+class TestPluginCanHandleUrlCanalPlus(PluginCanHandleUrl):
+    __plugin__ = CanalPlus
 
-        should_not_match = [
-            "http://www.cnews.fr/direct",
-            "http://www.cnews.fr/politique/video/des-electeurs-toujours-autant-indecis-174769",
-            "http://www.cnews.fr/magazines/plus-de-recul/de-recul-du-14042017-174594",
-            "http://www.canalplus.fr/",
-            "http://www.c8.fr/",
-            "http://replay.c8.fr/",
-            "http://www.cstar.fr/",
-            "http://replay.cstar.fr/",
-            "http://www.cnews.fr/",
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(CanalPlus.can_handle_url(url))
+    should_match = [
+        "https://www.mycanal.fr/docus-infos/l-info-du-vrai-du-13-12-politique-les-affaires-reprennent/p/1473830",
+        "https://www.mycanal.fr/sport/infosport-laurey-et-claudia/p/1473752",
+        "https://www.mycanal.fr/docus-infos/ses-debuts-a-madrid-extrait-le-k-benzema/p/1469050",
+        "https://www.mycanal.fr/d8-docs-mags/au-revoir-johnny-hallyday-le-doc/p/1473054"
+    ]
+
+    should_not_match = [
+        "http://www.cnews.fr/direct",
+        "http://www.cnews.fr/politique/video/des-electeurs-toujours-autant-indecis-174769",
+        "http://www.cnews.fr/magazines/plus-de-recul/de-recul-du-14042017-174594",
+        "http://www.canalplus.fr/",
+        "http://www.c8.fr/",
+        "http://replay.c8.fr/",
+        "http://www.cstar.fr/",
+        "http://replay.cstar.fr/",
+        "http://www.cnews.fr/",
+    ]

--- a/tests/plugins/test_cbsnews.py
+++ b/tests/plugins/test_cbsnews.py
@@ -1,26 +1,17 @@
-import unittest  # noqa: F401
-
-import pytest
-
 from streamlink.plugins.cbsnews import CBSNews
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestCBSNews:
-    valid_urls = [
-        ("https://www.cbsnews.com/live/cbs-sports-hq/",),
-        ("https://www.cbsnews.com/live/cbsn-local-bay-area/",),
-        ("https://www.cbsnews.com/live/",),
-    ]
-    invalid_urls = [
-        ("https://www.cbsnews.com/feature/election-2020/",),
-        ("https://www.cbsnews.com/48-hours/",),
-        ("https://twitch.tv/",)
+class TestPluginCanHandleUrlCBSNews(PluginCanHandleUrl):
+    __plugin__ = CBSNews
+
+    should_match = [
+        "https://www.cbsnews.com/live/cbs-sports-hq/",
+        "https://www.cbsnews.com/live/cbsn-local-bay-area/",
+        "https://www.cbsnews.com/live/",
     ]
 
-    @pytest.mark.parametrize(["url"], valid_urls)
-    def test_can_handle_url(self, url):
-        assert CBSNews.can_handle_url(url), "url should be handled"
-
-    @pytest.mark.parametrize(["url"], invalid_urls)
-    def test_can_handle_url_negative(self, url):
-        assert not CBSNews.can_handle_url(url), "url should not be handled"
+    should_not_match = [
+        "https://www.cbsnews.com/feature/election-2020/",
+        "https://www.cbsnews.com/48-hours/",
+    ]

--- a/tests/plugins/test_cdnbg.py
+++ b/tests/plugins/test_cdnbg.py
@@ -1,44 +1,37 @@
-import unittest
-
 from streamlink.plugins.cdnbg import CDNBG
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginCDNBG(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://bgonair.bg/tvonline',
-            'http://bgonair.bg/tvonline/',
-            'http://www.nova.bg/live',
-            'http://nova.bg/live',
-            'http://bnt.bg/live',
-            'http://bnt.bg/live/bnt1',
-            'http://bnt.bg/live/bnt2',
-            'http://bnt.bg/live/bnt3',
-            'http://bnt.bg/live/bnt4',
-            'http://tv.bnt.bg/bnt1',
-            'http://tv.bnt.bg/bnt2',
-            'http://tv.bnt.bg/bnt3',
-            'http://tv.bnt.bg/bnt4',
-            'http://mu-vi.tv/LiveStreams/pages/Live.aspx',
-            'http://live.bstv.bg/',
-            'https://www.bloombergtv.bg/video',
-            'https://i.cdn.bg/live/xfr3453g0d',
-        ]
-        for url in should_match:
-            self.assertTrue(CDNBG.can_handle_url(url))
+class TestPluginCanHandleUrlCDNBG(PluginCanHandleUrl):
+    __plugin__ = CDNBG
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.tvcatchup.com/',
-            'http://www.youtube.com/',
-            'https://www.tvevropa.com',
-            'http://www.kanal3.bg/live',
-            'http://inlife.bg/',
-            'http://videochanel.bstv.bg',
-            'http://video.bstv.bg/',
-            'http://bitelevision.com/live',
-            'http://mmtvmusic.com/live/',
-            'http://chernomore.bg/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(CDNBG.can_handle_url(url))
+    should_match = [
+        'http://bgonair.bg/tvonline',
+        'http://bgonair.bg/tvonline/',
+        'http://www.nova.bg/live',
+        'http://nova.bg/live',
+        'http://bnt.bg/live',
+        'http://bnt.bg/live/bnt1',
+        'http://bnt.bg/live/bnt2',
+        'http://bnt.bg/live/bnt3',
+        'http://bnt.bg/live/bnt4',
+        'http://tv.bnt.bg/bnt1',
+        'http://tv.bnt.bg/bnt2',
+        'http://tv.bnt.bg/bnt3',
+        'http://tv.bnt.bg/bnt4',
+        'http://mu-vi.tv/LiveStreams/pages/Live.aspx',
+        'http://live.bstv.bg/',
+        'https://www.bloombergtv.bg/video',
+        'https://i.cdn.bg/live/xfr3453g0d',
+    ]
+
+    should_not_match = [
+        'https://www.tvevropa.com',
+        'http://www.kanal3.bg/live',
+        'http://inlife.bg/',
+        'http://videochanel.bstv.bg',
+        'http://video.bstv.bg/',
+        'http://bitelevision.com/live',
+        'http://mmtvmusic.com/live/',
+        'http://chernomore.bg/',
+    ]

--- a/tests/plugins/test_ceskatelevize.py
+++ b/tests/plugins/test_ceskatelevize.py
@@ -1,24 +1,15 @@
-import unittest
-
 from streamlink.plugins.ceskatelevize import Ceskatelevize
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginCeskatelevize(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.ceskatelevize.cz/ct1/zive/',
-            'http://www.ceskatelevize.cz/ct2/zive/',
-            'http://www.ceskatelevize.cz/ct24/',
-            'http://www.ceskatelevize.cz/sport/zive-vysilani/',
-            'http://decko.ceskatelevize.cz/zive/',
-            'http://www.ceskatelevize.cz/art/zive/',
-        ]
-        for url in should_match:
-            self.assertTrue(Ceskatelevize.can_handle_url(url))
+class TestPluginCanHandleUrlCeskatelevize(PluginCanHandleUrl):
+    __plugin__ = Ceskatelevize
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Ceskatelevize.can_handle_url(url))
+    should_match = [
+        'http://www.ceskatelevize.cz/ct1/zive/',
+        'http://www.ceskatelevize.cz/ct2/zive/',
+        'http://www.ceskatelevize.cz/ct24/',
+        'http://www.ceskatelevize.cz/sport/zive-vysilani/',
+        'http://decko.ceskatelevize.cz/zive/',
+        'http://www.ceskatelevize.cz/art/zive/',
+    ]

--- a/tests/plugins/test_cinergroup.py
+++ b/tests/plugins/test_cinergroup.py
@@ -1,24 +1,15 @@
-import unittest
-
 from streamlink.plugins.cinergroup import CinerGroup
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginCinerGroup(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://showtv.com.tr/canli-yayin',
-            'http://haberturk.com/canliyayin',
-            'http://showmax.com.tr/canliyayin',
-            'http://showturk.com.tr/canli-yayin/showturk',
-            'http://bloomberght.com/tv',
-            'http://haberturk.tv/canliyayin',
-        ]
-        for url in should_match:
-            self.assertTrue(CinerGroup.can_handle_url(url))
+class TestPluginCanHandleUrlCinerGroup(PluginCanHandleUrl):
+    __plugin__ = CinerGroup
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(CinerGroup.can_handle_url(url))
+    should_match = [
+        'http://showtv.com.tr/canli-yayin',
+        'http://haberturk.com/canliyayin',
+        'http://showmax.com.tr/canliyayin',
+        'http://showturk.com.tr/canli-yayin/showturk',
+        'http://bloomberght.com/tv',
+        'http://haberturk.tv/canliyayin',
+    ]

--- a/tests/plugins/test_clubbingtv.py
+++ b/tests/plugins/test_clubbingtv.py
@@ -1,16 +1,13 @@
-import unittest
-
 from streamlink.plugins.clubbingtv import ClubbingTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginClubbingTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(ClubbingTV.can_handle_url("https://www.clubbingtv.com/live"))
-        self.assertTrue(ClubbingTV.can_handle_url("https://www.clubbingtv.com/video/play/3950/moonlight/"))
-        self.assertTrue(ClubbingTV.can_handle_url("https://www.clubbingtv.com/video/play/2897"))
-        self.assertTrue(ClubbingTV.can_handle_url("https://www.clubbingtv.com/tomer-s-pick/"))
+class TestPluginCanHandleUrlClubbingTV(PluginCanHandleUrl):
+    __plugin__ = ClubbingTV
 
-        # shouldn't match
-        self.assertFalse(ClubbingTV.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(ClubbingTV.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://www.clubbingtv.com/live",
+        "https://www.clubbingtv.com/video/play/3950/moonlight/",
+        "https://www.clubbingtv.com/video/play/2897",
+        "https://www.clubbingtv.com/tomer-s-pick/",
+    ]

--- a/tests/plugins/test_cnews.py
+++ b/tests/plugins/test_cnews.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.cnews import CNEWS
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginCNEWS(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.cnews.fr/le-direct",
-            "http://www.cnews.fr/direct",
-            "http://www.cnews.fr/emission/2018-06-12/meteo-du-12062018-784730",
-            "http://www.cnews.fr/emission/2018-06-12/le-journal-des-faits-divers-du-12062018-784704"
-        ]
-        for url in should_match:
-            self.assertTrue(CNEWS.can_handle_url(url))
+class TestPluginCanHandleUrlCNEWS(PluginCanHandleUrl):
+    __plugin__ = CNEWS
 
-        should_not_match = [
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(CNEWS.can_handle_url(url))
+    should_match = [
+        "http://www.cnews.fr/le-direct",
+        "http://www.cnews.fr/direct",
+        "http://www.cnews.fr/emission/2018-06-12/meteo-du-12062018-784730",
+        "http://www.cnews.fr/emission/2018-06-12/le-journal-des-faits-divers-du-12062018-784704"
+    ]

--- a/tests/plugins/test_crunchyroll.py
+++ b/tests/plugins/test_crunchyroll.py
@@ -1,27 +1,22 @@
-import unittest
-
 from streamlink.plugins.crunchyroll import Crunchyroll
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginCrunchyroll(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.crunchyroll.com/idol-incidents/episode-1-why-become-a-dietwoman-728233",
-            "http://www.crunchyroll.com/ru/idol-incidents/episode-1-why-become-a-dietwoman-728233",
-            "http://www.crunchyroll.com/idol-incidents/media-728233",
-            "http://www.crunchyroll.com/fr/idol-incidents/media-728233",
-            "http://www.crunchyroll.com/media-728233",
-            "http://www.crunchyroll.com/de/media-728233",
-            "http://www.crunchyroll.fr/media-728233",
-            "http://www.crunchyroll.fr/es/media-728233"
-        ]
-        for url in should_match:
-            self.assertTrue(Crunchyroll.can_handle_url(url))
+class TestPluginCanHandleUrlCrunchyroll(PluginCanHandleUrl):
+    __plugin__ = Crunchyroll
 
-        should_not_match = [
-            "http://www.crunchyroll.com/gintama",
-            "http://www.crunchyroll.es/gintama",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Crunchyroll.can_handle_url(url))
+    should_match = [
+        "http://www.crunchyroll.com/idol-incidents/episode-1-why-become-a-dietwoman-728233",
+        "http://www.crunchyroll.com/ru/idol-incidents/episode-1-why-become-a-dietwoman-728233",
+        "http://www.crunchyroll.com/idol-incidents/media-728233",
+        "http://www.crunchyroll.com/fr/idol-incidents/media-728233",
+        "http://www.crunchyroll.com/media-728233",
+        "http://www.crunchyroll.com/de/media-728233",
+        "http://www.crunchyroll.fr/media-728233",
+        "http://www.crunchyroll.fr/es/media-728233"
+    ]
+
+    should_not_match = [
+        "http://www.crunchyroll.com/gintama",
+        "http://www.crunchyroll.es/gintama",
+    ]

--- a/tests/plugins/test_dailymotion.py
+++ b/tests/plugins/test_dailymotion.py
@@ -1,16 +1,16 @@
-import unittest
-
 from streamlink.plugins.dailymotion import DailyMotion
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDailyMotion(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(DailyMotion.can_handle_url("https://www.dailymotion.com/video/xigbvx"))
-        self.assertTrue(DailyMotion.can_handle_url("https://www.dailymotion.com/france24"))
-        self.assertTrue(DailyMotion.can_handle_url("https://www.dailymotion.com/embed/video/xigbvx"))
+class TestPluginCanHandleUrlDailyMotion(PluginCanHandleUrl):
+    __plugin__ = DailyMotion
 
-        # shouldn't match
-        self.assertFalse(DailyMotion.can_handle_url("https://www.dailymotion.com/"))
-        self.assertFalse(DailyMotion.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(DailyMotion.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://www.dailymotion.com/video/xigbvx",
+        "https://www.dailymotion.com/france24",
+        "https://www.dailymotion.com/embed/video/xigbvx",
+    ]
+
+    should_not_match = [
+        "https://www.dailymotion.com/",
+    ]

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -4,22 +4,22 @@ from unittest.mock import patch
 from streamlink import Streamlink
 from streamlink.plugin.plugin import BIT_RATE_WEIGHT_RATIO, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.plugins.dash import MPEGDASH
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
+    __plugin__ = MPEGDASH
+
+    should_match = [
+        "http://example.com/foo.mpd",
+        "dash://http://www.testing.cat/directe",
+        "dash://https://www.testing.cat/directe",
+    ]
 
 
 class TestPluginMPEGDASH(unittest.TestCase):
     def setUp(self):
         self.session = Streamlink()
-
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(MPEGDASH.can_handle_url("http://example.com/foo.mpd"))
-        self.assertTrue(MPEGDASH.can_handle_url("dash://http://www.testing.cat/directe"))
-        self.assertTrue(MPEGDASH.can_handle_url("dash://https://www.testing.cat/directe"))
-
-    def test_can_handle_url_negative(self):
-        # shouldn't match
-        self.assertFalse(MPEGDASH.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(MPEGDASH.can_handle_url("http://www.youtube.com/"))
 
     def test_priority(self):
         self.assertEqual(MPEGDASH.priority("http://example.com/fpo.mpd"), LOW_PRIORITY)

--- a/tests/plugins/test_delfi.py
+++ b/tests/plugins/test_delfi.py
@@ -1,27 +1,18 @@
-import unittest
-
 from streamlink.plugins.delfi import Delfi
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDelfi(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.delfi.lt/video/sportas/kroatiska-tvarka-kaliningrade-laisvai-liejosi-gerimai-dainos"
-            + "-sokiai-ir-ziezirbos.d?id=78322857",
-            "https://www.delfi.lt/video/sportas/zalgiris-atsidure-per-pergale-nuo-lkl-aukso.d?id=78321125",
-            "https://www.delfi.lt/video/laidos/nba/warriors-cempioniskomis-tapusios-ketvirtos-finalo"
-            + "-rungtynes.d?id=78246059",
-            "http://rahvahaal.delfi.ee/news/videod/video-joviaalne-piduline-kaotab-raekoja-platsil-ilutulestiku"
-            + "-ule-kontrolli-ja-raketid-lendavad-rahva-sekka?id=82681069",
-            "http://www.delfi.lv/delfi-tv-ar-jani-domburu/pilnie-raidijumi/delfi-tv-ar-jani-domburu-atbild"
-            + "-veselibas-ministre-anda-caksa-pilna-intervija?id=49515013"
-        ]
-        for url in should_match:
-            self.assertTrue(Delfi.can_handle_url(url))
+class TestPluginCanHandleUrlDelfi(PluginCanHandleUrl):
+    __plugin__ = Delfi
 
-        should_not_match = [
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Delfi.can_handle_url(url))
+    should_match = [
+        "http://www.delfi.lt/video/sportas/kroatiska-tvarka-kaliningrade-laisvai-liejosi-gerimai-dainos"
+        + "-sokiai-ir-ziezirbos.d?id=78322857",
+        "https://www.delfi.lt/video/sportas/zalgiris-atsidure-per-pergale-nuo-lkl-aukso.d?id=78321125",
+        "https://www.delfi.lt/video/laidos/nba/warriors-cempioniskomis-tapusios-ketvirtos-finalo"
+        + "-rungtynes.d?id=78246059",
+        "http://rahvahaal.delfi.ee/news/videod/video-joviaalne-piduline-kaotab-raekoja-platsil-ilutulestiku"
+        + "-ule-kontrolli-ja-raketid-lendavad-rahva-sekka?id=82681069",
+        "http://www.delfi.lv/delfi-tv-ar-jani-domburu/pilnie-raidijumi/delfi-tv-ar-jani-domburu-atbild"
+        + "-veselibas-ministre-anda-caksa-pilna-intervija?id=49515013"
+    ]

--- a/tests/plugins/test_deutschewelle.py
+++ b/tests/plugins/test_deutschewelle.py
@@ -1,24 +1,15 @@
-import unittest
-
 from streamlink.plugins.deutschewelle import DeutscheWelle
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDeutscheWelle(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.dw.com/en/media-center/live-tv/s-100825",
-            "http://www.dw.com/fr/médiathèque/direct-tv/s-100948?channel=5",
-            "http://www.dw.com/de/tim-bendzko-deutsch-pop-darling-auf-tour/av-39101077",
-            "http://www.dw.com/de/trump-sagt-nein-die-welt-schüttelt-den-kopf/av-39096724",
-            "http://www.dw.com/el/ο-τραμπ-θεωρεί-την-ευρώπη-ανταγωνιστή-όχι-εταίρο/av-39103742",
-            "http://www.dw.com/ar/أي-البروتينات-صحية-الحيوانية-أم-النباتية/av-39095317",
-        ]
-        for url in should_match:
-            self.assertTrue(DeutscheWelle.can_handle_url(url))
+class TestPluginCanHandleUrlDeutscheWelle(PluginCanHandleUrl):
+    __plugin__ = DeutscheWelle
 
-        should_not_match = [
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(DeutscheWelle.can_handle_url(url))
+    should_match = [
+        "http://www.dw.com/en/media-center/live-tv/s-100825",
+        "http://www.dw.com/fr/médiathèque/direct-tv/s-100948?channel=5",
+        "http://www.dw.com/de/tim-bendzko-deutsch-pop-darling-auf-tour/av-39101077",
+        "http://www.dw.com/de/trump-sagt-nein-die-welt-schüttelt-den-kopf/av-39096724",
+        "http://www.dw.com/el/ο-τραμπ-θεωρεί-την-ευρώπη-ανταγωνιστή-όχι-εταίρο/av-39103742",
+        "http://www.dw.com/ar/أي-البروتينات-صحية-الحيوانية-أم-النباتية/av-39095317",
+    ]

--- a/tests/plugins/test_dlive.py
+++ b/tests/plugins/test_dlive.py
@@ -1,13 +1,15 @@
-import unittest
-
 from streamlink.plugins.dlive import DLive
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDLive(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(DLive.can_handle_url("https://dlive.tv/pewdiepie"))
-        self.assertTrue(DLive.can_handle_url("https://dlive.tv/p/pdp+K6DqqtYWR"))
+class TestPluginCanHandleUrlDLive(PluginCanHandleUrl):
+    __plugin__ = DLive
 
-        # shouldn't match
-        self.assertFalse(DLive.can_handle_url("https://dlive.tv/"))
+    should_match = [
+        "https://dlive.tv/pewdiepie",
+        "https://dlive.tv/p/pdp+K6DqqtYWR",
+    ]
+
+    should_not_match = [
+        "https://dlive.tv/",
+    ]

--- a/tests/plugins/test_dogan.py
+++ b/tests/plugins/test_dogan.py
@@ -1,45 +1,39 @@
-import unittest
-
 from streamlink.plugins.dogan import Dogan
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDogan(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.cnnturk.com/action/embedvideo/',
-            'https://www.cnnturk.com/action/embedvideo/5fa56d065cf3b018a8dd0bbc',
-            'https://www.cnnturk.com/canli-yayin',
-            'https://www.cnnturk.com/tv-cnn-turk/',
-            'https://www.cnnturk.com/tv-cnn-turk/belgeseller/bir-zamanlar/bir-zamanlar-90lar-belgeseli',
-            'https://www.cnnturk.com/video/',
-            'https://www.cnnturk.com/video/turkiye/polis-otomobiliyle-tur-atan-sahisla-ilgili-islem-baslatildi-video',
-            'https://www.dreamturk.com.tr/canli',
-            'https://www.dreamturk.com.tr/canli-yayin-izle',
-            'https://www.dreamturk.com.tr/dream-turk-ozel/',
-            'https://www.dreamturk.com.tr/dream-turk-ozel/radyo-d/ilyas-yalcintas-radyo-dnin-konugu-oldu',
-            'https://www.dreamturk.com.tr/programlar/',
-            'https://www.dreamturk.com.tr/programlar/t-rap/bolumler/t-rap-keisan-ozel',
-            'https://www.dreamtv.com.tr/dream-ozel/',
-            'https://www.dreamtv.com.tr/dream-ozel/konserler/acik-sahne-dream-ozel',
-            'https://www.kanald.com.tr/canli-yayin',
-            'https://www.kanald.com.tr/sadakatsiz/fragmanlar/sadakatsiz-10-bolum-fragmani',
-            'https://www.teve2.com.tr/canli-yayin',
-            'https://www.teve2.com.tr/diziler/',
-            'https://www.teve2.com.tr/diziler/guncel/oyle-bir-gecer-zaman-ki/bolumler/oyle-bir-gecer-zaman-ki-1-bolum',
-            'https://www.teve2.com.tr/embed/',
-            'https://www.teve2.com.tr/embed/55f6d5b8402011f264ec7f64',
-            'https://www.teve2.com.tr/filmler/',
-            'https://www.teve2.com.tr/filmler/guncel/yasamak-guzel-sey',
-            'https://www.teve2.com.tr/programlar/',
-            'https://www.teve2.com.tr/programlar/guncel/kelime-oyunu/bolumler/kelime-oyunu-800-bolum-19-12-2020',
-        ]
-        for url in should_match:
-            self.assertTrue(Dogan.can_handle_url(url))
+class TestPluginCanHandleUrlDogan(PluginCanHandleUrl):
+    __plugin__ = Dogan
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.dreamtv.com.tr/canli-yayin',
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Dogan.can_handle_url(url))
+    should_match = [
+        'https://www.cnnturk.com/action/embedvideo/',
+        'https://www.cnnturk.com/action/embedvideo/5fa56d065cf3b018a8dd0bbc',
+        'https://www.cnnturk.com/canli-yayin',
+        'https://www.cnnturk.com/tv-cnn-turk/',
+        'https://www.cnnturk.com/tv-cnn-turk/belgeseller/bir-zamanlar/bir-zamanlar-90lar-belgeseli',
+        'https://www.cnnturk.com/video/',
+        'https://www.cnnturk.com/video/turkiye/polis-otomobiliyle-tur-atan-sahisla-ilgili-islem-baslatildi-video',
+        'https://www.dreamturk.com.tr/canli',
+        'https://www.dreamturk.com.tr/canli-yayin-izle',
+        'https://www.dreamturk.com.tr/dream-turk-ozel/',
+        'https://www.dreamturk.com.tr/dream-turk-ozel/radyo-d/ilyas-yalcintas-radyo-dnin-konugu-oldu',
+        'https://www.dreamturk.com.tr/programlar/',
+        'https://www.dreamturk.com.tr/programlar/t-rap/bolumler/t-rap-keisan-ozel',
+        'https://www.dreamtv.com.tr/dream-ozel/',
+        'https://www.dreamtv.com.tr/dream-ozel/konserler/acik-sahne-dream-ozel',
+        'https://www.kanald.com.tr/canli-yayin',
+        'https://www.kanald.com.tr/sadakatsiz/fragmanlar/sadakatsiz-10-bolum-fragmani',
+        'https://www.teve2.com.tr/canli-yayin',
+        'https://www.teve2.com.tr/diziler/',
+        'https://www.teve2.com.tr/diziler/guncel/oyle-bir-gecer-zaman-ki/bolumler/oyle-bir-gecer-zaman-ki-1-bolum',
+        'https://www.teve2.com.tr/embed/',
+        'https://www.teve2.com.tr/embed/55f6d5b8402011f264ec7f64',
+        'https://www.teve2.com.tr/filmler/',
+        'https://www.teve2.com.tr/filmler/guncel/yasamak-guzel-sey',
+        'https://www.teve2.com.tr/programlar/',
+        'https://www.teve2.com.tr/programlar/guncel/kelime-oyunu/bolumler/kelime-oyunu-800-bolum-19-12-2020',
+    ]
+
+    should_not_match = [
+        'https://www.dreamtv.com.tr/canli-yayin',
+    ]

--- a/tests/plugins/test_dogus.py
+++ b/tests/plugins/test_dogus.py
@@ -1,23 +1,17 @@
-import unittest
-
 from streamlink.plugins.dogus import Dogus
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDogus(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://eurostartv.com.tr/canli-izle',
-            'http://kralmuzik.com.tr/tv/',
-            'http://ntv.com.tr/canli-yayin/ntv',
-            'http://startv.com.tr/canli-yayin',
-        ]
-        for url in should_match:
-            self.assertTrue(Dogus.can_handle_url(url))
+class TestPluginCanHandleUrlDogus(PluginCanHandleUrl):
+    __plugin__ = Dogus
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-            'http://www.ntvspor.net/canli-yayin',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Dogus.can_handle_url(url))
+    should_match = [
+        'http://eurostartv.com.tr/canli-izle',
+        'http://kralmuzik.com.tr/tv/',
+        'http://ntv.com.tr/canli-yayin/ntv',
+        'http://startv.com.tr/canli-yayin',
+    ]
+
+    should_not_match = [
+        'http://www.ntvspor.net/canli-yayin',
+    ]

--- a/tests/plugins/test_dommune.py
+++ b/tests/plugins/test_dommune.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.dommune import Dommune
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDommune(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://dommune.com',
-        ]
-        for url in should_match:
-            self.assertTrue(Dommune.can_handle_url(url))
+class TestPluginCanHandleUrlDommune(PluginCanHandleUrl):
+    __plugin__ = Dommune
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Dommune.can_handle_url(url))
+    should_match = [
+        'http://dommune.com',
+    ]

--- a/tests/plugins/test_drdk.py
+++ b/tests/plugins/test_drdk.py
@@ -1,24 +1,18 @@
-import unittest
-
 from streamlink.plugins.drdk import DRDK
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginDRDK(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.dr.dk/drtv/kanal/dr1_20875',
-            'https://www.dr.dk/drtv/kanal/dr2_20876',
-            'https://www.dr.dk/drtv/kanal/dr-ramasjang_20892',
-        ]
-        for url in should_match:
-            self.assertTrue(DRDK.can_handle_url(url))
+class TestPluginCanHandleUrlDRDK(PluginCanHandleUrl):
+    __plugin__ = DRDK
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.dr.dk/tv/live/dr1',
-            'https://www.dr.dk/tv/live/dr2',
-            'https://www.dr.dk/tv/se/matador/matador-saeson-3/matador-15-24',
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(DRDK.can_handle_url(url))
+    should_match = [
+        'https://www.dr.dk/drtv/kanal/dr1_20875',
+        'https://www.dr.dk/drtv/kanal/dr2_20876',
+        'https://www.dr.dk/drtv/kanal/dr-ramasjang_20892',
+    ]
+
+    should_not_match = [
+        'https://www.dr.dk/tv/live/dr1',
+        'https://www.dr.dk/tv/live/dr2',
+        'https://www.dr.dk/tv/se/matador/matador-saeson-3/matador-15-24',
+    ]

--- a/tests/plugins/test_earthcam.py
+++ b/tests/plugins/test_earthcam.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.earthcam import EarthCam
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginEarthCam(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.earthcam.com/usa/newyork/timessquare/?cam=tsstreet',
-            'https://www.earthcam.com/usa/newyork/timessquare/?cam=gts1',
-        ]
-        for url in should_match:
-            self.assertTrue(EarthCam.can_handle_url(url))
+class TestPluginCanHandleUrlEarthCam(PluginCanHandleUrl):
+    __plugin__ = EarthCam
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(EarthCam.can_handle_url(url))
+    should_match = [
+        'https://www.earthcam.com/usa/newyork/timessquare/?cam=tsstreet',
+        'https://www.earthcam.com/usa/newyork/timessquare/?cam=gts1',
+    ]

--- a/tests/plugins/test_egame.py
+++ b/tests/plugins/test_egame.py
@@ -1,23 +1,17 @@
-import unittest
-
 from streamlink.plugins.egame import Egame
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginEgame(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://egame.qq.com/497383565',
-        ]
-        for url in should_match:
-            self.assertTrue(Egame.can_handle_url(url))
+class TestPluginCanHandleUrlEgame(PluginCanHandleUrl):
+    __plugin__ = Egame
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-            'https://egame.qq.com/',
-            'https://egame.qq.com/livelist?layoutid=lol',
-            'https://egame.qq.com/vod?videoId=123123123123123',
-            'https://egame.qq.com/aaabbbb'
-        ]
-        for url in should_not_match:
-            self.assertFalse(Egame.can_handle_url(url))
+    should_match = [
+        'https://egame.qq.com/497383565',
+    ]
+
+    should_not_match = [
+        'https://egame.qq.com/',
+        'https://egame.qq.com/livelist?layoutid=lol',
+        'https://egame.qq.com/vod?videoId=123123123123123',
+        'https://egame.qq.com/aaabbbb'
+    ]

--- a/tests/plugins/test_eltrecetv.py
+++ b/tests/plugins/test_eltrecetv.py
@@ -1,15 +1,16 @@
-import unittest
-
 from streamlink.plugins.eltrecetv import ElTreceTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginElTreceTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(ElTreceTV.can_handle_url("http://www.eltrecetv.com.ar/vivo"))
-        self.assertTrue(ElTreceTV.can_handle_url("http://www.eltrecetv.com.ar/pasapalabra/capitulo-1_084027"))
-        self.assertTrue(ElTreceTV.can_handle_url("http://www.eltrecetv.com.ar/a-todo-o-nada-2014/programa-2_072251"))
+class TestPluginCanHandleUrlElTreceTV(PluginCanHandleUrl):
+    __plugin__ = ElTreceTV
 
-        # shouldn't match
-        self.assertFalse(ElTreceTV.can_handle_url("http://eltrecetv.com.ar/"))
-        self.assertFalse(ElTreceTV.can_handle_url("https://www.youtube.com/c/eltrece"))
+    should_match = [
+        "http://www.eltrecetv.com.ar/vivo",
+        "http://www.eltrecetv.com.ar/pasapalabra/capitulo-1_084027",
+        "http://www.eltrecetv.com.ar/a-todo-o-nada-2014/programa-2_072251",
+    ]
+
+    should_not_match = [
+        "http://eltrecetv.com.ar/",
+    ]

--- a/tests/plugins/test_euronews.py
+++ b/tests/plugins/test_euronews.py
@@ -1,33 +1,24 @@
-import unittest
-
 from streamlink.plugins.euronews import Euronews
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginEuronews(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.euronews.com/live",
-            "http://fr.euronews.com/live",
-            "http://de.euronews.com/live",
-            "http://it.euronews.com/live",
-            "http://es.euronews.com/live",
-            "http://pt.euronews.com/live",
-            "http://ru.euronews.com/live",
-            "http://ua.euronews.com/live",
-            "http://tr.euronews.com/live",
-            "http://gr.euronews.com/live",
-            "http://hu.euronews.com/live",
-            "http://fa.euronews.com/live",
-            "http://arabic.euronews.com/live",
-            "http://www.euronews.com/2017/05/10/peugeot-expects-more-opel-losses-this-year",
-            "http://fr.euronews.com/2017/05/10/l-ag-de-psa-approuve-le-rachat-d-opel"
-        ]
-        for url in should_match:
-            self.assertTrue(Euronews.can_handle_url(url))
+class TestPluginCanHandleUrlEuronews(PluginCanHandleUrl):
+    __plugin__ = Euronews
 
-        should_not_match = [
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Euronews.can_handle_url(url))
+    should_match = [
+        "http://www.euronews.com/live",
+        "http://fr.euronews.com/live",
+        "http://de.euronews.com/live",
+        "http://it.euronews.com/live",
+        "http://es.euronews.com/live",
+        "http://pt.euronews.com/live",
+        "http://ru.euronews.com/live",
+        "http://ua.euronews.com/live",
+        "http://tr.euronews.com/live",
+        "http://gr.euronews.com/live",
+        "http://hu.euronews.com/live",
+        "http://fa.euronews.com/live",
+        "http://arabic.euronews.com/live",
+        "http://www.euronews.com/2017/05/10/peugeot-expects-more-opel-losses-this-year",
+        "http://fr.euronews.com/2017/05/10/l-ag-de-psa-approuve-le-rachat-d-opel"
+    ]

--- a/tests/plugins/test_facebook.py
+++ b/tests/plugins/test_facebook.py
@@ -1,16 +1,18 @@
-import unittest
-
 from streamlink.plugins.facebook import Facebook
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginFacebook(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/nos/videos/1725546430794241/"))
-        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/nytfood/videos/1485091228202006/"))
-        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/SporTurkTR/videos/798553173631138/"))
-        self.assertTrue(Facebook.can_handle_url("https://www.facebook.com/119555411802156/posts/500665313691162/"))
-        self.assertTrue(Facebook.can_handle_url("https://www.facebookcorewwwi.onion/SporTurkTR/videos/798553173631138/"))
+class TestPluginCanHandleUrlFacebook(PluginCanHandleUrl):
+    __plugin__ = Facebook
 
-        # shouldn't match
-        self.assertFalse(Facebook.can_handle_url("https://www.facebook.com"))
+    should_match = [
+        "https://www.facebook.com/nos/videos/1725546430794241/",
+        "https://www.facebook.com/nytfood/videos/1485091228202006/",
+        "https://www.facebook.com/SporTurkTR/videos/798553173631138/",
+        "https://www.facebook.com/119555411802156/posts/500665313691162/",
+        "https://www.facebookcorewwwi.onion/SporTurkTR/videos/798553173631138/",
+    ]
+
+    should_not_match = [
+        "https://www.facebook.com",
+    ]

--- a/tests/plugins/test_filmon.py
+++ b/tests/plugins/test_filmon.py
@@ -1,31 +1,26 @@
 import unittest
 
 from streamlink.plugins.filmon import Filmon
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlFilmon(PluginCanHandleUrl):
+    __plugin__ = Filmon
+
+    should_match = [
+        'http://www.filmon.tv/channel/grandstand-show',
+        'http://www.filmon.tv/index/popout?channel_id=5510&quality=low',
+        'http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1',
+        'http://www.filmon.tv/tv/channel/grandstand-show',
+        'http://www.filmon.tv/tv/channel-4',
+        'https://www.filmon.com/tv/bbc-news',
+        'https://www.filmon.tv/tv/55',
+        'http://www.filmon.tv/vod/view/10250-0-crime-boss',
+        'http://www.filmon.tv/group/comedy',
+    ]
 
 
 class TestPluginFilmon(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.filmon.tv/channel/grandstand-show',
-            'http://www.filmon.tv/index/popout?channel_id=5510&quality=low',
-            'http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1',
-            'http://www.filmon.tv/tv/channel/grandstand-show',
-            'http://www.filmon.tv/tv/channel-4',
-            'https://www.filmon.com/tv/bbc-news',
-            'https://www.filmon.tv/tv/55',
-            'http://www.filmon.tv/vod/view/10250-0-crime-boss',
-            'http://www.filmon.tv/group/comedy',
-        ]
-        for url in should_match:
-            self.assertTrue(Filmon.can_handle_url(url), url)
-
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Filmon.can_handle_url(url), url)
-
     def _test_regex(self, url, expected):
         m = Filmon.url_re.match(url)
         self.assertIsNotNone(m, url)

--- a/tests/plugins/test_foxtr.py
+++ b/tests/plugins/test_foxtr.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.foxtr import FoxTR
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginFoxTR(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.fox.com.tr/canli-yayin',
-        ]
-        for url in should_match:
-            self.assertTrue(FoxTR.can_handle_url(url))
+class TestPluginCanHandleUrlFoxTR(PluginCanHandleUrl):
+    __plugin__ = FoxTR
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(FoxTR.can_handle_url(url))
+    should_match = [
+        'http://www.fox.com.tr/canli-yayin',
+    ]

--- a/tests/plugins/test_funimationnow.py
+++ b/tests/plugins/test_funimationnow.py
@@ -3,25 +3,21 @@ from unittest.mock import ANY, MagicMock, call
 
 from streamlink import Streamlink
 from streamlink.plugins.funimationnow import FunimationNow
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlFunimationNow(PluginCanHandleUrl):
+    __plugin__ = FunimationNow
+
+    should_match = [
+        "http://www.funimation.com/anything",
+        "http://www.funimation.com/anything123",
+        "http://www.funimationnow.uk/anything",
+        "http://www.funimationnow.uk/anything123",
+    ]
 
 
 class TestPluginFunimationNow(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.funimation.com/anything",
-            "http://www.funimation.com/anything123",
-            "http://www.funimationnow.uk/anything",
-            "http://www.funimationnow.uk/anything123",
-        ]
-        for url in should_match:
-            self.assertTrue(FunimationNow.can_handle_url(url))
-
-        should_not_match = [
-            "https://www.youtube.com/v/aqz-KE-bpKQ",
-        ]
-        for url in should_not_match:
-            self.assertFalse(FunimationNow.can_handle_url(url))
-
     def test_arguments(self):
         from streamlink_cli.main import setup_plugin_args
         session = Streamlink()

--- a/tests/plugins/test_galatasaraytv.py
+++ b/tests/plugins/test_galatasaraytv.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.galatasaraytv import GalatasarayTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginGalatasarayTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://galatasaray.com/',
-            'https://galatasaray.com',
-            'https://galatasaray.com/',
-            'https://www.galatasaray.com/',
-        ]
-        for url in should_match:
-            self.assertTrue(GalatasarayTV.can_handle_url(url))
+class TestPluginCanHandleUrlGalatasarayTV(PluginCanHandleUrl):
+    __plugin__ = GalatasarayTV
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(GalatasarayTV.can_handle_url(url))
+    should_match = [
+        'http://galatasaray.com/',
+        'https://galatasaray.com',
+        'https://galatasaray.com/',
+        'https://www.galatasaray.com/',
+    ]

--- a/tests/plugins/test_gardenersworld.py
+++ b/tests/plugins/test_gardenersworld.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.gardenersworld import GardenersWorld
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginGardenersWorld(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.gardenersworld.com/',
-        ]
-        for url in should_match:
-            self.assertTrue(GardenersWorld.can_handle_url(url))
+class TestPluginCanHandleUrlGardenersWorld(PluginCanHandleUrl):
+    __plugin__ = GardenersWorld
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(GardenersWorld.can_handle_url(url))
+    should_match = [
+        'http://www.gardenersworld.com/',
+    ]

--- a/tests/plugins/test_garena.py
+++ b/tests/plugins/test_garena.py
@@ -5,6 +5,16 @@ from unittest.mock import MagicMock, Mock
 from streamlink import Streamlink
 from streamlink.plugin.api import HTTPSession
 from streamlink.plugins.garena import Garena
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlGarena(PluginCanHandleUrl):
+    __plugin__ = Garena
+
+    should_match = [
+        "https://garena.live/LOLTW",
+        "https://garena.live/358220",
+    ]
 
 
 class TestPluginGarena(unittest.TestCase):
@@ -12,15 +22,6 @@ class TestPluginGarena(unittest.TestCase):
         self.session = Streamlink()
         self.session.http = MagicMock(HTTPSession)
         self.session.http.headers = {}
-
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Garena.can_handle_url("https://garena.live/LOLTW"))
-        self.assertTrue(Garena.can_handle_url("https://garena.live/358220"))
-
-        # shouldn't match
-        self.assertFalse(Garena.can_handle_url("http://local.local/"))
-        self.assertFalse(Garena.can_handle_url("http://localhost.localhost/"))
 
     def test_post_api_info(self):
         API_INFO = Garena.API_INFO

--- a/tests/plugins/test_goltelevision.py
+++ b/tests/plugins/test_goltelevision.py
@@ -1,16 +1,13 @@
-import unittest
-
 from streamlink.plugins.goltelevision import GOLTelevision
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginEuronews(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(GOLTelevision.can_handle_url("http://www.goltelevision.com/live"))
-        self.assertTrue(GOLTelevision.can_handle_url("http://goltelevision.com/live"))
-        self.assertTrue(GOLTelevision.can_handle_url("https://goltelevision.com/live"))
-        self.assertTrue(GOLTelevision.can_handle_url("https://www.goltelevision.com/live"))
+class TestPluginCanHandleUrlEuronews(PluginCanHandleUrl):
+    __plugin__ = GOLTelevision
 
-        # shouldn't match
-        self.assertFalse(GOLTelevision.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(GOLTelevision.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://www.goltelevision.com/live",
+        "http://goltelevision.com/live",
+        "https://goltelevision.com/live",
+        "https://www.goltelevision.com/live",
+    ]

--- a/tests/plugins/test_goodgame.py
+++ b/tests/plugins/test_goodgame.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.goodgame import GoodGame
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginGoodGame(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://goodgame.ru/channel/ABC_ABC/#autoplay',
-            'https://goodgame.ru/channel/ABC123ABC/#autoplay',
-            'https://goodgame.ru/channel/ABC/#autoplay',
-            'https://goodgame.ru/channel/123ABC123/#autoplay',
-        ]
-        for url in should_match:
-            self.assertTrue(GoodGame.can_handle_url(url))
+class TestPluginCanHandleUrlGoodGame(PluginCanHandleUrl):
+    __plugin__ = GoodGame
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(GoodGame.can_handle_url(url))
+    should_match = [
+        'https://goodgame.ru/channel/ABC_ABC/#autoplay',
+        'https://goodgame.ru/channel/ABC123ABC/#autoplay',
+        'https://goodgame.ru/channel/ABC/#autoplay',
+        'https://goodgame.ru/channel/123ABC123/#autoplay',
+    ]

--- a/tests/plugins/test_googledrive.py
+++ b/tests/plugins/test_googledrive.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.googledrive import GoogleDocs
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginGoogleDocs(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://drive.google.com/file/d/123123/preview?start=1',
-        ]
-        for url in should_match:
-            self.assertTrue(GoogleDocs.can_handle_url(url))
+class TestPluginCanHandleUrlGoogleDocs(PluginCanHandleUrl):
+    __plugin__ = GoogleDocs
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(GoogleDocs.can_handle_url(url))
+    should_match = [
+        'https://drive.google.com/file/d/123123/preview?start=1',
+    ]

--- a/tests/plugins/test_gulli.py
+++ b/tests/plugins/test_gulli.py
@@ -1,26 +1,20 @@
-import unittest
-
 from streamlink.plugins.gulli import Gulli
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginGulli(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://replay.gulli.fr/Direct",
-            "http://replay.gulli.fr/dessins-animes/My-Little-Pony-les-amies-c-est-magique/VOD68328764799000",
-            "https://replay.gulli.fr/emissions/In-Ze-Boite2/VOD68639028668000",
-            "https://replay.gulli.fr/series/Power-Rangers-Dino-Super-Charge/VOD68612908435000"
-        ]
-        for url in should_match:
-            self.assertTrue(Gulli.can_handle_url(url))
+class TestPluginCanHandleUrlGulli(PluginCanHandleUrl):
+    __plugin__ = Gulli
 
-        should_not_match = [
-            "http://replay.gulli.fr/",
-            "http://replay.gulli.fr/dessins-animes",
-            "http://replay.gulli.fr/emissions",
-            "http://replay.gulli.fr/series",
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Gulli.can_handle_url(url))
+    should_match = [
+        "http://replay.gulli.fr/Direct",
+        "http://replay.gulli.fr/dessins-animes/My-Little-Pony-les-amies-c-est-magique/VOD68328764799000",
+        "https://replay.gulli.fr/emissions/In-Ze-Boite2/VOD68639028668000",
+        "https://replay.gulli.fr/series/Power-Rangers-Dino-Super-Charge/VOD68612908435000"
+    ]
+
+    should_not_match = [
+        "http://replay.gulli.fr/",
+        "http://replay.gulli.fr/dessins-animes",
+        "http://replay.gulli.fr/emissions",
+        "http://replay.gulli.fr/series",
+    ]

--- a/tests/plugins/test_hitbox.py
+++ b/tests/plugins/test_hitbox.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.hitbox import Hitbox
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginHitbox(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.smashcast.tv/pixelradio',
-            'https://www.hitbox.tv/pixelradio',
-            'https://www.smashcast.tv/jurnalfm',
-            'https://www.smashcast.tv/sscaitournament',
-        ]
-        for url in should_match:
-            self.assertTrue(Hitbox.can_handle_url(url))
+class TestPluginCanHandleUrlHitbox(PluginCanHandleUrl):
+    __plugin__ = Hitbox
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Hitbox.can_handle_url(url))
+    should_match = [
+        'http://www.smashcast.tv/pixelradio',
+        'https://www.hitbox.tv/pixelradio',
+        'https://www.smashcast.tv/jurnalfm',
+        'https://www.smashcast.tv/sscaitournament',
+    ]

--- a/tests/plugins/test_huajiao.py
+++ b/tests/plugins/test_huajiao.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.huajiao import Huajiao
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginHuajiao(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.huajiao.com/l/123123123',
-        ]
-        for url in should_match:
-            self.assertTrue(Huajiao.can_handle_url(url))
+class TestPluginCanHandleUrlHuajiao(PluginCanHandleUrl):
+    __plugin__ = Huajiao
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Huajiao.can_handle_url(url))
+    should_match = [
+        'http://www.huajiao.com/l/123123123',
+    ]

--- a/tests/plugins/test_huomao.py
+++ b/tests/plugins/test_huomao.py
@@ -1,71 +1,56 @@
-import unittest
-
 from streamlink.plugins.huomao import Huomao
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginHuomao(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            # Assert that an URL containing the http:// prefix is correctly read.
-            "http://www.huomao.com/123456",
-            "http://www.huomao.tv/123456",
-            "http://huomao.com/123456",
-            "http://huomao.tv/123456",
-            "http://www.huomao.com/video/v/123456",
-            "http://www.huomao.tv/video/v/123456",
-            "http://huomao.com/video/v/123456",
-            "http://huomao.tv/video/v/123456",
+class TestPluginCanHandleUrlHuomao(PluginCanHandleUrl):
+    __plugin__ = Huomao
 
-            # Assert that an URL containing the https:// prefix is correctly read.
-            "https://www.huomao.com/123456",
-            "https://www.huomao.tv/123456",
-            "https://huomao.com/123456",
-            "https://huomao.tv/123456",
-            "https://www.huomao.com/video/v/123456",
-            "https://www.huomao.tv/video/v/123456",
-            "https://huomao.com/video/v/123456",
-            "https://huomao.tv/video/v/123456",
+    should_match = [
+        # Assert that an URL containing the http:// prefix is correctly read.
+        "http://www.huomao.com/123456",
+        "http://www.huomao.tv/123456",
+        "http://huomao.com/123456",
+        "http://huomao.tv/123456",
+        "http://www.huomao.com/video/v/123456",
+        "http://www.huomao.tv/video/v/123456",
+        "http://huomao.com/video/v/123456",
+        "http://huomao.tv/video/v/123456",
 
-            # Assert that an URL without the http(s):// prefix is correctly read.
-            "www.huomao.com/123456",
-            "www.huomao.tv/123456",
-            "www.huomao.com/video/v/123456",
-            "www.huomao.tv/video/v/123456",
+        # Assert that an URL containing the https:// prefix is correctly read.
+        "https://www.huomao.com/123456",
+        "https://www.huomao.tv/123456",
+        "https://huomao.com/123456",
+        "https://huomao.tv/123456",
+        "https://www.huomao.com/video/v/123456",
+        "https://www.huomao.tv/video/v/123456",
+        "https://huomao.com/video/v/123456",
+        "https://huomao.tv/video/v/123456",
 
-            # Assert that an URL without the www prefix is correctly read.
-            "huomao.com/123456",
-            "huomao.tv/123456",
-            "huomao.com/video/v/123456",
-            "huomao.tv/video/v/123456",
-        ]
-        for url in should_match:
-            self.assertTrue(Huomao.can_handle_url(url))
+        # Assert that an URL without the http(s):// prefix is correctly read.
+        "www.huomao.com/123456",
+        "www.huomao.tv/123456",
+        "www.huomao.com/video/v/123456",
+        "www.huomao.tv/video/v/123456",
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            # Assert that an URL without a room_id can't be read.
-            "http://www.huomao.com/",
-            "http://www.huomao.tv/",
-            "http://huomao.com/",
-            "http://huomao.tv/",
-            "https://www.huomao.com/",
-            "https://www.huomao.tv/",
-            "https://huomao.com/",
-            "https://huomao.tv/",
-            "www.huomao.com/",
-            "www.huomao.tv/",
-            "huomao.tv/",
-            "huomao.tv/",
+        # Assert that an URL without the www prefix is correctly read.
+        "huomao.com/123456",
+        "huomao.tv/123456",
+        "huomao.com/video/v/123456",
+        "huomao.tv/video/v/123456",
+    ]
 
-            # Assert that an URL without "huomao" can't be read.
-            "http://www.youtube.com/123456",
-            "http://www.youtube.tv/123456",
-            "http://youtube.com/123456",
-            "http://youtube.tv/123456",
-            "https://www.youtube.com/123456",
-            "https://www.youtube.tv/123456",
-            "https://youtube.com/123456",
-            "https://youtube.tv/123456",
-        ]
-        for url in should_not_match:
-            self.assertFalse(Huomao.can_handle_url(url))
+    should_not_match = [
+        # Assert that an URL without a room_id can't be read.
+        "http://www.huomao.com/",
+        "http://www.huomao.tv/",
+        "http://huomao.com/",
+        "http://huomao.tv/",
+        "https://www.huomao.com/",
+        "https://www.huomao.tv/",
+        "https://huomao.com/",
+        "https://huomao.tv/",
+        "www.huomao.com/",
+        "www.huomao.tv/",
+        "huomao.tv/",
+        "huomao.tv/",
+    ]

--- a/tests/plugins/test_huya.py
+++ b/tests/plugins/test_huya.py
@@ -1,21 +1,16 @@
-import unittest
-
 from streamlink.plugins.huya import Huya
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginHuya(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.huya.com/123123123',
-            'http://www.huya.com/name',
-            'https://www.huya.com/123123123',
-        ]
-        for url in should_match:
-            self.assertTrue(Huya.can_handle_url(url), url)
+class TestPluginCanHandleUrlHuya(PluginCanHandleUrl):
+    __plugin__ = Huya
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.huya.com',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Huya.can_handle_url(url), url)
+    should_match = [
+        'http://www.huya.com/123123123',
+        'http://www.huya.com/name',
+        'https://www.huya.com/123123123',
+    ]
+
+    should_not_match = [
+        'http://www.huya.com',
+    ]

--- a/tests/plugins/test_idf1.py
+++ b/tests/plugins/test_idf1.py
@@ -1,18 +1,18 @@
-import unittest
-
 from streamlink.plugins.idf1 import IDF1
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginIDF1(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(IDF1.can_handle_url("https://www.idf1.fr/live"))
-        self.assertTrue(IDF1.can_handle_url("https://www.idf1.fr/videos/jlpp/best-of-2018-02-24-partie-2.html"))
-        self.assertTrue(IDF1.can_handle_url("http://www.idf1.fr/videos/buzz-de-noel/partie-2.html"))
+class TestPluginCanHandleUrlIDF1(PluginCanHandleUrl):
+    __plugin__ = IDF1
 
-        # shouldn't match
-        self.assertFalse(IDF1.can_handle_url("https://www.idf1.fr/"))
-        self.assertFalse(IDF1.can_handle_url("https://www.idf1.fr/videos"))
-        self.assertFalse(IDF1.can_handle_url("https://www.idf1.fr/programmes/emissions/idf1-chez-vous.html"))
-        self.assertFalse(IDF1.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(IDF1.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://www.idf1.fr/live",
+        "https://www.idf1.fr/videos/jlpp/best-of-2018-02-24-partie-2.html",
+        "http://www.idf1.fr/videos/buzz-de-noel/partie-2.html",
+    ]
+
+    should_not_match = [
+        "https://www.idf1.fr/",
+        "https://www.idf1.fr/videos",
+        "https://www.idf1.fr/programmes/emissions/idf1-chez-vous.html",
+    ]

--- a/tests/plugins/test_ine.py
+++ b/tests/plugins/test_ine.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.ine import INE
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginINE(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://streaming.ine.com/play/11111111-2222-3333-4444-555555555555/introduction/',
-        ]
-        for url in should_match:
-            self.assertTrue(INE.can_handle_url(url))
+class TestPluginCanHandleUrlINE(PluginCanHandleUrl):
+    __plugin__ = INE
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(INE.can_handle_url(url))
+    should_match = [
+        'https://streaming.ine.com/play/11111111-2222-3333-4444-555555555555/introduction/',
+    ]

--- a/tests/plugins/test_invintus.py
+++ b/tests/plugins/test_invintus.py
@@ -1,18 +1,14 @@
-import unittest
-
 from streamlink.plugins.invintus import InvintusMedia
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginInvintusMedia(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://player.invintus.com/?clientID=9375922947&eventID=2020031185',
-            'https://player.invintus.com/?clientID=9375922947&eventID=2020031184',
-            'https://player.invintus.com/?clientID=9375922947&eventID=2020031183',
-            'https://player.invintus.com/?clientID=9375922947&eventID=2020031182',
-            'https://player.invintus.com/?clientID=9375922947&eventID=2020031181'
-        ]
-        for url in should_match:
-            self.assertTrue(InvintusMedia.can_handle_url(url))
+class TestPluginCanHandleUrlInvintusMedia(PluginCanHandleUrl):
+    __plugin__ = InvintusMedia
 
-        self.assertFalse(InvintusMedia.can_handle_url("https://example.com"))
+    should_match = [
+        'https://player.invintus.com/?clientID=9375922947&eventID=2020031185',
+        'https://player.invintus.com/?clientID=9375922947&eventID=2020031184',
+        'https://player.invintus.com/?clientID=9375922947&eventID=2020031183',
+        'https://player.invintus.com/?clientID=9375922947&eventID=2020031182',
+        'https://player.invintus.com/?clientID=9375922947&eventID=2020031181'
+    ]

--- a/tests/plugins/test_kugou.py
+++ b/tests/plugins/test_kugou.py
@@ -1,24 +1,15 @@
-import unittest
-
 from streamlink.plugins.kugou import Kugou
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginKugou(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://fanxing.kugou.com/1062645?refer=605',
-            'https://fanxing.kugou.com/77997777?refer=605',
-            'https://fanxing.kugou.com/1047927?refer=605',
-            'https://fanxing.kugou.com/1048570?refer=605',
-            'https://fanxing.kugou.com/1062642?refer=605',
-            'https://fanxing.kugou.com/1071651',
-        ]
-        for url in should_match:
-            self.assertTrue(Kugou.can_handle_url(url), url)
+class TestPluginCanHandleUrlKugou(PluginCanHandleUrl):
+    __plugin__ = Kugou
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Kugou.can_handle_url(url), url)
+    should_match = [
+        'https://fanxing.kugou.com/1062645?refer=605',
+        'https://fanxing.kugou.com/77997777?refer=605',
+        'https://fanxing.kugou.com/1047927?refer=605',
+        'https://fanxing.kugou.com/1048570?refer=605',
+        'https://fanxing.kugou.com/1062642?refer=605',
+        'https://fanxing.kugou.com/1071651',
+    ]

--- a/tests/plugins/test_latina.py
+++ b/tests/plugins/test_latina.py
@@ -1,19 +1,14 @@
-import unittest
-
 from streamlink.plugins.latina import Latina
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLatina(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.latina.pe/tvenvivo/',
-        ]
-        for url in should_match:
-            self.assertTrue(Latina.can_handle_url(url), url)
+class TestPluginCanHandleUrlLatina(PluginCanHandleUrl):
+    __plugin__ = Latina
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.latina.pe/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Latina.can_handle_url(url), url)
+    should_match = [
+        'http://www.latina.pe/tvenvivo/',
+    ]
+
+    should_not_match = [
+        'http://www.latina.pe/',
+    ]

--- a/tests/plugins/test_linelive.py
+++ b/tests/plugins/test_linelive.py
@@ -1,21 +1,15 @@
-import unittest
-
 from streamlink.plugins.linelive import LineLive
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLineLive(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://live.line.me/channels/123/broadcast/12345678',
-            'https://live.line.me/channels/123/broadcast/12345678',
-        ]
-        for url in should_match:
-            self.assertTrue(LineLive.can_handle_url(url))
+class TestPluginCanHandleUrlLineLive(PluginCanHandleUrl):
+    __plugin__ = LineLive
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-            'https://live.line.me/channels/123/upcoming/12345678',
-        ]
-        for url in should_not_match:
-            self.assertFalse(LineLive.can_handle_url(url))
+    should_match = [
+        'http://live.line.me/channels/123/broadcast/12345678',
+        'https://live.line.me/channels/123/broadcast/12345678',
+    ]
+
+    should_not_match = [
+        'https://live.line.me/channels/123/upcoming/12345678',
+    ]

--- a/tests/plugins/test_live_russia_tv.py
+++ b/tests/plugins/test_live_russia_tv.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.live_russia_tv import LiveRussia
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLiveRussiaTv(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://live.russia.tv/channel/1",
-            "https://live.russia.tv/channel/199",
-            "https://live.russia.tv/",
-            "https://live.russia.tv/video/show/brand_id/60473/episode_id/2187772/video_id/2204594"
-        ]
-        for url in should_match:
-            self.assertTrue(LiveRussia.can_handle_url(url))
+class TestPluginCanHandleUrlLiveRussiaTv(PluginCanHandleUrl):
+    __plugin__ = LiveRussia
 
-        should_not_match = [
-            "http://live.france.tv/somethingelse",
-            "https://youtube.com/watch?v=4567uj"
-        ]
-        for url in should_not_match:
-            self.assertFalse(LiveRussia.can_handle_url(url))
+    should_match = [
+        "https://live.russia.tv/channel/1",
+        "https://live.russia.tv/channel/199",
+        "https://live.russia.tv/",
+        "https://live.russia.tv/video/show/brand_id/60473/episode_id/2187772/video_id/2204594"
+    ]

--- a/tests/plugins/test_liveedu.py
+++ b/tests/plugins/test_liveedu.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.liveedu import LiveEdu
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLiveEdu(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.liveedu.tv/',
-        ]
-        for url in should_match:
-            self.assertTrue(LiveEdu.can_handle_url(url))
+class TestPluginCanHandleUrlLiveEdu(PluginCanHandleUrl):
+    __plugin__ = LiveEdu
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(LiveEdu.can_handle_url(url))
+    should_match = [
+        'https://www.liveedu.tv/',
+    ]

--- a/tests/plugins/test_liveme.py
+++ b/tests/plugins/test_liveme.py
@@ -1,21 +1,17 @@
-import unittest
-
 from streamlink.plugins.liveme import LiveMe
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLiveMe(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.liveme.com/live.html?videoid=12312312312312312312",
-            "http://www.liveme.com/live.html?videoid=23123123123123123123&countryCode=undefined"
-        ]
-        for url in should_match:
-            self.assertTrue(LiveMe.can_handle_url(url))
+class TestPluginCanHandleUrlLiveMe(PluginCanHandleUrl):
+    __plugin__ = LiveMe
 
-        should_not_match = [
-            "http://www.liveme.com/",
-            "http://www.liveme.com/explore.html",
-            "http://www.liveme.com/media/play"
-        ]
-        for url in should_not_match:
-            self.assertFalse(LiveMe.can_handle_url(url))
+    should_match = [
+        "http://www.liveme.com/live.html?videoid=12312312312312312312",
+        "http://www.liveme.com/live.html?videoid=23123123123123123123&countryCode=undefined"
+    ]
+
+    should_not_match = [
+        "http://www.liveme.com/",
+        "http://www.liveme.com/explore.html",
+        "http://www.liveme.com/media/play"
+    ]

--- a/tests/plugins/test_livestream.py
+++ b/tests/plugins/test_livestream.py
@@ -1,21 +1,12 @@
-import unittest
-
 from streamlink.plugins.livestream import Livestream
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLivestream(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://livestream.com/',
-            'https://www.livestream.com/',
-            'https://livestream.com/accounts/22300508/events/6675945',
-        ]
-        for url in should_match:
-            self.assertTrue(Livestream.can_handle_url(url), url)
+class TestPluginCanHandleUrlLivestream(PluginCanHandleUrl):
+    __plugin__ = Livestream
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Livestream.can_handle_url(url), url)
+    should_match = [
+        'https://livestream.com/',
+        'https://www.livestream.com/',
+        'https://livestream.com/accounts/22300508/events/6675945',
+    ]

--- a/tests/plugins/test_lrt.py
+++ b/tests/plugins/test_lrt.py
@@ -1,27 +1,20 @@
-import unittest
-
 from streamlink.plugins.lrt import LRT
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLRT(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.lrt.lt/mediateka/tiesiogiai/lrt-opus",
-            "https://www.lrt.lt/mediateka/tiesiogiai/lrt-klasika",
-            "https://www.lrt.lt/mediateka/tiesiogiai/lrt-radijas",
-            "https://www.lrt.lt/mediateka/tiesiogiai/lrt-lituanica",
-            "https://www.lrt.lt/mediateka/tiesiogiai/lrt-plius",
-            "https://www.lrt.lt/mediateka/tiesiogiai/lrt-televizija",
-        ]
-        for url in should_match:
-            self.assertTrue(LRT.can_handle_url(url), url)
+class TestPluginCanHandleUrlLRT(PluginCanHandleUrl):
+    __plugin__ = LRT
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            "https://www.lrt.lt",
-            "https://www.youtube.com",
-            "https://www.lrt.lt/mediateka/irasas/1013694276/savanoriai-tures-galimybe-pamatyti-popieziu-is-arciau",
+    should_match = [
+        "https://www.lrt.lt/mediateka/tiesiogiai/lrt-opus",
+        "https://www.lrt.lt/mediateka/tiesiogiai/lrt-klasika",
+        "https://www.lrt.lt/mediateka/tiesiogiai/lrt-radijas",
+        "https://www.lrt.lt/mediateka/tiesiogiai/lrt-lituanica",
+        "https://www.lrt.lt/mediateka/tiesiogiai/lrt-plius",
+        "https://www.lrt.lt/mediateka/tiesiogiai/lrt-televizija",
+    ]
 
-        ]
-        for url in should_not_match:
-            self.assertFalse(LRT.can_handle_url(url), url)
+    should_not_match = [
+        "https://www.lrt.lt",
+        "https://www.lrt.lt/mediateka/irasas/1013694276/savanoriai-tures-galimybe-pamatyti-popieziu-is-arciau",
+    ]

--- a/tests/plugins/test_ltv_lsm_lv.py
+++ b/tests/plugins/test_ltv_lsm_lv.py
@@ -1,21 +1,24 @@
-import unittest
-
 from streamlink.plugins.ltv_lsm_lv import LtvLsmLv
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginLtvLsmLv(unittest.TestCase):
-    def test_can_handle_url(self):
-        self.assertTrue(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv/tieshraide/example/"))
-        self.assertTrue(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv/tieshraide/example/"))
-        self.assertTrue(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv/tieshraide/example/live.123/"))
-        self.assertTrue(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv/tieshraide/example/live.123/"))
+class TestPluginCanHandleUrlLtvLsmLv(PluginCanHandleUrl):
+    __plugin__ = LtvLsmLv
 
-    def test_can_handle_url_negative(self):
-        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv"))
-        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv"))
-        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv"))
-        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv"))
-        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/other-site/"))
-        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/other-site/"))
-        self.assertFalse(LtvLsmLv.can_handle_url("https://ltv.lsm.lv/lv/other-site/"))
-        self.assertFalse(LtvLsmLv.can_handle_url("http://ltv.lsm.lv/lv/other-site/"))
+    should_match = [
+        "https://ltv.lsm.lv/lv/tieshraide/example/",
+        "http://ltv.lsm.lv/lv/tieshraide/example/",
+        "https://ltv.lsm.lv/lv/tieshraide/example/live.123/",
+        "http://ltv.lsm.lv/lv/tieshraide/example/live.123/",
+    ]
+
+    should_not_match = [
+        "https://ltv.lsm.lv",
+        "http://ltv.lsm.lv",
+        "https://ltv.lsm.lv/lv",
+        "http://ltv.lsm.lv/lv",
+        "https://ltv.lsm.lv/other-site/",
+        "http://ltv.lsm.lv/other-site/",
+        "https://ltv.lsm.lv/lv/other-site/",
+        "http://ltv.lsm.lv/lv/other-site/",
+    ]

--- a/tests/plugins/test_mediaklikk.py
+++ b/tests/plugins/test_mediaklikk.py
@@ -1,22 +1,17 @@
-import unittest
-
 from streamlink.plugins.mediaklikk import Mediaklikk
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginMediaklikk(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.mediaklikk.hu/duna-world-elo/',
-            'https://www.mediaklikk.hu/duna-world-radio-elo',
-            'https://www.mediaklikk.hu/m1-elo',
-            'https://www.mediaklikk.hu/m2-elo',
-        ]
-        for url in should_match:
-            self.assertTrue(Mediaklikk.can_handle_url(url))
+class TestPluginCanHandleUrlMediaklikk(PluginCanHandleUrl):
+    __plugin__ = Mediaklikk
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.mediaklikk.hu',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Mediaklikk.can_handle_url(url))
+    should_match = [
+        'https://www.mediaklikk.hu/duna-world-elo/',
+        'https://www.mediaklikk.hu/duna-world-radio-elo',
+        'https://www.mediaklikk.hu/m1-elo',
+        'https://www.mediaklikk.hu/m2-elo',
+    ]
+
+    should_not_match = [
+        'https://www.mediaklikk.hu',
+    ]

--- a/tests/plugins/test_mitele.py
+++ b/tests/plugins/test_mitele.py
@@ -1,26 +1,22 @@
-import unittest
-
 from streamlink.plugins.mitele import Mitele
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginMitele(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.mitele.es/directo/bemad",
-            "http://www.mitele.es/directo/boing",
-            "http://www.mitele.es/directo/cuatro",
-            "http://www.mitele.es/directo/divinity",
-            "http://www.mitele.es/directo/energy",
-            "http://www.mitele.es/directo/fdf",
-            "http://www.mitele.es/directo/telecinco",
-            "https://www.mitele.es/directo/gh-duo-24h-senal-1",
-            "https://www.mitele.es/directo/gh-duo-24h-senal-2",
-        ]
-        for url in should_match:
-            self.assertTrue(Mitele.can_handle_url(url))
+class TestPluginCanHandleUrlMitele(PluginCanHandleUrl):
+    __plugin__ = Mitele
 
-        should_not_match = [
-            "http://www.mitele.es",
-        ]
-        for url in should_not_match:
-            self.assertFalse(Mitele.can_handle_url(url))
+    should_match = [
+        "http://www.mitele.es/directo/bemad",
+        "http://www.mitele.es/directo/boing",
+        "http://www.mitele.es/directo/cuatro",
+        "http://www.mitele.es/directo/divinity",
+        "http://www.mitele.es/directo/energy",
+        "http://www.mitele.es/directo/fdf",
+        "http://www.mitele.es/directo/telecinco",
+        "https://www.mitele.es/directo/gh-duo-24h-senal-1",
+        "https://www.mitele.es/directo/gh-duo-24h-senal-2",
+    ]
+
+    should_not_match = [
+        "http://www.mitele.es",
+    ]

--- a/tests/plugins/test_mjunoon.py
+++ b/tests/plugins/test_mjunoon.py
@@ -5,20 +5,25 @@ import requests_mock
 
 from streamlink import Streamlink
 from streamlink.plugins.mjunoon import Mjunoon
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginMixer(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Mjunoon.can_handle_url('https://mjunoon.tv/news-live'))
-        self.assertTrue(Mjunoon.can_handle_url('http://mjunoon.tv/watch/some-long-vod-name23456'))
-        self.assertTrue(Mjunoon.can_handle_url('https://www.mjunoon.tv/other-live'))
-        self.assertTrue(Mjunoon.can_handle_url('https://www.mjunoon.tv/watch/something-else-2321'))
+class TestPluginCanHandleUrlMjunoon(PluginCanHandleUrl):
+    __plugin__ = Mjunoon
 
-    def test_can_handle_url_negative(self):
-        # shouldn't match
-        self.assertFalse(Mjunoon.can_handle_url('https://mjunoon.com'))
+    should_match = [
+        'https://mjunoon.tv/news-live',
+        'http://mjunoon.tv/watch/some-long-vod-name23456',
+        'https://www.mjunoon.tv/other-live',
+        'https://www.mjunoon.tv/watch/something-else-2321',
+    ]
 
+    should_not_match = [
+        'https://mjunoon.com',
+    ]
+
+
+class TestPluginMjunoon(unittest.TestCase):
     @patch('streamlink.plugins.mjunoon.HLSStream.parse_variant_playlist')
     def test_get_streams(self, parse_variant_playlist):
         session = Streamlink()

--- a/tests/plugins/test_mrtmk.py
+++ b/tests/plugins/test_mrtmk.py
@@ -1,22 +1,17 @@
-import unittest
-
 from streamlink.plugins.mrtmk import MRTmk
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginMRTmk(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://play.mrt.com.mk/live/658323455489957',
-            'http://play.mrt.com.mk/live/47',
-            'http://play.mrt.com.mk/play/1581',
-        ]
-        for url in should_match:
-            self.assertTrue(MRTmk.can_handle_url(url), url)
+class TestPluginCanHandleUrlMRTmk(PluginCanHandleUrl):
+    __plugin__ = MRTmk
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://play.mrt.com.mk/',
-            'http://play.mrt.com.mk/c/2',
-        ]
-        for url in should_not_match:
-            self.assertFalse(MRTmk.can_handle_url(url), url)
+    should_match = [
+        'http://play.mrt.com.mk/live/658323455489957',
+        'http://play.mrt.com.mk/live/47',
+        'http://play.mrt.com.mk/play/1581',
+    ]
+
+    should_not_match = [
+        'http://play.mrt.com.mk/',
+        'http://play.mrt.com.mk/c/2',
+    ]

--- a/tests/plugins/test_n13tv.py
+++ b/tests/plugins/test_n13tv.py
@@ -1,30 +1,21 @@
-import unittest
-
 from streamlink.plugins.n13tv import N13TV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginN13TV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://13tv.co.il/live",
-            "https://13tv.co.il/live",
-            "http://www.13tv.co.il/live/",
-            "https://www.13tv.co.il/live/",
-            "http://13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/",
-            "https://13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/",
-            "http://www.13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/",
-            "https://www.13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/"
-            "http://13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/",
-            "https://13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/",
-            "http://www.13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/"
-            "https://www.13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/"
-        ]
-        for url in should_match:
-            self.assertTrue(N13TV.can_handle_url(url))
+class TestPluginCanHandleUrlN13TV(PluginCanHandleUrl):
+    __plugin__ = N13TV
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            "https://www.youtube.com",
-        ]
-        for url in should_not_match:
-            self.assertFalse(N13TV.can_handle_url(url))
+    should_match = [
+        "http://13tv.co.il/live",
+        "https://13tv.co.il/live",
+        "http://www.13tv.co.il/live/",
+        "https://www.13tv.co.il/live/",
+        "http://13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/",
+        "https://13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/",
+        "http://www.13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/",
+        "https://www.13tv.co.il/item/entertainment/ambush/season-02/episodes/ffuk3-2026112/"
+        "http://13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/",
+        "https://13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/",
+        "http://www.13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/"
+        "https://www.13tv.co.il/item/entertainment/tzhok-mehamatzav/season-01/episodes/vkdoc-2023442/"
+    ]

--- a/tests/plugins/test_nbc.py
+++ b/tests/plugins/test_nbc.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.nbc import NBC
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNBC(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.nbc.com/nightly-news/video/nbc-nightly-news-jun-29-2018/3745314',
-        ]
-        for url in should_match:
-            self.assertTrue(NBC.can_handle_url(url))
+class TestPluginCanHandleUrlNBC(PluginCanHandleUrl):
+    __plugin__ = NBC
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NBC.can_handle_url(url))
+    should_match = [
+        'https://www.nbc.com/nightly-news/video/nbc-nightly-news-jun-29-2018/3745314',
+    ]

--- a/tests/plugins/test_nbcnews.py
+++ b/tests/plugins/test_nbcnews.py
@@ -1,21 +1,16 @@
-import unittest
-
 from streamlink.plugins.nbcnews import NBCNews
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNBCNews(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.nbcnews.com/now/',
-            'http://www.nbcnews.com/now/'
-        ]
-        for url in should_match:
-            self.assertTrue(NBCNews.can_handle_url(url))
+class TestPluginCanHandleUrlNBCNews(PluginCanHandleUrl):
+    __plugin__ = NBCNews
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.nbcnews.com/',
-            'http://www.nbcnews.com/'
-        ]
-        for url in should_not_match:
-            self.assertFalse(NBCNews.can_handle_url(url))
+    should_match = [
+        'https://www.nbcnews.com/now/',
+        'http://www.nbcnews.com/now/'
+    ]
+
+    should_not_match = [
+        'https://www.nbcnews.com/',
+        'http://www.nbcnews.com/'
+    ]

--- a/tests/plugins/test_nbcsports.py
+++ b/tests/plugins/test_nbcsports.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.nbcsports import NBCSports
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNBCSports(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.nbcsports.com/video/evertons-wayne-rooney-completes-hat-trick-goal-midfield',
-        ]
-        for url in should_match:
-            self.assertTrue(NBCSports.can_handle_url(url))
+class TestPluginCanHandleUrlNBCSports(PluginCanHandleUrl):
+    __plugin__ = NBCSports
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NBCSports.can_handle_url(url))
+    should_match = [
+        'https://www.nbcsports.com/video/evertons-wayne-rooney-completes-hat-trick-goal-midfield',
+    ]

--- a/tests/plugins/test_nhkworld.py
+++ b/tests/plugins/test_nhkworld.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.nhkworld import NHKWorld
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNHKWorld(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www3.nhk.or.jp/nhkworld/en/live/',
-        ]
-        for url in should_match:
-            self.assertTrue(NHKWorld.can_handle_url(url))
+class TestPluginCanHandleUrlNHKWorld(PluginCanHandleUrl):
+    __plugin__ = NHKWorld
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NHKWorld.can_handle_url(url))
+    should_match = [
+        'https://www3.nhk.or.jp/nhkworld/en/live/',
+    ]

--- a/tests/plugins/test_nicolive.py
+++ b/tests/plugins/test_nicolive.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.nicolive import NicoLive
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNicoLive(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://live2.nicovideo.jp/watch/lv534562961',
-            'http://live2.nicovideo.jp/watch/lv534562961',
-            'https://live.nicovideo.jp/watch/lv534562961',
-            'https://live2.nicovideo.jp/watch/lv534562961?ref=rtrec&zroute=recent',
-        ]
-        for url in should_match:
-            self.assertTrue(NicoLive.can_handle_url(url))
+class TestPluginCanHandleUrlNicoLive(PluginCanHandleUrl):
+    __plugin__ = NicoLive
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NicoLive.can_handle_url(url))
+    should_match = [
+        'https://live2.nicovideo.jp/watch/lv534562961',
+        'http://live2.nicovideo.jp/watch/lv534562961',
+        'https://live.nicovideo.jp/watch/lv534562961',
+        'https://live2.nicovideo.jp/watch/lv534562961?ref=rtrec&zroute=recent',
+    ]

--- a/tests/plugins/test_nimotv.py
+++ b/tests/plugins/test_nimotv.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.nimotv import NimoTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNimoTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.nimo.tv/live/737614',
-            'https://www.nimo.tv/live/737614',
-            'http://www.nimo.tv/sanz',
-            'https://www.nimo.tv/sanz',
-        ]
-        for url in should_match:
-            self.assertTrue(NimoTV.can_handle_url(url))
+class TestPluginNimoTV(PluginCanHandleUrl):
+    __plugin__ = NimoTV
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NimoTV.can_handle_url(url))
+    should_match = [
+        'http://www.nimo.tv/live/737614',
+        'https://www.nimo.tv/live/737614',
+        'http://www.nimo.tv/sanz',
+        'https://www.nimo.tv/sanz',
+    ]

--- a/tests/plugins/test_nos.py
+++ b/tests/plugins/test_nos.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.nos import NOS
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNOS(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://nos.nl/livestream/2220100-wk-sprint-schaatsen-1-000-meter-mannen.html',
-        ]
-        for url in should_match:
-            self.assertTrue(NOS.can_handle_url(url))
+class TestPluginCanHandleUrlNOS(PluginCanHandleUrl):
+    __plugin__ = NOS
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NOS.can_handle_url(url))
+    should_match = [
+        'https://nos.nl/livestream/2220100-wk-sprint-schaatsen-1-000-meter-mannen.html',
+    ]

--- a/tests/plugins/test_nownews.py
+++ b/tests/plugins/test_nownews.py
@@ -1,27 +1,18 @@
-import unittest  # noqa: F401
-
-import pytest
-
 from streamlink.plugins.nownews import NowNews
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNowNews:
-    valid_urls = [
-        ("https://news.now.com/home/live",),
-        ("http://news.now.com/home/live",),
-        ("https://news.now.com/home/live331a",),
-        ("http://news.now.com/home/live331a",)
-    ]
-    invalid_urls = [
-        ("https://news.now.com/home/local",),
-        ("http://media.now.com.hk/",),
-        ("https://www.youtube.com",)
+class TestPluginCanHandleUrlNowNews(PluginCanHandleUrl):
+    __plugin__ = NowNews
+
+    should_match = [
+        "https://news.now.com/home/live",
+        "http://news.now.com/home/live",
+        "https://news.now.com/home/live331a",
+        "http://news.now.com/home/live331a"
     ]
 
-    @pytest.mark.parametrize(["url"], valid_urls)
-    def test_can_handle_url(self, url):
-        assert NowNews.can_handle_url(url), "url should be handled"
-
-    @pytest.mark.parametrize(["url"], invalid_urls)
-    def test_can_handle_url_negative(self, url):
-        assert not NowNews.can_handle_url(url), "url should not be handled"
+    should_not_match = [
+        "https://news.now.com/home/local",
+        "http://media.now.com.hk/",
+    ]

--- a/tests/plugins/test_nrk.py
+++ b/tests/plugins/test_nrk.py
@@ -1,34 +1,29 @@
-import unittest
-
 from streamlink.plugins.nrk import NRK
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNRK(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://tv.nrk.no/direkte/nrk1',
-            'https://tv.nrk.no/direkte/nrk2',
-            'https://tv.nrk.no/direkte/nrk3',
-            'https://tv.nrk.no/direkte/nrksuper',
+class TestPluginCanHandleUrlNRK(PluginCanHandleUrl):
+    __plugin__ = NRK
 
-            'https://tv.nrk.no/serie/nytt-paa-nytt/2020/MUHH43003020',
-            'https://tv.nrk.no/serie/kongelige-fotografer/sesong/1/episode/2/avspiller',
+    should_match = [
+        'https://tv.nrk.no/direkte/nrk1',
+        'https://tv.nrk.no/direkte/nrk2',
+        'https://tv.nrk.no/direkte/nrk3',
+        'https://tv.nrk.no/direkte/nrksuper',
 
-            'https://tv.nrk.no/program/NNFA51102617',
+        'https://tv.nrk.no/serie/nytt-paa-nytt/2020/MUHH43003020',
+        'https://tv.nrk.no/serie/kongelige-fotografer/sesong/1/episode/2/avspiller',
 
-            'https://radio.nrk.no/direkte/p1',
-            'https://radio.nrk.no/direkte/p2',
+        'https://tv.nrk.no/program/NNFA51102617',
 
-            'https://radio.nrk.no/podkast/oppdatert/l_5005d62a-7f4f-4581-85d6-2a7f4f2581f2',
-        ]
-        for url in should_match:
-            self.assertTrue(NRK.can_handle_url(url))
+        'https://radio.nrk.no/direkte/p1',
+        'https://radio.nrk.no/direkte/p2',
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://tv.nrk.no/',
-            'https://radio.nrk.no/',
-            'https://nrk.no/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(NRK.can_handle_url(url))
+        'https://radio.nrk.no/podkast/oppdatert/l_5005d62a-7f4f-4581-85d6-2a7f4f2581f2',
+    ]
+
+    should_not_match = [
+        'https://tv.nrk.no/',
+        'https://radio.nrk.no/',
+        'https://nrk.no/',
+    ]

--- a/tests/plugins/test_ntv.py
+++ b/tests/plugins/test_ntv.py
@@ -1,21 +1,16 @@
-import unittest
-
 from streamlink.plugins.ntv import NTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginNTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.ntv.ru/air/',
-            'http://www.ntv.ru/air/'
-        ]
-        for url in should_match:
-            self.assertTrue(NTV.can_handle_url(url))
+class TestPluginCanHandleUrlNTV(PluginCanHandleUrl):
+    __plugin__ = NTV
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.ntv.ru/',
-            'http://www.ntv.ru/'
-        ]
-        for url in should_not_match:
-            self.assertFalse(NTV.can_handle_url(url))
+    should_match = [
+        'https://www.ntv.ru/air/',
+        'http://www.ntv.ru/air/'
+    ]
+
+    should_not_match = [
+        'https://www.ntv.ru/',
+        'http://www.ntv.ru/'
+    ]

--- a/tests/plugins/test_okru.py
+++ b/tests/plugins/test_okru.py
@@ -1,22 +1,13 @@
-import unittest
-
 from streamlink.plugins.okru import OKru
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginOKru(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://ok.ru/live/12345',
-            'http://ok.ru/live/12345',
-            'http://www.ok.ru/live/12345',
-            'https://ok.ru/video/266205792931',
-        ]
-        for url in should_match:
-            self.assertTrue(OKru.can_handle_url(url), url)
+class TestPluginCanHandleUrlOKru(PluginCanHandleUrl):
+    __plugin__ = OKru
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.example.com',
-        ]
-        for url in should_not_match:
-            self.assertFalse(OKru.can_handle_url(url), url)
+    should_match = [
+        'https://ok.ru/live/12345',
+        'http://ok.ru/live/12345',
+        'http://www.ok.ru/live/12345',
+        'https://ok.ru/video/266205792931',
+    ]

--- a/tests/plugins/test_olympicchannel.py
+++ b/tests/plugins/test_olympicchannel.py
@@ -1,22 +1,20 @@
-import unittest
-
 from streamlink.plugins.olympicchannel import OlympicChannel
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginOlympicChannel(unittest.TestCase):
-    def test_can_handle_url(self):
-        urls = (
-            "https://www.olympicchannel.com/en/video/detail/stefanidi-husband-coach-krier-relationship/",
-            "https://www.olympicchannel.com/en/live/",
-            "https://www.olympicchannel.com/en/live/video/detail/olympic-ceremonies-channel/",
-            "https://www.olympicchannel.com/de/video/detail/stefanidi-husband-coach-krier-relationship/",
-            "https://www.olympicchannel.com/de/original-series/detail/body/body-season-season-1/episodes/"
-            "treffen-sie-aaron-wheelz-fotheringham-den-paten-des-rollstuhl-extremsports/",
-        )
-        for url in urls:
-            # should match
-            self.assertTrue(OlympicChannel.can_handle_url(url))
+class TestPluginCanHandleUrlOlympicChannel(PluginCanHandleUrl):
+    __plugin__ = OlympicChannel
 
-        # shouldn't match
-        self.assertFalse(OlympicChannel.can_handle_url("https://www.olympicchannel.com/en/"))
-        self.assertFalse(OlympicChannel.can_handle_url("https://www.olympicchannel.com/en/channel/olympic-channel/"))
+    should_match = [
+        "https://www.olympicchannel.com/en/video/detail/stefanidi-husband-coach-krier-relationship/",
+        "https://www.olympicchannel.com/en/live/",
+        "https://www.olympicchannel.com/en/live/video/detail/olympic-ceremonies-channel/",
+        "https://www.olympicchannel.com/de/video/detail/stefanidi-husband-coach-krier-relationship/",
+        "https://www.olympicchannel.com/de/original-series/detail/body/body-season-season-1/episodes/"
+        + "treffen-sie-aaron-wheelz-fotheringham-den-paten-des-rollstuhl-extremsports/",
+    ]
+
+    should_not_match = [
+        "https://www.olympicchannel.com/en/",
+        "https://www.olympicchannel.com/en/channel/olympic-channel/",
+    ]

--- a/tests/plugins/test_oneplusone.py
+++ b/tests/plugins/test_oneplusone.py
@@ -1,26 +1,19 @@
-import unittest
-
 from streamlink.plugins.oneplusone import OnePlusOne
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginOnePlusOne(unittest.TestCase):
+class TestPluginCanHandleUrlOnePlusOne(PluginCanHandleUrl):
+    __plugin__ = OnePlusOne
 
-    def test_can_handle_url(self):
-        should_match = [
-            'https://1plus1.video/tvguide/1plus1/online',
-            'https://1plus1.video/tvguide/2plus2/online',
-            'https://1plus1.video/tvguide/tet/online',
-            'https://1plus1.video/tvguide/plusplus/online',
-            'https://1plus1.video/tvguide/bigudi/online',
-            'https://1plus1.video/tvguide/uniantv/online',
-        ]
-        for url in should_match:
-            self.assertTrue(OnePlusOne.can_handle_url(url), url)
+    should_match = [
+        'https://1plus1.video/tvguide/1plus1/online',
+        'https://1plus1.video/tvguide/2plus2/online',
+        'https://1plus1.video/tvguide/tet/online',
+        'https://1plus1.video/tvguide/plusplus/online',
+        'https://1plus1.video/tvguide/bigudi/online',
+        'https://1plus1.video/tvguide/uniantv/online',
+    ]
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com',
-            'https://1plus1.video/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(OnePlusOne.can_handle_url(url), url)
+    should_not_match = [
+        'https://1plus1.video/',
+    ]

--- a/tests/plugins/test_onetv.py
+++ b/tests/plugins/test_onetv.py
@@ -1,32 +1,28 @@
 import unittest
 
 from streamlink.plugins.onetv import OneTV
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlOneTV(PluginCanHandleUrl):
+    __plugin__ = OneTV
+
+    should_match = [
+        "https://www.1tv.ru/live",
+        "http://www.1tv.ru/live",
+        "http://www.1tv.ru/some-show/some-programme-2018-03-10",
+        "https://www.ctc.ru/online",
+        "http://www.ctc.ru/online",
+        "https://www.chetv.ru/online",
+        "http://www.chetv.ru/online",
+        "https://www.ctclove.ru/online",
+        "http://www.ctclove.ru/online",
+        "https://www.domashny.ru/online"
+        "http://www.domashny.ru/online"
+    ]
 
 
 class TestPluginOneTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.1tv.ru/live",
-            "http://www.1tv.ru/live",
-            "http://www.1tv.ru/some-show/some-programme-2018-03-10",
-            "https://www.ctc.ru/online",
-            "http://www.ctc.ru/online",
-            "https://www.chetv.ru/online",
-            "http://www.chetv.ru/online",
-            "https://www.ctclove.ru/online",
-            "http://www.ctclove.ru/online",
-            "https://www.domashny.ru/online"
-            "http://www.domashny.ru/online"
-        ]
-        for url in should_match:
-            self.assertTrue(OneTV.can_handle_url(url))
-
-        should_not_match = [
-            "https://www.youtube.com",
-        ]
-        for url in should_not_match:
-            self.assertFalse(OneTV.can_handle_url(url))
-
     def test_channel(self):
         self.assertEqual(OneTV("http://1tv.ru/live").channel,
                          "1tv")

--- a/tests/plugins/test_openrectv.py
+++ b/tests/plugins/test_openrectv.py
@@ -1,20 +1,15 @@
-import unittest
-
 from streamlink.plugins.openrectv import OPENRECtv
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginOPENRECtv(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.openrec.tv/live/DXRLAPSGTpx',
-            'https://www.openrec.tv/movie/JsDw3rAV2Rj',
-        ]
-        for url in should_match:
-            self.assertTrue(OPENRECtv.can_handle_url(url))
+class TestPluginCanHandleUrlOPENRECtv(PluginCanHandleUrl):
+    __plugin__ = OPENRECtv
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.openrec.tv/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(OPENRECtv.can_handle_url(url))
+    should_match = [
+        'https://www.openrec.tv/live/DXRLAPSGTpx',
+        'https://www.openrec.tv/movie/JsDw3rAV2Rj',
+    ]
+
+    should_not_match = [
+        'https://www.openrec.tv/',
+    ]

--- a/tests/plugins/test_orf_tvthek.py
+++ b/tests/plugins/test_orf_tvthek.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.orf_tvthek import ORFTVThek
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginORFTVThek(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://tvthek.orf.at/live/Wetter/13953206',
-        ]
-        for url in should_match:
-            self.assertTrue(ORFTVThek.can_handle_url(url))
+class TestPluginCanHandleUrlORFTVThek(PluginCanHandleUrl):
+    __plugin__ = ORFTVThek
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ORFTVThek.can_handle_url(url))
+    should_match = [
+        'http://tvthek.orf.at/live/Wetter/13953206',
+    ]

--- a/tests/plugins/test_periscope.py
+++ b/tests/plugins/test_periscope.py
@@ -1,22 +1,17 @@
-import unittest
-
 from streamlink.plugins.periscope import Periscope
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPeriscope(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.periscope.tv/Pac12Networks/1BdGYRLyzMyJX',
-            'https://www.periscope.tv/w/1YqKDdaoVXLKV',
-            'https://www.pscp.tv/Pac12Networks/1gqGvpPlVLlxB'
-        ]
-        for url in should_match:
-            self.assertTrue(Periscope.can_handle_url(url))
+class TestPluginCanHandleUrlPeriscope(PluginCanHandleUrl):
+    __plugin__ = Periscope
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.periscope.tv/',
-            'https://www.pscp.tv/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Periscope.can_handle_url(url))
+    should_match = [
+        'https://www.periscope.tv/Pac12Networks/1BdGYRLyzMyJX',
+        'https://www.periscope.tv/w/1YqKDdaoVXLKV',
+        'https://www.pscp.tv/Pac12Networks/1gqGvpPlVLlxB'
+    ]
+
+    should_not_match = [
+        'https://www.periscope.tv/',
+        'https://www.pscp.tv/',
+    ]

--- a/tests/plugins/test_picarto.py
+++ b/tests/plugins/test_picarto.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.picarto import Picarto
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPicarto(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://picarto.tv/example',
-            'https://picarto.tv/videopopout/example_2020.00.00.00.00.00_nsfw.mkv',
-        ]
-        for url in should_match:
-            self.assertTrue(Picarto.can_handle_url(url), url)
+class TestPluginCanHandleUrlPicarto(PluginCanHandleUrl):
+    __plugin__ = Picarto
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Picarto.can_handle_url(url), url)
+    should_match = [
+        'https://picarto.tv/example',
+        'https://picarto.tv/videopopout/example_2020.00.00.00.00.00_nsfw.mkv',
+    ]

--- a/tests/plugins/test_piczel.py
+++ b/tests/plugins/test_piczel.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.piczel import Piczel
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPiczel(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://piczel.tv/watch/example',
-        ]
-        for url in should_match:
-            self.assertTrue(Piczel.can_handle_url(url))
+class TestPluginCanHandleUrlPiczel(PluginCanHandleUrl):
+    __plugin__ = Piczel
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Piczel.can_handle_url(url))
+    should_match = [
+        'https://piczel.tv/watch/example',
+    ]

--- a/tests/plugins/test_pixiv.py
+++ b/tests/plugins/test_pixiv.py
@@ -1,19 +1,15 @@
-import unittest
-
 from streamlink.plugins.pixiv import Pixiv
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPixiv(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://sketch.pixiv.net/@exampleuser',
-            'https://sketch.pixiv.net/@exampleuser/lives/000000000000000000',
-        ]
-        for url in should_match:
-            self.assertTrue(Pixiv.can_handle_url(url))
+class TestPluginCanHandleUrlPixiv(PluginCanHandleUrl):
+    __plugin__ = Pixiv
 
-        should_not_match = [
-            'https://sketch.pixiv.net',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Pixiv.can_handle_url(url))
+    should_match = [
+        'https://sketch.pixiv.net/@exampleuser',
+        'https://sketch.pixiv.net/@exampleuser/lives/000000000000000000',
+    ]
+
+    should_not_match = [
+        'https://sketch.pixiv.net',
+    ]

--- a/tests/plugins/test_playtv.py
+++ b/tests/plugins/test_playtv.py
@@ -1,23 +1,23 @@
-import unittest
-
 from streamlink.plugins.playtv import PlayTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPlayTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/arte"))
-        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/arte/"))
-        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/tv5-monde"))
-        self.assertTrue(PlayTV.can_handle_url("http://playtv.fr/television/france-24-english/"))
-        self.assertTrue(PlayTV.can_handle_url("http://play.tv/live-tv/9/arte"))
-        self.assertTrue(PlayTV.can_handle_url("http://play.tv/live-tv/9/arte/"))
-        self.assertTrue(PlayTV.can_handle_url("http://play.tv/live-tv/21/tv5-monde"))
-        self.assertTrue(PlayTV.can_handle_url("http://play.tv/live-tv/50/france-24-english/"))
+class TestPluginCanHandleUrlPlayTV(PluginCanHandleUrl):
+    __plugin__ = PlayTV
 
-        # shouldn't match
-        self.assertFalse(PlayTV.can_handle_url("http://playtv.fr/television/"))
-        self.assertFalse(PlayTV.can_handle_url("http://playtv.fr/replay-tv/"))
-        self.assertFalse(PlayTV.can_handle_url("http://play.tv/live-tv/"))
-        self.assertFalse(PlayTV.can_handle_url("http://tvcatchup.com/"))
-        self.assertFalse(PlayTV.can_handle_url("http://youtube.com/"))
+    should_match = [
+        "http://playtv.fr/television/arte",
+        "http://playtv.fr/television/arte/",
+        "http://playtv.fr/television/tv5-monde",
+        "http://playtv.fr/television/france-24-english/",
+        "http://play.tv/live-tv/9/arte",
+        "http://play.tv/live-tv/9/arte/",
+        "http://play.tv/live-tv/21/tv5-monde",
+        "http://play.tv/live-tv/50/france-24-english/",
+    ]
+
+    should_not_match = [
+        "http://playtv.fr/television/",
+        "http://playtv.fr/replay-tv/",
+        "http://play.tv/live-tv/",
+    ]

--- a/tests/plugins/test_pluto.py
+++ b/tests/plugins/test_pluto.py
@@ -1,37 +1,31 @@
-import unittest
-
 from streamlink.plugins.pluto import Pluto
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPluto(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.pluto.tv/live-tv/channel-lineup',
-            'http://pluto.tv/live-tv/channel',
-            'http://pluto.tv/live-tv/channel/',
-            'https://pluto.tv/live-tv/red-bull-tv-2',
-            'https://pluto.tv/live-tv/4k-tv',
-            'http://www.pluto.tv/on-demand/series/leverage/season/1/episode/the-nigerian-job-2009-1-1',
-            'http://pluto.tv/on-demand/series/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3',
-            'https://www.pluto.tv/on-demand/movies/dr.-no-1963-1-1',
-            'http://pluto.tv/on-demand/movies/the-last-dragon-(1985)-1-1',
-        ]
-        for url in should_match:
-            self.assertTrue(Pluto.can_handle_url(url), url)
+class TestPluginCanHandleUrlPluto(PluginCanHandleUrl):
+    __plugin__ = Pluto
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://fake.pluto.tv/live-tv/hello',
-            'http://www.pluto.tv/live-tv/channel-lineup/extra',
-            'https://www.pluto.tv/live-tv',
-            'https://pluto.tv/live-tv',
-            'https://www.pluto.com/live-tv/swag',
-            'https://youtube.com/live-tv/swag.html',
-            'http://pluto.tv/movies/dr.-no-1963-1-1',
-            'http://pluto.tv/on-demand/movies/dr.-no-1/963-1-1',
-            'http://pluto.tv/on-demand/series/dr.-no-1963-1-1',
-            'http://pluto.tv/on-demand/movies/leverage/season/1/episode/the-nigerian-job-2009-1-1',
-            'http://pluto.tv/on-demand/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Pluto.can_handle_url(url), url)
+    should_match = [
+        'http://www.pluto.tv/live-tv/channel-lineup',
+        'http://pluto.tv/live-tv/channel',
+        'http://pluto.tv/live-tv/channel/',
+        'https://pluto.tv/live-tv/red-bull-tv-2',
+        'https://pluto.tv/live-tv/4k-tv',
+        'http://www.pluto.tv/on-demand/series/leverage/season/1/episode/the-nigerian-job-2009-1-1',
+        'http://pluto.tv/on-demand/series/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3',
+        'https://www.pluto.tv/on-demand/movies/dr.-no-1963-1-1',
+        'http://pluto.tv/on-demand/movies/the-last-dragon-(1985)-1-1',
+    ]
+
+    should_not_match = [
+        'https://fake.pluto.tv/live-tv/hello',
+        'http://www.pluto.tv/live-tv/channel-lineup/extra',
+        'https://www.pluto.tv/live-tv',
+        'https://pluto.tv/live-tv',
+        'https://www.pluto.com/live-tv/swag',
+        'http://pluto.tv/movies/dr.-no-1963-1-1',
+        'http://pluto.tv/on-demand/movies/dr.-no-1/963-1-1',
+        'http://pluto.tv/on-demand/series/dr.-no-1963-1-1',
+        'http://pluto.tv/on-demand/movies/leverage/season/1/episode/the-nigerian-job-2009-1-1',
+        'http://pluto.tv/on-demand/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3',
+    ]

--- a/tests/plugins/test_pluzz.py
+++ b/tests/plugins/test_pluzz.py
@@ -1,42 +1,36 @@
-import unittest
-
 from streamlink.plugins.pluzz import Pluzz
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPluzz(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.france.tv/france-2/direct.html",
-            "https://www.france.tv/france-3/direct.html",
-            "https://www.france.tv/france-3-franche-comte/direct.html",
-            "https://www.france.tv/france-4/direct.html",
-            "https://www.france.tv/france-5/direct.html",
-            "https://www.france.tv/france-o/direct.html",
-            "https://www.france.tv/franceinfo/direct.html",
-            "https://www.france.tv/france-2/journal-20h00/141003-edition-du-lundi-8-mai-2017.html",
-            "https://www.france.tv/france-o/underground/saison-1/132187-underground.html",
-            "http://www.ludo.fr/heros/the-batman",
-            "http://www.ludo.fr/heros/il-etait-une-fois-la-vie",
-            "http://www.zouzous.fr/heros/oui-oui",
-            "http://www.zouzous.fr/heros/marsupilami-1",
-            "http://france3-regions.francetvinfo.fr/bourgogne-franche-comte/tv/direct/franche-comte",
-            "http://sport.francetvinfo.fr/roland-garros/direct",
-            "http://sport.francetvinfo.fr/roland-garros/live-court-3",
-            "http://sport.francetvinfo.fr/roland-garros/andy-murray-gbr-1-andrey-kuznetsov-rus-1er-tour-court"
-            + "-philippe-chatrier",
-            "https://www.francetvinfo.fr/en-direct/tv.html"
-        ]
-        for url in should_match:
-            self.assertTrue(Pluzz.can_handle_url(url))
+class TestPluginCanHandleUrlPluzz(PluginCanHandleUrl):
+    __plugin__ = Pluzz
 
-        should_not_match = [
-            "http://www.france.tv/",
-            "http://pluzz.francetv.fr/",
-            "http://www.ludo.fr/",
-            "http://www.ludo.fr/jeux",
-            "http://www.zouzous.fr/",
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Pluzz.can_handle_url(url))
+    should_match = [
+        "https://www.france.tv/france-2/direct.html",
+        "https://www.france.tv/france-3/direct.html",
+        "https://www.france.tv/france-3-franche-comte/direct.html",
+        "https://www.france.tv/france-4/direct.html",
+        "https://www.france.tv/france-5/direct.html",
+        "https://www.france.tv/france-o/direct.html",
+        "https://www.france.tv/franceinfo/direct.html",
+        "https://www.france.tv/france-2/journal-20h00/141003-edition-du-lundi-8-mai-2017.html",
+        "https://www.france.tv/france-o/underground/saison-1/132187-underground.html",
+        "http://www.ludo.fr/heros/the-batman",
+        "http://www.ludo.fr/heros/il-etait-une-fois-la-vie",
+        "http://www.zouzous.fr/heros/oui-oui",
+        "http://www.zouzous.fr/heros/marsupilami-1",
+        "http://france3-regions.francetvinfo.fr/bourgogne-franche-comte/tv/direct/franche-comte",
+        "http://sport.francetvinfo.fr/roland-garros/direct",
+        "http://sport.francetvinfo.fr/roland-garros/live-court-3",
+        "http://sport.francetvinfo.fr/roland-garros/andy-murray-gbr-1-andrey-kuznetsov-rus-1er-tour-court"
+        + "-philippe-chatrier",
+        "https://www.francetvinfo.fr/en-direct/tv.html"
+    ]
+
+    should_not_match = [
+        "http://www.france.tv/",
+        "http://pluzz.francetv.fr/",
+        "http://www.ludo.fr/",
+        "http://www.ludo.fr/jeux",
+        "http://www.zouzous.fr/",
+    ]

--- a/tests/plugins/test_powerapp.py
+++ b/tests/plugins/test_powerapp.py
@@ -1,22 +1,17 @@
-import unittest
-
 from streamlink.plugins.powerapp import PowerApp
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginPowerApp(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://powerapp.com.tr/tv/powertv4k',
-            'http://powerapp.com.tr/tv/powerturktv4k',
-            'http://powerapp.com.tr/tv/powerEarthTV',
-            'http://www.powerapp.com.tr/tvs/powertv'
-        ]
-        for url in should_match:
-            self.assertTrue(PowerApp.can_handle_url(url), url)
+class TestPluginCanHandleUrlPowerApp(PluginCanHandleUrl):
+    __plugin__ = PowerApp
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://powerapp.com.tr/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(PowerApp.can_handle_url(url))
+    should_match = [
+        'http://powerapp.com.tr/tv/powertv4k',
+        'http://powerapp.com.tr/tv/powerturktv4k',
+        'http://powerapp.com.tr/tv/powerEarthTV',
+        'http://www.powerapp.com.tr/tvs/powertv'
+    ]
+
+    should_not_match = [
+        'http://powerapp.com.tr/',
+    ]

--- a/tests/plugins/test_qq.py
+++ b/tests/plugins/test_qq.py
@@ -1,29 +1,29 @@
 import unittest
 
 from streamlink.plugins.qq import QQ
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlQQ(PluginCanHandleUrl):
+    __plugin__ = QQ
+
+    should_match = [
+        "http://live.qq.com/10003715",
+        "http://live.qq.com/10007266",
+        "http://live.qq.com/10039165",
+        "http://m.live.qq.com/10003715",
+        "http://m.live.qq.com/10007266",
+        "http://m.live.qq.com/10039165"
+    ]
+
+    should_not_match = [
+        "http://live.qq.com/",
+        "http://qq.com/",
+        "http://www.qq.com/"
+    ]
 
 
 class TestPluginQQ(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://live.qq.com/10003715",
-            "http://live.qq.com/10007266",
-            "http://live.qq.com/10039165",
-            "http://m.live.qq.com/10003715",
-            "http://m.live.qq.com/10007266",
-            "http://m.live.qq.com/10039165"
-        ]
-        for url in should_match:
-            self.assertTrue(QQ.can_handle_url(url))
-
-        should_not_match = [
-            "http://live.qq.com/",
-            "http://qq.com/",
-            "http://www.qq.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(QQ.can_handle_url(url))
-
     def test_url_re(self):
         regex_match_list = [
             {

--- a/tests/plugins/test_radiko.py
+++ b/tests/plugins/test_radiko.py
@@ -1,24 +1,15 @@
-import unittest
-
 from streamlink.plugins.radiko import Radiko
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRadiko(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://radiko.jp/#!/live/QRR',
-            'https://radiko.jp/#!/ts/YFM/20201206010000',
-            'http://radiko.jp/#!/live/QRR',
-            'http://radiko.jp/live/QRR',
-            'http://radiko.jp/#!/ts/QRR/20200308180000',
-            'http://radiko.jp/ts/QRR/20200308180000'
-        ]
-        for url in should_match:
-            self.assertTrue(Radiko.can_handle_url(url), url)
+class TestPluginCanHandleUrlRadiko(PluginCanHandleUrl):
+    __plugin__ = Radiko
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Radiko.can_handle_url(url), url)
+    should_match = [
+        'https://radiko.jp/#!/live/QRR',
+        'https://radiko.jp/#!/ts/YFM/20201206010000',
+        'http://radiko.jp/#!/live/QRR',
+        'http://radiko.jp/live/QRR',
+        'http://radiko.jp/#!/ts/QRR/20200308180000',
+        'http://radiko.jp/ts/QRR/20200308180000'
+    ]

--- a/tests/plugins/test_radionet.py
+++ b/tests/plugins/test_radionet.py
@@ -1,24 +1,24 @@
-import unittest
-
 from streamlink.plugins.radionet import RadioNet
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRadioNet(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(RadioNet.can_handle_url("http://radioparadise.radio.net/"))
-        self.assertTrue(RadioNet.can_handle_url("http://oe1.radio.at/"))
-        self.assertTrue(RadioNet.can_handle_url("http://deutschlandfunk.radio.de/"))
-        self.assertTrue(RadioNet.can_handle_url("http://rneradionacional.radio.es/"))
-        self.assertTrue(RadioNet.can_handle_url("http://franceinfo.radio.fr/"))
-        self.assertTrue(RadioNet.can_handle_url("https://drp1bagklog.radio.dk/"))
-        self.assertTrue(RadioNet.can_handle_url("http://rairadiouno.radio.it/"))
-        self.assertTrue(RadioNet.can_handle_url("http://program1jedynka.radio.pl/"))
-        self.assertTrue(RadioNet.can_handle_url("http://rtpantena1983fm.radio.pt/"))
-        self.assertTrue(RadioNet.can_handle_url("http://sverigesp1.radio.se/"))
+class TestPluginCanHandleUrlRadioNet(PluginCanHandleUrl):
+    __plugin__ = RadioNet
 
-        # shouldn't match
-        self.assertFalse(RadioNet.can_handle_url("http://radio.net/"))
-        self.assertFalse(RadioNet.can_handle_url("http://radio.com/"))
-        self.assertFalse(RadioNet.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(RadioNet.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://radioparadise.radio.net/",
+        "http://oe1.radio.at/",
+        "http://deutschlandfunk.radio.de/",
+        "http://rneradionacional.radio.es/",
+        "http://franceinfo.radio.fr/",
+        "https://drp1bagklog.radio.dk/",
+        "http://rairadiouno.radio.it/",
+        "http://program1jedynka.radio.pl/",
+        "http://rtpantena1983fm.radio.pt/",
+        "http://sverigesp1.radio.se/",
+    ]
+
+    should_not_match = [
+        "http://radio.net/",
+        "http://radio.com/",
+    ]

--- a/tests/plugins/test_raiplay.py
+++ b/tests/plugins/test_raiplay.py
@@ -1,20 +1,16 @@
-import unittest
-
 from streamlink.plugins.raiplay import RaiPlay
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRaiPlay(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rai1"))
-        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rai2"))
-        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rai3"))
-        self.assertTrue(RaiPlay.can_handle_url("http://raiplay.it/dirette/rai3"))
-        self.assertTrue(RaiPlay.can_handle_url("https://raiplay.it/dirette/rai3"))
-        self.assertTrue(RaiPlay.can_handle_url("http://www.raiplay.it/dirette/rainews24"))
-        self.assertTrue(RaiPlay.can_handle_url("https://www.raiplay.it/dirette/rainews24"))
+class TestPluginCanHandleUrlRaiPlay(PluginCanHandleUrl):
+    __plugin__ = RaiPlay
 
-        # shouldn't match
-        self.assertFalse(RaiPlay.can_handle_url("http://www.adultswim.com/videos/streams/toonami"))
-        self.assertFalse(RaiPlay.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(RaiPlay.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://www.raiplay.it/dirette/rai1",
+        "http://www.raiplay.it/dirette/rai2",
+        "http://www.raiplay.it/dirette/rai3",
+        "http://raiplay.it/dirette/rai3",
+        "https://raiplay.it/dirette/rai3",
+        "http://www.raiplay.it/dirette/rainews24",
+        "https://www.raiplay.it/dirette/rainews24",
+    ]

--- a/tests/plugins/test_reuters.py
+++ b/tests/plugins/test_reuters.py
@@ -1,23 +1,15 @@
-import unittest
-
 from streamlink.plugins.reuters import Reuters
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginReuters(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://uk.reuters.com/video/watch/east-africa-battles-locust-invasion-idOVC2J9BHJ?chan=92jv7sln',
-            'https://www.reuters.com/livevideo?id=Pdeb',
-            'https://www.reuters.com/video/watch/baby-yoda-toy-makes-its-big-debut-idOVC1KAO9Z?chan=8adtq7aq',
-            'https://www.reuters.tv/l/PFJx/2019/04/19/way-of-the-cross-ritual-around-notre-dame-cathedral',
-            'https://www.reuters.tv/l/PFcO/2019/04/10/first-ever-black-hole-image-released-astrophysics-milestone',
-            'https://www.reuters.tv/p/WoRwM1a00y8',
-        ]
-        for url in should_match:
-            self.assertTrue(Reuters.can_handle_url(url), url)
+class TestPluginCanHandleUrlReuters(PluginCanHandleUrl):
+    __plugin__ = Reuters
 
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Reuters.can_handle_url(url), url)
+    should_match = [
+        'https://uk.reuters.com/video/watch/east-africa-battles-locust-invasion-idOVC2J9BHJ?chan=92jv7sln',
+        'https://www.reuters.com/livevideo?id=Pdeb',
+        'https://www.reuters.com/video/watch/baby-yoda-toy-makes-its-big-debut-idOVC1KAO9Z?chan=8adtq7aq',
+        'https://www.reuters.tv/l/PFJx/2019/04/19/way-of-the-cross-ritual-around-notre-dame-cathedral',
+        'https://www.reuters.tv/l/PFcO/2019/04/10/first-ever-black-hole-image-released-astrophysics-milestone',
+        'https://www.reuters.tv/p/WoRwM1a00y8',
+    ]

--- a/tests/plugins/test_rotana.py
+++ b/tests/plugins/test_rotana.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.rotana import Rotana
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRotana(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://rotana.net/live-classic',
-            'https://rotana.net/live-music',
-        ]
-        for url in should_match:
-            self.assertTrue(Rotana.can_handle_url(url), url)
+class TestPluginCanHandleUrlRotana(PluginCanHandleUrl):
+    __plugin__ = Rotana
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Rotana.can_handle_url(url), url)
+    should_match = [
+        'https://rotana.net/live-classic',
+        'https://rotana.net/live-music',
+    ]

--- a/tests/plugins/test_rtbf.py
+++ b/tests/plugins/test_rtbf.py
@@ -1,18 +1,18 @@
-import unittest
-
 from streamlink.plugins.rtbf import RTBF
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRTBF(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(RTBF.can_handle_url("https://www.rtbf.be/auvio/direct_doc-shot?lid=122046#/"))
-        self.assertTrue(RTBF.can_handle_url("https://www.rtbf.be/auvio/emissions/detail_dans-la-toile?id=11493"))
-        self.assertTrue(RTBF.can_handle_url("http://www.rtbfradioplayer.be/radio/liveradio/purefm"))
+class TestPluginCanHandleUrlRTBF(PluginCanHandleUrl):
+    __plugin__ = RTBF
 
-        # shouldn't match
-        self.assertFalse(RTBF.can_handle_url("http://www.rtbf.be/"))
-        self.assertFalse(RTBF.can_handle_url("http://www.rtbf.be/auvio"))
-        self.assertFalse(RTBF.can_handle_url("http://www.rtbfradioplayer.be/"))
-        self.assertFalse(RTBF.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(RTBF.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://www.rtbf.be/auvio/direct_doc-shot?lid=122046#/",
+        "https://www.rtbf.be/auvio/emissions/detail_dans-la-toile?id=11493",
+        "http://www.rtbfradioplayer.be/radio/liveradio/purefm",
+    ]
+
+    should_not_match = [
+        "http://www.rtbf.be/",
+        "http://www.rtbf.be/auvio",
+        "http://www.rtbfradioplayer.be/",
+    ]

--- a/tests/plugins/test_rtlxl.py
+++ b/tests/plugins/test_rtlxl.py
@@ -1,19 +1,14 @@
-import unittest
-
 from streamlink.plugins.rtlxl import RTLxl
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRTLxl(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.rtl.nl/video/206a0db0-9bc8-3a32-bda3-e9b3a9d4d377/',
-        ]
-        for url in should_match:
-            self.assertTrue(RTLxl.can_handle_url(url))
+class TestPluginCanHandleUrlrtlxl(PluginCanHandleUrl):
+    __plugin__ = RTLxl
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.rtl.nl/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(RTLxl.can_handle_url(url))
+    should_match = [
+        'https://www.rtl.nl/video/206a0db0-9bc8-3a32-bda3-e9b3a9d4d377/',
+    ]
+
+    should_not_match = [
+        'https://www.rtl.nl/',
+    ]

--- a/tests/plugins/test_rtlxl.py
+++ b/tests/plugins/test_rtlxl.py
@@ -1,19 +1,19 @@
 import unittest
 
-from streamlink.plugins.rtlxl import rtlxl
+from streamlink.plugins.rtlxl import RTLxl
 
 
-class TestPluginrtlxl(unittest.TestCase):
+class TestPluginRTLxl(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
             'https://www.rtl.nl/video/206a0db0-9bc8-3a32-bda3-e9b3a9d4d377/',
         ]
         for url in should_match:
-            self.assertTrue(rtlxl.can_handle_url(url))
+            self.assertTrue(RTLxl.can_handle_url(url))
 
     def test_can_handle_url_negative(self):
         should_not_match = [
             'https://www.rtl.nl/',
         ]
         for url in should_not_match:
-            self.assertFalse(rtlxl.can_handle_url(url))
+            self.assertFalse(RTLxl.can_handle_url(url))

--- a/tests/plugins/test_rtpplay.py
+++ b/tests/plugins/test_rtpplay.py
@@ -1,25 +1,20 @@
-import unittest
-
 from streamlink.plugins.rtpplay import RTPPlay
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRTPPlay(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.rtp.pt/play/',
-            'https://www.rtp.pt/play/',
-            'https://www.rtp.pt/play/direto/rtp1',
-            'https://www.rtp.pt/play/direto/rtpmadeira',
-        ]
-        for url in should_match:
-            self.assertTrue(RTPPlay.can_handle_url(url), url)
+class TestPluginCanHandleUrlRTPPlay(PluginCanHandleUrl):
+    __plugin__ = RTPPlay
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.rtp.pt/programa/',
-            'http://www.rtp.pt/programa/',
-            'https://media.rtp.pt/',
-            'http://media.rtp.pt/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(RTPPlay.can_handle_url(url), url)
+    should_match = [
+        'http://www.rtp.pt/play/',
+        'https://www.rtp.pt/play/',
+        'https://www.rtp.pt/play/direto/rtp1',
+        'https://www.rtp.pt/play/direto/rtpmadeira',
+    ]
+
+    should_not_match = [
+        'https://www.rtp.pt/programa/',
+        'http://www.rtp.pt/programa/',
+        'https://media.rtp.pt/',
+        'http://media.rtp.pt/',
+    ]

--- a/tests/plugins/test_rtve.py
+++ b/tests/plugins/test_rtve.py
@@ -1,23 +1,18 @@
-import unittest
-
 from streamlink.plugins.rtve import Rtve
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRtve(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.rtve.es/directo/la-1',
-            'http://www.rtve.es/directo/la-2/',
-            'http://www.rtve.es/directo/teledeporte/',
-            'http://www.rtve.es/directo/canal-24h/',
-            'http://www.rtve.es/infantil/directo/',
-        ]
-        for url in should_match:
-            self.assertTrue(Rtve.can_handle_url(url))
+class TestPluginCanHandleUrlRtve(PluginCanHandleUrl):
+    __plugin__ = Rtve
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.rtve.es',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Rtve.can_handle_url(url))
+    should_match = [
+        'http://www.rtve.es/directo/la-1',
+        'http://www.rtve.es/directo/la-2/',
+        'http://www.rtve.es/directo/teledeporte/',
+        'http://www.rtve.es/directo/canal-24h/',
+        'http://www.rtve.es/infantil/directo/',
+    ]
+
+    should_not_match = [
+        'https://www.rtve.es',
+    ]

--- a/tests/plugins/test_rtvs.py
+++ b/tests/plugins/test_rtvs.py
@@ -1,21 +1,16 @@
-import unittest
-
 from streamlink.plugins.rtvs import Rtvs
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRtvs(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.rtvs.sk/televizia/live-1',
-            'http://www.rtvs.sk/televizia/live-2',
-            'http://www.rtvs.sk/televizia/live-o',
-        ]
-        for url in should_match:
-            self.assertTrue(Rtvs.can_handle_url(url))
+class TestPluginCanHandleUrlRtvs(PluginCanHandleUrl):
+    __plugin__ = Rtvs
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.rtvs.sk/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Rtvs.can_handle_url(url))
+    should_match = [
+        'http://www.rtvs.sk/televizia/live-1',
+        'http://www.rtvs.sk/televizia/live-2',
+        'http://www.rtvs.sk/televizia/live-o',
+    ]
+
+    should_not_match = [
+        'http://www.rtvs.sk/',
+    ]

--- a/tests/plugins/test_ruv.py
+++ b/tests/plugins/test_ruv.py
@@ -1,35 +1,26 @@
-import unittest
-
 from streamlink.plugins.ruv import Ruv
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginRuv(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "ruv.is/ruv",
-            "http://ruv.is/ruv",
-            "http://ruv.is/ruv/",
-            "https://ruv.is/ruv/",
-            "http://www.ruv.is/ruv",
-            "http://www.ruv.is/ruv/",
-            "ruv.is/ruv2",
-            "ruv.is/ras1",
-            "ruv.is/ras2",
-            "ruv.is/rondo",
-            "http://www.ruv.is/spila/ruv/ol-2018-ishokki-karla/20180217",
-            "http://www.ruv.is/spila/ruv/frettir/20180217"
-        ]
-        for url in should_match:
-            self.assertTrue(Ruv.can_handle_url(url))
+class TestPluginCanHandleUrlRuv(PluginCanHandleUrl):
+    __plugin__ = Ruv
 
-        should_not_match = [
-            "rruv.is/ruv",
-            "ruv.is/ruvnew",
-            "https://www.bloomberg.com/live/",
-            "https://www.bloomberg.com/politics/articles/2017-04-17/french-race-up-for-grabs-days-before-voters"
-            + "-cast-first-ballots",
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Ruv.can_handle_url(url))
+    should_match = [
+        "ruv.is/ruv",
+        "http://ruv.is/ruv",
+        "http://ruv.is/ruv/",
+        "https://ruv.is/ruv/",
+        "http://www.ruv.is/ruv",
+        "http://www.ruv.is/ruv/",
+        "ruv.is/ruv2",
+        "ruv.is/ras1",
+        "ruv.is/ras2",
+        "ruv.is/rondo",
+        "http://www.ruv.is/spila/ruv/ol-2018-ishokki-karla/20180217",
+        "http://www.ruv.is/spila/ruv/frettir/20180217"
+    ]
+
+    should_not_match = [
+        "rruv.is/ruv",
+        "ruv.is/ruvnew",
+    ]

--- a/tests/plugins/test_sbscokr.py
+++ b/tests/plugins/test_sbscokr.py
@@ -1,19 +1,11 @@
-import unittest
-
 from streamlink.plugins.sbscokr import SBScokr
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSBScokr(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://play.sbs.co.kr/onair/pc/index.html',
-            'http://play.sbs.co.kr/onair/pc/index.html',
-        ]
-        for url in should_match:
-            self.assertTrue(SBScokr.can_handle_url(url))
+class TestPluginCanHandleUrlSBScokr(PluginCanHandleUrl):
+    __plugin__ = SBScokr
 
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(SBScokr.can_handle_url(url))
+    should_match = [
+        'https://play.sbs.co.kr/onair/pc/index.html',
+        'http://play.sbs.co.kr/onair/pc/index.html',
+    ]

--- a/tests/plugins/test_schoolism.py
+++ b/tests/plugins/test_schoolism.py
@@ -1,23 +1,22 @@
 import unittest
 
 from streamlink.plugins.schoolism import Schoolism
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlSchoolism(PluginCanHandleUrl):
+    __plugin__ = Schoolism
+
+    should_match = [
+        'https://www.schoolism.com/watchLesson.php',
+    ]
+
+    should_not_match = [
+        'https://www.schoolism.com',
+    ]
 
 
 class TestPluginSchoolism(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.schoolism.com/watchLesson.php',
-        ]
-        for url in should_match:
-            self.assertTrue(Schoolism.can_handle_url(url))
-
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.schoolism.com',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Schoolism.can_handle_url(url))
-
     def test_playlist_parse_subs(self):
         with_subs = """var allVideos=[
             {sources:[{type:"application/x-mpegurl",src:"https://d8u31iyce9xic.cloudfront.net/44/2/part1.m3u8?Policy=TOKEN&Signature=TOKEN&Key-Pair-Id=TOKEN",title:"Digital Painting - Lesson 2 - Part 1",playlistTitle:"Part 1",}],        subtitles: [{

--- a/tests/plugins/test_senategov.py
+++ b/tests/plugins/test_senategov.py
@@ -1,24 +1,21 @@
 import unittest
 
 from streamlink.plugins.senategov import SenateGov
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlSenateGov(PluginCanHandleUrl):
+    __plugin__ = SenateGov
+
+    should_match = [
+        "https://www.foreign.senate.gov/hearings/business-meeting-082218"
+        "https://www.senate.gov/isvp/?comm=foreign&type=arch&stt=21:50&filename=foreign082218&auto_play=false"
+        + "&wmode=transparent&poster=https%3A%2F%2Fwww%2Eforeign%2Esenate%2Egov%2Fthemes%2Fforeign%2Fimages"
+        + "%2Fvideo-poster-flash-fit%2Epng"
+    ]
 
 
 class TestPluginSenateGov(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(SenateGov.can_handle_url(
-            "https://www.foreign.senate.gov/hearings/business-meeting-082218"
-        ))
-        self.assertTrue(SenateGov.can_handle_url(
-            "https://www.senate.gov/isvp/?comm=foreign&type=arch&stt=21:50&filename=foreign082218&auto_play=false"
-            "&wmode=transparent&poster=https%3A%2F%2Fwww%2Eforeign%2Esenate%2Egov%2Fthemes%2Fforeign%2Fimages"
-            "%2Fvideo-poster-flash-fit%2Epng"
-        ))
-
-        # shouldn't match
-        self.assertFalse(SenateGov.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(SenateGov.can_handle_url("http://www.youtube.com/"))
-
     def test_stt_parse(self):
         self.assertEqual(600, SenateGov.parse_stt("10:00"))
         self.assertEqual(3600, SenateGov.parse_stt("01:00:00"))

--- a/tests/plugins/test_showroom.py
+++ b/tests/plugins/test_showroom.py
@@ -1,39 +1,36 @@
 import unittest
 
 from streamlink.plugins.showroom import Showroom
+from tests.plugins import PluginCanHandleUrl
 
-_should_match = (
-    "https://www.showroom-live.com/48_NISHIMURA_NANAKO",
-    "https://www.showroom-live.com/room/profile?room_id=61734",
-    "http://showroom-live.com/48_YAMAGUCHI_MAHO",
-    "https://www.showroom-live.com/4b9581094890",
-    "https://www.showroom-live.com/157941217780",
-    "https://www.showroom-live.com/madokacom"
-)
-_should_not_match = (
-    "https://www.showroom-live.com/mypage",
-    "https://www.showroom-live.com/ranking",
-    "https://www.showroom-live.com/payment/payment_start",
-    "https://www.showroom-live.com/s/licence",
-    "http://www.youtube.com/",
-    "http://www.dailymotion.com/video/x5cyk8f",
-    "http://www.crunchyroll.com/gintama"
-)
-_stream_weights = {
-    'high': (720, "quality"),
-    'other': (360, "quality"),
-    'low': (160, "quality")
-}
+
+class TestPluginCanHandleUrlShowroom(PluginCanHandleUrl):
+    __plugin__ = Showroom
+
+    should_match = [
+        "https://www.showroom-live.com/48_NISHIMURA_NANAKO",
+        "https://www.showroom-live.com/room/profile?room_id=61734",
+        "http://showroom-live.com/48_YAMAGUCHI_MAHO",
+        "https://www.showroom-live.com/4b9581094890",
+        "https://www.showroom-live.com/157941217780",
+        "https://www.showroom-live.com/madokacom"
+    ]
+
+    should_not_match = [
+        "https://www.showroom-live.com/mypage",
+        "https://www.showroom-live.com/ranking",
+        "https://www.showroom-live.com/payment/payment_start",
+        "https://www.showroom-live.com/s/licence",
+    ]
 
 
 class TestPluginShowroom(unittest.TestCase):
-    def test_can_handle_url(self):
-        for url in _should_match:
-            self.assertTrue(Showroom.can_handle_url(url))
-
-        for url in _should_not_match:
-            self.assertFalse(Showroom.can_handle_url(url))
+    stream_weights = {
+        'high': (720, "quality"),
+        'other': (360, "quality"),
+        'low': (160, "quality")
+    }
 
     def test_stream_weight(self):
-        for name, weight in _stream_weights.items():
+        for name, weight in self.stream_weights.items():
             self.assertEqual(Showroom.stream_weight(name), weight)

--- a/tests/plugins/test_sportal.py
+++ b/tests/plugins/test_sportal.py
@@ -1,15 +1,12 @@
-import unittest
-
 from streamlink.plugins.sportal import Sportal
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSportal(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Sportal.can_handle_url("http://sportal.bg/sportal_live_tv.php?str=15"))
-        self.assertTrue(Sportal.can_handle_url("http://www.sportal.bg/sportal_live_tv.php?"))
-        self.assertTrue(Sportal.can_handle_url("http://www.sportal.bg/sportal_live_tv.php?str=15"))
+class TestPluginCanHandleUrlSportal(PluginCanHandleUrl):
+    __plugin__ = Sportal
 
-        # shouldn't match
-        self.assertFalse(Sportal.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(Sportal.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://sportal.bg/sportal_live_tv.php?str=15",
+        "http://www.sportal.bg/sportal_live_tv.php?",
+        "http://www.sportal.bg/sportal_live_tv.php?str=15",
+    ]

--- a/tests/plugins/test_sportschau.py
+++ b/tests/plugins/test_sportschau.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.sportschau import Sportschau
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSportschau(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.sportschau.de/wintersport/videostream-livestream---wintersport-im-ersten-242.html',
-            'https://www.sportschau.de/weitere/allgemein/video-kite-surf-world-tour-100.html',
-        ]
-        for url in should_match:
-            self.assertTrue(Sportschau.can_handle_url(url))
+class TestPluginCanHandleUrlSportschau(PluginCanHandleUrl):
+    __plugin__ = Sportschau
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Sportschau.can_handle_url(url))
+    should_match = [
+        'http://www.sportschau.de/wintersport/videostream-livestream---wintersport-im-ersten-242.html',
+        'https://www.sportschau.de/weitere/allgemein/video-kite-surf-world-tour-100.html',
+    ]

--- a/tests/plugins/test_ssh101.py
+++ b/tests/plugins/test_ssh101.py
@@ -1,22 +1,16 @@
-import unittest
-
 from streamlink.plugins.ssh101 import SSH101
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSSH101(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://ssh101.com/live/sarggg',
-            'https://www.ssh101.com/securelive/index.php?id=aigaiotvlive',
-            'https://www.ssh101.com/live/aigaiotvlive',
-        ]
-        for url in should_match:
-            self.assertTrue(SSH101.can_handle_url(url))
+class TestPluginCanHandleUrlSSH101(PluginCanHandleUrl):
+    __plugin__ = SSH101
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-            'https://ssh101.com/m3u8/dyn/aigaiotvlive/index.m3u8',
-        ]
-        for url in should_not_match:
-            self.assertFalse(SSH101.can_handle_url(url))
+    should_match = [
+        'http://ssh101.com/live/sarggg',
+        'https://www.ssh101.com/securelive/index.php?id=aigaiotvlive',
+        'https://www.ssh101.com/live/aigaiotvlive',
+    ]
+
+    should_not_match = [
+        'https://ssh101.com/m3u8/dyn/aigaiotvlive/index.m3u8',
+    ]

--- a/tests/plugins/test_stadium.py
+++ b/tests/plugins/test_stadium.py
@@ -1,17 +1,17 @@
-import unittest
-
 from streamlink.plugins.stadium import Stadium
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginStadium(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Stadium.can_handle_url("http://www.watchstadium.com/live"))
-        self.assertTrue(Stadium.can_handle_url("https://www.watchstadium.com/live"))
-        self.assertTrue(Stadium.can_handle_url("https://watchstadium.com/live"))
-        self.assertTrue(Stadium.can_handle_url("http://watchstadium.com/live"))
+class TestPluginCanHandleUrlStadium(PluginCanHandleUrl):
+    __plugin__ = Stadium
 
-        # shouldn't match
-        self.assertFalse(Stadium.can_handle_url("http://www.watchstadium.com/anything/else"))
-        self.assertFalse(Stadium.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(Stadium.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://www.watchstadium.com/live",
+        "https://www.watchstadium.com/live",
+        "https://watchstadium.com/live",
+        "http://watchstadium.com/live",
+    ]
+
+    should_not_match = [
+        "http://www.watchstadium.com/anything/else"
+    ]

--- a/tests/plugins/test_steam.py
+++ b/tests/plugins/test_steam.py
@@ -1,17 +1,18 @@
-import unittest
-
 from streamlink.plugins.steam import SteamBroadcastPlugin
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSteamBroadcastPlugin(unittest.TestCase):
-    def test_can_handle_url(self):
-        self.assertTrue(SteamBroadcastPlugin.can_handle_url('https://steamcommunity.com/broadcast/watch/12432432'))
-        self.assertTrue(SteamBroadcastPlugin.can_handle_url('http://steamcommunity.com/broadcast/watch/342342'))
-        self.assertTrue(SteamBroadcastPlugin.can_handle_url('https://steam.tv/dota2'))
-        self.assertTrue(SteamBroadcastPlugin.can_handle_url('http://steam.tv/dota2'))
+class TestPluginCanHandleUrlSteamBroadcastPlugin(PluginCanHandleUrl):
+    __plugin__ = SteamBroadcastPlugin
 
-    def test_can_handle_url_negative(self):
-        # shouldn't match
-        self.assertFalse(SteamBroadcastPlugin.can_handle_url('http://steamcommunity.com/broadcast'))
-        self.assertFalse(SteamBroadcastPlugin.can_handle_url('https://steamcommunity.com'))
-        self.assertFalse(SteamBroadcastPlugin.can_handle_url('https://youtube.com'))
+    should_match = [
+        'https://steamcommunity.com/broadcast/watch/12432432',
+        'http://steamcommunity.com/broadcast/watch/342342',
+        'https://steam.tv/dota2',
+        'http://steam.tv/dota2',
+    ]
+
+    should_not_match = [
+        'http://steamcommunity.com/broadcast',
+        'https://steamcommunity.com',
+    ]

--- a/tests/plugins/test_streamable.py
+++ b/tests/plugins/test_streamable.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.streamable import Streamable
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginStreamable(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://streamable.com/example',
-        ]
-        for url in should_match:
-            self.assertTrue(Streamable.can_handle_url(url))
+class TestPluginCanHandleUrlStreamable(PluginCanHandleUrl):
+    __plugin__ = Streamable
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Streamable.can_handle_url(url))
+    should_match = [
+        'https://streamable.com/example',
+    ]

--- a/tests/plugins/test_streamingvideoprovider.py
+++ b/tests/plugins/test_streamingvideoprovider.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.streamingvideoprovider import Streamingvideoprovider
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginStreamingvideoprovider(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.streamingvideoprovider.co.uk/example',
-        ]
-        for url in should_match:
-            self.assertTrue(Streamingvideoprovider.can_handle_url(url))
+class TestPluginCanHandleUrlStreamingvideoprovider(PluginCanHandleUrl):
+    __plugin__ = Streamingvideoprovider
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Streamingvideoprovider.can_handle_url(url))
+    should_match = [
+        'http://www.streamingvideoprovider.co.uk/example',
+    ]

--- a/tests/plugins/test_streann.py
+++ b/tests/plugins/test_streann.py
@@ -1,29 +1,30 @@
-import unittest
-
 from streamlink.plugins.streann import Streann
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginStreann(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            # ott.streann.com
-            "https://ott.streann.com/streaming/player.html?U2FsdGVkX1/PAwXdSYuiw+o5BxSoG10K8ShiKMDOOUEuoYiQxiZlD0gg7y+Ij07/OaI9TWk+MHp40Fx4jrOv304Z+PZwLqGJgs+b0xsnfZJMpx+UmYnjys1rzTZ8UeztNjDeYEElKdaHHGkv0HFcGBGWjyWOvQuCbjGyr4dtzLyaChewqR9lNCuil/HOMiL/eYtEMEPVjMdeUFilb5GSVdIyeunr+JnI1tvdPC5ow3rx3NWjbqIHd13qWVSnaZSl/UZ0BDmWBf+Vr+3pPAd1Mg3y01mKaYZywOxRduBW2HZwoLQe2Lok5Z/q4aJHO02ZESqEPLRKkEqMntuuqGfy1g==",  # noqa: E501
-            "https://ott.streann.com/s-secure/player.html?U2FsdGVkX19Z8gO/ThCsK3I1DTIdVzIGRKiJP36DEx2K1n9HeXKV4nmJrKptTZRlTmM4KTxC/Mi5k3kWEsC1pr9QWmQJzKAfGdROMWB6voarQ1UQqe8IMDiibG+lcNTggCIkAS8a+99Kbe/C1W++YEP+BCBC/8Ss2RYIhNyVdqjUtqvv4Exk6l1gJDWNHc6b5P51020dUrkuJCgEJCbJBE/MYFuC5xlhmzf6kcN5GlBrTuwyHYBkkVi1nvjOm1QS0iQw36UgJx9JS3DDTf7BzlAimLV5M1rXS/ME3XpllejHV0aL3sghCBzc4f4AAz1IoTsl4qEamWBxyfy2kdNJRQ==",  # noqa: E501
-            # URL with iframe
-            "http://centroecuador.ec/tv-radio/",
-            "http://crc.cr/estaciones/crc-89-1/",
-            "https://columnaestilos.com/",
-            "https://crc.cr/estaciones/azul-999/",
-            "https://evtv.online/noticias-de-venezuela/",
-            "https://telecuracao.com/",
-            "https://willax.tv/en-vivo/",
-        ]
-        for url in should_match:
-            self.assertTrue(Streann.can_handle_url(url), url)
+class TestPluginCanHandleUrlStreann(PluginCanHandleUrl):
+    __plugin__ = Streann
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            "https://ott.streann.com",
-        ]
-        for url in should_not_match:
-            self.assertFalse(Streann.can_handle_url(url), url)
+    should_match = [
+        # ott.streann.com
+        "https://ott.streann.com/streaming/player.html?U2FsdGVkX1/PAwXdSYuiw+o5BxSoG10K8ShiKMDOOUEuoYiQxiZlD0gg7y+Ij07/OaI9TWk+"
+        + "MHp40Fx4jrOv304Z+PZwLqGJgs+b0xsnfZJMpx+UmYnjys1rzTZ8UeztNjDeYEElKdaHHGkv0HFcGBGWjyWOvQuCbjGyr4dtzLyaChewqR9lNCuil/HO"
+        + "MiL/eYtEMEPVjMdeUFilb5GSVdIyeunr+JnI1tvdPC5ow3rx3NWjbqIHd13qWVSnaZSl/UZ0BDmWBf+Vr+3pPAd1Mg3y01mKaYZywOxRduBW2HZwoLQe"
+        + "2Lok5Z/q4aJHO02ZESqEPLRKkEqMntuuqGfy1g==",
+        "https://ott.streann.com/s-secure/player.html?U2FsdGVkX19Z8gO/ThCsK3I1DTIdVzIGRKiJP36DEx2K1n9HeXKV4nmJrKptTZRlTmM4KTxC/"
+        + "Mi5k3kWEsC1pr9QWmQJzKAfGdROMWB6voarQ1UQqe8IMDiibG+lcNTggCIkAS8a+99Kbe/C1W++YEP+BCBC/8Ss2RYIhNyVdqjUtqvv4Exk6l1gJDWNH"
+        + "c6b5P51020dUrkuJCgEJCbJBE/MYFuC5xlhmzf6kcN5GlBrTuwyHYBkkVi1nvjOm1QS0iQw36UgJx9JS3DDTf7BzlAimLV5M1rXS/ME3XpllejHV0aL3"
+        + "sghCBzc4f4AAz1IoTsl4qEamWBxyfy2kdNJRQ==",
+        # URL with iframe
+        "http://centroecuador.ec/tv-radio/",
+        "http://crc.cr/estaciones/crc-89-1/",
+        "https://columnaestilos.com/",
+        "https://crc.cr/estaciones/azul-999/",
+        "https://evtv.online/noticias-de-venezuela/",
+        "https://telecuracao.com/",
+        "https://willax.tv/en-vivo/",
+    ]
+
+    should_not_match = [
+        "https://ott.streann.com",
+    ]

--- a/tests/plugins/test_stv.py
+++ b/tests/plugins/test_stv.py
@@ -1,12 +1,11 @@
-import unittest
-
 from streamlink.plugins.stv import STV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        self.assertTrue(STV.can_handle_url('https://player.stv.tv/live'))
-        self.assertTrue(STV.can_handle_url('http://player.stv.tv/live'))
+class TestPluginCanHandleUrlSTV(PluginCanHandleUrl):
+    __plugin__ = STV
 
-    def test_can_handle_url_negative(self):
-        self.assertFalse(STV.can_handle_url('http://example.com/live'))
+    should_match = [
+        'https://player.stv.tv/live',
+        'http://player.stv.tv/live',
+    ]

--- a/tests/plugins/test_svtplay.py
+++ b/tests/plugins/test_svtplay.py
@@ -1,35 +1,29 @@
-import unittest
-
 from streamlink.plugins.svtplay import SVTPlay
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSVTPlay(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.svtplay.se/kanaler/svt1',
-            'https://www.svtplay.se/kanaler/svt2?start=auto',
-            'https://www.svtplay.se/kanaler/svtbarn',
-            'https://www.svtplay.se/kanaler/kunskapskanalen?start=auto',
-            'https://www.svtplay.se/kanaler/svt24?start=auto',
-            'https://www.svtplay.se/video/27659457/den-giftbla-floden?start=auto',
-            'https://www.svtplay.se/video/27794015/100-vaginor',
-            'https://www.svtplay.se/video/28065172/motet/motet-sasong-1-det-skamtar-du-inte-om',
-            'https://www.svtplay.se/dokument-inifran-att-radda-ett-barn',
-            'https://www.oppetarkiv.se/video/1399273/varfor-ar-det-sa-ont-om-q-avsnitt-1-av-5',
-            'https://www.oppetarkiv.se/video/2781201/karlekens-mirakel',
-            'https://www.oppetarkiv.se/video/10354325/studio-pop',
-            'https://www.oppetarkiv.se/video/5792180/studio-pop-david-bowie',
-            'https://www.oppetarkiv.se/video/2923832/hipp-hipp-sasong-2-avsnitt-3-av-7',
-            'https://www.oppetarkiv.se/video/3945501/cccp-hockey-cccp-hockey',
-        ]
-        for url in should_match:
-            self.assertTrue(SVTPlay.can_handle_url(url))
+class TestPluginCanHandleUrlSVTPlay(PluginCanHandleUrl):
+    __plugin__ = SVTPlay
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.svtflow.se/video/2020285/avsnitt-6',
-            'https://www.svtflow.se/video/2020285/avsnitt-6',
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(SVTPlay.can_handle_url(url))
+    should_match = [
+        'https://www.svtplay.se/kanaler/svt1',
+        'https://www.svtplay.se/kanaler/svt2?start=auto',
+        'https://www.svtplay.se/kanaler/svtbarn',
+        'https://www.svtplay.se/kanaler/kunskapskanalen?start=auto',
+        'https://www.svtplay.se/kanaler/svt24?start=auto',
+        'https://www.svtplay.se/video/27659457/den-giftbla-floden?start=auto',
+        'https://www.svtplay.se/video/27794015/100-vaginor',
+        'https://www.svtplay.se/video/28065172/motet/motet-sasong-1-det-skamtar-du-inte-om',
+        'https://www.svtplay.se/dokument-inifran-att-radda-ett-barn',
+        'https://www.oppetarkiv.se/video/1399273/varfor-ar-det-sa-ont-om-q-avsnitt-1-av-5',
+        'https://www.oppetarkiv.se/video/2781201/karlekens-mirakel',
+        'https://www.oppetarkiv.se/video/10354325/studio-pop',
+        'https://www.oppetarkiv.se/video/5792180/studio-pop-david-bowie',
+        'https://www.oppetarkiv.se/video/2923832/hipp-hipp-sasong-2-avsnitt-3-av-7',
+        'https://www.oppetarkiv.se/video/3945501/cccp-hockey-cccp-hockey',
+    ]
+
+    should_not_match = [
+        'http://www.svtflow.se/video/2020285/avsnitt-6',
+        'https://www.svtflow.se/video/2020285/avsnitt-6',
+    ]

--- a/tests/plugins/test_swisstxt.py
+++ b/tests/plugins/test_swisstxt.py
@@ -1,33 +1,25 @@
-import unittest
-
 from streamlink.plugins.swisstxt import Swisstxt
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginSwisstxt(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.srf.ch/sport/resultcenter/tennis?eventId=338052",
-            "http://live.rsi.ch/tennis.html?eventId=338052",
-            "http://live.rsi.ch/sport.html?eventId=12345"
-        ]
-        for url in should_match:
-            self.assertTrue(Swisstxt.can_handle_url(url))
+class TestPluginCanHandleUrlSwisstxt(PluginCanHandleUrl):
+    __plugin__ = Swisstxt
 
-        should_not_match = [
-            # regular srgssr sites
-            "http://srf.ch/play/tv/live",
-            "http://www.rsi.ch/play/tv/live#?tvLiveId=livestream_La1",
-            "http://rsi.ch/play/tv/live?tvLiveId=livestream_La1",
-            "http://www.rtr.ch/play/tv/live",
-            "http://rtr.ch/play/tv/live",
-            "http://rts.ch/play/tv/direct#?tvLiveId=3608506",
-            "http://www.srf.ch/play/tv/live#?tvLiveId=c49c1d64-9f60-0001-1c36-43c288c01a10",
-            "http://www.rts.ch/sport/direct/8328501-tennis-open-daustralie.html",
-            "http://www.rts.ch/play/tv/tennis/video/tennis-open-daustralie?id=8328501",
-            # other sites
-            "http://www.crunchyroll.com/gintama",
-            "http://www.crunchyroll.es/gintama",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Swisstxt.can_handle_url(url))
+    should_match = [
+        "http://www.srf.ch/sport/resultcenter/tennis?eventId=338052",
+        "http://live.rsi.ch/tennis.html?eventId=338052",
+        "http://live.rsi.ch/sport.html?eventId=12345"
+    ]
+
+    should_not_match = [
+        # regular srgssr sites
+        "http://srf.ch/play/tv/live",
+        "http://www.rsi.ch/play/tv/live#?tvLiveId=livestream_La1",
+        "http://rsi.ch/play/tv/live?tvLiveId=livestream_La1",
+        "http://www.rtr.ch/play/tv/live",
+        "http://rtr.ch/play/tv/live",
+        "http://rts.ch/play/tv/direct#?tvLiveId=3608506",
+        "http://www.srf.ch/play/tv/live#?tvLiveId=c49c1d64-9f60-0001-1c36-43c288c01a10",
+        "http://www.rts.ch/sport/direct/8328501-tennis-open-daustralie.html",
+        "http://www.rts.ch/play/tv/tennis/video/tennis-open-daustralie?id=8328501",
+    ]

--- a/tests/plugins/test_teamliquid.py
+++ b/tests/plugins/test_teamliquid.py
@@ -1,19 +1,21 @@
-import unittest
-
 from streamlink.plugins.teamliquid import Teamliquid
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTeamliquid(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Teamliquid.can_handle_url("http://www.teamliquid.net/video/streams/Classic%20BW%20VODs"))
-        self.assertTrue(Teamliquid.can_handle_url("http://teamliquid.net/video/streams/iwl-fuNny"))
-        self.assertTrue(Teamliquid.can_handle_url("http://www.teamliquid.net/video/streams/OGamingTV%20SC2"))
-        self.assertTrue(Teamliquid.can_handle_url("http://www.teamliquid.net/video/streams/Check"))
-        self.assertTrue(Teamliquid.can_handle_url("https://tl.net/video/streams/GSL"))
+class TestPluginCanHandleUrlTeamliquid(PluginCanHandleUrl):
+    __plugin__ = Teamliquid
 
-        # shouldn't match
-        self.assertFalse(Teamliquid.can_handle_url("http://www.teamliquid.net/Classic%20BW%20VODs"))
-        self.assertFalse(Teamliquid.can_handle_url("http://www.teamliquid.net/video/Check"))
-        self.assertFalse(Teamliquid.can_handle_url("http://www.teamliquid.com/video/streams/Check"))
-        self.assertFalse(Teamliquid.can_handle_url("http://www.teamliquid.net/video/stream/Check"))
+    should_match = [
+        "http://www.teamliquid.net/video/streams/Classic%20BW%20VODs",
+        "http://teamliquid.net/video/streams/iwl-fuNny",
+        "http://www.teamliquid.net/video/streams/OGamingTV%20SC2",
+        "http://www.teamliquid.net/video/streams/Check",
+        "https://tl.net/video/streams/GSL",
+    ]
+
+    should_not_match = [
+        "http://www.teamliquid.net/Classic%20BW%20VODs",
+        "http://www.teamliquid.net/video/Check",
+        "http://www.teamliquid.com/video/streams/Check",
+        "http://www.teamliquid.net/video/stream/Check",
+    ]

--- a/tests/plugins/test_teleclubzoom.py
+++ b/tests/plugins/test_teleclubzoom.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.teleclubzoom import TeleclubZoom
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTeleclubZoom(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.teleclubzoom.ch',
-            'https://www.teleclubzoom.ch/',
-        ]
-        for url in should_match:
-            self.assertTrue(TeleclubZoom.can_handle_url(url))
+class TestPluginCanHandleUrlTeleclubZoom(PluginCanHandleUrl):
+    __plugin__ = TeleclubZoom
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TeleclubZoom.can_handle_url(url))
+    should_match = [
+        'https://www.teleclubzoom.ch',
+        'https://www.teleclubzoom.ch/',
+    ]

--- a/tests/plugins/test_telefe.py
+++ b/tests/plugins/test_telefe.py
@@ -1,16 +1,18 @@
-import unittest
-
 from streamlink.plugins.telefe import Telefe
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTelefe(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Telefe.can_handle_url("http://telefe.com/pone-a-francella/temporada-1/programa-01/"))
-        self.assertTrue(Telefe.can_handle_url("http://telefe.com/los-simuladores/temporada-1/capitulo-01/"))
-        self.assertTrue(Telefe.can_handle_url("http://telefe.com/dulce-amor/capitulos/capitulo-01/"))
+class TestPluginCanHandleUrlTelefe(PluginCanHandleUrl):
+    __plugin__ = Telefe
 
-        # shouldn't match
-        self.assertFalse(Telefe.can_handle_url("http://telefe.com/"))
-        self.assertFalse(Telefe.can_handle_url("http://www.telefeinternacional.com.ar/"))
-        self.assertFalse(Telefe.can_handle_url("http://marketing.telefe.com/"))
+    should_match = [
+        "http://telefe.com/pone-a-francella/temporada-1/programa-01/",
+        "http://telefe.com/los-simuladores/temporada-1/capitulo-01/",
+        "http://telefe.com/dulce-amor/capitulos/capitulo-01/",
+    ]
+
+    should_not_match = [
+        "http://telefe.com/",
+        "http://www.telefeinternacional.com.ar/",
+        "http://marketing.telefe.com/",
+    ]

--- a/tests/plugins/test_tf1.py
+++ b/tests/plugins/test_tf1.py
@@ -1,22 +1,21 @@
-import unittest
-
 from streamlink.plugins.tf1 import TF1
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTF1(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(TF1.can_handle_url("http://tf1.fr/tf1/direct/"))
-        self.assertTrue(TF1.can_handle_url("http://tf1.fr/tfx/direct/"))
-        self.assertTrue(TF1.can_handle_url("http://tf1.fr/tf1-series-films/direct/"))
-        self.assertTrue(TF1.can_handle_url("http://lci.fr/direct"))
-        self.assertTrue(TF1.can_handle_url("http://www.lci.fr/direct"))
-        self.assertTrue(TF1.can_handle_url("http://tf1.fr/tmc/direct"))
-        self.assertTrue(TF1.can_handle_url("http://tf1.fr/lci/direct"))
+class TestPluginCanHandleUrlTF1(PluginCanHandleUrl):
+    __plugin__ = TF1
 
-    def test_can_handle_url_negative(self):
-        # shouldn't match
-        self.assertFalse(TF1.can_handle_url("http://tf1.fr/direct"))
-        self.assertFalse(TF1.can_handle_url("http://www.tf1.fr/direct"))
-        self.assertFalse(TF1.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(TF1.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "http://tf1.fr/tf1/direct/",
+        "http://tf1.fr/tfx/direct/",
+        "http://tf1.fr/tf1-series-films/direct/",
+        "http://lci.fr/direct",
+        "http://www.lci.fr/direct",
+        "http://tf1.fr/tmc/direct",
+        "http://tf1.fr/lci/direct",
+    ]
+
+    should_not_match = [
+        "http://tf1.fr/direct",
+        "http://www.tf1.fr/direct",
+    ]

--- a/tests/plugins/test_tga.py
+++ b/tests/plugins/test_tga.py
@@ -1,21 +1,12 @@
-import unittest
-
 from streamlink.plugins.tga import Tga
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTga(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://star.longzhu.com/lpl',
-            'http://y.longzhu.com/y123123?from=tonglan2.1',
-            'http://star.longzhu.com/123123?from=tonglan4.3',
-        ]
-        for url in should_match:
-            self.assertTrue(Tga.can_handle_url(url))
+class TestPluginCanHandleUrlTga(PluginCanHandleUrl):
+    __plugin__ = Tga
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Tga.can_handle_url(url))
+    should_match = [
+        'http://star.longzhu.com/lpl',
+        'http://y.longzhu.com/y123123?from=tonglan2.1',
+        'http://star.longzhu.com/123123?from=tonglan4.3',
+    ]

--- a/tests/plugins/test_theplatform.py
+++ b/tests/plugins/test_theplatform.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.theplatform import ThePlatform
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginThePlatform(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://player.theplatform.com/p/',
-            'http://player.theplatform.com/p/',
-        ]
-        for url in should_match:
-            self.assertTrue(ThePlatform.can_handle_url(url))
+class TestPluginCanHandleUrlThePlatform(PluginCanHandleUrl):
+    __plugin__ = ThePlatform
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ThePlatform.can_handle_url(url))
+    should_match = [
+        'https://player.theplatform.com/p/',
+        'http://player.theplatform.com/p/',
+    ]

--- a/tests/plugins/test_tigerdile.py
+++ b/tests/plugins/test_tigerdile.py
@@ -1,22 +1,23 @@
-import unittest
-
 from streamlink.plugins.tigerdile import Tigerdile
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTigerdile(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Tigerdile.can_handle_url("https://www.tigerdile.com/stream/example_streamer"))
-        self.assertTrue(Tigerdile.can_handle_url("http://www.tigerdile.com/stream/example_streamer"))
-        self.assertTrue(Tigerdile.can_handle_url("https://www.tigerdile.com/stream/example_streamer/"))
-        self.assertTrue(Tigerdile.can_handle_url("http://www.tigerdile.com/stream/example_streamer/"))
-        self.assertTrue(Tigerdile.can_handle_url("https://sfw.tigerdile.com/stream/example_streamer"))
-        self.assertTrue(Tigerdile.can_handle_url("http://sfw.tigerdile.com/stream/example_streamer"))
-        self.assertTrue(Tigerdile.can_handle_url("https://sfw.tigerdile.com/stream/example_streamer/"))
-        self.assertTrue(Tigerdile.can_handle_url("http://sfw.tigerdile.com/stream/example_streamer/"))
+class TestPluginCanHandleUrlTigerdile(PluginCanHandleUrl):
+    __plugin__ = Tigerdile
 
-        # shouldn't match
-        self.assertFalse(Tigerdile.can_handle_url("http://www.tigerdile.com/"))
-        self.assertFalse(Tigerdile.can_handle_url("http://www.tigerdile.com/stream"))
-        self.assertFalse(Tigerdile.can_handle_url("http://www.tigerdile.com/stream/"))
-        self.assertFalse(Tigerdile.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://www.tigerdile.com/stream/example_streamer",
+        "http://www.tigerdile.com/stream/example_streamer",
+        "https://www.tigerdile.com/stream/example_streamer/",
+        "http://www.tigerdile.com/stream/example_streamer/",
+        "https://sfw.tigerdile.com/stream/example_streamer",
+        "http://sfw.tigerdile.com/stream/example_streamer",
+        "https://sfw.tigerdile.com/stream/example_streamer/",
+        "http://sfw.tigerdile.com/stream/example_streamer/",
+    ]
+
+    should_not_match = [
+        "http://www.tigerdile.com/",
+        "http://www.tigerdile.com/stream",
+        "http://www.tigerdile.com/stream/",
+    ]

--- a/tests/plugins/test_tlctr.py
+++ b/tests/plugins/test_tlctr.py
@@ -1,18 +1,10 @@
-import unittest
-
 from streamlink.plugins.tlctr import TLCtr
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTLCtr(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.tlctv.com.tr/canli-izle',
-        ]
-        for url in should_match:
-            self.assertTrue(TLCtr.can_handle_url(url))
+class TestPluginCanHandleUrlTLCtr(PluginCanHandleUrl):
+    __plugin__ = TLCtr
 
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TLCtr.can_handle_url(url))
+    should_match = [
+        'https://www.tlctv.com.tr/canli-izle',
+    ]

--- a/tests/plugins/test_turkuvaz.py
+++ b/tests/plugins/test_turkuvaz.py
@@ -1,31 +1,22 @@
-import unittest
-
 from streamlink.plugins.turkuvaz import Turkuvaz
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTurkuvaz(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.atv.com.tr/a2tv/canli-yayin',
-            'https://www.atv.com.tr/a2tv/canli-yayin',
-            'https://www.atv.com.tr/webtv/canli-yayin',
-            'http://www.a2tv.com.tr/webtv/canli-yayin',
-            'http://www.ahaber.com.tr/video/canli-yayin',
-            'https://www.ahaber.com.tr/video/canli-yayin',
-            'https://www.ahaber.com.tr/webtv/canli-yayin',
-            'https://www.aspor.com.tr/webtv/canli-yayin',
-            'http://www.anews.com.tr/webtv/live-broadcast',
-            'http://www.atvavrupa.tv/webtv/canli-yayin',
-            'http://www.minikacocuk.com.tr/webtv/canli-yayin',
-            'http://www.minikago.com.tr/webtv/canli-yayin',
-            'https://www.sabah.com.tr/apara/canli-yayin',
-        ]
-        for url in should_match:
-            self.assertTrue(Turkuvaz.can_handle_url(url))
+class TestPluginCanHandleUrlTurkuvaz(PluginCanHandleUrl):
+    __plugin__ = Turkuvaz
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Turkuvaz.can_handle_url(url))
+    should_match = [
+        'http://www.atv.com.tr/a2tv/canli-yayin',
+        'https://www.atv.com.tr/a2tv/canli-yayin',
+        'https://www.atv.com.tr/webtv/canli-yayin',
+        'http://www.a2tv.com.tr/webtv/canli-yayin',
+        'http://www.ahaber.com.tr/video/canli-yayin',
+        'https://www.ahaber.com.tr/video/canli-yayin',
+        'https://www.ahaber.com.tr/webtv/canli-yayin',
+        'https://www.aspor.com.tr/webtv/canli-yayin',
+        'http://www.anews.com.tr/webtv/live-broadcast',
+        'http://www.atvavrupa.tv/webtv/canli-yayin',
+        'http://www.minikacocuk.com.tr/webtv/canli-yayin',
+        'http://www.minikago.com.tr/webtv/canli-yayin',
+        'https://www.sabah.com.tr/apara/canli-yayin',
+    ]

--- a/tests/plugins/test_tv360.py
+++ b/tests/plugins/test_tv360.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.tv360 import TV360
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTV360(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://tv360.com.tr/canli-yayin',
-        ]
-        for url in should_match:
-            self.assertTrue(TV360.can_handle_url(url))
+class TestPluginCanHandleUrlTV360(PluginCanHandleUrl):
+    __plugin__ = TV360
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TV360.can_handle_url(url))
+    should_match = [
+        'http://tv360.com.tr/canli-yayin',
+    ]

--- a/tests/plugins/test_tv3cat.py
+++ b/tests/plugins/test_tv3cat.py
@@ -1,26 +1,17 @@
-import unittest
-
 from streamlink.plugins.tv3cat import TV3Cat
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTV3Cat(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://ccma.cat/tv3/directe/tv3/',
-            'http://ccma.cat/tv3/directe/324/',
-            'https://ccma.cat/tv3/directe/tv3/',
-            'https://ccma.cat/tv3/directe/324/',
-            'http://www.ccma.cat/tv3/directe/tv3/',
-            'http://www.ccma.cat/tv3/directe/324/',
-            'https://www.ccma.cat/tv3/directe/tv3/',
-            'https://www.ccma.cat/tv3/directe/324/',
-        ]
-        for url in should_match:
-            self.assertTrue(TV3Cat.can_handle_url(url))
+class TestPluginCanHandleUrlTV3Cat(PluginCanHandleUrl):
+    __plugin__ = TV3Cat
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TV3Cat.can_handle_url(url))
+    should_match = [
+        'http://ccma.cat/tv3/directe/tv3/',
+        'http://ccma.cat/tv3/directe/324/',
+        'https://ccma.cat/tv3/directe/tv3/',
+        'https://ccma.cat/tv3/directe/324/',
+        'http://www.ccma.cat/tv3/directe/tv3/',
+        'http://www.ccma.cat/tv3/directe/324/',
+        'https://www.ccma.cat/tv3/directe/tv3/',
+        'https://www.ccma.cat/tv3/directe/324/',
+    ]

--- a/tests/plugins/test_tv4play.py
+++ b/tests/plugins/test_tv4play.py
@@ -1,23 +1,13 @@
-import unittest
-
 from streamlink.plugins.tv4play import TV4Play
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTV4Play(unittest.TestCase):
+class TestPluginCanHandleUrlTV4Play(PluginCanHandleUrl):
+    __plugin__ = TV4Play
 
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.tv4play.se/program/fridas-vm-resa/10000884',
-            'https://www.tv4play.se/program/monk/3938989',
-            'https://www.tv4play.se/program/nyheterna/10378590',
-            'https://www.fotbollskanalen.se/video/10395484/ghoddos-fullbordar-vandningen---ger-ofk-ledningen/',
-        ]
-        for url in should_match:
-            self.assertTrue(TV4Play.can_handle_url(url))
-
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TV4Play.can_handle_url(url))
+    should_match = [
+        'https://www.tv4play.se/program/fridas-vm-resa/10000884',
+        'https://www.tv4play.se/program/monk/3938989',
+        'https://www.tv4play.se/program/nyheterna/10378590',
+        'https://www.fotbollskanalen.se/video/10395484/ghoddos-fullbordar-vandningen---ger-ofk-ledningen/',
+    ]

--- a/tests/plugins/test_tv5monde.py
+++ b/tests/plugins/test_tv5monde.py
@@ -1,26 +1,20 @@
-import unittest
-
 from streamlink.plugins.tv5monde import TV5Monde
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTV5Monde(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://live.tv5monde.com/fbs.html",
-            "http://information.tv5monde.com/les-jt/monde",
-            "http://information.tv5monde.com/info/legislatives-en-france-carnet-de-campagne-a-montreal-172631",
-            "http://www.tv5mondeplusafrique.com/video_karim_ben_khelifa_je_ne_suis_pas_votre_negre_oumou_sangare"
-            + "_4658602.html",
-            "http://www.tv5mondeplus.com/toutes-les-videos/information/tv5monde-le-journal-edition-du-02-06-17-11h00",
-            "http://focus.tv5monde.com/prevert/le-roi-et-loiseau/"
-        ]
-        for url in should_match:
-            self.assertTrue(TV5Monde.can_handle_url(url))
+class TestPluginCanHandleUrlTV5Monde(PluginCanHandleUrl):
+    __plugin__ = TV5Monde
 
-        should_not_match = [
-            "http://www.tv5.ca/",
-            "http://www.tvcatchup.com/",
-            "http://www.youtube.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(TV5Monde.can_handle_url(url))
+    should_match = [
+        "http://live.tv5monde.com/fbs.html",
+        "http://information.tv5monde.com/les-jt/monde",
+        "http://information.tv5monde.com/info/legislatives-en-france-carnet-de-campagne-a-montreal-172631",
+        "http://www.tv5mondeplusafrique.com/video_karim_ben_khelifa_je_ne_suis_pas_votre_negre_oumou_sangare"
+        + "_4658602.html",
+        "http://www.tv5mondeplus.com/toutes-les-videos/information/tv5monde-le-journal-edition-du-02-06-17-11h00",
+        "http://focus.tv5monde.com/prevert/le-roi-et-loiseau/"
+    ]
+
+    should_not_match = [
+        "http://www.tv5.ca/",
+    ]

--- a/tests/plugins/test_tv8.py
+++ b/tests/plugins/test_tv8.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.tv8 import TV8
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTV8(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.tv8.com.tr/canli-yayin',
-        ]
-        for url in should_match:
-            self.assertTrue(TV8.can_handle_url(url))
+class TestPluginCanHandleUrlTV8(PluginCanHandleUrl):
+    __plugin__ = TV8
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TV8.can_handle_url(url))
+    should_match = [
+        'https://www.tv8.com.tr/canli-yayin',
+    ]

--- a/tests/plugins/test_tv999.py
+++ b/tests/plugins/test_tv999.py
@@ -1,24 +1,18 @@
-import unittest
-
 from streamlink.plugins.tv999 import TV999
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTV999(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://tv999.bg/live.html',
-            'http://www.tv999.bg/live.html',
-            'https://tv999.bg/live.html',
-            'https://www.tv999.bg/live.html',
-        ]
-        for url in should_match:
-            self.assertTrue(TV999.can_handle_url(url))
+class TestPluginCanHandleUrlTV999(PluginCanHandleUrl):
+    __plugin__ = TV999
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://tv999.bg/',
-            'https://tv999.bg/live',
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TV999.can_handle_url(url))
+    should_match = [
+        'http://tv999.bg/live.html',
+        'http://www.tv999.bg/live.html',
+        'https://tv999.bg/live.html',
+        'https://www.tv999.bg/live.html',
+    ]
+
+    should_not_match = [
+        'http://tv999.bg/',
+        'https://tv999.bg/live',
+    ]

--- a/tests/plugins/test_tvibo.py
+++ b/tests/plugins/test_tvibo.py
@@ -1,22 +1,12 @@
-import unittest
-
 from streamlink.plugins.tvibo import Tvibo
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTvibo(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://player.tvibo.com/aztv/5929820',
-            'http://player.tvibo.com/aztv/6858270/',
-            'http://player.tvibo.com/aztv/3977238/',
-        ]
-        for url in should_match:
-            self.assertTrue(Tvibo.can_handle_url(url))
+class TestPluginCanHandleUrlTvibo(PluginCanHandleUrl):
+    __plugin__ = Tvibo
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'http://www.idmantv.az/',
-            'https://www.twitch.tv/twitch'
-        ]
-        for url in should_not_match:
-            self.assertFalse(Tvibo.can_handle_url(url))
+    should_match = [
+        'http://player.tvibo.com/aztv/5929820',
+        'http://player.tvibo.com/aztv/6858270/',
+        'http://player.tvibo.com/aztv/3977238/',
+    ]

--- a/tests/plugins/test_tvp.py
+++ b/tests/plugins/test_tvp.py
@@ -1,20 +1,16 @@
-import unittest
-
 from streamlink.plugins.tvp import TVP
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTVP(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://tvpstream.vod.tvp.pl/?channel_id=14327511',
-            'http://tvpstream.vod.tvp.pl/?channel_id=1455',
-        ]
-        for url in should_match:
-            self.assertTrue(TVP.can_handle_url(url))
+class TestPluginCanHandleUrlTVP(PluginCanHandleUrl):
+    __plugin__ = TVP
 
-        should_not_match = [
-            'http://tvp.pl/',
-            'http://vod.tvp.pl/',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TVP.can_handle_url(url))
+    should_match = [
+        'http://tvpstream.vod.tvp.pl/?channel_id=14327511',
+        'http://tvpstream.vod.tvp.pl/?channel_id=1455',
+    ]
+
+    should_not_match = [
+        'http://tvp.pl/',
+        'http://vod.tvp.pl/',
+    ]

--- a/tests/plugins/test_tvplayer.py
+++ b/tests/plugins/test_tvplayer.py
@@ -5,6 +5,31 @@ from streamlink import Streamlink
 from streamlink.plugin.api import HTTPSession
 from streamlink.plugins.tvplayer import TVPlayer
 from streamlink.stream import HLSStream
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlTVPlayer(PluginCanHandleUrl):
+    __plugin__ = TVPlayer
+
+    should_match = [
+        "http://tvplayer.com/watch/",
+        "http://www.tvplayer.com/watch/",
+        "http://tvplayer.com/watch",
+        "http://www.tvplayer.com/watch",
+        "http://www.tvplayer.com/uk/watch",
+        "http://tvplayer.com/watch/dave",
+        "http://tvplayer.com/uk/watch/dave",
+        "http://www.tvplayer.com/watch/itv",
+        "http://www.tvplayer.com/uk/watch/itv",
+        "https://www.tvplayer.com/watch/itv",
+        "https://www.tvplayer.com/uk/watch/itv",
+        "https://tvplayer.com/watch/itv",
+        "https://tvplayer.com/uk/watch/itv",
+    ]
+
+    should_not_match = [
+        "http://www.tvplayer.com/"
+    ]
 
 
 class TestPluginTVPlayer(unittest.TestCase):
@@ -12,27 +37,6 @@ class TestPluginTVPlayer(unittest.TestCase):
         self.session = Streamlink()
         self.session.http = MagicMock(HTTPSession)
         self.session.http.headers = {}
-
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/watch/"))
-        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/watch/"))
-        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/watch"))
-        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/watch"))
-        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/uk/watch"))
-        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/watch/dave"))
-        self.assertTrue(TVPlayer.can_handle_url("http://tvplayer.com/uk/watch/dave"))
-        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/watch/itv"))
-        self.assertTrue(TVPlayer.can_handle_url("http://www.tvplayer.com/uk/watch/itv"))
-        self.assertTrue(TVPlayer.can_handle_url("https://www.tvplayer.com/watch/itv"))
-        self.assertTrue(TVPlayer.can_handle_url("https://www.tvplayer.com/uk/watch/itv"))
-        self.assertTrue(TVPlayer.can_handle_url("https://tvplayer.com/watch/itv"))
-        self.assertTrue(TVPlayer.can_handle_url("https://tvplayer.com/uk/watch/itv"))
-
-        # shouldn't match
-        self.assertFalse(TVPlayer.can_handle_url("http://www.tvplayer.com/"))
-        self.assertFalse(TVPlayer.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(TVPlayer.can_handle_url("http://www.youtube.com/"))
 
     @patch('streamlink.plugins.tvplayer.TVPlayer._get_stream_data')
     @patch('streamlink.plugins.tvplayer.HLSStream')

--- a/tests/plugins/test_tvrby.py
+++ b/tests/plugins/test_tvrby.py
@@ -1,21 +1,21 @@
 import unittest
 
 from streamlink.plugins.tvrby import TVRBy
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlTVRBy(PluginCanHandleUrl):
+    __plugin__ = TVRBy
+
+    should_match = [
+        "http://www.tvr.by/televidenie/belarus-1/",
+        "http://www.tvr.by/televidenie/belarus-1",
+        "http://www.tvr.by/televidenie/belarus-24/",
+        "http://www.tvr.by/televidenie/belarus-24",
+    ]
 
 
 class TestPluginTVRBy(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(TVRBy.can_handle_url("http://www.tvr.by/televidenie/belarus-1/"))
-        self.assertTrue(TVRBy.can_handle_url("http://www.tvr.by/televidenie/belarus-1"))
-        self.assertTrue(TVRBy.can_handle_url("http://www.tvr.by/televidenie/belarus-24/"))
-        self.assertTrue(TVRBy.can_handle_url("http://www.tvr.by/televidenie/belarus-24"))
-
-        # shouldn't match
-        self.assertFalse(TVRBy.can_handle_url("http://www.tv8.cat/algo/"))
-        self.assertFalse(TVRBy.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(TVRBy.can_handle_url("http://www.youtube.com/"))
-
     def test_url_fix(self):
         self.assertTrue(
             "http://www.tvr.by/televidenie/belarus-1/",

--- a/tests/plugins/test_tvrplus.py
+++ b/tests/plugins/test_tvrplus.py
@@ -1,21 +1,17 @@
-import unittest
-
 from streamlink.plugins.tvrplus import TVRPlus
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTVRPlus(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://tvrplus.ro/live/tvr-1",
-            "http://www.tvrplus.ro/live/tvr-1",
-            "http://www.tvrplus.ro/live/tvr-3",
-            "http://www.tvrplus.ro/live/tvr-international",
-        ]
-        for url in should_match:
-            self.assertTrue(TVRPlus.can_handle_url(url))
+class TestPluginCanHandleUrlTVRPlus(PluginCanHandleUrl):
+    __plugin__ = TVRPlus
 
-        should_not_match = [
-            "http://www.tvrplus.ro/",
-        ]
-        for url in should_not_match:
-            self.assertFalse(TVRPlus.can_handle_url(url))
+    should_match = [
+        "http://tvrplus.ro/live/tvr-1",
+        "http://www.tvrplus.ro/live/tvr-1",
+        "http://www.tvrplus.ro/live/tvr-3",
+        "http://www.tvrplus.ro/live/tvr-international",
+    ]
+
+    should_not_match = [
+        "http://www.tvrplus.ro/",
+    ]

--- a/tests/plugins/test_tvtoya.py
+++ b/tests/plugins/test_tvtoya.py
@@ -1,16 +1,19 @@
-import unittest
-
 from streamlink.plugins.tvtoya import TVToya
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTVRPlus(unittest.TestCase):
-    def test_can_handle_url(self):
-        self.assertTrue(TVToya.can_handle_url("https://tvtoya.pl/live"))
-        self.assertTrue(TVToya.can_handle_url("http://tvtoya.pl/live"))
+class TestPluginCanHandleUrlTVRPlus(PluginCanHandleUrl):
+    __plugin__ = TVToya
 
-    def test_can_handle_url_negative(self):
-        self.assertFalse(TVToya.can_handle_url("https://tvtoya.pl"))
-        self.assertFalse(TVToya.can_handle_url("http://tvtoya.pl"))
-        self.assertFalse(TVToya.can_handle_url("http://tvtoya.pl/other-page"))
-        self.assertFalse(TVToya.can_handle_url("http://tvtoya.pl/"))
-        self.assertFalse(TVToya.can_handle_url("https://tvtoya.pl/"))
+    should_match = [
+        "https://tvtoya.pl/live",
+        "http://tvtoya.pl/live",
+    ]
+
+    should_not_match = [
+        "https://tvtoya.pl",
+        "http://tvtoya.pl",
+        "http://tvtoya.pl/other-page",
+        "http://tvtoya.pl/",
+        "https://tvtoya.pl/",
+    ]

--- a/tests/plugins/test_twitcasting.py
+++ b/tests/plugins/test_twitcasting.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.twitcasting import TwitCasting
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginTwitCasting(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://twitcasting.tv/c:kk1992kkkk',
-            'https://twitcasting.tv/icchy8591/movie/566593738',
-        ]
-        for url in should_match:
-            self.assertTrue(TwitCasting.can_handle_url(url))
+class TestPluginCanHandleUrlTwitCasting(PluginCanHandleUrl):
+    __plugin__ = TwitCasting
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(TwitCasting.can_handle_url(url))
+    should_match = [
+        'https://twitcasting.tv/c:kk1992kkkk',
+        'https://twitcasting.tv/icchy8591/movie/566593738',
+    ]

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -8,6 +8,24 @@ from streamlink import Streamlink
 from streamlink.plugin import PluginError
 from streamlink.plugins.twitch import Twitch, TwitchHLSStream, TwitchHLSStreamReader, TwitchHLSStreamWriter
 from tests.mixins.stream_hls import EventedHLSStreamWriter, Playlist, Segment as _Segment, Tag, TestMixinStreamHLS
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlTwitch(PluginCanHandleUrl):
+    __plugin__ = Twitch
+
+    should_match = [
+        'https://www.twitch.tv/twitch',
+        'https://www.twitch.tv/videos/150942279',
+        'https://clips.twitch.tv/ObservantBenevolentCarabeefPhilosoraptor',
+        'https://www.twitch.tv/twitch/video/292713971',
+        'https://www.twitch.tv/twitch/v/292713971',
+    ]
+
+    should_not_match = [
+        'https://www.twitch.tv',
+        'https://www.twitch.tv/',
+    ]
 
 
 DATETIME_BASE = datetime(2000, 1, 1, 0, 0, 0, 0)
@@ -54,26 +72,6 @@ class _TwitchHLSStreamReader(TwitchHLSStreamReader):
 
 class _TwitchHLSStream(TwitchHLSStream):
     __reader__ = _TwitchHLSStreamReader
-
-
-class TestPluginTwitch(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.twitch.tv/twitch',
-            'https://www.twitch.tv/videos/150942279',
-            'https://clips.twitch.tv/ObservantBenevolentCarabeefPhilosoraptor',
-            'https://www.twitch.tv/twitch/video/292713971',
-            'https://www.twitch.tv/twitch/v/292713971',
-        ]
-        for url in should_match:
-            self.assertTrue(Twitch.can_handle_url(url))
-
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.twitch.tv',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Twitch.can_handle_url(url))
 
 
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))

--- a/tests/plugins/test_ustreamtv.py
+++ b/tests/plugins/test_ustreamtv.py
@@ -3,29 +3,24 @@ from unittest.mock import ANY, MagicMock
 
 from streamlink import Streamlink
 from streamlink.plugins.ustreamtv import UStreamTV
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlUStreamTV(PluginCanHandleUrl):
+    __plugin__ = UStreamTV
+
+    should_match = [
+        "http://www.ustream.tv/streamlink",
+        "http://www.ustream.tv/channel/id/1234",
+        "http://www.ustream.tv/embed/1234",
+        "http://www.ustream.tv/recorded/6543",
+        "http://www.ustream.tv/embed/recorded/6543",
+        "https://video.ibm.com/channel/H5rQLwmTGrW",
+        "https://video.ibm.com/recorded/124680279",
+    ]
 
 
 class TestPluginUStreamTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.ustream.tv/streamlink",
-            "http://www.ustream.tv/channel/id/1234",
-            "http://www.ustream.tv/embed/1234",
-            "http://www.ustream.tv/recorded/6543",
-            "http://www.ustream.tv/embed/recorded/6543",
-            "https://video.ibm.com/channel/H5rQLwmTGrW",
-            "https://video.ibm.com/recorded/124680279",
-        ]
-        for url in should_match:
-            self.assertTrue(UStreamTV.can_handle_url(url))
-
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            "https://www.youtube.com/v/aqz-KE-bpKQ",
-        ]
-        for url in should_not_match:
-            self.assertFalse(UStreamTV.can_handle_url(url))
-
     def test_arguments(self):
         from streamlink_cli.main import setup_plugin_args
         session = Streamlink()

--- a/tests/plugins/test_ustvnow.py
+++ b/tests/plugins/test_ustvnow.py
@@ -1,15 +1,18 @@
 import unittest
 
 from streamlink.plugins.ustvnow import USTVNow
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlUSTVNow(PluginCanHandleUrl):
+    __plugin__ = USTVNow
+
+    should_match = [
+        "http://www.ustvnow.com/live/foo/-65"
+    ]
 
 
 class TestPluginUSTVNow(unittest.TestCase):
-    def test_can_handle_url(self):
-        self.assertTrue(USTVNow.can_handle_url("http://www.ustvnow.com/live/foo/-65"))
-
-    def test_can_not_handle_url(self):
-        self.assertFalse(USTVNow.can_handle_url("http://www.tvplayer.com"))
-
     def test_encrypt_data(self):
         key = "80035ad42d7d-bb08-7a14-f726-78403b29"
         iv = "3157b5680927cc4a"

--- a/tests/plugins/test_viasat.py
+++ b/tests/plugins/test_viasat.py
@@ -1,42 +1,36 @@
-import unittest
-
 from streamlink.plugins.viasat import Viasat
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginViasat(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.juicyplay.dk/story/se-robinson-benjamins-store-forandring",
-            "http://www.tv3.dk/paradise-hotel/paradise-hotel-2018-her-er-deltagerne",
-            "http://www.tv3.dk/paradise-hotel/paradise-hotel-2018-her-er-deltagerne",
-            "https://play.tv3.lt/programos/eurocup/903167?autostart=true",
-            "https://play.tv3.lt/programos/pamilti-vel/903174?autostart=true",
-            "https://skaties.lv/sports/futbols/video-liverpool-izbraukuma-rada-klasi-pret-bournemouth/",
-            "https://tv3play.tv3.ee/sisu/eesti-otsib-superstaari",
-            "https://tv3play.tv3.ee/sisu/inglite-aeg/902432?autostart=true",
-            "https://tvplay.skaties.lv/parraides/darma-un-gregs/902597?autostart=true&collection=719",
-            "https://tvplay.skaties.lv/parraides/kungfu-panda/900510?autostart=true",
-            "https://www.tv3.lt/naujiena/938699/ispudingiausi-kobe-bryanto-karjeros-epizodai-monstriski-dejimai-ir"
-            + "-pergalingi-metimai",
-            "https://www.tv6play.no/programmer/underholdning/paradise-hotel-sverige/sesong-8/episode-19",
-            "https://www.tv6play.no/programmer/underholdning/paradise-hotel/sesong-9/822763",
-            "https://www.viafree.dk/",
-            "https://www.viafree.dk/embed?id=898974&wmode=transparent&autostart=true",
-            "https://www.viafree.dk/programmer/reality/forside-fruer/saeson-2/872877",
-            "https://www.viafree.dk/programmer/reality/forside-fruer/saeson-2/episode-1",
-            "https://www.viafree.no/programmer/underholdning/paradise-hotel-sverige/sesong-8/episode-19",
-            "https://www.viafree.no/programmer/underholdning/paradise-hotel/sesong-9/822763",
-            "https://www.viafree.se/program/underhallning/det-stora-experimentet/sasong-1/897870",
-            "https://www.viafree.se/program/underhallning/det-stora-experimentet/sasong-1/avsnitt-19",
-        ]
-        for url in should_match:
-            self.assertTrue(Viasat.can_handle_url(url), url)
+class TestPluginCanHandleUrlViasat(PluginCanHandleUrl):
+    __plugin__ = Viasat
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            "http://www.tv3play.no",
-            "http://www.tv6play.se",
-            "https://play.nova.bg/programi/kh-faktor/902681?autostart=true",
-        ]
-        for url in should_not_match:
-            self.assertFalse(Viasat.can_handle_url(url), url)
+    should_match = [
+        "http://www.juicyplay.dk/story/se-robinson-benjamins-store-forandring",
+        "http://www.tv3.dk/paradise-hotel/paradise-hotel-2018-her-er-deltagerne",
+        "http://www.tv3.dk/paradise-hotel/paradise-hotel-2018-her-er-deltagerne",
+        "https://play.tv3.lt/programos/eurocup/903167?autostart=true",
+        "https://play.tv3.lt/programos/pamilti-vel/903174?autostart=true",
+        "https://skaties.lv/sports/futbols/video-liverpool-izbraukuma-rada-klasi-pret-bournemouth/",
+        "https://tv3play.tv3.ee/sisu/eesti-otsib-superstaari",
+        "https://tv3play.tv3.ee/sisu/inglite-aeg/902432?autostart=true",
+        "https://tvplay.skaties.lv/parraides/darma-un-gregs/902597?autostart=true&collection=719",
+        "https://tvplay.skaties.lv/parraides/kungfu-panda/900510?autostart=true",
+        "https://www.tv3.lt/naujiena/938699/ispudingiausi-kobe-bryanto-karjeros-epizodai-monstriski-dejimai-ir"
+        + "-pergalingi-metimai",
+        "https://www.tv6play.no/programmer/underholdning/paradise-hotel-sverige/sesong-8/episode-19",
+        "https://www.tv6play.no/programmer/underholdning/paradise-hotel/sesong-9/822763",
+        "https://www.viafree.dk/",
+        "https://www.viafree.dk/embed?id=898974&wmode=transparent&autostart=true",
+        "https://www.viafree.dk/programmer/reality/forside-fruer/saeson-2/872877",
+        "https://www.viafree.dk/programmer/reality/forside-fruer/saeson-2/episode-1",
+        "https://www.viafree.no/programmer/underholdning/paradise-hotel-sverige/sesong-8/episode-19",
+        "https://www.viafree.no/programmer/underholdning/paradise-hotel/sesong-9/822763",
+        "https://www.viafree.se/program/underhallning/det-stora-experimentet/sasong-1/897870",
+        "https://www.viafree.se/program/underhallning/det-stora-experimentet/sasong-1/avsnitt-19",
+    ]
+
+    should_not_match = [
+        "http://www.tv3play.no",
+        "http://www.tv6play.se",
+    ]

--- a/tests/plugins/test_vidio.py
+++ b/tests/plugins/test_vidio.py
@@ -1,15 +1,17 @@
-import unittest
-
 from streamlink.plugins.vidio import Vidio
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginVidio(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Vidio.can_handle_url('https://www.vidio.com/live/204-sctv-tv-stream'))
-        self.assertTrue(Vidio.can_handle_url('https://www.vidio.com/live/5075-dw-tv-stream'))
-        self.assertTrue(Vidio.can_handle_url('https://www.vidio.com/watch/766861-5-rekor-fantastis-zidane-bersama-real-madrid'))
+class TestPluginCanHandleUrlVidio(PluginCanHandleUrl):
+    __plugin__ = Vidio
 
-        # shouldn't match
-        self.assertFalse(Vidio.can_handle_url('http://www.vidio.com'))
-        self.assertFalse(Vidio.can_handle_url('https://www.vidio.com'))
+    should_match = [
+        'https://www.vidio.com/live/204-sctv-tv-stream',
+        'https://www.vidio.com/live/5075-dw-tv-stream',
+        'https://www.vidio.com/watch/766861-5-rekor-fantastis-zidane-bersama-real-madrid',
+    ]
+
+    should_not_match = [
+        'http://www.vidio.com',
+        'https://www.vidio.com',
+    ]

--- a/tests/plugins/test_vimeo.py
+++ b/tests/plugins/test_vimeo.py
@@ -1,19 +1,19 @@
-import unittest
-
 from streamlink.plugins.vimeo import Vimeo
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginVimeo(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Vimeo.can_handle_url("https://vimeo.com/237163735"))
-        self.assertTrue(Vimeo.can_handle_url("https://vimeo.com/channels/music/176894130"))
-        self.assertTrue(Vimeo.can_handle_url("https://vimeo.com/album/3706071/video/148903960"))
-        self.assertTrue(Vimeo.can_handle_url("https://vimeo.com/ondemand/surveyopenspace/92630739"))
-        self.assertTrue(Vimeo.can_handle_url("https://vimeo.com/ondemand/100footsurfingdays"))
-        self.assertTrue(Vimeo.can_handle_url("https://player.vimeo.com/video/176894130"))
+class TestPluginCanHandleUrlVimeo(PluginCanHandleUrl):
+    __plugin__ = Vimeo
 
-        # shouldn't match
-        self.assertFalse(Vimeo.can_handle_url("https://www.vimeo.com/"))
-        self.assertFalse(Vimeo.can_handle_url("http://www.tvcatchup.com/"))
-        self.assertFalse(Vimeo.can_handle_url("http://www.youtube.com/"))
+    should_match = [
+        "https://vimeo.com/237163735",
+        "https://vimeo.com/channels/music/176894130",
+        "https://vimeo.com/album/3706071/video/148903960",
+        "https://vimeo.com/ondemand/surveyopenspace/92630739",
+        "https://vimeo.com/ondemand/100footsurfingdays",
+        "https://player.vimeo.com/video/176894130",
+    ]
+
+    should_not_match = [
+        "https://www.vimeo.com/"
+    ]

--- a/tests/plugins/test_vinhlongtv.py
+++ b/tests/plugins/test_vinhlongtv.py
@@ -1,20 +1,12 @@
-import unittest
-
 from streamlink.plugins.vinhlongtv import VinhLongTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginVinhLongTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://thvli.vn/live/thvl1-hd/aab94d1f-44e1-4992-8633-6d46da08db42',
-            'http://thvli.vn/live/thvl2-hd/bc60bddb-99ac-416e-be26-eb4d0852f5cc',
-            'http://thvli.vn/live/phat-thanh/c87174ba-7aeb-4cb4-af95-d59de715464c',
-        ]
-        for url in should_match:
-            self.assertTrue(VinhLongTV.can_handle_url(url))
+class TestPluginCanHandleUrlVinhLongTV(PluginCanHandleUrl):
+    __plugin__ = VinhLongTV
 
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(VinhLongTV.can_handle_url(url))
+    should_match = [
+        'http://thvli.vn/live/thvl1-hd/aab94d1f-44e1-4992-8633-6d46da08db42',
+        'http://thvli.vn/live/thvl2-hd/bc60bddb-99ac-416e-be26-eb4d0852f5cc',
+        'http://thvli.vn/live/phat-thanh/c87174ba-7aeb-4cb4-af95-d59de715464c',
+    ]

--- a/tests/plugins/test_viutv.py
+++ b/tests/plugins/test_viutv.py
@@ -1,23 +1,14 @@
-import unittest  # noqa: F401
-
-import pytest
-
 from streamlink.plugins.viutv import ViuTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginViuTV:
-    valid_urls = [
-        ("https://viu.tv/ch/99",),
+class TestPluginCanHandleUrlViuTV(PluginCanHandleUrl):
+    __plugin__ = ViuTV
+
+    should_match = [
+        "https://viu.tv/ch/99"
     ]
-    invalid_urls = [
-        ("https://viu.tv/encore/king-maker-ii/king-maker-iie4fuk-hei-baan-hui-ji-on-ji-sun-dang-cheung",),
-        ("https://www.youtube.com",)
+
+    should_not_match = [
+        "https://viu.tv/encore/king-maker-ii/king-maker-iie4fuk-hei-baan-hui-ji-on-ji-sun-dang-cheung"
     ]
-
-    @pytest.mark.parametrize(["url"], valid_urls)
-    def test_can_handle_url(self, url):
-        assert ViuTV.can_handle_url(url), "url should be handled"
-
-    @pytest.mark.parametrize(["url"], invalid_urls)
-    def test_can_handle_url_negative(self, url):
-        assert not ViuTV.can_handle_url(url), "url should not be handled"

--- a/tests/plugins/test_vk.py
+++ b/tests/plugins/test_vk.py
@@ -1,6 +1,30 @@
 import unittest
 
 from streamlink.plugins.vk import VK
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlVK(PluginCanHandleUrl):
+    __plugin__ = VK
+
+    should_match = [
+        "https://vk.com/video-9944999_456239622",
+        "http://vk.com/video-24136539_456239830",
+        "https://www.vk.com/video-34453259_456240574",
+        "https://vk.com/videos-24136539?z=video-24136539_456241155%2Fpl_-24136539_-2",
+        "https://vk.com/video?z=video-15755094_456245149%2Fpl_cat_lives",
+        "https://vk.com/video?z=video132886594_167211693%2Fpl_cat_8",
+        "https://vk.com/video132886594_167211693",
+        "https://vk.com/videos132886594?z=video132886594_167211693",
+        "https://vk.com/video-73154028_456239128",
+    ]
+
+    should_not_match = [
+        "https://vk.com/",
+        "https://vk.com/restore",
+        "https://www.vk.com/videos-24136539",
+        "http://vk.com/videos-24136539",
+    ]
 
 
 class TestPluginVK(unittest.TestCase):
@@ -23,22 +47,3 @@ class TestPluginVK(unittest.TestCase):
         self.assertEqual(VK.follow_vk_redirect("http://vk.com/"), "http://vk.com/")
         self.assertEqual(VK.follow_vk_redirect("http://vk.com/videos-24136539"), "http://vk.com/videos-24136539")
         self.assertEqual(VK.follow_vk_redirect("http://www.youtube.com/"), "http://www.youtube.com/")
-
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(VK.can_handle_url("https://vk.com/video-9944999_456239622"))
-        self.assertTrue(VK.can_handle_url("http://vk.com/video-24136539_456239830"))
-        self.assertTrue(VK.can_handle_url("https://www.vk.com/video-34453259_456240574"))
-        self.assertTrue(VK.can_handle_url("https://vk.com/videos-24136539?z=video-24136539_456241155%2Fpl_-24136539_-2"))
-        self.assertTrue(VK.can_handle_url("https://vk.com/video?z=video-15755094_456245149%2Fpl_cat_lives"))
-        self.assertTrue(VK.can_handle_url("https://vk.com/video?z=video132886594_167211693%2Fpl_cat_8"))
-        self.assertTrue(VK.can_handle_url("https://vk.com/video132886594_167211693"))
-        self.assertTrue(VK.can_handle_url("https://vk.com/videos132886594?z=video132886594_167211693"))
-        self.assertTrue(VK.can_handle_url("https://vk.com/video-73154028_456239128"))
-
-        # shouldn't match
-        self.assertFalse(VK.can_handle_url("https://vk.com/"))
-        self.assertFalse(VK.can_handle_url("https://vk.com/restore"))
-        self.assertFalse(VK.can_handle_url("https://www.vk.com/videos-24136539"))
-        self.assertFalse(VK.can_handle_url("http://vk.com/videos-24136539"))
-        self.assertFalse(VK.can_handle_url("http://www.youtube.com/"))

--- a/tests/plugins/test_vlive.py
+++ b/tests/plugins/test_vlive.py
@@ -1,24 +1,15 @@
-import unittest  # noqa: F401
-
-import pytest
-
 from streamlink.plugins.vlive import Vlive
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginVlive:
-    valid_urls = [
-        ("https://www.vlive.tv/video/156824",),
-        ("https://www.vlive.tv/post/0-19740901",)
+class TestPluginCanHandleUrlVlive(PluginCanHandleUrl):
+    __plugin__ = Vlive
+
+    should_match = [
+        "https://www.vlive.tv/video/156824",
+        "https://www.vlive.tv/post/0-19740901"
     ]
-    invalid_urls = [
-        ("https://www.vlive.tv/events/2019vheartbeat?lang=en",),
-        ("https://twitch.tv/",)
+
+    should_not_match = [
+        "https://www.vlive.tv/events/2019vheartbeat?lang=en",
     ]
-
-    @pytest.mark.parametrize(["url"], valid_urls)
-    def test_can_handle_url(self, url):
-        assert Vlive.can_handle_url(url), "url should be handled"
-
-    @pytest.mark.parametrize(["url"], invalid_urls)
-    def test_can_handle_url_negative(self, url):
-        assert not Vlive.can_handle_url(url), "url should not be handled"

--- a/tests/plugins/test_vrtbe.py
+++ b/tests/plugins/test_vrtbe.py
@@ -1,27 +1,18 @@
-import unittest
-
 from streamlink.plugins.vrtbe import VRTbe
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginVRTbe(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            # LIVE
-            "https://www.vrt.be/vrtnu/kanalen/canvas/",
-            "https://www.vrt.be/vrtnu/kanalen/een/",
-            "https://www.vrt.be/vrtnu/kanalen/ketnet/",
-            # VOD
-            "https://www.vrt.be/vrtnu/a-z/belfast-zoo/1/belfast-zoo-s1a14/",
-            "https://www.vrt.be/vrtnu/a-z/sporza--korfbal/2017/sporza--korfbal-s2017-sporza-korfbal/",
-            "https://www.vrt.be/vrtnu/a-z/de-grote-peter-van-de-veire-ochtendshow/2017/de-grote-peter-van-de-veire"
-            + "-ochtendshow-s2017--en-parels-voor-de-zwijnen-ook/"
-        ]
-        for url in should_match:
-            self.assertTrue(VRTbe.can_handle_url(url))
+class TestPluginCanHandleUrlVRTbe(PluginCanHandleUrl):
+    __plugin__ = VRTbe
 
-        should_not_match = [
-            "https://example.com/",
-            "http://www.local.local/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(VRTbe.can_handle_url(url))
+    should_match = [
+        # LIVE
+        "https://www.vrt.be/vrtnu/kanalen/canvas/",
+        "https://www.vrt.be/vrtnu/kanalen/een/",
+        "https://www.vrt.be/vrtnu/kanalen/ketnet/",
+        # VOD
+        "https://www.vrt.be/vrtnu/a-z/belfast-zoo/1/belfast-zoo-s1a14/",
+        "https://www.vrt.be/vrtnu/a-z/sporza--korfbal/2017/sporza--korfbal-s2017-sporza-korfbal/",
+        "https://www.vrt.be/vrtnu/a-z/de-grote-peter-van-de-veire-ochtendshow/2017/de-grote-peter-van-de-veire"
+        + "-ochtendshow-s2017--en-parels-voor-de-zwijnen-ook/"
+    ]

--- a/tests/plugins/test_vtvgo.py
+++ b/tests/plugins/test_vtvgo.py
@@ -1,32 +1,27 @@
-import unittest
-
 from streamlink.plugins.vtvgo import VTVgo
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginVTVgo(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv2-2.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv3-3.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv4-4.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv5-5.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv6-6.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv7-27.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv8-36.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv9-39.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv5-t%C3%A2y-nam-b%E1%BB%99-7.html',
-            'https://vtvgo.vn/xem-truc-tuyen-kenh-k%C3%AAnh-vtv5-t%C3%A2y-nguy%C3%AAn-163.html',
-        ]
-        for url in should_match:
-            self.assertTrue(VTVgo.can_handle_url(url))
+class TestPluginCanHandleUrlVTVgo(PluginCanHandleUrl):
+    __plugin__ = VTVgo
 
-        should_not_match = [
-            'https://example.com/index.html',
-            # POST request will error with www.
-            'https://www.vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
-            # POST request will error with http://
-            'http://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(VTVgo.can_handle_url(url))
+    should_match = [
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv2-2.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv3-3.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv4-4.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv5-5.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv6-6.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv7-27.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv8-36.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv9-39.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv5-t%C3%A2y-nam-b%E1%BB%99-7.html',
+        'https://vtvgo.vn/xem-truc-tuyen-kenh-k%C3%AAnh-vtv5-t%C3%A2y-nguy%C3%AAn-163.html',
+    ]
+
+    should_not_match = [
+        # POST request will error with www.
+        'https://www.vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
+        # POST request will error with http://
+        'http://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
+    ]

--- a/tests/plugins/test_wasd.py
+++ b/tests/plugins/test_wasd.py
@@ -1,23 +1,17 @@
-import unittest
-
 from streamlink.plugins.wasd import WASD
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginWasd(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://wasd.tv/channel',
-            'https://wasd.tv/channel/',
-        ]
-        for url in should_match:
-            self.assertTrue(WASD.can_handle_url(url), url)
+class TestPluginCanHandleUrlWasd(PluginCanHandleUrl):
+    __plugin__ = WASD
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-            'https://wasd.tv/channel/12345',
-            'https://wasd.tv/channel/12345/videos/67890',
-            'https://wasd.tv/voodik/videos?record=123456',
-        ]
-        for url in should_not_match:
-            self.assertFalse(WASD.can_handle_url(url), url)
+    should_match = [
+        'https://wasd.tv/channel',
+        'https://wasd.tv/channel/',
+    ]
+
+    should_not_match = [
+        'https://wasd.tv/channel/12345',
+        'https://wasd.tv/channel/12345/videos/67890',
+        'https://wasd.tv/voodik/videos?record=123456',
+    ]

--- a/tests/plugins/test_webcast_india_gov.py
+++ b/tests/plugins/test_webcast_india_gov.py
@@ -1,16 +1,12 @@
-import unittest
-
 from streamlink.plugins.webcast_india_gov import WebcastIndiaGov
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginWebcastIndiaGov(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(WebcastIndiaGov.can_handle_url("http://webcast.gov.in/ddpunjabi/"))
-        self.assertTrue(WebcastIndiaGov.can_handle_url("http://webcast.gov.in/#Channel1"))
-        self.assertTrue(WebcastIndiaGov.can_handle_url("http://webcast.gov.in/#Channel3"))
+class TestPluginCanHandleUrlWebcastIndiaGov(PluginCanHandleUrl):
+    __plugin__ = WebcastIndiaGov
 
-        # shouldn't match
-        self.assertFalse(WebcastIndiaGov.can_handle_url("http://meity.gov.in/"))
-        self.assertFalse(WebcastIndiaGov.can_handle_url("http://www.nic.in/"))
-        self.assertFalse(WebcastIndiaGov.can_handle_url("http://digitalindiaawards.gov.in/"))
+    should_match = [
+        "http://webcast.gov.in/ddpunjabi/",
+        "http://webcast.gov.in/#Channel1",
+        "http://webcast.gov.in/#Channel3",
+    ]

--- a/tests/plugins/test_webtv.py
+++ b/tests/plugins/test_webtv.py
@@ -1,24 +1,20 @@
-import unittest
-
 from streamlink.plugins.webtv import WebTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginWebTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(WebTV.can_handle_url("http://planetmutfak.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://telex.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://nasamedia.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://genctv.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://etvmanisa.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://startv.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://akuntv.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://telebarnn.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://kanal48.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://digi24tv.web.tv"))
-        self.assertTrue(WebTV.can_handle_url("http://french24.web.tv"))
+class TestPluginCanHandleUrlWebTV(PluginCanHandleUrl):
+    __plugin__ = WebTV
 
-        # shouldn't match
-        self.assertFalse(WebTV.can_handle_url("http://www.youtube.com/"))
-        self.assertFalse(WebTV.can_handle_url("https://www.tvplayer.com/watch/itv"))
-        self.assertFalse(WebTV.can_handle_url("https://tvplayer.com/watch/itv"))
+    should_match = [
+        "http://planetmutfak.web.tv",
+        "http://telex.web.tv",
+        "http://nasamedia.web.tv",
+        "http://genctv.web.tv",
+        "http://etvmanisa.web.tv",
+        "http://startv.web.tv",
+        "http://akuntv.web.tv",
+        "http://telebarnn.web.tv",
+        "http://kanal48.web.tv",
+        "http://digi24tv.web.tv",
+        "http://french24.web.tv",
+    ]

--- a/tests/plugins/test_welt.py
+++ b/tests/plugins/test_welt.py
@@ -1,28 +1,29 @@
 import unittest
 
 from streamlink.plugins.welt import Welt
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlWelt(PluginCanHandleUrl):
+    __plugin__ = Welt
+
+    should_match = [
+        "http://welt.de",
+        "http://welt.de/",
+        "http://welt.de/tv-programm-live-stream/",
+        "http://www.welt.de",
+        "http://www.welt.de/",
+        "http://www.welt.de/tv-programm-live-stream/",
+        "https://welt.de",
+        "https://welt.de/",
+        "https://welt.de/tv-programm-live-stream/",
+        "https://www.welt.de",
+        "https://www.welt.de/",
+        "https://www.welt.de/tv-programm-live-stream/",
+    ]
 
 
 class TestPluginWelt(unittest.TestCase):
-    def test_can_handle_url(self):
-        # should match
-        self.assertTrue(Welt.can_handle_url("http://welt.de"))
-        self.assertTrue(Welt.can_handle_url("http://welt.de/"))
-        self.assertTrue(Welt.can_handle_url("http://welt.de/tv-programm-live-stream/"))
-        self.assertTrue(Welt.can_handle_url("http://www.welt.de"))
-        self.assertTrue(Welt.can_handle_url("http://www.welt.de/"))
-        self.assertTrue(Welt.can_handle_url("http://www.welt.de/tv-programm-live-stream/"))
-        self.assertTrue(Welt.can_handle_url("https://welt.de"))
-        self.assertTrue(Welt.can_handle_url("https://welt.de/"))
-        self.assertTrue(Welt.can_handle_url("https://welt.de/tv-programm-live-stream/"))
-        self.assertTrue(Welt.can_handle_url("https://www.welt.de"))
-        self.assertTrue(Welt.can_handle_url("https://www.welt.de/"))
-        self.assertTrue(Welt.can_handle_url("https://www.welt.de/tv-programm-live-stream/"))
-
-        # shouldn't match
-        self.assertFalse(Welt.can_handle_url("http://www.youtube.com/"))
-        self.assertFalse(Welt.can_handle_url("http://youtube.com/"))
-
     def test_validate_live(self):
         hls_url = Welt._schema.validate("""
             <!DOCTYPE html><html><body>

--- a/tests/plugins/test_wwenetwork.py
+++ b/tests/plugins/test_wwenetwork.py
@@ -1,19 +1,10 @@
-import unittest
-
 from streamlink.plugins.wwenetwork import WWENetwork
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginWWENetwork(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://watch.wwe.com/in-ring/3622',
-        ]
-        for url in should_match:
-            self.assertTrue(WWENetwork.can_handle_url(url))
+class TestPluginCanHandleUrlWWENetwork(PluginCanHandleUrl):
+    __plugin__ = WWENetwork
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(WWENetwork.can_handle_url(url))
+    should_match = [
+        'https://watch.wwe.com/in-ring/3622',
+    ]

--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -1,39 +1,39 @@
 import unittest
 
 from streamlink.plugins.youtube import YouTube, _url_re
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
+    __plugin__ = YouTube
+
+    should_match = [
+        "https://www.youtube.com/EXAMPLE/live",
+        "https://www.youtube.com/c/EXAMPLE",
+        "https://www.youtube.com/c/EXAMPLE/",
+        "https://www.youtube.com/c/EXAMPLE/live",
+        "https://www.youtube.com/c/EXAMPLE/live/",
+        "https://www.youtube.com/channel/EXAMPLE",
+        "https://www.youtube.com/channel/EXAMPLE/",
+        "https://www.youtube.com/embed/aqz-KE-bpKQ",
+        "https://www.youtube.com/embed/live_stream?channel=UCNye-wNBqNL5ZzHSJj3l8Bg",
+        "https://www.youtube.com/user/EXAMPLE",
+        "https://www.youtube.com/user/EXAMPLE/",
+        "https://www.youtube.com/user/EXAMPLE/live",
+        "https://www.youtube.com/v/aqz-KE-bpKQ",
+        "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
+    ]
+
+    should_not_match = [
+        "https://accounts.google.com/",
+        "https://www.youtube.com",
+        "https://www.youtube.com/account",
+        "https://www.youtube.com/feed/guide_builder",
+        "https://www.youtube.com/t/terms",
+    ]
 
 
 class TestPluginYouTube(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "https://www.youtube.com/EXAMPLE/live",
-            "https://www.youtube.com/c/EXAMPLE",
-            "https://www.youtube.com/c/EXAMPLE/",
-            "https://www.youtube.com/c/EXAMPLE/live",
-            "https://www.youtube.com/c/EXAMPLE/live/",
-            "https://www.youtube.com/channel/EXAMPLE",
-            "https://www.youtube.com/channel/EXAMPLE/",
-            "https://www.youtube.com/embed/aqz-KE-bpKQ",
-            "https://www.youtube.com/embed/live_stream?channel=UCNye-wNBqNL5ZzHSJj3l8Bg",
-            "https://www.youtube.com/user/EXAMPLE",
-            "https://www.youtube.com/user/EXAMPLE/",
-            "https://www.youtube.com/user/EXAMPLE/live",
-            "https://www.youtube.com/v/aqz-KE-bpKQ",
-            "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
-        ]
-        for url in should_match:
-            self.assertTrue(YouTube.can_handle_url(url), url)
-
-        should_not_match = [
-            "https://accounts.google.com/",
-            "https://www.youtube.com",
-            "https://www.youtube.com/account",
-            "https://www.youtube.com/feed/guide_builder",
-            "https://www.youtube.com/t/terms",
-        ]
-        for url in should_not_match:
-            self.assertFalse(YouTube.can_handle_url(url), url)
-
     def _test_regex(self, url, expected_string, expected_group):
         m = _url_re.match(url)
         self.assertIsNotNone(m)

--- a/tests/plugins/test_yupptv.py
+++ b/tests/plugins/test_yupptv.py
@@ -1,22 +1,11 @@
-import unittest
-
 from streamlink.plugins.yupptv import YuppTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginYuppTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.yupptv.com/channels/etv-telugu/live',
-            'https://www.yupptv.com/channels/india-today-news/news/25326023/15-jun-2018',
-        ]
-        for url in should_match:
-            self.assertTrue(YuppTV.can_handle_url(url))
+class TestPluginCanHandleUrlYuppTV(PluginCanHandleUrl):
+    __plugin__ = YuppTV
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://ewe.de',
-            'https://netcologne.de',
-            'https://zattoo.com',
-        ]
-        for url in should_not_match:
-            self.assertFalse(YuppTV.can_handle_url(url))
+    should_match = [
+        'https://www.yupptv.com/channels/etv-telugu/live',
+        'https://www.yupptv.com/channels/india-today-news/news/25326023/15-jun-2018',
+    ]

--- a/tests/plugins/test_zattoo.py
+++ b/tests/plugins/test_zattoo.py
@@ -1,55 +1,50 @@
-import unittest
-
 from streamlink.plugins.zattoo import Zattoo
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginZattoo(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            # mirrors
-            "https://iptv.glattvision.ch/watch/ard",
-            "https://mobiltv.quickline.com/watch/ard",
-            "https://player.waly.tv/watch/ard",
-            "https://tvplus.m-net.de/watch/ard",
-            "https://www.bbv-tv.net/watch/ard",
-            "https://www.meinewelt.cc/watch/ard",
-            "https://www.myvisiontv.ch/watch/ard",
-            "https://www.netplus.tv/watch/ard",
-            "https://www.quantum-tv.com/watch/ard",
-            "https://www.saktv.ch/watch/ard",
-            "https://www.vtxtv.ch/watch/ard",
-            "http://tvonline.ewe.de/watch/daserste",
-            "http://tvonline.ewe.de/watch/zdf",
-            "https://nettv.netcologne.de/watch/daserste",
-            "https://nettv.netcologne.de/watch/zdf",
-            "https://www.1und1.tv/watch/daserste",
-            "https://www.1und1.tv/watch/zdf",
-            # zattoo live
-            "https://zattoo.com/watch/daserste",
-            "https://zattoo.com/watch/zdf",
-            "https://zattoo.com/live/zdf",
-            "https://zattoo.com/channels?channel=daserste",
-            "https://zattoo.com/channels/favorites?channel=zdf",
-            "https://zattoo.com/channels/zattoo?channel=zdf",
-            # zattoo vod
-            "https://zattoo.com/ondemand/watch/ibR2fpisWFZGvmPBRaKnFnuT-alarm-am-airport",
-            "https://zattoo.com/ondemand/watch/G8S7JxcewY2jEwAgMzvFWK8c-berliner-schnauzen",
-            "https://zattoo.com/ondemand?video=x4hUTiCv4FLAA72qLvahiSFp",
-            # zattoo recording
-            "https://zattoo.com/ondemand/watch/srf_zwei/110223896-die-schweizermacher/52845783/1455130800000"
-            + "/1455137700000/6900000",
-            "https://zattoo.com/watch/tve/130920738-viaje-al-centro-de-la-tele/96847859/1508777100000/1508779800000/0",
-            "https://zattoo.com/recording/193074536",
-            "https://zattoo.com/recordings?recording=186466965"
-        ]
-        for url in should_match:
-            self.assertTrue(Zattoo.can_handle_url(url), url)
+class TestPluginCanHandleUrlZattoo(PluginCanHandleUrl):
+    __plugin__ = Zattoo
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            "https://ewe.de",
-            "https://netcologne.de",
-            "https://zattoo.com"
-        ]
-        for url in should_not_match:
-            self.assertFalse(Zattoo.can_handle_url(url), url)
+    should_match = [
+        # mirrors
+        "https://iptv.glattvision.ch/watch/ard",
+        "https://mobiltv.quickline.com/watch/ard",
+        "https://player.waly.tv/watch/ard",
+        "https://tvplus.m-net.de/watch/ard",
+        "https://www.bbv-tv.net/watch/ard",
+        "https://www.meinewelt.cc/watch/ard",
+        "https://www.myvisiontv.ch/watch/ard",
+        "https://www.netplus.tv/watch/ard",
+        "https://www.quantum-tv.com/watch/ard",
+        "https://www.saktv.ch/watch/ard",
+        "https://www.vtxtv.ch/watch/ard",
+        "http://tvonline.ewe.de/watch/daserste",
+        "http://tvonline.ewe.de/watch/zdf",
+        "https://nettv.netcologne.de/watch/daserste",
+        "https://nettv.netcologne.de/watch/zdf",
+        "https://www.1und1.tv/watch/daserste",
+        "https://www.1und1.tv/watch/zdf",
+        # zattoo live
+        "https://zattoo.com/watch/daserste",
+        "https://zattoo.com/watch/zdf",
+        "https://zattoo.com/live/zdf",
+        "https://zattoo.com/channels?channel=daserste",
+        "https://zattoo.com/channels/favorites?channel=zdf",
+        "https://zattoo.com/channels/zattoo?channel=zdf",
+        # zattoo vod
+        "https://zattoo.com/ondemand/watch/ibR2fpisWFZGvmPBRaKnFnuT-alarm-am-airport",
+        "https://zattoo.com/ondemand/watch/G8S7JxcewY2jEwAgMzvFWK8c-berliner-schnauzen",
+        "https://zattoo.com/ondemand?video=x4hUTiCv4FLAA72qLvahiSFp",
+        # zattoo recording
+        "https://zattoo.com/ondemand/watch/srf_zwei/110223896-die-schweizermacher/52845783/1455130800000"
+        + "/1455137700000/6900000",
+        "https://zattoo.com/watch/tve/130920738-viaje-al-centro-de-la-tele/96847859/1508777100000/1508779800000/0",
+        "https://zattoo.com/recording/193074536",
+        "https://zattoo.com/recordings?recording=186466965"
+    ]
+
+    should_not_match = [
+        "https://ewe.de",
+        "https://netcologne.de",
+        "https://zattoo.com"
+    ]

--- a/tests/plugins/test_zdf_mediathek.py
+++ b/tests/plugins/test_zdf_mediathek.py
@@ -1,9 +1,9 @@
 import unittest
 
-from streamlink.plugins.zdf_mediathek import zdf_mediathek
+from streamlink.plugins.zdf_mediathek import ZDFMediathek
 
 
-class TestPluginzdf_mediathek(unittest.TestCase):
+class TestPluginZDFMediathek(unittest.TestCase):
     def test_can_handle_url(self):
         should_match = [
             'http://www.zdf.de/live-tv',
@@ -19,11 +19,11 @@ class TestPluginzdf_mediathek(unittest.TestCase):
             'https://www.3sat.de/wissen/nano',
         ]
         for url in should_match:
-            self.assertTrue(zdf_mediathek.can_handle_url(url))
+            self.assertTrue(ZDFMediathek.can_handle_url(url))
 
     def test_can_handle_url_negative(self):
         should_not_match = [
             'https://www.example.com',
         ]
         for url in should_not_match:
-            self.assertFalse(zdf_mediathek.can_handle_url(url))
+            self.assertFalse(ZDFMediathek.can_handle_url(url))

--- a/tests/plugins/test_zdf_mediathek.py
+++ b/tests/plugins/test_zdf_mediathek.py
@@ -1,29 +1,20 @@
-import unittest
-
 from streamlink.plugins.zdf_mediathek import ZDFMediathek
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginZDFMediathek(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'http://www.zdf.de/live-tv',
-            'https://www.zdf.de/sender/zdf/zdf-live-beitrag-100.html',
-            'https://www.zdf.de/sender/zdfneo/zdfneo-live-beitrag-100.html',
-            'https://www.zdf.de/sender/3sat/3sat-live-beitrag-100.html',
-            'https://www.zdf.de/sender/phoenix/phoenix-live-beitrag-100.html',
-            'https://www.zdf.de/sender/arte/arte-livestream-100.html',
-            'https://www.zdf.de/sender/kika/kika-live-beitrag-100.html',
-            'https://www.zdf.de/dokumentation/zdfinfo-doku/zdfinfo-live-beitrag-100.html',
-            'https://www.zdf.de/comedy/heute-show/videos/diy-hazel-habeck-100.html',
-            'https://www.zdf.de/nachrichten/heute-sendungen/so-wird-das-wetter-102.html',
-            'https://www.3sat.de/wissen/nano',
-        ]
-        for url in should_match:
-            self.assertTrue(ZDFMediathek.can_handle_url(url))
+class TestPluginCanHandleUrlZDFMediathek(PluginCanHandleUrl):
+    __plugin__ = ZDFMediathek
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://www.example.com',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ZDFMediathek.can_handle_url(url))
+    should_match = [
+        'http://www.zdf.de/live-tv',
+        'https://www.zdf.de/sender/zdf/zdf-live-beitrag-100.html',
+        'https://www.zdf.de/sender/zdfneo/zdfneo-live-beitrag-100.html',
+        'https://www.zdf.de/sender/3sat/3sat-live-beitrag-100.html',
+        'https://www.zdf.de/sender/phoenix/phoenix-live-beitrag-100.html',
+        'https://www.zdf.de/sender/arte/arte-livestream-100.html',
+        'https://www.zdf.de/sender/kika/kika-live-beitrag-100.html',
+        'https://www.zdf.de/dokumentation/zdfinfo-doku/zdfinfo-live-beitrag-100.html',
+        'https://www.zdf.de/comedy/heute-show/videos/diy-hazel-habeck-100.html',
+        'https://www.zdf.de/nachrichten/heute-sendungen/so-wird-das-wetter-102.html',
+        'https://www.3sat.de/wissen/nano',
+    ]

--- a/tests/plugins/test_zeenews.py
+++ b/tests/plugins/test_zeenews.py
@@ -1,20 +1,11 @@
-import unittest
-
 from streamlink.plugins.zeenews import ZeeNews
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginZeeNews(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://zeenews.india.com/live-tv',
-            'https://zeenews.india.com/live-tv/embed',
-        ]
-        for url in should_match:
-            self.assertTrue(ZeeNews.can_handle_url(url), url)
+class TestPluginCanHandleUrlZeeNews(PluginCanHandleUrl):
+    __plugin__ = ZeeNews
 
-    def test_can_handle_url_negative(self):
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(ZeeNews.can_handle_url(url), url)
+    should_match = [
+        'https://zeenews.india.com/live-tv',
+        'https://zeenews.india.com/live-tv/embed',
+    ]

--- a/tests/plugins/test_zengatv.py
+++ b/tests/plugins/test_zengatv.py
@@ -1,22 +1,18 @@
-import unittest
-
 from streamlink.plugins.zengatv import ZengaTV
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginZengaTV(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            "http://www.zengatv.com/indiatoday.html",
-            "http://www.zengatv.com/live/87021a6d-411e-11e2-b4c6-7071bccc85ac.html",
-            "http://zengatv.com/indiatoday.html",
-            "http://zengatv.com/live/87021a6d-411e-11e2-b4c6-7071bccc85ac.html",
-        ]
-        for url in should_match:
-            self.assertTrue(ZengaTV.can_handle_url(url))
+class TestPluginCanHandleUrlZengaTV(PluginCanHandleUrl):
+    __plugin__ = ZengaTV
 
-        should_not_match = [
-            "http://www.zengatv.com",
-            "http://www.zengatv.com/"
-        ]
-        for url in should_not_match:
-            self.assertFalse(ZengaTV.can_handle_url(url))
+    should_match = [
+        "http://www.zengatv.com/indiatoday.html",
+        "http://www.zengatv.com/live/87021a6d-411e-11e2-b4c6-7071bccc85ac.html",
+        "http://zengatv.com/indiatoday.html",
+        "http://zengatv.com/live/87021a6d-411e-11e2-b4c6-7071bccc85ac.html",
+    ]
+
+    should_not_match = [
+        "http://www.zengatv.com",
+        "http://www.zengatv.com/"
+    ]

--- a/tests/plugins/test_zhanqi.py
+++ b/tests/plugins/test_zhanqi.py
@@ -1,18 +1,10 @@
-import unittest
-
 from streamlink.plugins.zhanqi import Zhanqitv
+from tests.plugins import PluginCanHandleUrl
 
 
-class TestPluginZhanqitv(unittest.TestCase):
-    def test_can_handle_url(self):
-        should_match = [
-            'https://www.zhanqi.tv/lpl',
-        ]
-        for url in should_match:
-            self.assertTrue(Zhanqitv.can_handle_url(url))
+class TestPluginCanHandleUrlZhanqitv(PluginCanHandleUrl):
+    __plugin__ = Zhanqitv
 
-        should_not_match = [
-            'https://example.com/index.html',
-        ]
-        for url in should_not_match:
-            self.assertFalse(Zhanqitv.can_handle_url(url))
+    should_match = [
+        'https://www.zhanqi.tv/lpl',
+    ]

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -23,6 +23,10 @@ class PluginTestMeta(type):
                 assert hasattr(plugin, "__plugin__"), "It exports __plugin__"
                 assert issubclass(plugin.__plugin__, Plugin), "__plugin__ is an instance of the Plugin class"
 
+                classname = plugin.__plugin__.__name__
+                assert classname == classname[0].upper() + classname[1:], "__plugin__ class name starts with uppercase letter"
+                assert "_" not in classname, "__plugin__ class name does not contain underscores"
+
                 assert callable(plugin.__plugin__._get_streams), "The plugin implements _get_streams"
                 assert callable(plugin.__plugin__.can_handle_url), "The plugin implements can_handle_url"
                 sig = inspect.signature(plugin.__plugin__.can_handle_url)


### PR DESCRIPTION
1. **Fix invalid plugin class names**
   Class names should always be written in camel-case with the first letter being uppercase.
2. **Use `PluginCanHandleUrl` base class for `can_handle_url` plugin tests**
   - The plugin URL tests are currently a total mess with several different test styles. This commit therefore adds a common base class that runs the test assertions on declarative URL lists, namely `should_match` and `should_not_match`, which was the most common style. This simplifies the plugin tests and makes them much more legible.
   - The URL tests get parametrized via `pytest_generate_tests` in `tests/plugins/conftest.py`, so that each URL gets turned into its own test case.
   - This commit also removes lots of unnecessary and unrelated negative URL tests. There might still be some left for certain plugins where I wasn't 100% sure that the URLs are indeed unrelated. Most unrelated URL tests were youtube and tvcatchup, probably due to copy-pasting from other test modules.
   - Instead of having inconsistent negative tests, a list of generic negative URL matches has been added.