### PR TITLE
plugins.rtpplay: fix obfuscated HLS URL parsing

### DIFF
--- a/src/streamlink/plugins/rtpplay.py
+++ b/src/streamlink/plugins/rtpplay.py
@@ -1,4 +1,5 @@
 import re
+from base64 import b64decode
 from urllib.parse import unquote
 
 from streamlink.plugin import Plugin
@@ -10,22 +11,38 @@ from streamlink.utils import parse_json
 class RTPPlay(Plugin):
     _url_re = re.compile(r"https?://www\.rtp\.pt/play/")
     _m3u8_re = re.compile(r"""
-        hls:\s*(?:(["'])(?P<string>[^"']+)\1
-        |
-        decodeURIComponent\((?P<obfuscated>\[.*?])\.join\()
+        hls\s*:\s*(?:
+            (["'])(?P<string>[^"']*)\1
+            |
+            decodeURIComponent\s*\((?P<obfuscated>\[.*?])\.join\(
+            |
+            atob\s*\(\s*decodeURIComponent\s*\((?P<obfuscated_b64>\[.*?])\.join\(
+        )
     """, re.VERBOSE)
 
     _schema_hls = validate.Schema(
-        validate.transform(_m3u8_re.search),
+        validate.transform(lambda text: next(reversed(list(RTPPlay._m3u8_re.finditer(text))), None)),
         validate.any(
             None,
             validate.all(
                 validate.get("string"),
-                validate.url()
+                str,
+                validate.any(
+                    validate.length(0),
+                    validate.url()
+                )
             ),
             validate.all(
                 validate.get("obfuscated"),
+                str,
                 validate.transform(lambda arr: unquote("".join(parse_json(arr)))),
+                validate.url()
+            ),
+            validate.all(
+                validate.get("obfuscated_b64"),
+                str,
+                validate.transform(lambda arr: unquote("".join(parse_json(arr)))),
+                validate.transform(lambda b64: b64decode(b64).decode("utf-8")),
                 validate.url()
             )
         )
@@ -39,9 +56,8 @@ class RTPPlay(Plugin):
         self.session.http.headers.update({"User-Agent": useragents.CHROME,
                                           "Referer": self.url})
         hls_url = self.session.http.get(self.url, schema=self._schema_hls)
-        if not hls_url:
-            return
-        return HLSStream.parse_variant_playlist(self.session, hls_url)
+        if hls_url:
+            return HLSStream.parse_variant_playlist(self.session, hls_url)
 
 
 __plugin__ = RTPPlay

--- a/tests/plugins/test_rtpplay.py
+++ b/tests/plugins/test_rtpplay.py
@@ -1,5 +1,12 @@
+import unittest
+
+import requests_mock
+
+from streamlink import Streamlink
 from streamlink.plugins.rtpplay import RTPPlay
+from streamlink.stream import HLSStream
 from tests.plugins import PluginCanHandleUrl
+from tests.resources import text
 
 
 class TestPluginCanHandleUrlRTPPlay(PluginCanHandleUrl):
@@ -18,3 +25,54 @@ class TestPluginCanHandleUrlRTPPlay(PluginCanHandleUrl):
         'https://media.rtp.pt/',
         'http://media.rtp.pt/',
     ]
+
+
+class TestRTPPlay(unittest.TestCase):
+    # all invalid HLS URLs at the beginning need to be ignored ("https://invalid")
+    _content_pre = """
+        /*  var player1 = new RTPPlayer({
+                file: {hls : atob( decodeURIComponent(["aHR0c", "HM6Ly", "9pbnZ", "hbGlk"].join("") ) ), dash : foo() } }); */
+        var f = {hls : atob( decodeURIComponent(["aHR0c", "HM6Ly", "9pbnZ", "hbGlk"].join("") ) ), dash: foo() };
+    """
+    # invalid resources sometimes have an empty string as HLS URL
+    _content_invalid = """
+        var f = {hls : ""};
+    """
+    # the actual HLS URL always comes last ("https://valid")
+    _content_valid = """
+        var f = {hls : decodeURIComponent(["https%3","A%2F%2F", "valid"].join("") ), dash: foo() };
+    """
+    _content_valid_b64 = """
+        var f = {hls : atob( decodeURIComponent(["aHR0c", "HM6Ly", "92YWx", "pZA=="].join("") ) ), dash: foo() };
+    """
+
+    @property
+    def playlist(self):
+        with text("hls/test_master.m3u8") as pl:
+            return pl.read()
+
+    def subject(self, url, response):
+        with requests_mock.Mocker() as mock:
+            mock.get(url=url, text=response)
+            mock.get("https://valid", text=self.playlist)
+            mock.get("https://invalid", exc=AssertionError)
+            session = Streamlink()
+            RTPPlay.bind(session, "tests.plugins.test_rtpplay")
+            plugin = RTPPlay(url)
+            return plugin._get_streams()
+
+    def test_empty(self):
+        streams = self.subject("https://www.rtp.pt/play/id/title", "")
+        self.assertEqual(streams, None)
+
+    def test_invalid(self):
+        streams = self.subject("https://www.rtp.pt/play/id/title", self._content_pre + self._content_invalid)
+        self.assertEqual(streams, None)
+
+    def test_valid(self):
+        streams = self.subject("https://www.rtp.pt/play/id/title", self._content_pre + self._content_valid)
+        self.assertIsInstance(next(iter(streams.values())), HLSStream)
+
+    def test_valid_b64(self):
+        streams = self.subject("https://www.rtp.pt/play/id/title", self._content_pre + self._content_valid_b64)
+        self.assertIsInstance(next(iter(streams.values())), HLSStream)


### PR DESCRIPTION
Resolves #3741 

This is the second time this site has obfuscated their HLS URLs so that they can't be parsed easily.
See my comment here: https://github.com/streamlink/streamlink/pull/3627#discussion_r596186958

These changes however are again simple and only require a quick adjustment of the regex and additional base64 decoding in the validation schema.

I've also added tests with mocked HTTP responses, since there are several different response types.

----

**VOD**
```
$ streamlink -l debug 'https://www.rtp.pt/play/p8501/cidade-despida'
[cli][debug] OS:         Linux-5.12.4-2-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.5
[cli][debug] Streamlink: 2.1.2+1.g0cdc1de
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.rtp.pt/play/p8501/cidade-despida
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin rtpplay for URL https://www.rtp.pt/play/p8501/cidade-despida
[utils.l10n][debug] Language code: en_US
Available streams: 1080p (worst, best)
```

**VOD (invalid ID)**
```
$ streamlink -l debug 'https://www.rtp.pt/play/p0123456789/title'
[cli][debug] OS:         Linux-5.12.4-2-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.5
[cli][debug] Streamlink: 2.1.2+1.g0cdc1de
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.rtp.pt/play/p0123456789/title
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin rtpplay for URL https://www.rtp.pt/play/p0123456789/title
error: No playable streams found on this URL: https://www.rtp.pt/play/p0123456789/title
```

**live**
```
$ streamlink -l debug 'https://www.rtp.pt/play/direto/rtp1'
[cli][debug] OS:         Linux-5.12.4-2-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.5
[cli][debug] Streamlink: 2.1.2+1.g0cdc1de
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.rtp.pt/play/direto/rtp1
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin rtpplay for URL https://www.rtp.pt/play/direto/rtp1
[utils.l10n][debug] Language code: en_US
Available streams: 640k (worst), 1300k, 2500k (best)
```

**live (invalid channel)**
```
$ streamlink -l debug 'https://www.rtp.pt/play/direto/rtp12345'
[cli][debug] OS:         Linux-5.12.4-2-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.5
[cli][debug] Streamlink: 2.1.2+1.g0cdc1de
[cli][debug] Requests(2.25.1), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.rtp.pt/play/direto/rtp12345
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin rtpplay for URL https://www.rtp.pt/play/direto/rtp12345
error: No playable streams found on this URL: https://www.rtp.pt/play/direto/rtp12345
```