### PR TITLE
plugins.funimationnow: fix subtitle language

### DIFF
--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -238,7 +238,7 @@ class FunimationNow(Plugin):
                 for subtitle in exp.subtitles():
                     log.debug(f"Subtitles: {subtitle['src']}")
                     if subtitle["src"].endswith(".vtt") or subtitle["src"].endswith(".srt"):
-                        sub_lang = {"en": "eng", "ja": "jpn"}[subtitle["language"]]
+                        sub_lang = {"en": "eng", "ja": "jpn", "es": "esp", "pt": "por"}[subtitle["language"]]
                         # pick the first suitable subtitle stream
                         subtitles = subtitles or HTTPStream(self.session, subtitle["src"])
                         stream_metadata["s:s:0"] = ["language={0}".format(sub_lang)]

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -7,6 +7,7 @@ from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.utils.l10n import Localization
 
 log = logging.getLogger(__name__)
 
@@ -238,7 +239,7 @@ class FunimationNow(Plugin):
                 for subtitle in exp.subtitles():
                     log.debug(f"Subtitles: {subtitle['src']}")
                     if subtitle["src"].endswith(".vtt") or subtitle["src"].endswith(".srt"):
-                        sub_lang = {"en": "eng", "ja": "jpn", "es": "esp", "pt": "por"}[subtitle["language"]]
+                        sub_lang = Localization.get_language(subtitle["language"]).alpha3
                         # pick the first suitable subtitle stream
                         subtitles = subtitles or HTTPStream(self.session, subtitle["src"])
                         stream_metadata["s:s:0"] = ["language={0}".format(sub_lang)]


### PR DESCRIPTION
This fixes a common error with the FunimationNow failing due to an inability to handle content with these select subtitle formats attached to them, such as every single show released past the year 2021 that isn't dubbed.
To reproduce this issue, simply run for yourself 
`streamlink --funimation-email="xxx" --funimation-password="xxx" --http-cookie "incap_ses_xxxx_xxxxxx=xxxxxxxxxxxx" "https://www.funimation.com/en/shows/any-simulcast-show-not-listed-dubbed/"`
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
