### PR TITLE
plugins.nicolive: fix nicolive broken with proxy

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -197,7 +197,7 @@ class NicoLive(Plugin):
             on_error=on_error)
         self.ws_worker_thread = threading.Thread(
             target=self._ws.run_forever,
-            args=proxy_options)
+            kwargs=proxy_options)
         self.ws_worker_thread.daemon = True
         self.ws_worker_thread.start()
 


### PR DESCRIPTION
nico live run failed with error:

#> streamlink --http-proxy=127.0.0.1:8080 -o ./out.ts "https://live.nicovideo.jp/watch/lv********" test

[plugins.nicolive][warning] setsockopt() takes exactly 3 arguments (1 given)
[plugins.nicolive][warning] wss api disconnected.
[plugins.nicolive][warning] Attempting to reconnect in 5 secs...

fix: websocket threading should init with `kwargs`, not `args`.