### PR TITLE
cli: debug-log arguments set by the user

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -927,22 +927,25 @@ def check_root():
 
 def log_current_versions():
     """Show current installed versions"""
-    if logger.root.isEnabledFor(logging.DEBUG):
-        # MAC OS X
-        if sys.platform == "darwin":
-            os_version = "macOS {0}".format(platform.mac_ver()[0])
-        # Windows
-        elif sys.platform.startswith("win"):
-            os_version = "{0} {1}".format(platform.system(), platform.release())
-        # linux / other
-        else:
-            os_version = platform.platform()
+    if not logger.root.isEnabledFor(logging.DEBUG):
+        return
 
-        log.debug("OS:         {0}".format(os_version))
-        log.debug("Python:     {0}".format(platform.python_version()))
-        log.debug("Streamlink: {0}".format(streamlink_version))
-        log.debug("Requests({0}), Socks({1}), Websocket({2})".format(
-            requests.__version__, socks_version, websocket_version))
+    # macOS
+    if sys.platform == "darwin":
+        os_version = f"macOS {platform.mac_ver()[0]}"
+    # Windows
+    elif sys.platform == "win32":
+        os_version = f"{platform.system()} {platform.release()}"
+    # Linux / other
+    else:
+        os_version = platform.platform()
+
+    log.debug(f"OS:         {os_version}")
+    log.debug(f"Python:     {platform.python_version()}")
+    log.debug(f"Streamlink: {streamlink_version}")
+    log.debug(f"Requests({requests.__version__}), "
+              f"Socks({socks_version}), "
+              f"Websocket({websocket_version})")
 
 
 def log_current_arguments(session, parser):

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -2,6 +2,7 @@ from io import BytesIO
 
 from streamlink import NoStreamsError
 from streamlink.options import Options
+from streamlink.plugin import PluginArgument, PluginArguments
 from streamlink.plugins import Plugin
 from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream, Stream
 
@@ -14,6 +15,18 @@ class TestStream(Stream):
 
 
 class TestPlugin(Plugin):
+    arguments = PluginArguments(
+        PluginArgument(
+            "bool",
+            action="store_true"
+        ),
+        PluginArgument(
+            "password",
+            metavar="PASSWORD",
+            sensitive=True
+        )
+    )
+
     options = Options({
         "a_option": "default"
     })

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -13,6 +13,7 @@ from streamlink_cli.main import (
     handle_stream,
     handle_url,
     log_current_arguments,
+    log_current_versions,
     resolve_stream_name
 )
 from streamlink_cli.output import FileOutput, PlayerOutput
@@ -279,6 +280,65 @@ class TestCLIMainDebugLogging(unittest.TestCase):
                 streamlink_cli.main.main()
             except SystemExit:
                 pass
+
+    @patch("streamlink_cli.main.log_current_versions")
+    @patch("streamlink_cli.main.streamlink_version", "streamlink")
+    @patch("streamlink_cli.main.requests.__version__", "requests")
+    @patch("streamlink_cli.main.socks_version", "socks")
+    @patch("streamlink_cli.main.websocket_version", "websocket")
+    @patch("platform.python_version", Mock(return_value="python"))
+    def test_log_current_versions(self, mock_log_current_versions, mock_log):
+        def _log_current_versions():
+            log_current_versions()
+            raise SystemExit
+
+        mock_log_current_versions.side_effect = _log_current_versions
+
+        self.subject(["streamlink", "--loglevel", "info"])
+        self.assertEqual(mock_log.debug.mock_calls, [], "Doesn't log anything if not debug logging")
+
+        with patch("sys.platform", "linux"), \
+             patch("platform.platform", Mock(return_value="linux")):
+            self.subject(["streamlink", "--loglevel", "debug"])
+            self.assertEqual(
+                mock_log.debug.mock_calls,
+                [
+                    call("OS:         linux"),
+                    call("Python:     python"),
+                    call("Streamlink: streamlink"),
+                    call("Requests(requests), Socks(socks), Websocket(websocket)")
+                ]
+            )
+            mock_log.debug.mock_calls.clear()
+
+        with patch("sys.platform", "darwin"), \
+             patch("platform.mac_ver", Mock(return_value=["0.0.0"])):
+            self.subject(["streamlink", "--loglevel", "debug"])
+            self.assertEqual(
+                mock_log.debug.mock_calls,
+                [
+                    call("OS:         macOS 0.0.0"),
+                    call("Python:     python"),
+                    call("Streamlink: streamlink"),
+                    call("Requests(requests), Socks(socks), Websocket(websocket)")
+                ]
+            )
+            mock_log.debug.mock_calls.clear()
+
+        with patch("sys.platform", "win32"), \
+             patch("platform.system", Mock(return_value="Windows")), \
+             patch("platform.release", Mock(return_value="0.0.0")):
+            self.subject(["streamlink", "--loglevel", "debug"])
+            self.assertEqual(
+                mock_log.debug.mock_calls,
+                [
+                    call("OS:         Windows 0.0.0"),
+                    call("Python:     python"),
+                    call("Streamlink: streamlink"),
+                    call("Requests(requests), Socks(socks), Websocket(websocket)")
+                ]
+            )
+            mock_log.debug.mock_calls.clear()
 
     @patch("streamlink_cli.main.log_current_arguments")
     @patch("streamlink_cli.main.log_current_versions", Mock())


### PR DESCRIPTION
We've had this discussion a while ago and I think we should log all arguments set by the user while debug logging, not just plugin specific arguments.

- The first commit therefore replaces the "Plugin specific arguments" logging with the new `streamlink_cli.main.log_current_arguments` method which logs all arguments set by the user, on the command line, from the main config file, from the plugin config file and from any custom config files. Sensitive plugin argument values get replaced (just like previously) and it prints double-dash argument names instead of the argument's `dest` name, if possible.
- The second commit additionally cleans up `streamlink_cli.main.log_current_versions` and adds tests, for good measure.

----

Example with a mixture of CLI arguments, main-config arguments and plugin-config arguments from my system:
```
$ streamlink -l debug --title foo twitch.tv/esl_csgo best
[cli][debug] OS:         Linux-5.11.7-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.2
[cli][debug] Streamlink: 2.0.0+64.gce6a60c
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.57.0)
[cli][debug] Arguments:
[cli][debug]  url=twitch.tv/esl_csgo
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --player-args=--cache=yes --demuxer-max-bytes=750k --demuxer-max-back-bytes=2G
[cli][debug]  --title=foo
[cli][debug]  --hls-live-edge=2
[cli][debug]  --hls-segment-threads=2
[cli][debug]  --twitch-disable-hosting=True
[cli][debug]  --twitch-disable-ads=True
[cli][debug]  --twitch-disable-reruns=True
[cli][debug]  --twitch-low-latency=True
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_csgo
^CInterrupted! Exiting...
```