### PR TITLE
docs: set man_make_section_directory to false

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,3 +187,7 @@ man_pages = [
 
 # If true, show URL addresses after external links.
 #man_show_urls = False
+
+# If true, make a section directory on build man page.
+# Always set this to false to fix inconsistencies between recent sphinx releases
+man_make_section_directory = False


### PR DESCRIPTION
And fix inconsistent manpage build paths between recent sphinx
releases. False is the currently expected value, as setup.py
will check for a built manpage in `docs/_build/man/streamlink.1`
for inclusion in the release tarballs.

Even though the doc's HTML theme "furo" does currently limit the
used sphinx version to 3.x, this won't stop users building the
manpage using sphinx 4.x, eg. via a global system-package.

----

What a mess...
https://www.sphinx-doc.org/en/master/changes.html

Sphinx 4:
https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-man_make_section_directory

> **man_make_section_directory**
> If true, make a section directory on build man page. Default is `True`.
>
> *New in version 3.3.*
> *Changed in version 4.0:* The default is changed to False from `True`.
> *Changed in version 4.0.2:* The default is changed to True from `False` again.

Sphinx 3:
https://www.sphinx-doc.org/en/3.x/usage/configuration.html#confval-man_make_section_directory

> **man_make_section_directory**
> If true, make a section directory on build man page. Default is `False`.
>
> *New in version 3.3.*