### PR TITLE
plugins.mitele: use '_{bitrate}' and remove duplicates

### DIFF
--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -78,6 +78,7 @@ class Mitele(Plugin):
                                                                     self.token_errors.get(tokens["code"], "unknown error")))
             return
 
+        list_urls = []
         for stream in pdata["dls"]:
             if stream["drm"]:
                 log.warning("Stream may be protected by DRM")
@@ -87,7 +88,13 @@ class Mitele(Plugin):
                 cdn_token = tokens.get(stream["lid"], {}).get("cdn", "")
                 qsd = parse_qsd(cdn_token)
                 if sformat == "hls":
-                    yield from HLSStream.parse_variant_playlist(self.session, update_qsd(stream["stream"], qsd)).items()
+                    list_urls.append(update_qsd(stream["stream"], qsd))
+
+        if not list_urls:
+            return
+
+        for url in list(set(list_urls)):
+            yield from HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items()
 
 
 __plugin__ = Mitele


### PR DESCRIPTION
before

```
[cli][info] Available streams: 360p (worst), 480p, 576p, 720p_alt2, 720p_alt, 720p (best)
```

now

```
[cli][info] Available streams: 360p_364k (worst), 480p_764k, 720p_1564k, 720p_2564k, 576p_5008k, 720p_6891k, 720p_9726k (best)
```

closes https://github.com/streamlink/streamlink/issues/3708
