### PR TITLE
ci.codecov: disable GH status check annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,6 +9,8 @@ comment:
   layout: "reach, diff, flags, files"
   # don't ever let the codecov bot comment on PRs
   after_n_builds: 999999999
+github_checks:
+  annotations: false
 coverage:
   range: "50...100"
   precision: 2


### PR DESCRIPTION
The "patch" status which was added by fba55ae also accidentally added
annotations. These are annoying when lots of new and uncovered lines get
added, and it makes reading and reviewing the PR diff unnecessarily
difficult. We are only interested in the "patch" status check itself.

https://docs.codecov.io/docs/github-checks-beta
