### PR TITLE
ci.github: increase git fetch depth of tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 300
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}


### PR DESCRIPTION
Set fetch depth to 300, like all the other CI runners do, and fix the
Codecov upload error/warning:
> Issue detecting commit SHA. Please run actions/checkout with
> fetch-depth > 1 or set to 0

----

https://github.com/streamlink/streamlink/pull/3547/checks?check_run_id=1853586479#step:9:28