### PR TITLE
cli: implement --logfile

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -25,6 +25,7 @@ _note_re = re.compile(r"Note: (.*)(?:\n\n|\n*$)", re.DOTALL)
 _option_line_re = re.compile(r"^(?!\s{2}|Example: )(.+)$", re.MULTILINE)
 _option_re = re.compile(r"(?:^|(?<=\s))(--\w[\w-]*\w)\b")
 _prog_re = re.compile(r"%\(prog\)s")
+_percent_re = re.compile(r"%%")
 
 
 def get_parser(module_name, attr):
@@ -82,6 +83,9 @@ class ArgparseDirective(Directive):
 
         # workaround to replace %(prog)s with streamlink
         help = _prog_re.sub("streamlink", help)
+
+        # fix escaped chars for percent-formatted argparse help strings
+        help = _percent_re.sub("%", help)
 
         return indent(help)
 

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -60,7 +60,7 @@ class StringFormatter(logging.Formatter):
         return super().format(record)
 
 
-def basicConfig(**kwargs):
+def basicConfig(**kwargs) -> logging.StreamHandler:
     with _config_lock:
         filename = kwargs.get("filename")
         if filename:
@@ -81,6 +81,8 @@ def basicConfig(**kwargs):
         level = kwargs.get("level")
         if level is not None:
             root.setLevel(level)
+
+    return handler
 
 
 BASIC_FORMAT = "[{name}][{levelname}] {message}"

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -254,6 +254,30 @@ def build_parser():
         """
     )
     general.add_argument(
+        "--logfile",
+        metavar="FILE",
+        help="""
+        Append log output to FILE instead of writing to stdout/stderr.
+
+        User prompts and download progress won't be written to FILE.
+
+        A value of ``-`` will set the file name to an ISO8601-like string
+        and will choose the following default log directories.
+
+        Windows:
+
+          %%TEMP%%\\streamlink\\logs
+
+        macOS:
+
+          ${HOME}/Library/logs/streamlink
+
+        Linux/BSD:
+
+          ${XDG_STATE_HOME:-${HOME}/.local/state}/streamlink/logs
+        """
+    )
+    general.add_argument(
         "-Q", "--quiet",
         action="store_true",
         help="""

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,9 +1,10 @@
 import os
 import sys
 
+is_darwin = sys.platform == "darwin"
 is_win32 = os.name == "nt"
 
 stdout = sys.stdout.buffer
 
 
-__all__ = ["is_win32", "stdout"]
+__all__ = ["is_darwin", "is_win32", "stdout"]

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -1,6 +1,8 @@
 import os
+import tempfile
+from pathlib import Path
 
-from streamlink_cli.compat import is_win32
+from streamlink_cli.compat import is_darwin, is_win32
 
 PLAYER_ARGS_INPUT_DEFAULT = "playerinput"
 PLAYER_ARGS_INPUT_FALLBACK = "filename"
@@ -24,6 +26,7 @@ if is_win32:
     APPDATA = os.environ["APPDATA"]
     CONFIG_FILES = [os.path.join(APPDATA, "streamlink", "streamlinkrc")]
     PLUGINS_DIR = os.path.join(APPDATA, "streamlink", "plugins")
+    LOG_DIR = Path(tempfile.gettempdir()) / "streamlink" / "logs"
 else:
     XDG_CONFIG_HOME = os.environ.get("XDG_CONFIG_HOME", "~/.config")
     CONFIG_FILES = [
@@ -31,6 +34,10 @@ else:
         os.path.expanduser("~/.streamlinkrc")
     ]
     PLUGINS_DIR = os.path.expanduser(XDG_CONFIG_HOME + "/streamlink/plugins")
+    if is_darwin:
+        LOG_DIR = Path.home() / "Library" / "logs" / "streamlink"
+    else:
+        LOG_DIR = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser() / "streamlink" / "logs"
 
 STREAM_SYNONYMS = ["best", "worst", "best-unfiltered", "worst-unfiltered"]
 STREAM_PASSTHROUGH = ["hls", "http", "rtmp"]
@@ -38,5 +45,5 @@ STREAM_PASSTHROUGH = ["hls", "http", "rtmp"]
 __all__ = [
     "PLAYER_ARGS_INPUT_DEFAULT", "PLAYER_ARGS_INPUT_FALLBACK",
     "DEFAULT_STREAM_METADATA", "SUPPORTED_PLAYERS",
-    "CONFIG_FILES", "PLUGINS_DIR", "STREAM_SYNONYMS", "STREAM_PASSTHROUGH"
+    "CONFIG_FILES", "PLUGINS_DIR", "LOG_DIR", "STREAM_SYNONYMS", "STREAM_PASSTHROUGH"
 ]

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -916,7 +916,7 @@ def setup_plugin_options(session, plugin):
                                           console.ask(prompt + ": "))
 
 
-def check_root():
+def log_root_warning():
     if hasattr(os, "getuid"):
         if os.geteuid() == 0:
             log.info("streamlink is running as root! Be careful!")
@@ -1042,7 +1042,8 @@ def main():
     logger.root.setLevel(log_level)
 
     setup_http_session()
-    check_root()
+
+    log_root_warning()
     log_current_versions()
     log_current_arguments(streamlink, parser)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1,4 +1,5 @@
 import argparse
+import datetime
 import errno
 import logging
 import os
@@ -11,6 +12,7 @@ from distutils.version import StrictVersion
 from functools import partial
 from gettext import gettext
 from itertools import chain
+from pathlib import Path
 from time import sleep
 
 import requests
@@ -27,7 +29,7 @@ from streamlink.utils import LazyFormatter, NamedPipe
 from streamlink_cli.argparser import build_parser
 from streamlink_cli.compat import is_win32, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
-from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, PLUGINS_DIR, STREAM_SYNONYMS
+from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGINS_DIR, STREAM_SYNONYMS
 from streamlink_cli.output import FileOutput, PlayerOutput
 from streamlink_cli.utils import HTTPServer, ignored, progress, stream_to_url
 
@@ -669,13 +671,7 @@ def setup_config_args(parser, ignore_unknown=False):
         setup_args(parser, config_files, ignore_unknown=ignore_unknown)
 
 
-def setup_console(output):
-    """Console setup."""
-    global console
-
-    # All console related operations is handled via the ConsoleOutput class
-    console = ConsoleOutput(output, args.json)
-
+def setup_signals():
     # Handle SIGTERM just like SIGINT
     signal.signal(signal.SIGTERM, signal.default_int_handler)
 
@@ -998,14 +994,27 @@ def check_version(force=False):
         sys.exit()
 
 
-def setup_logging(stream=sys.stdout, level="info"):
-    logger.basicConfig(
+def setup_logger_and_console(stream=sys.stdout, filename=None, level="info", json=False):
+    global console
+
+    if filename == "-":
+        filename = LOG_DIR / datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S.log")
+    elif filename:
+        filename = Path(filename).expanduser().resolve()
+
+    if filename:
+        filename.parent.mkdir(parents=True, exist_ok=True)
+
+    streamhandler = logger.basicConfig(
         stream=stream,
+        filename=filename,
         level=level,
         style="{",
         format=("[{asctime}]" if level == "trace" else "") + "[{name}][{levelname}] {message}",
         datefmt="%H:%M:%S" + (".%f" if level == "trace" else "")
     )
+
+    console = ConsoleOutput(streamhandler.stream, json)
 
 
 def main():
@@ -1026,8 +1035,10 @@ def main():
     # We don't want log output when we are printing JSON or a command-line.
     silent_log = any(getattr(args, attr) for attr in QUIET_OPTIONS)
     log_level = args.loglevel if not silent_log else "none"
-    setup_logging(console_out, log_level)
-    setup_console(console_out)
+    log_file = args.logfile if log_level != "none" else None
+    setup_logger_and_console(console_out, log_file, log_level, args.json)
+
+    setup_signals()
 
     setup_streamlink()
     # load additional plugins

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, call, patch
 import streamlink_cli.main
 from streamlink.plugin.plugin import Plugin
 from streamlink.session import Streamlink
+from streamlink_cli.compat import is_win32
 from streamlink_cli.main import (
     check_file_output,
     create_output,
@@ -13,7 +14,6 @@ from streamlink_cli.main import (
     handle_stream,
     handle_url,
     log_current_arguments,
-    log_current_versions,
     resolve_stream_name
 )
 from streamlink_cli.output import FileOutput, PlayerOutput
@@ -264,36 +264,49 @@ class TestCLIMain(unittest.TestCase):
         console.exit.assert_called_with("Cannot use record options with other file output options.")
 
 
-@patch("streamlink_cli.main.log")
-@patch("streamlink_cli.main.CONFIG_FILES", ["/dev/null"])
-@patch("streamlink_cli.main.setup_plugins", Mock())
-@patch("streamlink_cli.main.setup_streamlink", Mock())
-@patch("streamlink.session.Streamlink.load_builtin_plugins", Mock())
-class TestCLIMainDebugLogging(unittest.TestCase):
-    def subject(self, argv):
+class _TestCLIMainLogging(unittest.TestCase):
+    @classmethod
+    def subject(cls, argv):
         session = Streamlink()
         session.load_plugins(os.path.join(os.path.dirname(__file__), "plugin"))
 
-        with patch("streamlink_cli.main.streamlink", session), patch("sys.argv") as mock_argv:
+        def _log_current_arguments(*args, **kwargs):
+            log_current_arguments(*args, **kwargs)
+            raise SystemExit
+
+        with patch("streamlink_cli.main.streamlink", session), \
+             patch("streamlink_cli.main.log_current_arguments", side_effect=_log_current_arguments), \
+             patch("streamlink_cli.main.CONFIG_FILES", ["/dev/null"]), \
+             patch("streamlink_cli.main.setup_streamlink"), \
+             patch("streamlink_cli.main.setup_plugins"), \
+             patch("streamlink_cli.main.setup_http_session"), \
+             patch("streamlink.session.Streamlink.load_builtin_plugins"), \
+             patch("sys.argv") as mock_argv:
             mock_argv.__getitem__.side_effect = lambda x: argv[x]
             try:
                 streamlink_cli.main.main()
             except SystemExit:
                 pass
 
-    @patch("streamlink_cli.main.log_current_versions")
+    def tearDown(self):
+        streamlink_cli.main.logger.root.handlers.clear()
+
+
+class TestCLIMainLogging(_TestCLIMainLogging):
+    @unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
+    @patch("streamlink_cli.main.log")
+    @patch("streamlink_cli.main.os.geteuid", Mock(return_value=0))
+    def test_log_root_warning(self, mock_log):
+        self.subject(["streamlink"])
+        self.assertEqual(mock_log.info.mock_calls, [call("streamlink is running as root! Be careful!")])
+
+    @patch("streamlink_cli.main.log")
     @patch("streamlink_cli.main.streamlink_version", "streamlink")
     @patch("streamlink_cli.main.requests.__version__", "requests")
     @patch("streamlink_cli.main.socks_version", "socks")
     @patch("streamlink_cli.main.websocket_version", "websocket")
     @patch("platform.python_version", Mock(return_value="python"))
-    def test_log_current_versions(self, mock_log_current_versions, mock_log):
-        def _log_current_versions():
-            log_current_versions()
-            raise SystemExit
-
-        mock_log_current_versions.side_effect = _log_current_versions
-
+    def test_log_current_versions(self, mock_log):
         self.subject(["streamlink", "--loglevel", "info"])
         self.assertEqual(mock_log.debug.mock_calls, [], "Doesn't log anything if not debug logging")
 
@@ -301,7 +314,7 @@ class TestCLIMainDebugLogging(unittest.TestCase):
              patch("platform.platform", Mock(return_value="linux")):
             self.subject(["streamlink", "--loglevel", "debug"])
             self.assertEqual(
-                mock_log.debug.mock_calls,
+                mock_log.debug.mock_calls[:4],
                 [
                     call("OS:         linux"),
                     call("Python:     python"),
@@ -309,13 +322,13 @@ class TestCLIMainDebugLogging(unittest.TestCase):
                     call("Requests(requests), Socks(socks), Websocket(websocket)")
                 ]
             )
-            mock_log.debug.mock_calls.clear()
+            mock_log.debug.reset_mock()
 
         with patch("sys.platform", "darwin"), \
              patch("platform.mac_ver", Mock(return_value=["0.0.0"])):
             self.subject(["streamlink", "--loglevel", "debug"])
             self.assertEqual(
-                mock_log.debug.mock_calls,
+                mock_log.debug.mock_calls[:4],
                 [
                     call("OS:         macOS 0.0.0"),
                     call("Python:     python"),
@@ -323,14 +336,14 @@ class TestCLIMainDebugLogging(unittest.TestCase):
                     call("Requests(requests), Socks(socks), Websocket(websocket)")
                 ]
             )
-            mock_log.debug.mock_calls.clear()
+            mock_log.debug.reset_mock()
 
         with patch("sys.platform", "win32"), \
              patch("platform.system", Mock(return_value="Windows")), \
              patch("platform.release", Mock(return_value="0.0.0")):
             self.subject(["streamlink", "--loglevel", "debug"])
             self.assertEqual(
-                mock_log.debug.mock_calls,
+                mock_log.debug.mock_calls[:4],
                 [
                     call("OS:         Windows 0.0.0"),
                     call("Python:     python"),
@@ -338,17 +351,10 @@ class TestCLIMainDebugLogging(unittest.TestCase):
                     call("Requests(requests), Socks(socks), Websocket(websocket)")
                 ]
             )
-            mock_log.debug.mock_calls.clear()
+            mock_log.debug.reset_mock()
 
-    @patch("streamlink_cli.main.log_current_arguments")
-    @patch("streamlink_cli.main.log_current_versions", Mock())
-    def test_log_current_arguments(self, mock_log_current_arguments, mock_log):
-        def _log_current_arguments(*args, **kwargs):
-            log_current_arguments(*args, **kwargs)
-            raise SystemExit
-
-        mock_log_current_arguments.side_effect = _log_current_arguments
-
+    @patch("streamlink_cli.main.log")
+    def test_log_current_arguments(self, mock_log):
         self.subject([
             "streamlink",
             "--loglevel", "info"
@@ -365,7 +371,7 @@ class TestCLIMainDebugLogging(unittest.TestCase):
             "best,worst"
         ])
         self.assertEqual(
-            mock_log.debug.mock_calls,
+            mock_log.debug.mock_calls[-7:],
             [
                 call("Arguments:"),
                 call(" url=website.tld/channel"),


### PR DESCRIPTION
1. tests: refactor TestCLIMainLogging
   - always exit streamlink_cli.main.main at the same function call, namely
     log_current_arguments
   - patch out dummy functions in context manager
   - slice debug log mock calls due to common test exit function
   - properly reset mocks
   - rename streamlink_cli.main.check_root to log_root_warning
   - add test for streamlink_cli.main.log_root_warning
2. cli: implement --logfile
   - refactor streamlink_cli.main.{setup_logging,setup_console}
     and split into setup_logger_and_console and setup_signals
   - add LOG_DIR to streamlink_cli.constants
   - pass filename to logger.basicConfig
   - re-use write stream of logger in ConsoleOutput
   - fix escaped chars for percent-formatted argparse help strings in docs
   - add tests

----

Resolves #2485