### PR TITLE
build: don't build sdist/bdist quietly

### DIFF
--- a/script/build-and-sign.sh
+++ b/script/build-and-sign.sh
@@ -23,14 +23,14 @@ wheel_platforms_windows=("win32" "win-amd64")
 mkdir -p "${dist_dir}"
 
 echo "build: Building Streamlink sdist" >&2
-python setup.py -q sdist --dist-dir "${dist_dir}"
+python setup.py sdist --dist-dir "${dist_dir}"
 
 echo "build: Building Streamlink bdist_wheel" >&2
-python setup.py -q bdist_wheel --dist-dir "${dist_dir}"
+python setup.py bdist_wheel --dist-dir "${dist_dir}"
 
 for platform in "${wheel_platforms_windows[@]}"; do
     echo "build: Building Streamlink bdist_wheel (${platform})" >&2
-    python setup.py -q bdist_wheel --plat-name "${platform}" --dist-dir "${dist_dir}"
+    python setup.py bdist_wheel --plat-name "${platform}" --dist-dir "${dist_dir}"
 done
 
 


### PR DESCRIPTION
This removes the `-q` option from the sdist/bdist build commands, so that all files are printed to stdout in the build log.
https://github.com/streamlink/streamlink/runs/2171755471?check_suite_focus=true#step:9:11