### PR TITLE
plugins.abematv: Fixed download problem.

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -192,7 +192,7 @@ class AbemaTV(Plugin):
             res = self.session.http.get(self._PRGM_API.format(vid),
                                         headers=auth_header)
             jsonres = self.session.http.json(res, schema=self._PRGM_SCHEMA)
-            return jsonres["label"].get("free", False) is True
+            return jsonres["terms"][0].get("onDemandType", False) == 3
         elif vtype == "slots":
             res = self.session.http.get(self._SLOTS_API.format(vid),
                                         headers=auth_header)


### PR DESCRIPTION
Fixed a bug where some free videos (like this:https://abema.tv/video/episode/199-12_s0_p1) were determined to be premium exclusive and could not be downloaded.

*onDemandType list
1: premium only
2: rental only
3: free

