### PR TITLE
plugins.facebook: add accept header for DASH manifests

### DIFF
--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -81,6 +81,7 @@ class Facebook(Plugin):
     def _get_streams(self):
         self.session.set_option("ffmpeg-start-at-zero", True)
         self.session.http.headers.update({"Accept-Language": "en-US"})
+        self.session.http.headers.update({"Accept": "application/xhtml+xml"})
 
         done = False
         res = self.session.http.get(self.url)


### PR DESCRIPTION
DASH manifests are not returned in the base HTML unless the client indicates
it will accept: application/xhtml+xml

I was trying to fix #3615.  This does not achieve a fix for that issue.  I thought it might still be worth including for the future, however, as this enables DASH manifests within the base HTML.
