### PR TITLE
docs: add pip to packages lists

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,6 +17,8 @@ Installers                           See the `Windows binaries`_ section below
 
 Portable                             See the `Windows portable version`_ section below
 
+Python pip                           See the `PyPI package and source code`_ section below
+
 `Chocolatey`_                        .. code-block:: bat
 
                                         choco install streamlink
@@ -68,6 +70,8 @@ Linux and BSD
 Distribution                         Installing
 ==================================== ===========================================
 AppImage                             See the `AppImages`_ section below
+
+Python pip                           See the `PyPI package and source code`_ section below
 
 `Arch Linux`_                        .. code-block:: bash
 


### PR DESCRIPTION
This makes it consistent with the macOS packages list, as pip is already
listed there, and it also highlights the install option on other OSes.

Special native install options are listed first, then pip, then native
packages with their install commands and further links.

----

https://github.com/streamlink/streamlink/pull/3611#issuecomment-792522236