### PR TITLE
stream.hls: replace custom PKCS#7 unpad function

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -6,6 +6,7 @@ from threading import Event
 from urllib.parse import urlparse
 
 from Crypto.Cipher import AES
+from Crypto.Util.Padding import unpad
 from requests.exceptions import ChunkedEncodingError
 
 from streamlink.exceptions import StreamError
@@ -21,18 +22,6 @@ Sequence = namedtuple("Sequence", "num segment")
 
 def num_to_iv(n):
     return struct.pack(">8xq", n)
-
-
-def pkcs7_decode(paddedData, keySize=16):
-    '''
-    Remove the PKCS#7 padding
-    '''
-    # Use ord + [-1:] to support both python 2 and 3
-    val = ord(paddedData[-1:])
-    if val > keySize:
-        raise StreamError("Input is not padded or padding is corrupt, got padding size of {0}".format(val))
-
-    return paddedData[:-val]
 
 
 class HLSStreamWriter(SegmentedStreamWriter):
@@ -156,21 +145,21 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
             data = res.content
             # If the input data is not a multiple of 16, cut off any garbage
-            garbage_len = len(data) % 16
+            garbage_len = len(data) % AES.block_size
             if garbage_len:
                 log.debug(f"Cutting off {garbage_len} bytes of garbage before decrypting")
                 decrypted_chunk = decryptor.decrypt(data[:-garbage_len])
             else:
                 decrypted_chunk = decryptor.decrypt(data)
 
-            self.reader.buffer.write(pkcs7_decode(decrypted_chunk))
+            chunk = unpad(decrypted_chunk, AES.block_size, style="pkcs7")
+            self.reader.buffer.write(chunk)
         else:
             try:
                 for chunk in res.iter_content(chunk_size):
                     self.reader.buffer.write(chunk)
             except ChunkedEncodingError:
                 log.error(f"Download of segment {sequence.num} failed")
-
                 return
 
         log.debug(f"Download of segment {sequence.num} complete")


### PR DESCRIPTION
- replace stream.hls.pkcs7_decode with Crypto.Util.Padding.unpad
- add tests for invalid encryption data

----

This is what I had originally suggested in #3446 but it keeps the garbage data removal.