### PR TITLE
plugins.onetv: fix/update URL for ctc API

### DIFF
--- a/tests/plugins/test_onetv.py
+++ b/tests/plugins/test_onetv.py
@@ -34,9 +34,3 @@ class TestPluginOneTV(unittest.TestCase):
     def test_live_api_url(self):
         self.assertEqual(OneTV("http://1tv.ru/live").live_api_url,
                          "http://stream.1tv.ru/api/playlist/1tvch_as_array.json")
-
-        self.assertEqual(OneTV("https://www.ctclove.ru/online").live_api_url,
-                         "https://media.1tv.ru/api/v1/ctc/playlist/ctc-love_as_array.json")
-
-        self.assertEqual(OneTV("http://domashny.ru/online").live_api_url,
-                         "http://media.1tv.ru/api/v1/ctc/playlist/ctc-dom_as_array.json")


### PR DESCRIPTION
- Implement token request
- Remove DASH support, streams appear to be encrypted
- Update tests

WIP:
- [ ] Test all supported sites
- [ ] Mock token response for test_live_api_url()

closes #3587
