### PR TITLE
plugin.api.validate: add nested lookups to get() and implement union_get()

### DIFF
--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -26,7 +26,7 @@ from streamlink.exceptions import PluginError
 
 __all__ = [
     "any", "all", "filter", "get", "getattr", "hasattr", "length", "optional",
-    "transform", "text", "union", "url", "startswith", "endswith", "contains",
+    "transform", "text", "union", "union_get", "url", "startswith", "endswith", "contains",
     "xml_element", "xml_find", "xml_findall", "xml_findtext",
     "validate", "Schema", "SchemaContainer"
 ]
@@ -85,6 +85,12 @@ class union(SchemaContainer):
 
 class attr(SchemaContainer):
     """Validates an object's attributes."""
+
+
+class union_get:
+    def __init__(self, *keys, seq=tuple):
+        self.keys = keys
+        self.seq = seq
 
 
 class xml_element:
@@ -427,6 +433,11 @@ def validate_attr(schema, value):
         setattr(new, attr, validate(schema, _getattr(value, attr)))
 
     return new
+
+
+@validate.register(union_get)
+def validate_union_from(schema, value):
+    return schema.seq(validate(get(k), value) for k in schema.keys)
 
 
 @singledispatch

--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -18,6 +18,7 @@
 
 from copy import copy as copy_obj
 from functools import singledispatch
+from typing import Any, Tuple, Union
 from urllib.parse import urlparse
 from xml.etree import ElementTree as ET
 
@@ -140,25 +141,36 @@ def contains(string):
     return contains_str
 
 
-def get(item, default=None):
+def get(item: Union[Any, Tuple[Any]], default: Any = None, strict: bool = False):
     """Get item from value (value[item]).
 
-    If the item is not found, return the default.
+    Unless strict is set to True, item can be a tuple of items for recursive lookups.
+
+    If the item is not found in the last object of a recursive lookup, return the default.
 
     Handles XML elements, regex matches and anything that has __getitem__.
     """
 
-    def getter(value):
-        if ET.iselement(value):
-            value = value.attrib
+    if type(item) is not tuple or strict:
+        item = (item,)
 
+    def getter(value):
+        idx = 0
         try:
-            # Use .group() if this is a regex match object
-            if _is_re_match(value):
-                return value.group(item)
-            else:
-                return value[item]
+            for key in item:
+                if ET.iselement(value):
+                    value = value.attrib
+                # Use .group() if this is a regex match object
+                elif _is_re_match(value):
+                    value = value.group(key)
+                else:
+                    value = value[key]
+                idx += 1
+            return value
         except (KeyError, IndexError):
+            # only return default value on last item in nested lookup
+            if idx < len(item) - 1:
+                raise ValueError(f"Object \"{value}\" does not have item \"{key}\"")
             return default
         except (TypeError, AttributeError) as err:
             raise ValueError(err)

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -4,7 +4,7 @@ from xml.etree.ElementTree import Element
 
 from streamlink.plugin.api.validate import (
     all, any, attr, endswith, filter, get, getattr, hasattr,
-    length, map, optional, startswith, text, transform, union, url,
+    length, map, optional, startswith, text, transform, union, union_get, url,
     validate, xml_element, xml_find, xml_findall, xml_findtext
 )
 
@@ -40,6 +40,12 @@ class TestPluginAPIValidate(unittest.TestCase):
     def test_union(self):
         assert validate(union((get("foo"), get("bar"))),
                         {"foo": "alpha", "bar": "beta"}) == ("alpha", "beta")
+
+    def test_union_get(self):
+        assert validate(union_get("foo", "bar"), {"foo": "alpha", "bar": "beta"}) == ("alpha", "beta")
+        assert validate(union_get("foo", "bar", seq=list), {"foo": "alpha", "bar": "beta"}) == ["alpha", "beta"]
+        assert validate(union_get(("foo", "bar"), ("baz", "qux")),
+                        {"foo": {"bar": "alpha"}, "baz": {"qux": "beta"}}) == ("alpha", "beta")
 
     def test_list(self):
         assert validate([1, 0], [1, 0, 1, 1]) == [1, 0, 1, 1]

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -84,7 +84,25 @@ class TestPluginAPIValidate(unittest.TestCase):
 
     def test_get(self):
         assert validate(get("key"), {"key": "value"}) == "value"
+        assert validate(get("key"), re.match(r"(?P<key>.+)", "value")) == "value"
+        assert validate(get("invalidkey"), {"key": "value"}) is None
         assert validate(get("invalidkey", "default"), {"key": "value"}) == "default"
+        assert validate(get(3, "default"), [0, 1, 2]) == "default"
+
+        with self.assertRaisesRegex(ValueError, "'NoneType' object is not subscriptable"):
+            validate(get("key"), None)
+
+        data = {"one": {"two": {"three": "value1"}},
+                ("one", "two", "three"): "value2"}
+        assert validate(get(("one", "two", "three")), data) == "value1", "Recursive lookup"
+        assert validate(get(("one", "two", "three"), strict=True), data) == "value2", "Strict tuple-key lookup"
+        assert validate(get(("one", "two", "invalidkey")), data) is None, "Default value is None"
+        assert validate(get(("one", "two", "invalidkey"), "default"), data) == "default", "Custom default value"
+
+        with self.assertRaisesRegex(ValueError, "Object \"{'two': {'three': 'value1'}}\" does not have item \"invalidkey\""):
+            validate(get(("one", "invalidkey", "three")), data)
+        with self.assertRaisesRegex(ValueError, "'NoneType' object is not subscriptable"):
+            validate(all(get("one"), get("invalidkey"), get("three")), data)
 
     def test_get_re(self):
         m = re.match(r"(\d+)p", "720p")


### PR DESCRIPTION
There are two validation schema patterns which get re-used all the time and which can be improved.

1. **Nested/recursive `validate.get` calls:**
   Nested key lookups currently require three separate `get`-transform calls and one `all` call, which is wasteful and tedious to write. Also, since the `get` method sets its default value to `None` and returns it on any `KeyError`/`IndexError`, error messages in consecutive lookups are not particularly useful.
   ```py
   >>> validate(
   ...     all(get("first"), get("second"), get("third")),
   ...     {"first": {"second": {"third": "value"}}}
   ... )
   "value"

   >>> validate(
   ...     all(get("invalid"), get("second")),
   ...     {"first": {"second": "value"}}
   ... )
   ValueError: "'NoneType' object is not subscriptable"
   ```

   Single `get()` calls with nested lookups improve the readability, only use one single transform and allow having better error messages. The runtime performance difference for non-recursive lookups should be minimal, as it's just a simple iterator over the input that now always gets turned into a tuple.

   ```py
   >>> validate(
   ...     get(("first", "second", "third")),
   ...     {"first": {"second": {"third": "value"}}}
   ... )
   "value"

   >>> validate(
   ...     get(("invalid", "second")),
   ...     {"first": {"second": "value"}}
   ... )
   ValueError: "Object \"{'first': {'second': 'value'}}\" does not have item \"invalid\""

   >>> validate(
   ...     get(("first", "invalid")),
   ...     {"first": {"second": "value"}}
   ... )
   None

   >>> validate(
   ...     get(("first", "second"), strict=True),
   ...     {("first", "second"): "value"}
   ... )
   "value"
   ```

2. **`validate.union(tuple(...))` calls with multiple `validate.get()` calls:**
   The purpose here is to simplify tuples of items that are used for destructuring. The `get`-transforms are created during validation and not during declaration, which can improve overall memory consumption.
   ```py
   >>> validate(
   ...     union((get("first"), get("second"))),
   ...     {"first": "foo", "second": "bar"}
   ... )
   ("foo", "bar")
   ```

   ```py
   >>> validate(
   ...     union_get("first", "second"),
   ...     {"first": "foo", "second": "bar"}
   ... )
   ("foo", "bar")
   ```