### PR TITLE
utils.named_pipe: rewrite named pipes

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -1,6 +1,4 @@
 import logging
-import os
-import random
 import subprocess
 import sys
 import threading
@@ -62,7 +60,7 @@ class FFMPEGMuxer(StreamIO):
     @staticmethod
     def copy_to_pipe(self, stream, pipe):
         log.debug("Starting copy to pipe: {0}".format(pipe.path))
-        pipe.open("wb")
+        pipe.open()
         while not stream.closed:
             try:
                 data = stream.read(8192)
@@ -87,7 +85,7 @@ class FFMPEGMuxer(StreamIO):
         self.process = None
         self.streams = streams
 
-        self.pipes = [NamedPipe("ffmpeg-{0}-{1}".format(os.getpid(), random.randint(0, 1000))) for _ in self.streams]
+        self.pipes = [NamedPipe() for _ in self.streams]
         self.pipe_threads = [threading.Thread(target=self.copy_to_pipe, args=(self, stream, np))
                              for stream, np in
                              zip(self.streams, self.pipes)]
@@ -103,7 +101,7 @@ class FFMPEGMuxer(StreamIO):
 
         self._cmd = [self.command(session), '-nostats', '-y']
         for np in self.pipes:
-            self._cmd.extend(["-i", np.path])
+            self._cmd.extend(["-i", str(np.path)])
 
         self._cmd.extend(['-c:v', videocodec])
         self._cmd.extend(['-c:a', audiocodec])

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -96,11 +96,8 @@ def create_output(plugin):
                          "executable with --player.")
 
         if args.player_fifo:
-            pipename = "streamlinkpipe-{0}".format(os.getpid())
-            log.info("Creating pipe {0}".format(pipename))
-
             try:
-                namedpipe = NamedPipe(pipename)
+                namedpipe = NamedPipe()
             except OSError as err:
                 console.exit("Failed to create pipe: {0}", err)
         elif args.player_http:

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -270,7 +270,7 @@ class PlayerOutput(Output):
             raise OSError("Process exited prematurely")
 
         if self.namedpipe:
-            self.namedpipe.open("wb")
+            self.namedpipe.open()
         elif self.http:
             self.http.open()
 

--- a/tests/test_utils_named_pipe.py
+++ b/tests/test_utils_named_pipe.py
@@ -1,0 +1,164 @@
+import threading
+import unittest
+from unittest.mock import Mock, call, patch
+
+from streamlink.compat import is_win32
+from streamlink.utils.named_pipe import NamedPipe, NamedPipePosix, NamedPipeWindows
+
+if is_win32:
+    from ctypes import windll, create_string_buffer, c_ulong, byref
+
+
+GENERIC_READ = 0x80000000
+OPEN_EXISTING = 3
+
+
+class ReadNamedPipeThread(threading.Thread):
+    def __init__(self, pipe: NamedPipe):
+        super().__init__(daemon=True)
+        self.path = str(pipe.path)
+        self.error = None
+        self.data = b""
+        self.done = threading.Event()
+
+    def run(self):
+        try:
+            self.read()
+        except OSError as err:  # pragma: no cover
+            self.error = err
+        self.done.set()
+
+    def read(self):
+        raise NotImplementedError
+
+
+class ReadNamedPipeThreadPosix(ReadNamedPipeThread):
+    def read(self):
+        with open(self.path, "rb") as file:
+            while True:
+                data = file.read(-1)
+                if len(data) == 0:
+                    break
+                self.data += data
+
+
+class ReadNamedPipeThreadWindows(ReadNamedPipeThread):
+    def read(self):
+        handle = windll.kernel32.CreateFileW(self.path, GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
+        try:
+            while True:
+                data = create_string_buffer(NamedPipeWindows.bufsize)
+                read = c_ulong(0)
+                if not windll.kernel32.ReadFile(handle, data, NamedPipeWindows.bufsize, byref(read), None):  # pragma: no cover
+                    raise OSError(f"Failed reading pipe: {windll.kernel32.GetLastError()}")
+                self.data += data.value
+                if read.value != len(data.value):
+                    break
+        finally:
+            windll.kernel32.CloseHandle(handle)
+
+
+class TestNamedPipe(unittest.TestCase):
+    @patch("streamlink.utils.named_pipe._id", 0)
+    @patch("streamlink.utils.named_pipe.os.getpid", Mock(return_value=12345))
+    @patch("streamlink.utils.named_pipe.random.randint", Mock(return_value=67890))
+    @patch("streamlink.utils.named_pipe.NamedPipe._create", Mock(return_value=None))
+    @patch("streamlink.utils.named_pipe.log")
+    def test_name(self, mock_log):
+        NamedPipe()
+        NamedPipe()
+        self.assertEqual(mock_log.info.mock_calls, [
+            call("Creating pipe streamlinkpipe-12345-1-67890"),
+            call("Creating pipe streamlinkpipe-12345-2-67890")
+        ])
+
+
+@unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
+class TestNamedPipePosix(unittest.TestCase):
+    def test_export(self):
+        self.assertEqual(NamedPipe, NamedPipePosix)
+
+    @patch("streamlink.utils.named_pipe.os.mkfifo")
+    def test_create(self, mock_mkfifo):
+        mock_mkfifo.side_effect = OSError()
+        with self.assertRaises(OSError):
+            NamedPipePosix()
+        self.assertEqual(mock_mkfifo.call_args[0][1:], (0o660,))
+
+    def test_close_before_open(self):
+        pipe = NamedPipePosix()
+        self.assertTrue(pipe.path.is_fifo())
+        pipe.close()
+        self.assertFalse(pipe.path.is_fifo())
+        # closing twice doesn't raise
+        pipe.close()
+
+    def test_write_before_open(self):
+        pipe = NamedPipePosix()
+        self.assertTrue(pipe.path.is_fifo())
+        with self.assertRaises(Exception):
+            pipe.write(b"foo")
+        pipe.close()
+
+    def test_named_pipe(self):
+        pipe = NamedPipePosix()
+        self.assertTrue(pipe.path.is_fifo())
+        reader = ReadNamedPipeThreadPosix(pipe)
+        reader.start()
+        pipe.open()
+        self.assertEqual(pipe.write(b"foo"), 3)
+        self.assertEqual(pipe.write(b"bar"), 3)
+        pipe.close()
+        self.assertFalse(pipe.path.is_fifo())
+        reader.done.wait(4000)
+        self.assertEqual(reader.error, None)
+        self.assertEqual(reader.data, b"foobar")
+        self.assertFalse(reader.is_alive())
+
+
+@unittest.skipIf(not is_win32, "test only applicable on Windows")
+class TestNamedPipeWindows(unittest.TestCase):
+    def test_export(self):
+        self.assertEqual(NamedPipe, NamedPipeWindows)
+
+    @patch("streamlink.utils.named_pipe.windll.kernel32")
+    def test_create(self, mock_kernel32):
+        mock_kernel32.CreateNamedPipeW.return_value = NamedPipeWindows.INVALID_HANDLE_VALUE
+        mock_kernel32.GetLastError.return_value = 12345
+        with self.assertRaises(OSError) as cm:
+            NamedPipeWindows()
+        self.assertEqual(str(cm.exception), "Named pipe error code 0x00003039")
+        self.assertEqual(mock_kernel32.CreateNamedPipeW.call_args[0][1:], (
+            0x00000002,
+            0x00000000,
+            255,
+            8192,
+            8192,
+            0,
+            None
+        ))
+
+    def test_close_before_open(self):
+        pipe = NamedPipeWindows()
+        handle = windll.kernel32.CreateFileW(str(pipe.path), GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
+        self.assertNotEqual(handle, NamedPipeWindows.INVALID_HANDLE_VALUE)
+        windll.kernel32.CloseHandle(handle)
+        pipe.close()
+        handle = windll.kernel32.CreateFileW(str(pipe.path), GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
+        self.assertEqual(handle, NamedPipeWindows.INVALID_HANDLE_VALUE)
+        # closing twice doesn't raise
+        pipe.close()
+
+    def test_named_pipe(self):
+        pipe = NamedPipeWindows()
+        reader = ReadNamedPipeThreadWindows(pipe)
+        reader.start()
+        pipe.open()
+        self.assertEqual(pipe.write(b"foo"), 3)
+        self.assertEqual(pipe.write(b"bar"), 3)
+        self.assertEqual(pipe.write(b"\0"), 1)
+        reader.done.wait(4000)
+        self.assertEqual(reader.error, None)
+        self.assertEqual(reader.data, b"foobar")
+        self.assertFalse(reader.is_alive())
+        pipe.close()


### PR DESCRIPTION
- split into two classes with an abstract base class
- remove name parameter from class and generate proper names
- remove mode parameter from open() as it's always binary mode
- change type of NamedPipe.path from str to pathlib.Path
- add tests

This is just a code refactor and doesn't fix the other issues mentioned here, as it would require refactoring the cli.output classes and stream.ffmpegmux in addition to the current changes:
https://github.com/streamlink/streamlink/issues/3568#issuecomment-783130671

There are also a couple of other issues I found while rewriting the Windows specific stuff and it seems like it doesn't close the named pipe gracefully and instead just swallows/supresses errors on the last (invalid) write attempt. I couldn't find a solution for this now, hence the lack of `TestNamedPipeWindows.test_write_before_open`, which would also cover this issue.