### PR TITLE
docs: update Debian stable install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -90,7 +90,7 @@ Distribution                         Installing
                                         echo "deb http://deb.debian.org/debian buster-backports main" | sudo tee "/etc/apt/sources.list.d/streamlink.list"
 
                                         sudo apt update
-                                        sudo apt install streamlink
+                                        sudo apt -t buster-backports install streamlink
 
                                      `Installing Debian backported packages`_
 


### PR DESCRIPTION
The install instructions for Debian stable are not exactly accurate, `-t buster-backports` needs to be added else apt will try to use the Debian stable package instead (which is older).