### PR TITLE
docs: remove RosadinTV Windows portable version 

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -376,18 +376,10 @@ Windows portable version
 ==================================== ===========================================
 Maintainer                           Links
 ==================================== ===========================================
-RosadinTV                            `Latest precompiled stable release`__ |br|
-                                     `Latest builder`__ |br|
-                                     `More info`__
-
 Beardypig                            `Latest precompiled stable release`__ |br|
                                      `Latest builder`__ |br|
                                      `More info`__
 ==================================== ===========================================
-
-__ https://github.com/streamlink/streamlink-portable/releases/latest
-__ https://github.com/streamlink/streamlink-portable/archive/master.zip
-__ https://github.com/streamlink/streamlink-portable
 
 __ https://github.com/beardypig/streamlink-portable/releases/latest
 __ https://github.com/beardypig/streamlink-portable/archive/master.zip


### PR DESCRIPTION
as it is unmaintained and currently incompatible with Streamlink 2.0.0

----

Since the repo is currently hosted at streamlink/streamlink-portable, what should we do with it? Should this be archived?