### PR TITLE
build: include removed plugins file in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include README.md
 include LICENSE*
 include *requirements.txt
 include src/streamlink/_version.py
+include src/streamlink/plugins/.removed
 include versioneer.py
 
 recursive-include docs *


### PR DESCRIPTION
Fixes #3643 

For some reason, the `src/streamlink/plugins/.removed` file is not part of the sdist tarball in `2.1.0`.
This PR forces the inclusion of that file via `MANIFEST.in`.

I don't know why, but when I build `2.1.0` locally, the file is part of the tarball, but the one built by the CI runner does not include it. Can someone confirm this?