### PR TITLE
cli.output: fix named pipe player input on Windows

### DIFF
--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -180,6 +180,11 @@ class PlayerOutput(Output):
     def _create_arguments(self):
         if self.namedpipe:
             filename = self.namedpipe.path
+            if is_win32:
+                if self.player_name == "vlc":
+                    filename = f"stream://\\{filename}"
+                elif self.player_name == "mpv":
+                    filename = f"file://{filename}"
         elif self.filename:
             filename = self.filename
         elif self.http:

--- a/tests/test_cmdline_player_fifo.py
+++ b/tests/test_cmdline_player_fifo.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from streamlink.compat import is_win32
+from tests.test_cmdline import CommandLineTestCase
+
+
+@unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+@patch("streamlink_cli.main.NamedPipe", Mock(return_value=Mock(path="/tmp/streamlinkpipe")))
+class TestCommandLineWithPlayerFifoPosix(CommandLineTestCase):
+    def test_player_fifo_default(self):
+        self._test_args(
+            ["streamlink", "--player-fifo",
+             "-p", "any-player",
+             "http://test.se", "test"],
+            ["any-player", "/tmp/streamlinkpipe"]
+        )
+
+
+@unittest.skipIf(not is_win32, "test only applicable on Windows")
+@patch("streamlink_cli.main.NamedPipe", Mock(return_value=Mock(path="\\\\.\\pipe\\streamlinkpipe")))
+class TestCommandLineWithPlayerFifoWindows(CommandLineTestCase):
+    def test_player_fifo_default(self):
+        self._test_args(
+            ["streamlink", "--player-fifo",
+             "-p", "any-player.exe",
+             "http://test.se", "test"],
+            "any-player.exe \\\\.\\pipe\\streamlinkpipe"
+        )
+
+    def test_player_fifo_vlc(self):
+        self._test_args(
+            ["streamlink", "--player-fifo",
+             "-p", "C:\\Program Files\\VideoLAN\\vlc.exe",
+             "http://test.se", "test"],
+            "C:\\Program Files\\VideoLAN\\vlc.exe --input-title-format http://test.se stream://\\\\\\.\\pipe\\streamlinkpipe"
+        )
+
+    def test_player_fifo_mpv(self):
+        self._test_args(
+            ["streamlink", "--player-fifo",
+             "-p", "C:\\Program Files\\mpv\\mpv.exe",
+             "http://test.se", "test"],
+            "C:\\Program Files\\mpv\\mpv.exe --force-media-title=http://test.se file://\\\\.\\pipe\\streamlinkpipe"
+        )


### PR DESCRIPTION
Fixes #3568

Originally I had intended to refactor the NamedPipe class and a little bit of the PlayerOutput class as well, but I ran into some other issues which I haven't resolved yet, so here's a simple fix for #3568. I could refactor NamedPipe and keep the same logic as it is right now, but it's not really worth it. A proper implementation will require a complete rewrite of the PlayerOutput as well, and that's a bit much now.

Also, as mentioned in #3568, the named pipe currently doesn't get cleaned up properly if the player fails to start, which I also wanted to fix with my code refactoring.