### PR TITLE
chore: remove square brackets from issue titles

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_plugin_issue.md
+++ b/.github/ISSUE_TEMPLATE/1_plugin_issue.md
@@ -1,7 +1,7 @@
 ---
 name: Plugin Issue
 about: One of Streamlink's plugins doesn't work correctly
-title: "plugins.[pluginname]: [A very brief summary of what's broken]"
+title: "plugins.plugin-name-here: A very brief summary of what's broken"
 labels: plugin issue
 ---
 

--- a/.github/ISSUE_TEMPLATE/1_plugin_request.md
+++ b/.github/ISSUE_TEMPLATE/1_plugin_request.md
@@ -1,7 +1,7 @@
 ---
 name: Plugin Request
 about: Discuss adding a new plugin to Streamlink
-title: "[Name of the website / streaming provider]"
+title: "Name of the website / streaming provider"
 labels: plugin request
 ---
 

--- a/.github/ISSUE_TEMPLATE/2_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug Report
 about: A core functionality of Streamlink is broken
-title: "[A very brief summary of what's broken]"
+title: "A very brief summary of what's broken"
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Discuss adding new functionality to Streamlink
-title: "[A very brief summary of your request]"
+title: "A very brief summary of your request"
 labels: feature request
 ---
 


### PR DESCRIPTION
My intention with the issue title templates was having a common format for all the issues which get set automatically, but that's a bit difficult to achieve when there are parts which are supposed to be edited by the user and some not. Square brackets seemed like a good idea, but apparently people don't understand that they should be removed when filling out the template. Using all-uppercase text for the parts that should be replaced is also not ideal as there's also room for misinterpretation. So here's a slightly better version, which will probably still get misinterpreted...