### PR TITLE
plugins.abematv: Fixed download problem again.

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -192,10 +192,10 @@ class AbemaTV(Plugin):
             res = self.session.http.get(self._PRGM_API.format(vid),
                                         headers=auth_header)
             jsonres = self.session.http.json(res, schema=self._PRGM_SCHEMA)
-            playable=false
+            playable=0
             for item in jsonres["terms"]:
                 if item.get("onDemandType", False) == 3:
-                    playable=true
+                    playable=1
             return playable
         elif vtype == "slots":
             res = self.session.http.get(self._SLOTS_API.format(vid),

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -192,10 +192,10 @@ class AbemaTV(Plugin):
             res = self.session.http.get(self._PRGM_API.format(vid),
                                         headers=auth_header)
             jsonres = self.session.http.json(res, schema=self._PRGM_SCHEMA)
-            playable=False
+            playable = False
             for item in jsonres["terms"]:
                 if item.get("onDemandType", False) == 3:
-                    playable=True
+                    playable = True
             return playable
         elif vtype == "slots":
             res = self.session.http.get(self._SLOTS_API.format(vid),

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -192,7 +192,11 @@ class AbemaTV(Plugin):
             res = self.session.http.get(self._PRGM_API.format(vid),
                                         headers=auth_header)
             jsonres = self.session.http.json(res, schema=self._PRGM_SCHEMA)
-            return jsonres["terms"][0].get("onDemandType", False) == 3
+            playable=false
+            for item in jsonres["terms"]:
+                if item.get("onDemandType", False) == 3:
+                    playable=true
+            return playable
         elif vtype == "slots":
             res = self.session.http.get(self._SLOTS_API.format(vid),
                                         headers=auth_header)

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -192,10 +192,10 @@ class AbemaTV(Plugin):
             res = self.session.http.get(self._PRGM_API.format(vid),
                                         headers=auth_header)
             jsonres = self.session.http.json(res, schema=self._PRGM_SCHEMA)
-            playable=0
+            playable=False
             for item in jsonres["terms"]:
                 if item.get("onDemandType", False) == 3:
-                    playable=1
+                    playable=True
             return playable
         elif vtype == "slots":
             res = self.session.http.get(self._SLOTS_API.format(vid),


### PR DESCRIPTION
I found a new response from api of abema from [https://api.abema.io/v1/video/programs/203-2_s1_p113](https://github.com/streamlink/streamlink/files/6226501/203-2_s1_p113.txt)
The previous response contained only one "terms", but we found a new response with two "terms", so we fixed it.

> Known Response
> {~,"terms":[{"onDemandType":3,"endAt":＊＊＊}]}

> New Response
> {~,"terms":[{"onDemandType":3,"endAt":＊＊＊},{"onDemandType":1,"endAt":＊＊＊}]}