### PR TITLE
plugins.nicolive: fixed websocket-client and use websocket-client>=0.58.0

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -290,7 +290,7 @@ Name                                 Notes
 `iso3166`_                           Used for localization settings, provides country information
 `isodate`_                           Used for MPEG-DASH streams
 `PySocks`_                           Used for SOCKS Proxies
-`websocket-client`_                  Used for some plugins
+`websocket-client`_                  At least version **0.58.0**. (used for some plugins)
 
 **Optional**
 --------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ data_files = []
 deps = [
     "requests>=2.21.0,<3.0",
     "isodate",
-    "websocket-client",
+    "websocket-client>=0.58.0",
     # Support for SOCKS proxies
     "PySocks!=1.5.7,>=1.5.6",
 ]

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -7,6 +7,7 @@ from urllib.parse import unquote_plus, urlparse
 
 import websocket
 
+from streamlink import logger
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
@@ -176,12 +177,24 @@ class NicoLive(Plugin):
                 proxy_options.get('http_proxy_port') or 80))
 
         _log.debug("Connecting: {0}".format(url))
+        if logger.root.level <= logger.TRACE:
+            websocket.enableTrace(True, _log)
+
+        def on_error(wssapp, error):
+            return self.api_on_error(wssapp, error)
+
+        def on_message(wssapp, message):
+            return self.handle_api_message(message)
+
+        def on_open(wssapp):
+            return self.api_on_open()
+
         self._ws = websocket.WebSocketApp(
             url,
             header=["User-Agent: {0}".format(useragents.CHROME)],
-            on_open=self.api_on_open,
-            on_message=self.handle_api_message,
-            on_error=self.api_on_error)
+            on_open=on_open,
+            on_message=on_message,
+            on_error=on_error)
         self.ws_worker_thread = threading.Thread(
             target=self._ws.run_forever,
             args=proxy_options)


### PR DESCRIPTION
```
setup.py: require websocket-client>=0.58.0

Make sure all User use the same version where `callback(self, *args)` was changed.
```

```
plugins.nicolive: fixed websocket-client 
```

closes https://github.com/streamlink/streamlink/issues/3631
closes https://github.com/streamlink/streamlink/issues/3633