### PR TITLE
plugins.youtube: add short video URLs

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -59,7 +59,8 @@ _config_schema = validate.Schema(
 )
 
 _ytdata_re = re.compile(r'ytInitialData\s*=\s*({.*?});', re.DOTALL)
-_url_re = re.compile(r"""(?x)https?://(?:\w+\.)?youtube\.com
+_url_re = re.compile(r"""
+    https?://(?:\w+\.)?youtube\.com
     (?:
         (?:
             /(?:
@@ -83,7 +84,9 @@ _url_re = re.compile(r"""(?x)https?://(?:\w+\.)?youtube\.com
             /(?:c/)?[^/?]+/live/?$
         )
     )
-""")
+    |
+    https?://youtu\.be/(?P<video_id_short>[0-9A-z_-]{11})
+""", re.VERBOSE)
 
 
 class YouTube(Plugin):
@@ -223,9 +226,10 @@ class YouTube(Plugin):
 
     def _find_video_id(self, url):
         m = _url_re.match(url)
-        if m.group("video_id"):
+        video_id = m.group("video_id") or m.group("video_id_short")
+        if video_id:
             log.debug("Video ID from URL")
-            return m.group("video_id")
+            return video_id
 
         res = self.session.http.get(url)
         if urlparse(res.url).netloc == "consent.youtube.com":

--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -22,6 +22,7 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
         "https://www.youtube.com/user/EXAMPLE/live",
         "https://www.youtube.com/v/aqz-KE-bpKQ",
         "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
+        "https://youtu.be/0123456789A",
     ]
 
     should_not_match = [
@@ -30,6 +31,10 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
         "https://www.youtube.com/account",
         "https://www.youtube.com/feed/guide_builder",
         "https://www.youtube.com/t/terms",
+        "https://youtu.be",
+        "https://youtu.be/",
+        "https://youtu.be/c/CHANNEL",
+        "https://youtu.be/c/CHANNEL/live",
     ]
 
 


### PR DESCRIPTION
Resolves #3676 

```
$ streamlink -l debug https://youtu.be/SebJIjQgdjg
[cli][debug] OS:         Linux-5.12.0-rc5-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.2
[cli][debug] Streamlink: 2.1.1+4.g303c424
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://youtu.be/SebJIjQgdjg
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin youtube for URL https://youtu.be/SebJIjQgdjg
[plugins.youtube][debug] Video ID from URL
[plugins.youtube][debug] Using video ID: SebJIjQgdjg
[plugins.youtube][debug] get_video_info - 1: Found data
[plugins.youtube][debug] This video is live.
[utils.l10n][debug] Language code: en_US
Available streams: 144p (worst), 240p, 360p, 480p, 720p, 1080p (best)
```