### PR TITLE
chore: reorder and improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_use_the_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/0_use_the_issue_template.md
@@ -1,0 +1,15 @@
+---
+name: CHOOSE ONE OF THE ISSUE TEMPLATES LISTED BELOW
+about: DON'T IGNORE OR REMOVE THE TEMPLATE. EXCLUDING TEMPLATE DATA WILL RESULT IN THE ISSUE BEING CLOSED.
+---
+
+**Please choose one of the issue templates listed on the previous page:**  
+https://github.com/streamlink/streamlink/issues/new/choose
+
+Don't ignore the template and read before filling out all the required informations.
+
+Issues that don't adhere to our request will be closed and ignored.
+
+This is because analyzing bugs, issues or requests without proper details and log output is harder than necessary.
+
+Low quality and low effort issues are noise and steal the time of the maintainers and contributors.

--- a/.github/ISSUE_TEMPLATE/1_plugin_issue.md
+++ b/.github/ISSUE_TEMPLATE/1_plugin_issue.md
@@ -1,6 +1,8 @@
 ---
 name: Plugin Issue
-about: Create a plugin issue report
+about: One of Streamlink's plugins doesn't work correctly
+title: "plugins.[pluginname]: [A very brief summary of what's broken]"
+labels: plugin issue
 ---
 
 <!--
@@ -9,6 +11,8 @@ USE THE TEMPLATE. Otherwise your plugin issue may be rejected.
 
 First, see the contribution guidelines:
 https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink
+
+Plugin issues describe broken functionality within a plugin's code base, eg. the streaming site has made breaking changes, streams don't get resolved correctly, or authentication has stopped working, etc.
 
 Also check the list of open and closed plugin issues:
 https://github.com/streamlink/streamlink/issues?q=is%3Aissue+label%3A%22plugin+issue%22
@@ -41,11 +45,13 @@ Please see the text preview to avoid unnecessary formatting errors.
 ### Log output
 
 <!--
-TEXT LOG OUTPUT IS REQUIRED for a plugin issue!
-Use the `--loglevel debug` parameter and avoid using parameters which suppress log output.
-https://streamlink.github.io/cli.html#cmdoption-l
+DEBUG LOG OUTPUT IS REQUIRED for a plugin issue!
+INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
 
-Make sure to **remove usernames and passwords**
+Use the `--loglevel debug` parameter and avoid using parameters which suppress log output.
+Debug log includes important details about your platform. Don't remove it.
+https://streamlink.github.io/latest/cli.html#cmdoption-loglevel
+
 You can copy the output to https://gist.github.com/ or paste it below.
 
 Don't post screenshots of the log output and instead copy the text from your terminal application.
@@ -53,6 +59,7 @@ Don't post screenshots of the log output and instead copy the text from your ter
 
 ```
 REPLACE THIS TEXT WITH THE LOG OUTPUT
+All log output should go between two blocks of triple backticks (grave accents) for proper formatting.
 ```
 
 

--- a/.github/ISSUE_TEMPLATE/1_plugin_request.md
+++ b/.github/ISSUE_TEMPLATE/1_plugin_request.md
@@ -1,16 +1,20 @@
 ---
 name: Plugin Request
-about: Create a plugin request to discuss adding a new plugin to Streamlink
+about: Discuss adding a new plugin to Streamlink
+title: "[Name of the website / streaming provider]"
+labels: plugin request
 ---
 
 <!--
 Thanks for requesting a plugin!
 USE THE TEMPLATE. Otherwise your plugin request may be rejected.
 
-First, see the contribution guidelines and plugin request requirements:
+First, see the contribution guidelines:
 https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink
 
+READ THE PLUGIN REQUEST REQUIREMENTS BEFORE POSTING!
 Plugin requests which fall into the categories we will not implement will be closed immediately.
+https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#plugin-requests
 
 Also check the list of open and closed plugin requests:
 https://github.com/streamlink/streamlink/issues?q=is%3Aissue+label%3A%22plugin+request%22

--- a/.github/ISSUE_TEMPLATE/2_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.md
@@ -1,6 +1,8 @@
 ---
 name: Bug Report
-about: Create a bug report to help us improve Streamlink
+about: A core functionality of Streamlink is broken
+title: "[A very brief summary of what's broken]"
+labels: bug
 ---
 
 <!--
@@ -9,6 +11,8 @@ USE THE TEMPLATE. Otherwise your bug report may be rejected.
 
 First, see the contribution guidelines:
 https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink
+
+Bugs are the result of broken functionality within Streamlink's main code base. Use the plugin issue template if your report is about a broken plugin.
 
 Also check the list of open and closed bug reports:
 https://github.com/streamlink/streamlink/issues?q=is%3Aissue+label%3A%22bug%22
@@ -46,11 +50,13 @@ Please see the text preview to avoid unnecessary formatting errors.
 ### Log output
 
 <!--
-TEXT LOG OUTPUT IS REQUIRED for a bug report!
-Use the `--loglevel debug` parameter and avoid using parameters which suppress log output.
-https://streamlink.github.io/cli.html#cmdoption-l
+DEBUG LOG OUTPUT IS REQUIRED for a bug report!
+INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
 
-Make sure to **remove usernames and passwords**
+Use the `--loglevel debug` parameter and avoid using parameters which suppress log output.
+Debug log includes important details about your platform. Don't remove it.
+https://streamlink.github.io/latest/cli.html#cmdoption-loglevel
+
 You can copy the output to https://gist.github.com/ or paste it below.
 
 Don't post screenshots of the log output and instead copy the text from your terminal application.
@@ -58,6 +64,7 @@ Don't post screenshots of the log output and instead copy the text from your ter
 
 ```
 REPLACE THIS TEXT WITH THE LOG OUTPUT
+All log output should go between two blocks of triple backticks (grave accents) for proper formatting.
 ```
 
 

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,6 +1,8 @@
 ---
 name: Feature Request
-about: Create a feature request to help us add additional functionality to Streamlink
+about: Discuss adding new functionality to Streamlink
+title: "[A very brief summary of your request]"
+labels: feature request
 ---
 
 <!-- 
@@ -30,10 +32,6 @@ Please see the text preview to avoid unnecessary formatting errors.
 
 <!-- Explain the feature as clearly as you can. What is it, how would you expect it to work, and what value does it bring to Streamlink? -->
 
-
-### Expected / Actual behavior
-
-<!-- What do you expect to happen with this new feature, and what is happening currently that does not satisfy this need? -->
 
 
 ### Additional comments, etc.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -16,9 +16,10 @@ Please see the text preview to avoid unnecessary formatting errors.
 
 ## Issue
 
-<!-- Replace [ ] with [x] in order to check the box -->
+<!-- Replace the space character between the square brackets with an x in order to check the boxes -->
 - [ ] This is not a bug report, feature request, or plugin issue/request.
 - [ ] I have read the contribution guidelines.
+- [ ] I am using the latest development version from the master branch.
 
 
 ### Description
@@ -40,17 +41,17 @@ Please see the text preview to avoid unnecessary formatting errors.
 3. ...
 
 
-### Logs
+### Log output
 
 <!--
-TEXT LOG OUTPUT IS OPTIONAL for generic issues!
-However, depending on the issue, log output can be useful for the developers to understand the problem. It also includes information about your platform. If you don't intend to include log output, please at least provide these platform details.
-Thanks!
+DEBUG LOG OUTPUT IS OPTIONAL for generic issues!
+INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
+
+Despite being optional for generic issues, depending on the issue, log output can be useful for the developers to understand the problem. It also includes information about your platform. If you don't intend to include log output, please at least provide these platform details. Thanks!
 
 Use the `--loglevel debug` parameter and avoid using parameters which suppress log output.
-https://streamlink.github.io/cli.html#cmdoption-l
+https://streamlink.github.io/latest/cli.html#cmdoption-loglevel
 
-Make sure to **remove usernames and passwords**
 You can copy the output to https://gist.github.com/ or paste it below.
 
 Don't post screenshots of the log output and instead copy the text from your terminal application.
@@ -58,6 +59,7 @@ Don't post screenshots of the log output and instead copy the text from your ter
 
 ```
 REPLACE THIS TEXT WITH THE LOG OUTPUT
+All log output should go between two blocks of triple backticks (grave accents) for proper formatting.
 ```
 
 


### PR DESCRIPTION
- add template for showing the "use the templates" note at the top
- reorder templates by prepending numbers to the file names
- add data for title templates and automatic labels (where applicable)
- make templates more consistent and add more descriptions
- improve debug log comments
- remove "expected/actual behavior" from feature request template

----

The main motivation behind this PR is that the issue templates are currently not that well ordered in the [new issue list](https://github.com/streamlink/streamlink/issues/new/choose) and their descriptions are rather useless. This leads to confusion and thus misuse of the templates.

I've also added a template with the "CHOOSE ONE OF THE ISSUE TEMPLATES" title (similar to the [mpv-player/mpv repo](https://github.com/mpv-player/mpv/issues/new/choose)) and a short description text.

The rest of the changes is described in the commit message.

If there's anything that should or needs to be reworded here (also unchanged lines), please post a suggestion.