### PR TITLE
plugins.vtvgo: ignore duplicate params

### DIFF
--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -1,19 +1,37 @@
 import logging
 import re
 
-from streamlink.exceptions import PluginError
 from streamlink.plugin import Plugin
+from streamlink.plugin.api import validate
+from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
 
 class VTVgo(Plugin):
-
     AJAX_URL = 'https://vtvgo.vn/ajax-get-stream'
 
     _url_re = re.compile(r'https://vtvgo\.vn/xem-truc-tuyen-kenh-')
-    _params_re = re.compile(r'''var\s(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;''')
+    _params_re = re.compile(r'''var\s+(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;''')
+
+    _schema_params = validate.Schema(
+        validate.transform(lambda html: next(tag.text for tag in itertags(html, "script") if "setplayer(" in tag.text)),
+        validate.transform(_params_re.findall),
+        [
+            ("id", int),
+            ("type_id", str),
+            ("time", str),
+            ("token", str)
+        ]
+    )
+    _schema_stream_url = validate.Schema(
+        validate.transform(parse_json),
+        {"stream_url": [validate.url()]},
+        validate.get("stream_url"),
+        validate.get(0)
+    )
 
     @classmethod
     def can_handle_url(cls, url):
@@ -25,17 +43,10 @@ class VTVgo(Plugin):
             'Referer': self.url,
             'X-Requested-With': 'XMLHttpRequest',
         })
-        res = self.session.http.get(self.url)
-
-        params = self._params_re.findall(res.text)
-        if not params:
-            raise PluginError('No POST data')
-        elif len(params) != 4:
-            raise PluginError('Not enough POST data: {0!r}'.format(params))
+        params = self.session.http.get(self.url, schema=self._schema_params)
 
         log.trace('{0!r}'.format(params))
-        res = self.session.http.post(self.AJAX_URL, data=dict(params))
-        hls_url = self.session.http.json(res)['stream_url'][0]
+        hls_url = self.session.http.post(self.AJAX_URL, data=dict(params), schema=self._schema_stream_url)
 
         return HLSStream.parse_variant_playlist(self.session, hls_url)
 


### PR DESCRIPTION
Fixes #3558

- add schemas for params and stream_url
- find first script tag via itertags which includes `setplayer(`
- validate params via schema

```
$ streamlink -l trace https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html
[15:52:13.032591][cli][debug] OS:         Linux-5.11.0-rc6-2-git-x86_64-with-glibc2.33
[15:52:13.032737][cli][debug] Python:     3.9.1
[15:52:13.032774][cli][debug] Streamlink: 2.0.0+45.g4f98eed
[15:52:13.032805][cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.57.0)
[15:52:13.032868][cli][info] Found matching plugin vtvgo for URL https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html
[15:52:14.803509][plugins.vtvgo][trace] [('id', '1'), ('type_id', '1'), ('time', '1613055134'), ('token', '1613055134.591a084a6b190783781ae8232e365350')]
[15:52:15.249249][utils.l10n][debug] Language code: en_US
Available streams: 360p (worst), 480p (best)
```

The other channels should be working as well, don't want to post more logs.