### PR TITLE
plugins.youtube: add html5=1 parameter

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -286,7 +286,7 @@ class YouTube(Plugin):
         info_parsed = None
         for _params in (_params_1, _params_2, _params_3):
             count += 1
-            params = {"video_id": video_id}
+            params = {"video_id": video_id, "html5": "1"}
             params.update(_params)
 
             res = self.session.http.get(self._video_info_url, params=params)


### PR DESCRIPTION
Resolves #3724

I have been using streamlink for more than 1 year and recording Youtube live streams. I started to have the same problem as of May 14, 2021. The PR I posted seems to solve the problem.