### PR TITLE
tests.hls: test headers on segment+key requests

### DIFF
--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -193,8 +193,11 @@ class TestMixinStreamHLS(unittest.TestCase):
     def mock(self, method, url, *args, **kwargs):
         self.mocks[url] = self.mocker.request(method, url, *args, **kwargs)
 
+    def get_mock(self, item):
+        return self.mocks[self.url(item)]
+
     def called(self, item):
-        return self.mocks[self.url(item)].called
+        return self.get_mock(item).called
 
     def url(self, item):
         return item.url(self.id())

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -114,6 +114,7 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
     def get_session(self, options=None, *args, **kwargs):
         session = super().get_session(options)
         session.set_option("hls-live-edge", 3)
+        session.set_option("http-headers", {"X-FOO": "BAR"})
 
         return session
 
@@ -139,8 +140,10 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
         expected = self.content(segments, prop="content_plain", cond=lambda s: s.num >= 1)
         self.assertEqual(data, expected, "Decrypts the AES-128 identity stream")
         self.assertTrue(self.called(key), "Downloads encryption key")
+        self.assertEqual(self.get_mock(key).last_request._request.headers.get("X-FOO"), "BAR")
         self.assertFalse(any([self.called(s) for s in segments.values() if s.num < 1]), "Skips first segment")
         self.assertTrue(all([self.called(s) for s in segments.values() if s.num >= 1]), "Downloads all remaining segments")
+        self.assertEqual(self.get_mock(segments[1]).last_request._request.headers.get("X-FOO"), "BAR")
 
     def test_hls_encrypted_aes128_key_uri_override(self):
         aesKey, aesIv, key = self.gen_key(uri="http://real-mocked/{namespace}/encryption.key?foo=bar")
@@ -158,6 +161,7 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
         self.assertEqual(data, expected, "Decrypts stream from custom key")
         self.assertFalse(self.called(key_invalid), "Skips encryption key")
         self.assertTrue(self.called(key), "Downloads custom encryption key")
+        self.assertEqual(self.get_mock(key).last_request._request.headers.get("X-FOO"), "BAR")
 
 
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", Mock(return_value=True))


### PR DESCRIPTION
There are currently no tests for custom HTTP session headers. The tests could have instead been added to the overall session tests, but these changes here also assure that headers are set on HLS segments and (custom) HLS segment keys, so basically killing two birds with one stone.
https://github.com/streamlink/streamlink/issues/3754#issuecomment-849503897