### PR TITLE
plugins.nasa: add plugin for NasaTV

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -111,6 +111,7 @@ mitele                  mitele.es            Yes   No    Streams may be geo-rest
 mjunoon                 mjunoon.tv           Yes   Yes
 mrtmk                   play.mrt.com.mk      Yes   Yes   Streams may be geo-restricted to North Macedonia.
 n13tv                   13tv.co.il           Yes   Yes   Streams may be geo-restricted to Israel.
+nasa                    nasa.gov             Yes   No
 nbc                     nbc.com              No    Yes   Streams are geo-restricted to USA. Authentication is not supported.
 nbcnews                 nbcnews.com          Yes   No
 nbcsports               nbcsports.com        No    Yes   Streams maybe be geo-restricted to USA. Authentication is not supported.

--- a/src/streamlink/plugins/nasa.py
+++ b/src/streamlink/plugins/nasa.py
@@ -1,0 +1,94 @@
+import re
+
+from streamlink.plugin import Plugin, PluginError
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
+
+
+class Nasa(Plugin):
+    # hardcoded API version, extracted from player.min.js
+    _api_version = "201510271133"
+    # hardcoded "vendor-id/stream-id", extracted from nasa.js (EmberJS component properties)
+    _vendorandstreamids = {
+        "public": "3117/108566",
+        "media": "3117/108567"
+    }
+
+    # the API URL also optionally takes an "u" parameter read from the "mrp-v-id" cookie, and "_" with an UNIX timestamp
+    _tpl_api_url = "https://mr-a.akamaihd.net/c/data/{id}/{filename}?domain=www.nasa.gov&r={url}"
+    # reconstructed from player.min.js
+    _tpl_filename = "{streamid}.{ishttps}.1.{apiversion}.json"
+
+    _re_url = re.compile(r"https?://www\.nasa\.gov/multimedia/nasatv/(?:index\.html)?#(?P<channel>public|media)")
+    _re_jsonp = re.compile(r"_data_callback_\d+json\(({.+})\);")
+
+    _schema_api_response = validate.Schema(
+        validate.transform(_re_jsonp.match),
+        validate.any(None, validate.all(
+            validate.get(1),
+            validate.transform(parse_json),
+            {"playlist": {"playlist_items": [validate.all(
+                {"media_items": list},
+                validate.get("media_items")
+            )]}},
+            validate.get("playlist"),
+            validate.get("playlist_items")
+        ))
+    )
+    _schema_media_items = validate.Schema(
+        {
+            "list_item_type": "media",
+            "stream_names": validate.all({"default": str}, validate.get("default")),
+            "video_url": validate.all({"default": validate.url()}, validate.get("default"))
+        },
+        validate.union((
+            validate.get("stream_names"),
+            validate.get("video_url")
+        ))
+    )
+
+    @classmethod
+    def can_handle_url(cls, url):
+        return cls._re_url.match(url) is not None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._title = None
+
+    def get_title(self):
+        return self._title
+
+    def _get_api_url(self, channel):
+        if channel not in self._vendorandstreamids:
+            raise PluginError(f"Missing stream id for channel '{channel}'")
+        vendorandstreamid = self._vendorandstreamids[channel]
+
+        return self._tpl_api_url.format(
+            id=vendorandstreamid,
+            filename=self._tpl_filename.format(
+                streamid=vendorandstreamid.split("/")[1],
+                ishttps="1",
+                apiversion=self._api_version
+            ),
+            url=self.url
+        )
+
+    def _get_streams(self):
+        channel = self._re_url.match(self.url).group("channel")
+        api_url = self._get_api_url(channel)
+        playlist_items = self.session.http.get(api_url, schema=self._schema_api_response)
+        if not playlist_items:
+            return
+
+        for media_items in playlist_items:
+            for item in media_items:
+                try:
+                    title, url = self._schema_media_items.validate(item)
+                    self._title = title
+                    return HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}")
+                except PluginError:
+                    continue
+
+
+__plugin__ = Nasa

--- a/tests/plugins/test_nasa.py
+++ b/tests/plugins/test_nasa.py
@@ -1,0 +1,27 @@
+import unittest
+
+from streamlink.plugins.nasa import Nasa
+
+
+class TestPluginNasa(unittest.TestCase):
+    def test_can_handle_url_positive(self):
+        should_match = [
+            "https://www.nasa.gov/multimedia/nasatv/index.html#public",
+            "https://www.nasa.gov/multimedia/nasatv/index.html#media",
+            "https://www.nasa.gov/multimedia/nasatv/#public",
+            "https://www.nasa.gov/multimedia/nasatv/#media",
+        ]
+        for url in should_match:
+            self.assertTrue(Nasa.can_handle_url(url), url)
+
+    def test_can_handle_url_negative(self):
+        should_not_match = [
+            "https://www.nasa.gov/multimedia/nasatv/index.html",
+            "https://www.nasa.gov/multimedia/nasatv/index.html#",
+            "https://www.nasa.gov/multimedia/nasatv/index.html#foo",
+            "https://www.nasa.gov/multimedia/nasatv/",
+            "https://www.nasa.gov/multimedia/nasatv/#",
+            "https://www.nasa.gov/multimedia/nasatv/#foo",
+        ]
+        for url in should_not_match:
+            self.assertFalse(Nasa.can_handle_url(url), url)


### PR DESCRIPTION
Resolves #3541 

I don't know how much sense it makes adding this plugin, because the main "public" stream is also being broadcasted on Youtube AFAICT. I'm also not sure how often the API version string and "vendorID/streamID" strings which are required for getting the JSON data will change. They are hardcoded into the plugin, because it's almost impossible to extract it from the minified JS code, which could also change at any point and break the extraction code. There's also an "education" stream according to the code, but I couldn't find it on their site and it also has a different format which I didn't spent any time on figuring out.

Also, should the plugin be renamed to `NasaTV`, or `NASA` instead of `Nasa`?

```
$ streamlink -l debug 'https://www.nasa.gov/multimedia/nasatv/#public'
[cli][debug] OS:         Linux-5.11.0-rc6-2-git-x86_64-with-glibc2.32
[cli][debug] Python:     3.9.1
[cli][debug] Streamlink: 2.0.0+35.g1d33f6e
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.57.0)
[cli][info] Found matching plugin nasa for URL https://www.nasa.gov/multimedia/nasatv/#public
[utils.l10n][debug] Language code: en_US
Available streams: 720p_549k (worst), 720p_812k, 720p_2059k (best)
```

```
$ streamlink -l debug 'https://www.nasa.gov/multimedia/nasatv/#media'
[cli][debug] OS:         Linux-5.11.0-rc6-2-git-x86_64-with-glibc2.32
[cli][debug] Python:     3.9.1
[cli][debug] Streamlink: 2.0.0+35.g1d33f6e
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.57.0)
[cli][info] Found matching plugin nasa for URL https://www.nasa.gov/multimedia/nasatv/#media
[utils.l10n][debug] Language code: en_US
Available streams: 720p_549k (worst), 720p_812k, 720p_2059k (best)
```