### PR TITLE
plugins: fix and update removed plugins list

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -132,4 +132,4 @@ Removing plugins
 
 1. Remove the plugin file in ``src/streamlink/plugins/`` and the test file in ``tests/plugins/``
 2. Remove the plugin entry from the documentation in ``docs/plugin_matrix.rst``
-3. Add an entry to ``src/streamlink/plugins/.removed``
+3. Run ``script/update-removed-plugins.sh`` once to update ``src/streamlink/plugins/.removed``

--- a/script/update-removed-plugins.sh
+++ b/script/update-removed-plugins.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$(readlink -f "${0}")")/..")
+DIR_PLUGINS="${ROOT}/src/streamlink/plugins/"
+FILE_REMOVED="${DIR_PLUGINS}/.removed"
+
+# ----
+
+[[ -d "${DIR_PLUGINS}" ]] || { echo >&2 "Missing directory: ${DIR_PLUGINS}"; exit 1; }
+[[ -f "${FILE_REMOVED}" ]] || { echo >&2 "Missing file: ${FILE_REMOVED}"; exit 1; }
+
+get_plugin_names() {
+    grep -E '\.py$' | LC_ALL=C sort -u | xargs -I@ basename @ .py
+}
+
+header=$(sed -e '/^[^#;]/d' "${FILE_REMOVED}")
+content=$(
+    `# Only show plugin names which are unique to the first list` \
+    comm -23 --nocheck-order \
+        `# Find all deleted and renamed files in the plugins directory` \
+        <(git log --diff-filter=DR --name-status --pretty=tformat: "${DIR_PLUGINS}" | cut -f2 | get_plugin_names) \
+        `# Find all current plugin names` \
+        <(find "${DIR_PLUGINS}" -type f | get_plugin_names)
+)
+
+cat >"${FILE_REMOVED}" <<EOF
+${header}
+${content}
+EOF

--- a/src/streamlink/plugins/.removed
+++ b/src/streamlink/plugins/.removed
@@ -9,11 +9,14 @@ aljazeeraen
 antenna
 apac
 arconai
+arconia
+atv
 azubutv
 bambuser
 beam
 beattv
 bliptv
+bnt
 bongacams
 brittv
 cam4
@@ -31,6 +34,7 @@ dmcloud
 dmcloud_embed
 douyutv
 douyutv_blackbox
+dplay
 ellobo
 eurocom
 europaplus
@@ -39,9 +43,11 @@ filmon_us
 furstream
 gaminglive
 gomexp
+googledocs
 itvplayer
 kanal7
 kingkong
+kralmuzik
 letontv
 livecodingtv
 livestation
@@ -66,6 +72,7 @@ rte
 seemeplay
 seetv
 servustv
+showtv
 skai
 speedrunslive
 srgssr
@@ -76,6 +83,7 @@ streamlive
 streamme
 streamupcom
 tamago
+toya
 trt
 trtspor
 tv1channel

--- a/tests/test_plugins_meta.py
+++ b/tests/test_plugins_meta.py
@@ -59,6 +59,13 @@ class TestPluginMeta(unittest.TestCase):
                 self.assertIn(pname, self.session.plugins.keys(),
                               "{0} is not a plugin but has tests".format(pname))
 
+    def test_plugin_not_in_removed_list(self):
+        from streamlink import plugins as streamlinkplugins
+        with open(os.path.abspath(os.path.join(streamlinkplugins.__path__[0], ".removed"))) as file:
+            plugins = {name for name in file.read().split("\n") if name and not name.startswith("#")}
+            for pname in self.session.plugins.keys():
+                self.assertNotIn(pname, plugins, f"{pname} is not in removed plugins list")
+
     def test_plugin_has_valid_global_args(self):
         from streamlink_cli.argparser import build_parser
         parser = build_parser()


### PR DESCRIPTION
- add shell script for updating the removed plugins list from the git
  history of deleted and renamed plugin files, compared with the current
  list of plugins
- test that the removed plugins list does not include any active plugins
- update removing plugins section in developing docs

----

Resolves #3291 
See #2003

The new removed plugin entries come from here:

- `arconia` 3973bb9 (renamed)
- `atv` cad43f9 (renamed)
- `bnt` 8a66ee7 (renamed)
- `dplay` 2eb54a3 (deleted)
- `googledocs` 7eee543 (renamed)
- `kralmuzik` cad43f9 (deleted)
- `showtv` cad43f9 (renamed)
- `toya` 40e2bb0 (deleted)