### PR TITLE
plugins.bbciplayer: fix/update state_re regex

### DIFF
--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -28,7 +28,7 @@ class BBCiPlayer(Plugin):
     """, re.VERBOSE)
     mediator_re = re.compile(
         r'window\.__IPLAYER_REDUX_STATE__\s*=\s*({.*?});', re.DOTALL)
-    state_re = re.compile(r'window.__IPLAYER_REDUX_STATE__\s*=\s*({.*});')
+    state_re = re.compile(r'window.__IPLAYER_REDUX_STATE__\s*=\s*({.*?});</script>')
     account_locals_re = re.compile(r'window.bbcAccount.locals\s*=\s*({.*?});')
     hash = base64.b64decode(b"N2RmZjc2NzFkMGM2OTdmZWRiMWQ5MDVkOWExMjE3MTk5MzhiOTJiZg==")
     api_url = "https://open.live.bbc.co.uk/mediaselector/6/select/version/2.0/mediaset/" \


### PR DESCRIPTION
This started happening yesterday:
```
error: Unable to parse JSON: Extra data: line 1 column 32793 (char 32792) ('{"navigation":{"items":[{"id":"cha ...)
```
The old greedy regex was also grabbing:
```
;</script><script id="tvip-script-app-client-config">window.__IPLAYER_CLIENT_CONFIG__ = {"logger":{"level":"error","telemetryUrl":"https://monitoring.ede565d7c6c3ee6b.xhst.bbci.co.uk/tvr-telemetry/iplayer-web/telemetry","serviceName":"iplayer-web-app-highlights","telemetrySamplingRate":0}}
```
This fixes it.  Tested on various live channels and VODs.

closes #3726
