### PR TITLE
ci.github: add python 3.10-dev to test runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,13 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest]
         python: [3.6, 3.7, 3.8, 3.9]
-#       include:
-#         - python: X.Y-dev
-#           continue: true
+        include:
+          - python: 3.10-dev
+            os: ubuntu-20.04
+            continue: true
+          - python: 3.10-dev
+            os: windows-latest
+            continue: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
cpython 3.10-beta is already out since almost two weeks, so let's add it to the test runners.
https://www.python.org/downloads/release/python-3100b1/

The `-dev` suffix is an undocumented feature of the setup-python action and an alias for `>= maj.min.0-a0`.