### PR TITLE
cli.argparser: fix description text

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -133,7 +133,7 @@ def build_parser():
         add_help=False,
         usage="%(prog)s [OPTIONS] <URL> [STREAM]",
         description=dedent("""
-        Streamlink is command-line utility that extracts streams from various
+        Streamlink is a command-line utility that extracts streams from various
         services and pipes them into a video player of choice.
         """),
         epilog=dedent("""


### PR DESCRIPTION
The `--help` text has been like this since 2437393c922a641229b8f22fc7cf277462f302e1 :worried: 

The package description which uses the same text was fixed in the py2 removal:
https://github.com/streamlink/streamlink/commit/8034b1606388e325916baf9f8ce738915fa6b528#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R69

And the docs were fixed here:
https://github.com/streamlink/streamlink/commit/b4298c8185cad978c2f1bbccbfeb095e30028c05#diff-c2a3f968b7ac8d84c3935f76af3a93c094b3c5c068777c4cd2548789b9a8d417R9