### PR TITLE
plugin: new matchers API

### DIFF
--- a/src/streamlink/plugin/__init__.py
+++ b/src/streamlink/plugin/__init__.py
@@ -1,5 +1,9 @@
 from streamlink.exceptions import PluginError
 from streamlink.options import Argument as PluginArgument, Arguments as PluginArguments, Options as PluginOptions
-from streamlink.plugin.plugin import Plugin
+from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, Plugin, pluginmatcher
 
-__all__ = ["Plugin", "PluginError", "PluginOptions", "PluginArguments", "PluginArgument"]
+__all__ = [
+    "HIGH_PRIORITY", "NORMAL_PRIORITY", "LOW_PRIORITY", "NO_PRIORITY",
+    "Plugin", "PluginArguments", "PluginArgument", "PluginError", "PluginOptions",
+    "pluginmatcher",
+]

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -5,7 +5,7 @@ import re
 import time
 from collections import OrderedDict
 from functools import partial
-from typing import Callable, ClassVar, List, Match, NamedTuple, Optional, Pattern, Sequence, Type
+from typing import Any, Callable, ClassVar, Dict, List, Match, NamedTuple, Optional, Pattern, Sequence, Type
 
 import requests.cookies
 
@@ -136,15 +136,11 @@ def stream_sorting_filter(expr, stream_weight):
     return func
 
 
-def parse_url_params(url):
-    split = url.split(" ", 1)
-    url = split[0]
-    params = split[1] if len(split) > 1 else ''
-    return url, parse_params(params)
-
-
-def parse_params(params):
+def parse_params(params: Optional[str] = None) -> Dict[str, Any]:
     rval = {}
+    if not params:
+        return rval
+
     matches = re.findall(PARAMS_REGEX, params)
 
     for key, value in matches:

--- a/src/streamlink/plugins/abweb.py
+++ b/src/streamlink/plugins/abweb.py
@@ -1,8 +1,7 @@
 import logging
 import re
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
@@ -11,10 +10,13 @@ from streamlink.utils.url import url_concat
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?abweb\.com/BIS-TV-Online/bistvo-tele-universal\.aspx",
+    re.IGNORECASE
+))
 class ABweb(Plugin):
     url_l = 'https://www.abweb.com/BIS-TV-Online/identification.aspx?ReturnUrl=%2fBIS-TV-Online%2fbistvo-tele-universal.aspx'
 
-    _url_re = re.compile(r'https?://(?:www\.)?abweb\.com/BIS-TV-Online/bistvo-tele-universal.aspx', re.IGNORECASE)
     _hls_re = re.compile(r'''["']file["']:\s?["'](?P<url>[^"']+\.m3u8[^"']+)["']''')
 
     arguments = PluginArguments(
@@ -49,10 +51,6 @@ class ABweb(Plugin):
         super().__init__(url)
         self._authed = (self.session.http.cookies.get('ASP.NET_SessionId', domain='.abweb.com')
                         and self.session.http.cookies.get('.abportail1', domain='.abweb.com'))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _login(self, username, password):
         log.debug('Attempting to login.')

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.stream.hls import HLSStreamReader, HLSStreamWriter
@@ -22,9 +22,11 @@ class AfreecaHLSStream(HLSStream):
     __reader__ = AfreecaHLSStreamReader
 
 
+@pluginmatcher(re.compile(
+    r"https?://play\.afreecatv\.com/(?P<username>\w+)(?:/(?P<bno>:\d+))?"
+))
 class AfreecaTV(Plugin):
     _re_bno = re.compile(r"var nBroadNo = (?P<bno>\d+);")
-    _re_url = re.compile(r"https?://play\.afreecatv\.com/(?P<username>\w+)(?:/(?P<bno>:\d+))?")
 
     CHANNEL_API_URL = "http://live.afreecatv.com/afreeca/player_live_api.php"
     CHANNEL_RESULT_OK = 1
@@ -89,10 +91,6 @@ class AfreecaTV(Plugin):
             and self.session.http.cookies.get("PdboxUser")
             and self.session.http.cookies.get("RDB")
         )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     @classmethod
     def stream_weight(cls, key):
@@ -191,7 +189,7 @@ class AfreecaTV(Plugin):
             else:
                 log.error("Failed to login")
 
-        m = self._re_url.match(self.url).groupdict()
+        m = self.match.groupdict()
         username = m["username"]
         bno = m["bno"]
         if bno is None:

--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -1,28 +1,25 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.plugin import parse_params
 from streamlink.stream import AkamaiHDStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"akamaihd://(?P<url>\S+)(?:\s(?P<params>.+))?"
+))
 class AkamaiHDPlugin(Plugin):
-    _url_re = re.compile(r"akamaihd://(.+)")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        url, params = parse_url_params(self.url)
-        urlnoproto = self._url_re.match(url).group(1)
-        urlnoproto = update_scheme("http://", urlnoproto)
+        data = self.match.groupdict()
+        url = update_scheme("http://", data.get("url"))
+        params = parse_params(data.get("params"))
+        log.debug(f"URL={url}; params={params}")
 
-        log.debug("URL={0}; params={1}".format(urlnoproto, params))
-        return {"live": AkamaiHDStream(self.session, urlnoproto, **params)}
+        return {"live": AkamaiHDStream(self.session, url, **params)}
 
 
 __plugin__ = AkamaiHDPlugin

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -11,16 +11,17 @@ import re
 import time
 from urllib.parse import quote, urlencode, urlparse
 
-from streamlink import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?(tvc\.com\.ec|rts\.com\.ec|elnueve\.com\.ar|atv\.pe)/en-?vivo(?:/ATV(?:Mas)?)?"
+))
 class Albavision(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?(tvc.com.ec|rts.com.ec|elnueve.com.ar|atv.pe)/en-?vivo(?:/ATV(?:Mas)?)?")
     _token_input_re = re.compile(r"Math.floor\(Date.now\(\) / 3600000\),'([a-f0-9OK]+)'")
     _live_url_re = re.compile(r"LIVE_URL = '(.*?)';")
     _playlist_re = re.compile(r"file:\s*'(http.*m3u8)'")
@@ -37,10 +38,6 @@ class Albavision(Plugin):
     def __init__(self, url):
         super().__init__(url)
         self._page = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     @property
     def page(self):

--- a/src/streamlink/plugins/animelab.py
+++ b/src/streamlink/plugins/animelab.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
 from streamlink.utils import parse_json
@@ -9,8 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?animelab\.com/player/"
+))
 class AnimeLab(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?animelab\.com/player/")
     login_url = "https://www.animelab.com/login"
     video_collection_re = re.compile(r"VideoCollection\((\[.*?\])\);")
     playlist_position_re = re.compile(r"playlistPosition\s*=\s*(\d+);")
@@ -49,10 +51,6 @@ class AnimeLab(Plugin):
             help="A animelab.com account password to use with --animelab-email."
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def login(self, email, password):
         log.debug("Attempting to log in as {0}".format(email))

--- a/src/streamlink/plugins/app17.py
+++ b/src/streamlink/plugins/app17.py
@@ -1,15 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://17\.live/live/(?P<channel>[^/&?]+)"
+))
 class App17(Plugin):
-    _url_re = re.compile(r"https://17.live/live/(?P<channel>[^/&?]+)")
     API_URL = "https://api-dsa.17app.co/api/v1/lives/{0}/viewers/alive"
 
     _api_schema = validate.Schema(
@@ -22,13 +24,8 @@ class App17(Plugin):
         validate.get("rtmpUrls"),
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        match = self._url_re.match(self.url)
-        channel = match.group("channel")
+        channel = self.match.group("channel")
 
         self.session.http.headers.update({'User-Agent': useragents.CHROME, 'Referer': self.url})
 

--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json, verifyjson
@@ -10,8 +10,10 @@ from streamlink.utils import parse_json, verifyjson
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://((www|live)\.)?daserste\.de/"
+))
 class ARDLive(Plugin):
-    _url_re = re.compile(r"https?://((www|live)\.)?daserste\.de/")
     _player_re = re.compile(r'''data-ctrl-player\s*=\s*"(?P<jsondata>.*?)"''')
     _player_url_schema = validate.Schema(
         validate.transform(_player_re.search),
@@ -43,10 +45,6 @@ class ARDLive(Plugin):
         1: "288p",
         0: "144p"
     }
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import update_scheme
@@ -16,7 +16,6 @@ QUALITY_MAP = {
     0: "144p"
 }
 
-_url_re = re.compile(r"https?://(?:(\w+\.)?ardmediathek\.de/|mediathek\.daserste\.de/)")
 _media_id_re = re.compile(r"/play/(?:media|config|sola)/(\d+)")
 _media_schema = validate.Schema({
     "_mediaArray": [{
@@ -31,11 +30,10 @@ _media_schema = validate.Schema({
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:(\w+\.)?ardmediathek\.de/|mediathek\.daserste\.de/)"
+))
 class ARDMediathek(Plugin):
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url) is not None
-
     def _get_http_streams(self, info):
         name = QUALITY_MAP.get(info["_quality"], "vod")
         urls = info["_stream"]

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -2,7 +2,7 @@ import logging
 import re
 from functools import partial
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream
 from streamlink.utils import parse_json, search_dict, update_scheme
@@ -10,8 +10,10 @@ from streamlink.utils import parse_json, search_dict, update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?atresplayer\.com/"
+))
 class AtresPlayer(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?atresplayer\.com/")
     state_re = re.compile(r"""window.__PRELOADED_STATE__\s*=\s*({.*?});""", re.DOTALL)
     channel_id_schema = validate.Schema(
         validate.transform(state_re.search),
@@ -41,10 +43,6 @@ class AtresPlayer(Plugin):
                 validate.optional("type"): validate.text
             })
         ]}, validate.get("sources"))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def __init__(self, url):
         # must be HTTPS

--- a/src/streamlink/plugins/bfmtv.py
+++ b/src/streamlink/plugins/bfmtv.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urljoin, urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.plugins.brightcove import BrightcovePlayer
 from streamlink.stream import HTTPStream
@@ -10,8 +10,10 @@ from streamlink.stream import HTTPStream
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:[\w-]+\.)+(?:bfmtv|01net)\.com'
+))
 class BFMTV(Plugin):
-    _url_re = re.compile(r'https://.+\.(?:bfmtv|01net)\.com')
     _dailymotion_url = 'https://www.dailymotion.com/embed/video/{}'
     _brightcove_video_re = re.compile(
         r'accountid="(?P<account_id>[0-9]+).*?videoid="(?P<video_id>[0-9]+)"',
@@ -29,10 +31,6 @@ class BFMTV(Plugin):
     _js_brightcove_video_re = re.compile(
         r'i\?\([A-Z]="[^"]+",y="(?P<video_id>[0-9]+).*"data-account"\s*:\s*"(?P<account_id>[0-9]+)',
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -1,12 +1,14 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?bigo\.tv/([^/]+)$"
+))
 class Bigo(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?bigo\.tv/([^/]+)$")
     _api_url = "https://www.bigo.tv/OInterface/getVideoParam?bigoId={0}"
 
     _video_info_schema = validate.Schema({
@@ -17,14 +19,9 @@ class Bigo(Plugin):
         }
     })
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        match = self._url_re.match(self.url)
         res = self.session.http.get(
-            self._api_url.format(match.group(1)),
+            self._api_url.format(self.match.group(1)),
             allow_redirects=True,
             headers={"User-Agent": useragents.IPHONE_6}
         )

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -2,19 +2,17 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?booyah\.live/(?:(?P<type>channels|clips|vods)/)?(?P<id>[^?]+)"
+))
 class Booyah(Plugin):
-    url_re = re.compile(r'''
-        https?://(?:www\.)?booyah\.live/
-        (?:(?P<type>channels|clips|vods)/)?(?P<id>[^?]+)
-    ''', re.VERBOSE)
-
     auth_api_url = 'https://booyah.live/api/v3/auths/sessions'
     vod_api_url = 'https://booyah.live/api/v3/playbacks/{0}'
     live_api_url = 'https://booyah.live/api/v3/channels/{0}'
@@ -69,10 +67,6 @@ class Booyah(Plugin):
     author = None
     category = None
     title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_author(self):
         return self.author
@@ -138,8 +132,7 @@ class Booyah(Plugin):
     def _get_streams(self):
         self.do_auth()
 
-        m = self.url_re.match(self.url)
-        url_data = m.groupdict()
+        url_data = self.match.groupdict()
         log.debug(f'ID={url_data["id"]}')
 
         if not url_data['type'] or url_data['type'] == 'channels':

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -4,10 +4,9 @@ import re
 from io import BytesIO
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink import PluginError
 from streamlink.packages.flashmedia import AMFMessage, AMFPacket
 from streamlink.packages.flashmedia.types import AMF3ObjectBase
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
@@ -166,13 +165,10 @@ class BrightcovePlayer:
         return bp.get_streams(video_id)
 
 
+@pluginmatcher(re.compile(
+    r"https?://players\.brightcove\.net/.*?/index\.html"
+))
 class Brightcove(Plugin):
-    url_re = re.compile(r"https?://players\.brightcove\.net/.*?/index.html")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
         return BrightcovePlayer.from_url(self.session, self.url)
 

--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -9,8 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?btvplus\.bg/live/?"
+))
 class BTV(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?btvplus\.bg/live/?")
     api_url = "https://btvplus.bg/lbin/v3/btvplus/player_config.php"
 
     media_id_re = re.compile(r"media_id=(\d+)")
@@ -29,10 +31,6 @@ class BTV(Plugin):
             )
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_hls_url(self, media_id):
         res = self.session.http.get(self.api_url, params=dict(media_id=media_id))

--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -1,13 +1,15 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
 
+@pluginmatcher(re.compile(
+    r"https?://www\.cbsnews\.com/live/"
+))
 class CBSNews(Plugin):
-    url_re = re.compile(r"https://www\.cbsnews\.com/live/")
     _re_default_payload = re.compile(r"CBSNEWS.defaultPayload = (\{.*)")
 
     _schema_items = validate.Schema(
@@ -22,10 +24,6 @@ class CBSNews(Plugin):
             validate.get("items")
         ))
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         items = self.session.http.get(self.url, schema=self._schema_items)

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -3,7 +3,7 @@ import re
 from html import unescape as html_unescape
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
@@ -11,19 +11,19 @@ from streamlink.utils import update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?(?:
+        armymedia\.bg|
+        bgonair\.bg/tvonline|
+        bloombergtv\.bg/video|
+        (?:tv\.)?bnt\.bg/\w+(?:/\w+)?|
+        live\.bstv\.bg|
+        i\.cdn\.bg/live/|
+        nova\.bg/live|
+        mu-vi\.tv/LiveStreams/pages/Live\.aspx
+    )/?
+""", re.VERBOSE))
 class CDNBG(Plugin):
-    url_re = re.compile(r"""
-        https?://(?:www\.)?(?:
-            armymedia\.bg|
-            bgonair\.bg/tvonline|
-            bloombergtv\.bg/video|
-            (?:tv\.)?bnt\.bg/\w+(?:/\w+)?|
-            live\.bstv\.bg|
-            i\.cdn\.bg/live/|
-            nova\.bg/live|
-            mu-vi\.tv/LiveStreams/pages/Live\.aspx
-        )/?
-    """, re.VERBOSE)
     iframe_re = re.compile(r"iframe .*?src=\"((?:https?(?::|&#58;))?//(?:\w+\.)?cdn.bg/live[^\"]+)\"", re.DOTALL)
     sdata_re = re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>http.*?)(?P=q)")
     hls_file_re = re.compile(r"(src|file): (?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)")
@@ -36,10 +36,6 @@ class CDNBG(Plugin):
             validate.all(validate.transform(hls_src_re.search), validate.get("url")),
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def find_iframe(self, url):
         self.session.http.headers.update({"User-Agent": useragents.CHROME})

--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -17,20 +17,18 @@ import re
 from html import unescape as html_unescape
 from urllib.parse import quote
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import DASHStream, HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://([\w-]+\.)*ceskatelevize\.cz'
+))
 class Ceskatelevize(Plugin):
-
     ajax_url = 'https://www.ceskatelevize.cz/ivysilani/ajax/get-client-playlist'
-    _url_re = re.compile(
-        r'http(s)?://([^.]*.)?ceskatelevize.cz'
-    )
     _player_re = re.compile(
         r'ivysilani/embed/iFramePlayer[^"]+'
     )
@@ -56,10 +54,6 @@ class Ceskatelevize(Plugin):
             }
         }]
     })
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     def _get_streams(self):
         self.session.http.headers.update({'User-Agent': useragents.IPAD})

--- a/src/streamlink/plugins/cinergroup.py
+++ b/src/streamlink/plugins/cinergroup.py
@@ -2,25 +2,24 @@ import json
 import re
 from urllib.parse import unquote
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?
+    (?:
+        showtv\.com\.tr/canli-yayin(/showtv)?|
+        haberturk\.com/canliyayin|
+        haberturk\.com/tv/canliyayin|
+        showmax\.com\.tr/canliyayin|
+        showturk\.com\.tr/canli-yayin/showturk|
+        bloomberght\.com/tv|
+        haberturk\.tv/canliyayin
+    )/?
+""", re.VERBOSE))
 class CinerGroup(Plugin):
-    """
-    Support for the live stream on www.showtv.com.tr
-    """
-    url_re = re.compile(r"""https?://(?:www.)?
-        (?:
-            showtv.com.tr/canli-yayin(/showtv)?|
-            haberturk.com/canliyayin|
-            haberturk.com/tv/canliyayin|
-            showmax.com.tr/canliyayin|
-            showturk.com.tr/canli-yayin/showturk|
-            bloomberght.com/tv|
-            haberturk.tv/canliyayin
-        )/?""", re.VERBOSE)
     stream_re = re.compile(r"""div .*? data-ht=(?P<quote>["'])(?P<data>.*?)(?P=quote)""", re.DOTALL)
     stream_data_schema = validate.Schema(
         validate.transform(stream_re.search),
@@ -38,10 +37,6 @@ class CinerGroup(Plugin):
             )
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/clubbingtv.py
+++ b/src/streamlink/plugins/clubbingtv.py
@@ -1,16 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(www\.)?clubbingtv\.com/"
+))
 class ClubbingTV(Plugin):
     _login_url = "https://www.clubbingtv.com/user/login"
 
-    _url_re = re.compile(r"https://(www\.)?clubbingtv\.com/")
     _live_re = re.compile(
         r'playerInstance\.setup\({\s*"file"\s*:\s*"(?P<stream_url>.+?)"',
         re.DOTALL,
@@ -31,10 +33,6 @@ class ClubbingTV(Plugin):
             help="A Clubbing TV account password to use with --clubbingtv-username.",
         ),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def login(self):
         username = self.get_option("username")

--- a/src/streamlink/plugins/cnews.py
+++ b/src/streamlink/plugins/cnews.py
@@ -1,12 +1,14 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.utils import parse_json
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?cnews\.fr'
+))
 class CNEWS(Plugin):
-    _url_re = re.compile(r'https?://(?:www\.)?cnews\.fr')
     _json_data_re = re.compile(r'jQuery\.extend\(Drupal\.settings, ({.*})\);')
     _dailymotion_url = 'https://www.dailymotion.com/embed/video/{}'
 
@@ -25,10 +27,6 @@ class CNEWS(Plugin):
             },
         )),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         data = self.session.http.get(self.url, schema=self._data_schema)

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -7,7 +7,7 @@ import itertools
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.utils import update_scheme
@@ -15,22 +15,19 @@ from streamlink.utils import update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:[\w-]+\.)?delfi\.(lt|lv|ee)"
+))
 class Delfi(Plugin):
-    url_re = re.compile(r"https?://(?:[\w-]+\.)?delfi\.(lt|lv|ee)")
     _api = {
         "lt": "http://g2.dcdn.lt/vfe/data.php",
         "lv": "http://g.delphi.lv/vfe/data.php",
         "ee": "http://g4.nh.ee/vfe/data.php"
     }
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     @property
     def api_server(self):
-        m = self.url_re.match(self.url)
-        domain = m and m.group(1)
+        domain = self.match.group(1)
         return self._api.get(domain, "lt")  # fallback to lt
 
     def _get_streams_api(self, video_id):

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -2,16 +2,18 @@ import logging
 import re
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?dw\.com/"
+))
 class DeutscheWelle(Plugin):
     default_channel = "1"
-    url_re = re.compile(r"https?://(?:www\.)?dw\.com/")
 
     channel_re = re.compile(r'''<a.*?data-id="(\d+)".*?class="ici"''')
     live_stream_div = re.compile(r'''
@@ -54,10 +56,6 @@ class DeutscheWelle(Plugin):
             )
         })
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _create_stream(self, url, quality=None):
         if url.startswith('rtmp://'):

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -2,25 +2,24 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?
+    (?:
+        cnnturk\.com/(?:action/embedvideo/|canli-yayin|tv-cnn-turk|video/)|
+        dreamturk\.com\.tr/(?:canli|canli-yayin-izle|dream-turk-ozel/|programlar/)|
+        dreamtv\.com\.tr/dream-ozel/|
+        kanald\.com\.tr/|
+        teve2\.com\.tr/(?:canli-yayin|diziler/|embed/|filmler/|programlar/)
+    )
+""", re.VERBOSE))
 class Dogan(Plugin):
-    """
-    Support for the live streams from Doğan Media Group channels
-    """
-    url_re = re.compile(r"""
-        https?://(?:www\.)?
-        (?:cnnturk\.com/(?:action/embedvideo/.*|canli-yayin|tv-cnn-turk|video/.*)|
-           dreamturk\.com\.tr/(?:canli|canli-yayin-izle|dream-turk-ozel/.*|programlar/.*)|
-           dreamtv\.com\.tr/dream-ozel/.*|
-           kanald\.com\.tr/.*|
-           teve2\.com\.tr/(?:canli-yayin|diziler/.*|embed/.*|filmler/.*|programlar/.*))
-    """, re.VERBOSE)
     playerctrl_re = re.compile(r'''<div\s+id="video-element".*?>''', re.DOTALL)
     data_id_re = re.compile(r'''data-id=(?P<quote>["'])/?(?P<id>\w+)(?P=quote)''')
     content_id_re = re.compile(r'"content[Ii]d",\s*"(\w+)"')
@@ -59,10 +58,6 @@ class Dogan(Plugin):
         validate.get("Media"),
         validate.get("Link"),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_content_id(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/dogus.py
+++ b/src/streamlink/plugins/dogus.py
@@ -1,42 +1,36 @@
 import logging
 import re
+from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.plugins.youtube import YouTube
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?
+    (?:
+        eurostartv\.com\.tr/canli-izle|
+        kralmuzik\.com\.tr/tv/|
+        ntv\.com\.tr/canli-yayin/ntv|
+        startv\.com\.tr/canli-yayin
+    )/?
+""", re.VERBOSE))
 class Dogus(Plugin):
-    """
-    Support for live streams from Dogus sites include ntv, and kralmuzik
-    """
-
-    url_re = re.compile(r"""https?://(?:www\.)?
-        (?:
-            eurostartv\.com\.tr/canli-izle|
-            kralmuzik\.com\.tr/tv/|
-            ntv\.com\.tr/canli-yayin/ntv|
-            startv\.com\.tr/canli-yayin
-        )/?""", re.VERBOSE)
     mobile_url_re = re.compile(r"""(?P<q>["'])(?P<url>(https?:)?//[^'"]*?/live/hls/[^'"]*?\?token=)
                                    (?P<token>[^'"]*?)(?P=q)""", re.VERBOSE)
     token_re = re.compile(r"""token=(?P<q>["'])(?P<token>[^'"]*?)(?P=q)""")
     kral_token_url = "https://service.kralmuzik.com.tr/version/gettoken"
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
         res = self.session.http.get(self.url)
 
         # Look for Youtube embedded video first
-        for iframe in itertags(res.text, 'iframe'):
-            if YouTube.can_handle_url(iframe.attributes.get("src")):
+        for iframe in itertags(res.text, "iframe"):
+            if urlparse(iframe.attributes.get("src")).netloc.endswith("youtube.com"):
                 log.debug("Handing off to YouTube plugin")
                 return self.session.streams(iframe.attributes.get("src"))
 

--- a/src/streamlink/plugins/drdk.py
+++ b/src/streamlink/plugins/drdk.py
@@ -1,20 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?dr\.dk/drtv(/kanal/[\w-]+)"
+))
 class DRDK(Plugin):
     live_api_url = 'https://www.dr-massive.com/api/page'
-
-    url_re = re.compile(r'''
-        https?://(?:www\.)?dr\.dk/drtv
-        (/kanal/[\w-]+)
-    ''', re.VERBOSE)
 
     _live_data_schema = validate.Schema(
         {'item': {'customFields': {
@@ -24,10 +22,6 @@ class DRDK(Plugin):
         validate.get('item'),
         validate.get('customFields'),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_live(self, path):
         params = dict(
@@ -52,8 +46,7 @@ class DRDK(Plugin):
         return streams
 
     def _get_streams(self):
-        m = self.url_re.match(self.url)
-        path = m and m.group(1)
+        path = self.match.group(1)
         log.debug("Path={0}".format(path))
 
         return self._get_live(path)

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
 from streamlink.utils import parse_json, update_scheme
@@ -9,8 +9,10 @@ from streamlink.utils import parse_json, update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?earthcam\.com/"
+))
 class EarthCam(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?earthcam\.com/.*")
     playpath_re = re.compile(r"(?P<folder>/.*/)(?P<file>.*?\.flv)")
     swf_url = "http://static.earthcam.com/swf/streaming/stream_viewer_v3.swf"
     json_base_re = re.compile(r"""var[ ]+json_base[^=]+=.*?(\{.*?});""", re.DOTALL)
@@ -26,10 +28,6 @@ class EarthCam(Plugin):
             )
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/egame.py
+++ b/src/streamlink/plugins/egame.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
 from streamlink.utils import parse_json
@@ -9,8 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://egame\.qq\.com/(?P<channel>\d+)"
+))
 class Egame(Plugin):
-
     STREAM_WEIGHTS = {
         "source": 65535,
         # "sd6m": 6000,
@@ -21,17 +23,12 @@ class Egame(Plugin):
         # "low": 900,
     }
 
-    _url_re = re.compile(r"https://egame\.qq\.com/(?P<channel>\d+)")
     _room_json_re = re.compile(r"window\._playerInfo\s*=\s*({.*});")
 
     data_schema = validate.Schema({
         "vid": validate.text,
         "urlArray": [{"playUrl": validate.text}],
     })
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     @classmethod
     def stream_weight(cls, stream):

--- a/src/streamlink/plugins/eltrecetv.py
+++ b/src/streamlink/plugins/eltrecetv.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -9,13 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?eltrecetv\.com\.ar/.+"
+))
 class ElTreceTV(Plugin):
-    _url_re = re.compile(r'https?://(?:www\.)?eltrecetv.com.ar/.+')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
-
     def _get_streams(self):
         if "eltrecetv.com.ar/vivo" in self.url.lower():
             try:

--- a/src/streamlink/plugins/euronews.py
+++ b/src/streamlink/plugins/euronews.py
@@ -1,19 +1,16 @@
 import re
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HTTPStream
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:\w+\.)*euronews\.com/'
+))
 class Euronews(Plugin):
-    _url_re = re.compile(r'https?://(?:\w+\.)*euronews\.com/')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
-
     def _get_vod_stream(self):
         def find_video_url(content):
             for elem in itertags(content, "meta"):

--- a/src/streamlink/plugins/foxtr.py
+++ b/src/streamlink/plugins/foxtr.py
@@ -1,25 +1,14 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?fox(?:play)?\.com\.tr/"
+))
 class FoxTR(Plugin):
-    """
-    Support for Turkish Fox live stream: http://www.fox.com.tr/canli-yayin
-    """
-
-    url_re = re.compile(r"""
-        https?://(?:www.)?
-        (?:fox.com.tr/.*|
-           foxplay.com.tr/.*)
-    """, re.VERBOSE)
-
     playervars_re = re.compile(r"source\s*:\s*\[\s*\{\s*videoSrc\s*:\s*(?:mobilecheck\(\)\s*\?\s*)?'([^']+)'")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -2,7 +2,7 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
@@ -152,6 +152,9 @@ class Experience:
         return self.token is not None
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?funimation(\.com|now\.uk)"
+))
 class FunimationNow(Plugin):
     arguments = PluginArguments(
         PluginArgument(
@@ -180,15 +183,8 @@ class FunimationNow(Plugin):
         PluginArgument("mux-subtitles", is_global=True)
     )
 
-    url_re = re.compile(r"""
-        https?://(?:www\.)funimation(.com|now.uk)
-    """, re.VERBOSE)
     experience_id_re = re.compile(r"/player/(\d+)")
     mp4_quality = "480p"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         self.session.http.headers = {"User-Agent": useragents.CHROME}

--- a/src/streamlink/plugins/galatasaraytv.py
+++ b/src/streamlink/plugins/galatasaraytv.py
@@ -1,19 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?galatasaray\.com"
+))
 class GalatasarayTV(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?galatasaray\.com")
     playervars_re = re.compile(r"sources\s*:\s*\[\s*\{\s*type\s*:\s*\"(.*?)\",\s*src\s*:\s*\"(.*?)\"", re.DOTALL)
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_title(self):
         return "Galatasaray TV"

--- a/src/streamlink/plugins/gardenersworld.py
+++ b/src/streamlink/plugins/gardenersworld.py
@@ -2,20 +2,17 @@ import logging
 import re
 
 from streamlink import NoPluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?gardenersworld\.com/"
+))
 class GardenersWorld(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?gardenersworld\.com/")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
         page = self.session.http.get(self.url)
         for iframe in itertags(page.text, "iframe"):

--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -1,13 +1,15 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?goltelevision\.com/live"
+))
 class GOLTelevision(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?goltelevision\.com/live")
     api_url = "https://api.goltelevision.com/api/v1/media/hls/service/live"
     api_schema = validate.Schema(validate.transform(parse_json), {
         "code": 200,
@@ -17,10 +19,6 @@ class GOLTelevision(Plugin):
             }
         }
     }, validate.get("message"), validate.get("success"), validate.get("manifest"))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         return HLSStream.parse_variant_playlist(self.session,

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
@@ -15,16 +15,14 @@ QUALITIES = {
     "240p": "_240"
 }
 
-_url_re = re.compile(r"https?://(?:www\.)?goodgame.ru/channel/(?P<user>[^/]+)")
 _apidata_re = re.compile(r'''(?P<quote>["']?)channel(?P=quote)\s*:\s*(?P<data>{.*?})\s*,''')
 _ddos_re = re.compile(r'document.cookie="(__DDOS_[^;]+)')
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?goodgame\.ru/channel/(?P<user>[^/]+)"
+))
 class GoodGame(Plugin):
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url)
-
     def _check_stream(self, url):
         res = self.session.http.get(url, acceptable_status=(200, 404))
         if res.status_code == 200:

--- a/src/streamlink/plugins/googledrive.py
+++ b/src/streamlink/plugins/googledrive.py
@@ -2,22 +2,20 @@ import logging
 import re
 from urllib.parse import parse_qsl
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HTTPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:drive|docs)\.google\.com/file/d/([^/]+)/?"
+))
 class GoogleDocs(Plugin):
-    url_re = re.compile(r"https?://(?:drive|docs)\.google\.com/file/d/([^/]+)/?")
     api_url = "https://docs.google.com/get_video_info"
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
-        docid = self.url_re.match(self.url).group(1)
+        docid = self.match.group(1)
         log.debug("Google Docs ID: {0}".format(docid))
         res = self.session.http.get(self.api_url, params=dict(docid=docid))
         data = dict(parse_qsl(res.text))

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
@@ -9,11 +9,13 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://replay\.gulli\.fr/(?:Direct|.+/(?P<video_id>VOD\d+))'
+))
 class Gulli(Plugin):
     LIVE_PLAYER_URL = 'https://replay.gulli.fr/jwplayer/embedstreamtv'
     VOD_PLAYER_URL = 'https://replay.gulli.fr/jwplayer/embed/{0}'
 
-    _url_re = re.compile(r'https?://replay\.gulli\.fr/(?:Direct|.+/(?P<video_id>VOD[0-9]+))')
     _playlist_re = re.compile(r'sources: (\[.+?\])', re.DOTALL)
     _vod_video_index_re = re.compile(r'jwplayer\(idplayer\).playlistItem\((?P<video_index>[0-9]+)\)')
     _mp4_bitrate_re = re.compile(r'.*_(?P<bitrate>[0-9]+)\.mp4')
@@ -31,13 +33,8 @@ class Gulli(Plugin):
         )
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return Gulli._url_re.match(url)
-
     def _get_streams(self):
-        match = self._url_re.match(self.url)
-        video_id = match.group('video_id')
+        video_id = self.match.group('video_id')
         if video_id is not None:
             # VOD
             live = False

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -1,47 +1,28 @@
+import logging
 import re
-from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, parse_url_params
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.plugin import LOW_PRIORITY, parse_params
 from streamlink.stream import HDSStream
 from streamlink.utils import update_scheme
 
+log = logging.getLogger(__name__)
 
+
+@pluginmatcher(re.compile(
+    r"hds://(?P<url>\S+)(?:\s(?P<params>.+))?"
+))
+@pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
+    r"(?P<url>\S+\.f4m(?:\?\S*)?)(?:\s(?P<params>.+))?"
+))
 class HDSPlugin(Plugin):
-    _url_re = re.compile(r"(hds://)?(.+(?:\.f4m)?.*)")
-
-    @classmethod
-    def priority(cls, url):
-        """
-        Returns LOW priority if the URL is not prefixed with hds:// but ends with
-        .f4m and return NORMAL priority if the URL is prefixed.
-        :param url: the URL to find the plugin priority for
-        :return: plugin priority for the given URL
-        """
-        m = cls._url_re.match(url)
-        if m:
-            prefix, url = cls._url_re.match(url).groups()
-            url_path = urlparse(url).path
-            if prefix is None and url_path.endswith(".f4m"):
-                return LOW_PRIORITY
-            elif prefix is not None:
-                return NORMAL_PRIORITY
-        return NO_PRIORITY
-
-    @classmethod
-    def can_handle_url(cls, url):
-        m = cls._url_re.match(url)
-        if m:
-            url_path = urlparse(m.group(2)).path
-            return m.group(1) is not None or url_path.endswith(".f4m")
-
     def _get_streams(self):
-        url, params = parse_url_params(self.url)
+        data = self.match.groupdict()
+        url = update_scheme("http://", data.get("url"))
+        params = parse_params(data.get("params"))
+        log.debug(f"URL={url}; params={params}")
 
-        urlnoproto = self._url_re.match(url).group(2)
-        urlnoproto = update_scheme("http://", urlnoproto)
-
-        return HDSStream.parse_manifest(self.session, urlnoproto, **params)
+        return HDSStream.parse_manifest(self.session, url, **params)
 
 
 __plugin__ = HDSPlugin

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -1,54 +1,30 @@
 import logging
 import re
-from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, parse_url_params
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.plugin import LOW_PRIORITY, parse_params
 from streamlink.stream import HLSStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"hls(?:variant)?://(?P<url>\S+)(?:\s(?P<params>.+))?"
+))
+@pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
+    r"(?P<url>\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?"
+))
 class HLSPlugin(Plugin):
-    _url_re = re.compile(r"(hls(?:variant)?://)?(.+(?:\.m3u8)?.*)")
-
-    @classmethod
-    def priority(cls, url):
-        """
-        Returns LOW priority if the URL is not prefixed with hls:// but ends with
-        .m3u8 and return NORMAL priority if the URL is prefixed.
-        :param url: the URL to find the plugin priority for
-        :return: plugin priority for the given URL
-        """
-        m = cls._url_re.match(url)
-        if m:
-            prefix, url = cls._url_re.match(url).groups()
-            url_path = urlparse(url).path
-            if prefix is None and url_path.endswith(".m3u8"):
-                return LOW_PRIORITY
-            elif prefix is not None:
-                return NORMAL_PRIORITY
-        return NO_PRIORITY
-
-    @classmethod
-    def can_handle_url(cls, url):
-        m = cls._url_re.match(url)
-        if m:
-            url_path = urlparse(m.group(2)).path
-            return m.group(1) is not None or url_path.endswith(".m3u8")
-
     def _get_streams(self):
-        url, params = parse_url_params(self.url)
-        urlnoproto = self._url_re.match(url).group(2)
-        urlnoproto = update_scheme("http://", urlnoproto)
+        data = self.match.groupdict()
+        url = update_scheme("http://", data.get("url"))
+        params = parse_params(data.get("params"))
+        log.debug(f"URL={url}; params={params}")
 
-        log.debug("URL={0}; params={1}".format(urlnoproto, params))
-        streams = HLSStream.parse_variant_playlist(self.session, urlnoproto, **params)
-        if not streams:
-            return {"live": HLSStream(self.session, urlnoproto, **params)}
-        else:
-            return streams
+        streams = HLSStream.parse_variant_playlist(self.session, url, **params)
+
+        return streams if streams else {"live": HLSStream(self.session, url, **params)}
 
 
 __plugin__ = HLSPlugin

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -1,28 +1,25 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
-from streamlink.plugin.plugin import parse_url_params
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.plugin import parse_params
 from streamlink.stream import HTTPStream
 from streamlink.utils import update_scheme
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"httpstream://(?P<url>\S+)(?:\s(?P<params>.+))?"
+))
 class HTTPStreamPlugin(Plugin):
-    _url_re = re.compile(r"httpstream://(.+)")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        url, params = parse_url_params(self.url)
-        urlnoproto = self._url_re.match(url).group(1)
-        urlnoproto = update_scheme("http://", urlnoproto)
+        data = self.match.groupdict()
+        url = update_scheme("http://", data.get("url"))
+        params = parse_params(data.get("params"))
+        log.debug(f"URL={url}; params={params}")
 
-        log.debug("URL={0}; params={1}".format(urlnoproto, params))
-        return {"live": HTTPStream(self.session, urlnoproto, **params)}
+        return {"live": HTTPStream(self.session, url, **params)}
 
 
 __plugin__ = HTTPStreamPlugin

--- a/src/streamlink/plugins/huajiao.py
+++ b/src/streamlink/plugins/huajiao.py
@@ -5,7 +5,7 @@ import re
 import time
 import uuid
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.useragents import CHROME as USER_AGENT
 from streamlink.stream import (HLSStream, HTTPStream)
@@ -13,11 +13,6 @@ from streamlink.stream import (HLSStream, HTTPStream)
 HUAJIAO_URL = "http://www.huajiao.com/l/{}"
 LAPI_URL = "http://g2.live.360.cn/liveplay?stype=flv&channel={}&bid=huajiao&sn={}&sid={}&_rate=xd&ts={}&r={}" \
            "&_ostype=flash&_delay=0&_sign=null&_ver=13"
-
-_url_re = re.compile(r"""
-        http(s)?://(www\.)?huajiao.com
-        /l/(?P<channel>[^/]+)
-""", re.VERBOSE)
 
 _feed_json_re = re.compile(r'^\s*var\s*feed\s*=\s*(?P<feed>{.*})\s*;', re.MULTILINE)
 
@@ -35,14 +30,12 @@ _feed_json_schema = validate.Schema(
 )
 
 
+@pluginmatcher(re.compile(
+    r"https?://(www\.)?huajiao\.com/l/(?P<channel>[^/]+)"
+))
 class Huajiao(Plugin):
-    @classmethod
-    def can_handle_url(self, url):
-        return _url_re.match(url)
-
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        channel = match.group("channel")
+        channel = self.match.group("channel")
 
         self.session.http.headers.update({"User-Agent": USER_AGENT})
         self.session.http.verify = False

--- a/src/streamlink/plugins/huomao.py
+++ b/src/streamlink/plugins/huomao.py
@@ -3,8 +3,7 @@ import logging
 import re
 import time
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -12,6 +11,9 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?huomao\.(?:tv|com)(?P<path>/|/video/v/)(?P<room_id>\d+)'
+))
 class Huomao(Plugin):
     magic_val = '6FE26D855E1AEAE090E243EB1AF73685'
     mobile_url = 'https://m.huomao.com/mobile/mob_live/{0}'
@@ -21,12 +23,6 @@ class Huomao(Plugin):
     author = None
     category = None
     title = None
-
-    url_re = re.compile(r'''
-        (?:https?://)?(?:www\.)?huomao(?:\.tv|\.com)
-        (?P<path>/|/video/v/)
-        (?P<room_id>\d+)
-    ''', re.VERBOSE)
 
     author_re = re.compile(
         r'<p class="nickname_live">\s*<span>\s*(.*?)\s*</span>',
@@ -61,10 +57,6 @@ class Huomao(Plugin):
             }],
         ),
     })
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_live_streams_data(self, video_id):
         client_type = 'huomaomobileh5'
@@ -184,7 +176,7 @@ class Huomao(Plugin):
             return self.title
 
     def _get_streams(self):
-        path, url_id = self.url_re.search(self.url).groups()
+        path, url_id = self.match.groups()
         log.debug("Path={0}".format(path))
         log.debug("URL ID={0}".format(url_id))
 

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -3,7 +3,7 @@ import logging
 import re
 from html import unescape as html_unescape
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
 from streamlink.utils import parse_json
@@ -11,8 +11,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?huya\.com/(?P<channel>[^/]+)'
+))
 class Huya(Plugin):
-    _re_url = re.compile(r'https?://(?:www\.)?huya\.com/(?P<channel>[^/]+)')
     _re_stream = re.compile(r'"stream"\s?:\s?"([^"]+)"')
     _schema_data = validate.Schema(
         {
@@ -42,10 +44,6 @@ class Huya(Plugin):
         validate.get('gameStreamInfoList'),
     )
     QUALITY_WEIGHTS = {}
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     @classmethod
     def stream_weight(cls, key):

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -1,17 +1,18 @@
-
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, update_scheme
 
 
+@pluginmatcher(re.compile(
+    r'https?://www\.idf1\.fr/(videos/[^/]+/[^/]+\.html|live\b)'
+))
 class IDF1(Plugin):
     DACAST_API_URL = 'https://json.dacast.com/b/{}/{}/{}'
     DACAST_TOKEN_URL = 'https://services.dacast.com/token/i/b/{}/{}/{}'
 
-    _url_re = re.compile(r'https?://www\.idf1\.fr/(videos/[^/]+/[^/]+\.html|live\b)')
     _video_id_re = re.compile(r"""
             dacast\('(?P<broadcaster_id>\d+)_(?P<video_type>[a-z]+)_(?P<video_id>\d+)',\s*'replay_content',\s*data\);
         """, re.VERBOSE)
@@ -47,10 +48,6 @@ class IDF1(Plugin):
     )
 
     _user_agent = useragents.IE_11
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return IDF1._url_re.match(url)
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/invintus.py
+++ b/src/streamlink/plugins/invintus.py
@@ -1,34 +1,31 @@
 import json
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils.url import update_scheme
 
 
+@pluginmatcher(re.compile(
+    r"https?://player\.invintus\.com/\?clientID=(\d+)&eventID=(\d+)"
+))
 class InvintusMedia(Plugin):
     WSC_API_KEY = "7WhiEBzijpritypp8bqcU7pfU9uicDR"  # hard coded in the middle of https://player.invintus.com/app.js
     API_URL = "https://api.v3.invintusmedia.com/v2/Event/getDetailed"
 
-    url_re = re.compile(r"https?://player\.invintus\.com/\?clientID=(\d+)&eventID=(\d+)")
     api_response_schema = validate.Schema({"data": {"streamingURIs": {"main": validate.url()}}})
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
-        m = self.url_re.match(self.url)
         postdata = {
-            "clientID": m.group(1),
+            "clientID": self.match.group(1),
             "showEncoder": True,
             "showMediaAssets": True,
             "showStreams": True,
             "includePrivate": False,
             "advancedDetails": True,
             "VAST": True,
-            "eventID": m.group(2)
+            "eventID": self.match.group(2)
         }
         headers = {
             "Content-Type": "application/json",

--- a/src/streamlink/plugins/latina.py
+++ b/src/streamlink/plugins/latina.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -9,13 +9,10 @@ from streamlink.stream import HLSStream
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?latina\.pe/tvenvivo"
+))
 class Latina(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?latina\.pe/tvenvivo")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def get_title(self):
         return "Latina"
 

--- a/src/streamlink/plugins/live_russia_tv.py
+++ b/src/streamlink/plugins/live_russia_tv.py
@@ -2,22 +2,20 @@ import logging
 import re
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:live\.)?russia\.tv/(?:channel/(?P<channel>\d+))?"
+))
 class LiveRussia(Plugin):
-    url_re = re.compile(r'https?://(?:live\.)?russia\.tv/(?:channel/(?P<channel>[0-9]+))?')
     _data_re = re.compile(r"""window\.pl\.data\.([\w_]+)\s*=\s*['"]?(.*?)['"]?;""")
 
     DATA_LIVE_URL = 'https:{domain}/iframe/datalive/id/{id}/sid/{sid}'
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_iframe_url(self, url):
         res = self.session.http.get(url)
@@ -47,7 +45,7 @@ class LiveRussia(Plugin):
     def _get_streams(self):
         info_url = None
 
-        channel = self.url_re.match(self.url).group('channel')
+        channel = self.match.group('channel')
         if channel:
             log.debug('Channel: {0}'.format(channel))
             API_URL = 'https://live.russia.tv/api/now/channel/{0}'

--- a/src/streamlink/plugins/liveedu.py
+++ b/src/streamlink/plugins/liveedu.py
@@ -2,17 +2,18 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink import PluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:\w+\.)?(?:livecoding|liveedu)\.tv/"
+))
 class LiveEdu(Plugin):
     login_url = "https://www.liveedu.tv/accounts/login/"
-    url_re = re.compile(r"https?://(?:\w+\.)?(?:livecoding|liveedu)\.tv/")
     config_re = re.compile(r"""\Wconfig.(?P<key>\w+)\s*=\s*(?P<q>['"])(?P<value>.*?)(?P=q);""")
     csrf_re = re.compile(r'''"csrfToken"\s*:\s*"(\w+)"''')
     api_schema = validate.Schema({
@@ -46,10 +47,6 @@ class LiveEdu(Plugin):
             help="A LiveEdu account password to use with --liveedu-email."
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def login(self):
         """

--- a/src/streamlink/plugins/liveme.py
+++ b/src/streamlink/plugins/liveme.py
@@ -3,15 +3,17 @@ import random
 import re
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(www\.)?liveme\.com/live\.html\?videoid=(\d+)"
+))
 class LiveMe(Plugin):
-    url_re = re.compile(r"https?://(www\.)?liveme\.com/live\.html\?videoid=(\d+)")
     api_url = "https://live.ksmobile.net/live/queryinfo"
     api_schema = validate.Schema(validate.all({
         "status": "200",
@@ -22,10 +24,6 @@ class LiveMe(Plugin):
             }
         }
     }, validate.get("data")))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _random_t(self, t):
         return "".join(random.choice("ABCDEFGHJKMNPQRSTWXYZabcdefhijkmnprstwxyz2345678") for _ in range(t))

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
@@ -9,8 +9,10 @@ from streamlink.stream import HLSStream
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?livestream\.com/"
+))
 class Livestream(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?livestream\.com/")
     _config_re = re.compile(r"window.config = ({.+})")
     _stream_config_schema = validate.Schema(validate.any({
         "event": {
@@ -20,10 +22,6 @@ class Livestream(Plugin):
             }, None),
         }
     }, {}), validate.get("event", {}), validate.get("stream_info", {}))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/lrt.py
+++ b/src/streamlink/plugins/lrt.py
@@ -1,20 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?lrt\.lt/mediateka/tiesiogiai/"
+))
 class LRT(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?lrt.lt/mediateka/tiesiogiai/.")
     _video_id_re = re.compile(r"""var\svideo_id\s*=\s*["'](?P<video_id>\w+)["']""")
     API_URL = "https://www.lrt.lt/servisai/stream_url/live/get_live_url.php?channel={0}"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     def _get_streams(self):
         page = self.session.http.get(self.url)

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -2,23 +2,20 @@ import logging
 import re
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://ltv\.lsm\.lv/lv/tieshraide"
+))
 class LtvLsmLv(Plugin):
     """
     Support for Latvian live channels streams on ltv.lsm.lv
     """
-    url_re = re.compile(r"https?://ltv\.lsm\.lv/lv/tieshraide")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
         self.session.http.headers.update({"Referer": self.url})
 

--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import unquote, urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, update_scheme
@@ -11,10 +11,11 @@ from streamlink.utils import parse_json, update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?(?:mediaklikk|m4sport|hirado|petofilive)\.hu/"
+))
 class Mediaklikk(Plugin):
     PLAYER_URL = "https://player.mediaklikk.hu/playernew/player.php"
-
-    _url_re = re.compile(r"https?://(?:www\.)?(?:mediaklikk|m4sport|hirado|petofilive)\.hu/")
 
     _re_player_manager = re.compile(r"""
         mtva_player_manager\.player\s*\(\s*
@@ -23,10 +24,6 @@ class Mediaklikk(Plugin):
         \)\s*;
     """, re.VERBOSE | re.DOTALL)
     _re_player_json = re.compile(r"pl\.setup\s*\(\s*(?P<json>{.*?})\s*\)\s*;", re.DOTALL)
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         params = self.session.http.get(self.url, schema=validate.Schema(

--- a/src/streamlink/plugins/mediavitrina.py
+++ b/src/streamlink/plugins/mediavitrina.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -10,25 +10,18 @@ from streamlink.utils.url import update_qsd
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?P<channel>ctc(?:love)?|chetv|domashniy|5-tv)\.ru/(?:online|live)"
+))
+@pluginmatcher(re.compile(
+    r"https?://(?P<channel>ren)\.tv/live"
+))
+@pluginmatcher(re.compile(
+    r"https?://player\.mediavitrina\.ru/(?P<channel>[^/?]+.)(?:/[^/]+)?/\w+/player\.html"
+))
 class MediaVitrina(Plugin):
-    _re_url_1 = re.compile(r'https?://(?P<channel>ctc(?:love)?|chetv|domashniy|5-tv)\.ru/(?:online|live)')
-    _re_url_2 = re.compile(r'https?://(?P<channel>ren)\.tv/live')
-    _re_url_3 = re.compile(r'https?://player\.mediavitrina\.ru/(?P<channel>[^/?]+.)(?:/[^/]+)?/[\w_]+/player\.html')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return (
-            cls._re_url_1.match(url) is not None
-            or cls._re_url_2.match(url) is not None
-            or cls._re_url_3.match(url) is not None
-        )
-
     def _get_streams(self):
-        channel = (self._re_url_1.match(self.url)
-                   or self._re_url_2.match(self.url)
-                   or self._re_url_3.match(self.url)
-                   ).group("channel")
-
+        channel = self.match.group("channel")
         channels = [
             # ((channels), (path, channel))
             (("5-tv", "tv-5", "5tv"), ("tv5", "tv-5")),

--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, parse_qsd
@@ -10,9 +10,10 @@ from streamlink.utils.url import update_qsd
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?mitele\.es/directo/(?P<channel>[\w-]+)"
+))
 class Mitele(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?mitele\.es/directo/(?P<channel>[\w-]+)")
-
     caronte_url = "https://caronte.mediaset.es/delivery/channel/mmc/{channel}/mtweb"
     gbx_url = "https://mab.mediaset.es/1.0.0/get?oid=mtmw&eid=%2Fapi%2Fmtmw%2Fv2%2Fgbx%2Fmtweb%2Flive%2Fmmc%2F{channel}"
 
@@ -50,12 +51,8 @@ class Mitele(Plugin):
         4038: "User has no privileges"
     }
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        channel = self._url_re.match(self.url).group("channel")
+        channel = self.match.group("channel")
 
         pdata = self.session.http.get(self.caronte_url.format(channel=channel),
                                       acceptable_status=(200, 403, 404),

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import unpad
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -14,9 +14,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?mjunoon\.tv/(?:watch/)?([\w-]+)'
+))
 class Mjunoon(Plugin):
-    url_re = re.compile(r'https?://(?:www\.)?mjunoon\.tv/(?:watch/)?([\w-]+)')
-
     login_url = 'https://cdn2.mjunoon.tv:9191/v2/auth/login'
     stream_url = 'https://cdn2.mjunoon.tv:9191/v2/streaming-url'
 
@@ -63,10 +64,6 @@ class Mjunoon(Plugin):
     author = None
     category = None
     title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_author(self):
         return self.author
@@ -169,8 +166,7 @@ class Mjunoon(Plugin):
         return stream_data['live_stream_url']
 
     def _get_streams(self):
-        m = self.url_re.match(self.url)
-        slug = m.group(1)
+        slug = self.match.group(1)
         log.debug(f'Slug={slug}')
 
         js_data = self.get_data()

--- a/src/streamlink/plugins/mrtmk.py
+++ b/src/streamlink/plugins/mrtmk.py
@@ -1,15 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://play\.mrt\.com\.mk/(live|play)/"
+))
 class MRTmk(Plugin):
-    url_re = re.compile(r"""https?://play\.mrt\.com\.mk/(live|play)/""")
     file_re = re.compile(r"""(?P<url>https?://vod-[\d\w]+\.interspace\.com[^"',]+\.m3u8[^"',]*)""")
 
     stream_schema = validate.Schema(
@@ -22,10 +24,6 @@ class MRTmk(Plugin):
             validate.transform(list),
         ),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/nbc.py
+++ b/src/streamlink/plugins/nbc.py
@@ -1,17 +1,15 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugins.theplatform import ThePlatform
 from streamlink.utils import update_scheme
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?nbc\.com"
+))
 class NBC(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?nbc\.com")
     embed_url_re = re.compile(r'''(?P<q>["'])embedURL(?P=q)\s*:\s*(?P<q2>["'])(?P<url>.*?)(?P=q2)''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/nbcnews.py
+++ b/src/streamlink/plugins/nbcnews.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -9,8 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?nbcnews\.com/now'
+))
 class NBCNews(Plugin):
-    url_re = re.compile(r'https?://(?:www\.)?nbcnews\.com/now')
     json_data_re = re.compile(
         r'<script id="__NEXT_DATA__" type="application/json">({.*})</script>'
     )
@@ -61,10 +63,6 @@ class NBCNews(Plugin):
         validate.get(0),
         validate.get('tokenizedUrl'),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_title(self):
         return 'NBC News Now'

--- a/src/streamlink/plugins/nbcsports.py
+++ b/src/streamlink/plugins/nbcsports.py
@@ -1,17 +1,15 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugins.theplatform import ThePlatform
 from streamlink.utils import update_scheme
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?nbcsports\.com"
+))
 class NBCSports(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?nbcsports\.com")
     embed_url_re = re.compile(r'''id\s*=\s*"vod-player".*?\ssrc\s*=\s*"(?P<url>.*?)"''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/nhkworld.py
+++ b/src/streamlink/plugins/nhkworld.py
@@ -1,23 +1,18 @@
-"""Plugin for NHK World, NHK Japan's english TV channel."""
-
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 API_URL = "http://{}.nhk.or.jp/nhkworld/app/tv/hlslive_web.json"
 
-_url_re = re.compile(r"http(?:s)?://(?:(\w+)\.)?nhk.or.jp/nhkworld")
 
-
+@pluginmatcher(re.compile(
+    r"https?://(?:(\w+)\.)?nhk\.or\.jp/nhkworld"
+))
 class NHKWorld(Plugin):
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url) is not None
-
     def _get_streams(self):
         # get the HLS json from the same sub domain as the main url, defaulting to www
-        sdomain = _url_re.match(self.url).group(1) or "www"
+        sdomain = self.match.group(1) or "www"
         res = self.session.http.get(API_URL.format(sdomain))
 
         stream_url = self.session.http.json(res)['main']['wstrm']

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -8,16 +8,13 @@ from urllib.parse import unquote_plus, urlparse
 import websocket
 
 from streamlink import logger
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils.times import hours_minutes_seconds
 from streamlink.utils.url import update_qsd
 
 _log = logging.getLogger(__name__)
-
-_url_re = re.compile(
-    r"^https?://(?P<domain>live[0-9]*\.nicovideo\.jp)/watch/lv[0-9]*")
 
 _login_url = "https://account.nicovideo.jp/login/redirector"
 
@@ -27,6 +24,9 @@ _login_url_params = {
     "next_url": "/"}
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?P<domain>live\d*\.nicovideo\.jp)/watch/lv\d*"
+))
 class NicoLive(Plugin):
     arguments = PluginArguments(
         PluginArgument(
@@ -74,10 +74,6 @@ class NicoLive(Plugin):
     _ws = None
 
     frontend_id = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url) is not None
 
     def _get_streams(self):
         if self.options.get("purge_credentials"):

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -9,8 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?nimo\.tv/(?P<username>.*)'
+))
 class NimoTV(Plugin):
-    url_re = re.compile(r'https?://(?:www\.)?nimo\.tv/(?P<username>.*)')
     data_url = 'https://m.nimo.tv/{0}'
     data_re = re.compile(r'<script>var G_roomBaseInfo = ({.*?});</script>')
 
@@ -48,10 +50,6 @@ class NimoTV(Plugin):
         6000: '1080p',
     }
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def get_author(self):
         if self.author is not None:
             return self.author
@@ -65,10 +63,8 @@ class NimoTV(Plugin):
             return self.title
 
     def _get_streams(self):
-        m = self.url_re.match(self.url)
-        if m and m.group('username'):
-            username = m.group('username')
-        else:
+        username = self.match.group('username')
+        if not username:
             return
 
         headers = {'User-Agent': useragents.ANDROID}

--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -10,26 +10,16 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:\w+\.)?nos\.nl/(?:livestream|collectie|video|uitzendingen)",
+))
 class NOS(Plugin):
-    _re_url = re.compile(r"""https?://(?:\w+\.)?nos\.nl/(?:
-        livestream
-        |
-        collectie
-        |
-        video
-        |
-        uitzendingen
-    )""", re.VERBOSE)
     _msg_live_offline = "This livestream is offline."
     title = None
     vod_keys = {
         "pages/Collection/Video/Video": "item",
         "pages/Video/Video": "video",
     }
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     def get_title(self):
         return self.title

--- a/src/streamlink/plugins/nownews.py
+++ b/src/streamlink/plugins/nownews.py
@@ -2,22 +2,20 @@ import json
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://news\.now\.com/home/live"
+))
 class NowNews(Plugin):
-    _url_re = re.compile(r"https?://news\.now\.com/home/live")
     epg_re = re.compile(r'''epg.getEPG\("(\d+)"\);''')
     api_url = "https://hkt-mobile-api.nowtv.now.com/09/1/getLiveURL"
     backup_332_api = "https://d7lz7jwg8uwgn.cloudfront.net/apps_resource/news/live.json"
     backup_332_stream = "https://d3i3yn6xwv1jpw.cloudfront.net/live/now332/playlist.m3u8"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/ntv.py
+++ b/src/streamlink/plugins/ntv.py
@@ -1,16 +1,13 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 
+@pluginmatcher(re.compile(
+    r'https?://www\.ntv\.ru/air/'
+))
 class NTV(Plugin):
-    url_re = re.compile(r'https?://www.ntv.ru/air/.*')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
         body = self.session.http.get(self.url).text
         mrl = None

--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -3,8 +3,7 @@ import re
 from html import unescape as html_unescape
 from urllib.parse import unquote
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 from streamlink.utils import parse_json
@@ -12,10 +11,11 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?ok\.ru/'
+))
 class OKru(Plugin):
-
     _data_re = re.compile(r'''data-options=(?P<q>["'])(?P<data>{[^"']+})(?P=q)''')
-    _url_re = re.compile(r'''https?://(?:www\.)?ok\.ru/''')
 
     _metadata_schema = validate.Schema(
         validate.transform(parse_json),
@@ -62,10 +62,6 @@ class OKru(Plugin):
         'lowest': 240,
         'mobile': 144,
     }
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     @classmethod
     def stream_weight(cls, key):

--- a/src/streamlink/plugins/olympicchannel.py
+++ b/src/streamlink/plugins/olympicchannel.py
@@ -4,7 +4,7 @@ from html import unescape as html_unescape
 from time import time
 from urllib.parse import urljoin, urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -12,8 +12,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(\w+\.)?(?:olympics|olympicchannel)\.com/(?:[\w-]+/)?../.+"
+))
 class OlympicChannel(Plugin):
-    _url_re = re.compile(r"https?://(\w+\.)?(?:olympics|olympicchannel)\.com/(?:[\w-]+/)?../.+")
     _token_api_path = "/tokenGenerator?url={url}&domain={netloc}&_ts={time}"
     _api_schema = validate.Schema(
         validate.transform(parse_json),
@@ -42,10 +44,6 @@ class OlympicChannel(Plugin):
         validate.transform(parse_json),
         validate.url(),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     def _get_streams(self):
         api_url = self.session.http.get(self.url, schema=self._data_content_schema)

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -4,8 +4,7 @@ from base64 import b64decode
 from html.parser import HTMLParser
 from urllib.parse import urlparse
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -35,8 +34,10 @@ class Iframe_Parser(HTMLParser):
             self.data = data
 
 
+@pluginmatcher(re.compile(
+    r"https?://1plus1\.video/tvguide/.*/online"
+))
 class OnePlusOne(Plugin):
-    url_re = re.compile(r'https://1plus1\.video/tvguide/.*/online')
     data_re = re.compile(r"ovva-player\",\"([^\"]*)\"\)")
     ovva_data_schema = validate.Schema({
         "balancer": validate.url()
@@ -46,10 +47,6 @@ class OnePlusOne(Plugin):
         ['302', validate.url()],
         validate.get(1)
     ))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def find_iframe(self, res):
         parser = Online_Parser()

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -3,7 +3,7 @@ import random
 import re
 from urllib.parse import unquote
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.plugin import stream_weight
 from streamlink.stream import HLSStream
@@ -13,13 +13,10 @@ from streamlink.utils.url import update_qsd
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?1tv\.ru/live"
+))
 class OneTV(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?1tv\.ru/live")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     @classmethod
     def stream_weight(cls, stream):
         return dict(ld=(140, "pixels"), sd=(360, "pixels"), hd=(720, "pixels")).get(stream, stream_weight(stream))

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -1,15 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?openrec\.tv/(?:live|movie)/(?P<id>[^/]+)"
+))
 class OPENRECtv(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?openrec.tv/(?:live|movie)/(?P<id>[^/]+)")
     _stores_re = re.compile(r"window.stores\s*=\s*({.*?});", re.DOTALL | re.MULTILINE)
     _config_re = re.compile(r"window.sharedConfig\s*=\s*({.*?});", re.DOTALL | re.MULTILINE)
 
@@ -55,10 +57,6 @@ class OPENRECtv(Plugin):
         self.author = None
         self.title = None
         self.video_id = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def login(self, email, password):
         res = self.session.http.post(self.login_url, data={"mail": email, "password": password})

--- a/src/streamlink/plugins/orf_tvthek.py
+++ b/src/streamlink/plugins/orf_tvthek.py
@@ -1,28 +1,26 @@
 import json
 import re
 
-from streamlink.plugin import Plugin, PluginError
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.stream import HLSStream
 
-_stream_url_re = re.compile(r'https?://tvthek\.orf\.at/(index\.php/)?live/(?P<title>[^/]+)/(?P<id>[0-9]+)')
-_vod_url_re = re.compile(r'''
-    https?://tvthek\.orf\.at/pro(gram|file)
-    /(?P<showtitle>[^/]+)/(?P<showid>[0-9]+)
-    /(?P<episodetitle>[^/]+)/(?P<epsiodeid>[0-9]+)
-    (/(?P<segmenttitle>[^/]+)/(?P<segmentid>[0-9]+))?
-''', re.VERBOSE)
 _json_re = re.compile(r'<div class="jsb_ jsb_VideoPlaylist" data-jsb="(?P<json>[^"]+)">')
 
 MODE_STREAM, MODE_VOD = 0, 1
 
 
+@pluginmatcher(re.compile(
+    r"https?://tvthek\.orf\.at/(index\.php/)?live/(?P<title>[^/]+)/(?P<id>\d+)"
+))
+@pluginmatcher(re.compile(r"""
+    https?://tvthek\.orf\.at/pro(gram|file)
+    /(?P<showtitle>[^/]+)/(?P<showid>\d+)
+    /(?P<episodetitle>[^/]+)/(?P<epsiodeid>\d+)
+    (/(?P<segmenttitle>[^/]+)/(?P<segmentid>\d+))?
+""", re.VERBOSE))
 class ORFTVThek(Plugin):
-    @classmethod
-    def can_handle_url(self, url):
-        return _stream_url_re.match(url) or _vod_url_re.match(url)
-
     def _get_streams(self):
-        if _stream_url_re.match(self.url):
+        if self.matches[0]:
             mode = MODE_STREAM
         else:
             mode = MODE_VOD

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -1,21 +1,20 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?picarto\.tv/
+    (?:(?P<po>streampopout|videopopout)/)?
+    (?P<user>[^&?/]+)
+    (?:\?tab=videos&id=(?P<vod_id>\d+))?
+""", re.VERBOSE))
 class Picarto(Plugin):
-    url_re = re.compile(r'''
-        https?://(?:www\.)?picarto\.tv/
-            (?:(?P<po>streampopout|videopopout)/)?
-            (?P<user>[^&?/]+)
-            (?:\?tab=videos&id=(?P<vod_id>\d+))?
-    ''', re.VERBOSE)
-
     channel_schema = validate.Schema({
         'channel': validate.any(None, {
             'stream_name': str,
@@ -49,10 +48,6 @@ class Picarto(Plugin):
     author = None
     category = None
     title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_author(self):
         return self.author
@@ -130,7 +125,7 @@ class Picarto(Plugin):
                                                                     origin='recording-eu-1'))
 
     def _get_streams(self):
-        m = self.url_re.match(self.url).groupdict()
+        m = self.match.groupdict()
 
         if (m['po'] == 'streampopout' or not m['po']) and m['user'] and not m['vod_id']:
             log.debug('Type=Live')

--- a/src/streamlink/plugins/piczel.py
+++ b/src/streamlink/plugins/piczel.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
@@ -10,8 +10,6 @@ log = logging.getLogger(__name__)
 
 STREAMS_URL = "https://piczel.tv/api/streams?followedStreams=false&live_only=false&sfw=false"
 HLS_URL = "https://piczel.tv/hls/{0}/index.m3u8"
-
-_url_re = re.compile(r"https://piczel.tv/watch/(\w+)")
 
 _streams_schema = validate.Schema([
     {
@@ -22,17 +20,12 @@ _streams_schema = validate.Schema([
 ])
 
 
+@pluginmatcher(re.compile(
+    r"https?://piczel\.tv/watch/(\w+)"
+))
 class Piczel(Plugin):
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url)
-
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        if not match:
-            return
-
-        channel_name = match.group(1)
+        channel_name = self.match.group(1)
 
         res = self.session.http.get(STREAMS_URL)
         streams = self.session.http.json(res, schema=_streams_schema)

--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -2,7 +2,7 @@ import logging
 import re
 from uuid import uuid4
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -11,20 +11,17 @@ from streamlink.utils.url import update_qsd
 log = logging.getLogger(__name__)
 
 
-class Pluto(Plugin):
-    _re_url = re.compile(r'''^https?://(?:www\.)?pluto\.tv/(?:
+@pluginmatcher(re.compile(r'''
+    https?://(?:www\.)?pluto\.tv/(?:
         live-tv/(?P<slug_live>[^/?]+)/?$
         |
         on-demand/series/(?P<slug_series>[^/]+)/season/\d+/episode/(?P<slug_episode>[^/]+)$
         |
         on-demand/movies/(?P<slug_movies>[^/]+)$
-    )''', re.VERBOSE)
-
+    )
+''', re.VERBOSE))
+class Pluto(Plugin):
     title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     def get_title(self):
         return self.title
@@ -50,7 +47,7 @@ class Pluto(Plugin):
     def _get_streams(self):
         data = None
 
-        m = self._re_url.match(self.url).groupdict()
+        m = self.match.groupdict()
         if m['slug_live']:
             res = self.session.http.get('https://api.pluto.tv/v2/channels')
             data = self.session.http.json(res,

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -3,7 +3,7 @@ import re
 import sys
 import time
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HDSStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -11,6 +11,15 @@ from streamlink.stream.ffmpegmux import MuxedStream
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r'''
+    https?://(
+        (?:www\.)?france\.tv/.+\.html
+        |
+        www\.(ludo|zouzous)\.fr/heros/[\w-]+
+        |
+        (.+\.)?francetvinfo\.fr
+    )
+''', re.VERBOSE))
 class Pluzz(Plugin):
     GEO_URL = 'http://geo.francetv.fr/ws/edgescape.json'
     API_URL = 'http://sivideo.webservices.francetelevisions.fr/tools/getInfosOeuvre/v2/?idDiffusion={0}'
@@ -18,12 +27,6 @@ class Pluzz(Plugin):
     SWF_PLAYER_URL = 'https://staticftv-a.akamaihd.net/player/bower_components/player_flash/dist/' \
                      'FranceTVNVPVFlashPlayer.akamai-7301b6035a43c4e29b7935c9c36771d2.swf'
 
-    _url_re = re.compile(r'''
-        https?://(
-            (?:www\.)france\.tv/.+\.html |
-            www\.(ludo|zouzous)\.fr/heros/[\w-]+ |
-            (.+\.)?francetvinfo\.fr)
-    ''', re.VERBOSE)
     _pluzz_video_id_re = re.compile(r'''(?P<q>["']*)videoId(?P=q):\s*["'](?P<video_id>[^"']+)["']''')
     _jeunesse_video_id_re = re.compile(r'playlist: \[{.*?,"identity":"(?P<video_id>.+?)@(?P<catalogue>Ludo|Zouzous)"')
     _sport_video_id_re = re.compile(r'data-video="(?P<video_id>.+?)"')
@@ -87,10 +90,6 @@ class Pluzz(Plugin):
     arguments = PluginArguments(
         PluginArgument("mux-subtitles", is_global=True)
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         # Retrieve geolocation data

--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -6,28 +6,25 @@ import re
 import xml.etree.ElementTree as ET
 from urllib.parse import urlencode
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 
+@pluginmatcher(re.compile(
+    r'https?://radiko\.jp/(#!/)?(?P<state>live|ts)/(?P<station_id>[a-zA-Z0-9-]+)/?(?P<start_at>\d+)?'
+))
 class Radiko(Plugin):
-    _url_re = re.compile(r'https?://radiko\.jp/(#!/)?(?P<state>live|ts)/(?P<station_id>[a-zA-Z0-9-]+)/?(?P<start_at>\d+)?')
     _api_auth_1 = 'https://radiko.jp/v2/api/auth1'
     _api_auth_2 = 'https://radiko.jp/v2/api/auth2'
     _auth_key = 'bcd151073c03b352e1ef2fd66c32209da9ca0afa'
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
-
     def _get_streams(self):
-        match = self._url_re.match(self.url)
-        state = match.group('state')
-        station_id = match.group('station_id').upper()
+        state = self.match.group('state')
+        station_id = self.match.group('station_id').upper()
         if state == 'live':
             url, token = self._live(station_id)
         else:
-            start_at = match.group('start_at')
+            start_at = self.match.group('start_at')
             url, token = self._timefree(station_id, start_at)
         headers = {
             'X-Radiko-AuthToken': token

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urlparse, urlunparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
@@ -10,8 +10,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(\w+)\.radio\.(net|at|de|dk|es|fr|it|pl|pt|se)"
+))
 class RadioNet(Plugin):
-    _url_re = re.compile(r"https?://(\w+)\.radio\.(net|at|de|dk|es|fr|it|pl|pt|se)")
     _stream_data_re = re.compile(r'\bstation\s*:\s*(\{.+\}),?\s*')
 
     _stream_schema = validate.Schema(
@@ -31,10 +33,6 @@ class RadioNet(Plugin):
             )
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         streams = self.session.http.get(self.url, schema=self._stream_schema)

--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urlparse, urlunparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -10,9 +10,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?raiplay\.it/dirette/(\w+)/?"
+))
 class RaiPlay(Plugin):
-    _re_url = re.compile(r"https?://(?:www\.)?raiplay\.it/dirette/(\w+)/?")
-
     _re_data = re.compile(r"data-video-json\s*=\s*\"([^\"]+)\"")
     _schema_data = validate.Schema(
         validate.transform(_re_data.search),
@@ -24,10 +25,6 @@ class RaiPlay(Plugin):
         validate.get("content_url"),
         validate.url()
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     def _get_streams(self):
         json_url = self.session.http.get(self.url, schema=self._schema_data)

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -10,8 +10,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://([\w-]+\.)*reuters\.(com|tv)'
+))
 class Reuters(Plugin):
-    _url_re = re.compile(r'https?://(.*?\.)?reuters\.(com|tv)')
     _id_re = re.compile(r'(/l/|id=)(?P<id>.*?)(/|\?|$)')
     _iframe_url = 'https://www.reuters.tv/l/{0}/?nonav=true'
     _hls_re = re.compile(r'''(?<!')https://[^"';!<>]+\.m3u8''')
@@ -47,10 +49,6 @@ class Reuters(Plugin):
     def __init__(self, url):
         super().__init__(url)
         self.title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def get_title(self):
         if not self.title:

--- a/src/streamlink/plugins/rotana.py
+++ b/src/streamlink/plugins/rotana.py
@@ -1,19 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?rotana\.net/live'
+))
 class Rotana(Plugin):
-    _url_re = re.compile(r'https?://(?:www\.)?rotana\.net/live')
     _hls_re = re.compile(r'''["'](?P<url>[^"']+\.m3u8)["']''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/rtlxl.py
+++ b/src/streamlink/plugins/rtlxl.py
@@ -1,20 +1,17 @@
 import json
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
-_url_re = re.compile(r"http(?:s)?://(?:\w+\.)?rtl.nl/video/(?P<uuid>.*?)\Z", re.IGNORECASE)
 
-
+@pluginmatcher(re.compile(
+    r"https?://(?:\w+\.)?rtl\.nl/video/(?P<uuid>.*?)\Z",
+    re.IGNORECASE
+))
 class RTLxl(Plugin):
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url)
-
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        uuid = match.group("uuid")
+        uuid = self.match.group("uuid")
         videourlfeed = self.session.http.get(
             'https://tm-videourlfeed.rtl.nl/api/url/{}?device=pc&drm&format=hls'.format(uuid)
         ).text

--- a/src/streamlink/plugins/rtpplay.py
+++ b/src/streamlink/plugins/rtpplay.py
@@ -2,14 +2,16 @@ import re
 from base64 import b64decode
 from urllib.parse import unquote
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
 
+@pluginmatcher(re.compile(
+    r"https?://www\.rtp\.pt/play/"
+))
 class RTPPlay(Plugin):
-    _url_re = re.compile(r"https?://www\.rtp\.pt/play/")
     _m3u8_re = re.compile(r"""
         hls\s*:\s*(?:
             (["'])(?P<string>[^"']*)\1
@@ -47,10 +49,6 @@ class RTPPlay(Plugin):
             )
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         self.session.http.headers.update({"User-Agent": useragents.CHROME,

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -5,7 +5,7 @@ from functools import partial
 
 from Crypto.Cipher import Blowfish
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
@@ -50,11 +50,11 @@ class ZTNRClient:
             return data
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?rtve\.es/(?:directo|infantil|noticias|television|deportes|alacarta|drmn)/.*?/?"
+))
 class Rtve(Plugin):
     secret_key = base64.b64decode("eWVMJmRhRDM=")
-    url_re = re.compile(r"""
-        https?://(?:www\.)?rtve\.es/(?:directo|infantil|noticias|television|deportes|alacarta|drmn)/.*?/?
-    """, re.VERBOSE)
     cdn_schema = validate.Schema(
         validate.transform(partial(parse_xml, invalid_char_entities=True)),
         validate.xml_findall(".//preset"),
@@ -98,10 +98,6 @@ class Rtve(Plugin):
     arguments = PluginArguments(
         PluginArgument("mux-subtitles", is_global=True)
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def __init__(self, url):
         Plugin.__init__(self, url)

--- a/src/streamlink/plugins/rtvs.py
+++ b/src/streamlink/plugins/rtvs.py
@@ -1,18 +1,16 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
 
+@pluginmatcher(re.compile(
+    r"https?://www\.rtvs\.sk/televizia/live-[\w-]+"
+))
 class Rtvs(Plugin):
-    _re_url = re.compile(r"https?://www\.rtvs\.sk/televizia/live-[\w-]+")
     _re_channel_id = re.compile(r"'stream':\s*'live-(\d+)'")
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -2,19 +2,19 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://play\.sbs\.co\.kr/onair/pc/index\.html'
+))
 class SBScokr(Plugin):
-
     api_channel = 'http://apis.sbs.co.kr/play-api/1.0/onair/channel/{0}'
     api_channels = 'http://static.apis.sbs.co.kr/play-api/1.0/onair/channels'
-
-    _url_re = re.compile(r'https?://play\.sbs\.co\.kr/onair/pc/index.html')
 
     _channels_schema = validate.Schema({
         'list': [{
@@ -61,10 +61,6 @@ class SBScokr(Plugin):
             '''
         )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         user_channel_id = self.get_option('id')

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -2,7 +2,7 @@ import logging
 import re
 from functools import partial
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
@@ -10,8 +10,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?schoolism\.com/(viewAssignment|watchLesson)\.php"
+))
 class Schoolism(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?schoolism\.com/(viewAssignment|watchLesson).php")
     login_url = "https://www.schoolism.com/index.php"
     key_time_url = "https://www.schoolism.com/video-html/key-time.php"
     playlist_re = re.compile(r"var allVideos\s*=\s*(\[.*\]);", re.DOTALL)
@@ -73,10 +75,6 @@ class Schoolism(Plugin):
         )
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def login(self, email, password):
         """
         Login to the schoolism account and return the users account
@@ -105,7 +103,7 @@ class Schoolism(Plugin):
             lesson_playlist = self.playlist_schema.validate(res.text)
 
             part = self.options.get("part")
-            video_type = "Lesson" if "lesson" in self.url_re.match(self.url).group(1).lower() else "Assignment Feedback"
+            video_type = "Lesson" if "lesson" in self.match.group(1).lower() else "Assignment Feedback"
 
             log.info(f"Attempting to play {video_type} Part {part}")
             found = False

--- a/src/streamlink/plugins/sportal.py
+++ b/src/streamlink/plugins/sportal.py
@@ -1,21 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?sportal\.bg/sportal_live_tv\.php'
+))
 class Sportal(Plugin):
-
-    _url_re = re.compile(
-        r'https?://(?:www\.)?sportal\.bg/sportal_live_tv.php.*')
     _hls_re = re.compile(r'''["'](?P<url>[^"']+\.m3u8[^"']*?)["']''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, update_scheme
@@ -9,9 +9,10 @@ from streamlink.utils import parse_json, update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:\w+\.)*sportschau\.de/"
+))
 class Sportschau(Plugin):
-    _re_url = re.compile(r"https?://(?:\w+\.)*sportschau.de/")
-
     _re_player = re.compile(r"https?:(//deviceids-medp.wdr.de/ondemand/\S+\.js)")
     _re_json = re.compile(r"\$mediaObject.jsonpHelper.storeAndPlay\(({.+})\);?")
 
@@ -31,10 +32,6 @@ class Sportschau(Plugin):
         validate.get("videoURL"),
         validate.transform(lambda url: update_scheme("https:", url))
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
 
     def _get_streams(self):
         player_js = self.session.http.get(self.url, schema=self._schema_player)

--- a/src/streamlink/plugins/ssh101.py
+++ b/src/streamlink/plugins/ssh101.py
@@ -2,20 +2,18 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?ssh101\.com/(?:secure)?live/'
+))
 class SSH101(Plugin):
-    url_re = re.compile(r'https?://(?:www\.)?ssh101\.com/(?:secure)?live/')
     src_re = re.compile(r'sources.*?src:\s"(?P<url>.*?)"')
     iframe_re = re.compile(r'iframe.*?src="(?P<url>.*?)"')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url)
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/stadium.py
+++ b/src/streamlink/plugins/stadium.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -9,8 +9,10 @@ from streamlink.stream import HLSStream
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?watchstadium\.com/live"
+))
 class Stadium(Plugin):
-    _url_re = re.compile(r"""https?://(?:www\.)?watchstadium\.com/live""")
     _policy_key_re = re.compile(r"""options:\s*\{.+policyKey:\s*"([^"]+)""", re.DOTALL)
     _API_URL = (
         "https://edge.api.brightcove.com/playback/v1/accounts/{data_account}/videos/{data_video_id}"
@@ -31,10 +33,6 @@ class Stadium(Plugin):
         },
         validate.get("sources"),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/streamable.py
+++ b/src/streamlink/plugins/streamable.py
@@ -1,13 +1,15 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
 from streamlink.utils import parse_json, update_scheme
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?streamable\.com/(.+)"
+))
 class Streamable(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?streamable\.com/(.+)")
     meta_re = re.compile(r'''var\s*videoObject\s*=\s*({.*});''')
     config_schema = validate.Schema(
         validate.transform(meta_re.search),
@@ -23,10 +25,6 @@ class Streamable(Plugin):
                          })
                      )
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         data = self.session.http.get(self.url, schema=self.config_schema)

--- a/src/streamlink/plugins/streamingvideoprovider.py
+++ b/src/streamlink/plugins/streamingvideoprovider.py
@@ -2,7 +2,7 @@ import logging
 import re
 from time import time
 
-from streamlink.plugin import Plugin, PluginError
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
 
@@ -11,9 +11,6 @@ log = logging.getLogger(__name__)
 SWF_URL = "http://play.streamingvideoprovider.com/player2.swf"
 API_URL = "http://player.webvideocore.net/index.php"
 
-_url_re = re.compile(
-    r"http(s)?://(\w+\.)?streamingvideoprovider\.co\.uk/(?P<channel>[^/&?]+)"
-)
 _hls_re = re.compile(r"'(http://.+\.m3u8)'")
 
 _rtmp_schema = validate.Schema(
@@ -35,11 +32,10 @@ _hls_schema = validate.Schema(
 )
 
 
+@pluginmatcher(re.compile(
+    r"https?://(\w+\.)?streamingvideoprovider\.co\.uk/(?P<channel>[^/&?]+)"
+))
 class Streamingvideoprovider(Plugin):
-    @classmethod
-    def can_handle_url(self, url):
-        return _url_re.match(url)
-
     def _get_hls_stream(self, channel_name):
         params = {
             "l": "info",
@@ -70,8 +66,7 @@ class Streamingvideoprovider(Plugin):
         })
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        channel_name = match.group("channel")
+        channel_name = self.match.group("channel")
 
         try:
             stream = self._get_rtmp_stream(channel_name)

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -6,7 +6,7 @@ import time
 from html import unescape as html_unescape
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -16,6 +16,25 @@ from streamlink.utils.crypto import decrypt_openssl
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:
+        ott\.streann\.com/s(?:treaming|-secure)/player\.html
+        |
+        (?:www\.)?(?:
+            centroecuador\.ec
+            |
+            columnaestilos\.com
+            |
+            crc\.cr/estaciones/
+            |
+            evtv\.online/noticias-de-venezuela/
+            |
+            telecuracao\.com
+            |
+            willax\.tv/en-vivo
+        )
+    )
+""", re.VERBOSE))
 class Streann(Plugin):
     arguments = PluginArguments(
         PluginArgument(
@@ -29,24 +48,6 @@ class Streann(Plugin):
         )
     )
 
-    _url_re = re.compile(r"""(?x)https?://(?:
-        ott\.streann\.com/s(?:treaming|-secure)/player\.html
-        |
-        (?:www\.)?(?:
-            centroecuador\.ec
-            |
-            columnaestilos\.com
-            |
-            crc.cr/estaciones/
-            |
-            evtv\.online/noticias-de-venezuela/
-            |
-            telecuracao\.com
-            |
-            willax\.tv/en-vivo
-        )
-    )""")
-
     base_url = "https://ott.streann.com"
     get_time_url = base_url + "/web/services/public/get-server-time"
     token_url = base_url + "/loadbalancer/services/web-players/{playerId}/token/{type}/{dataId}/{deviceId}"
@@ -58,10 +59,6 @@ class Streann(Plugin):
     _device_id = None
     _domain = None
     title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def get_title(self):
         return self.title

--- a/src/streamlink/plugins/stv.py
+++ b/src/streamlink/plugins/stv.py
@@ -1,23 +1,19 @@
 import logging
 import re
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://player\.stv\.tv/live'
+))
 class STV(Plugin):
-    _url_re = re.compile(r'https?://player\.stv\.tv/live')
-
     API_URL = 'https://player.api.stv.tv/v1/streams/stv/'
 
     title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def get_title(self):
         if self.title is None:

--- a/src/streamlink/plugins/teamliquid.py
+++ b/src/streamlink/plugins/teamliquid.py
@@ -2,20 +2,17 @@ import logging
 import re
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugins.afreeca import AfreecaTV
 from streamlink.plugins.twitch import Twitch
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?(?:tl|teamliquid)\.net/video/streams/"
+))
 class Teamliquid(Plugin):
-    _url_re = re.compile(r'''https?://(?:www\.)?(?:tl|teamliquid)\.net/video/streams/''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
         res = self.session.http.get(self.url)
 

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json
@@ -9,13 +9,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://telefe\.com/.+'
+))
 class Telefe(Plugin):
-    _url_re = re.compile(r'https?://telefe.com/.+')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
-
     def _get_streams(self):
         res = self.session.http.get(self.url, headers={'User-Agent': useragents.CHROME})
         video_search = res.text

--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -1,16 +1,17 @@
 import logging
 import re
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import DASHStream, HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?(?:tf1\.fr/([\w-]+)/direct|(lci)\.fr/direct)/?"
+))
 class TF1(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?(?:tf1\.fr/([\w-]+)/direct|(lci).fr/direct)/?")
     api_url = "https://mediainfo.tf1.fr/mediainfocombo/{}?context=MYTF1&pver=4001000"
 
     def api_call(self, channel, useragent=useragents.CHROME):
@@ -29,12 +30,8 @@ class TF1(Plugin):
             log.debug("Got {format} stream {url}".format(**data['delivery']))
             yield data['delivery']['format'], data['delivery']['url']
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
-
     def _get_streams(self):
-        m = self.url_re.match(self.url)
+        m = self.match
         if m:
             channel = m.group(1) or m.group(2)
             log.debug("Found channel {0}".format(channel))

--- a/src/streamlink/plugins/tga.py
+++ b/src/streamlink/plugins/tga.py
@@ -1,6 +1,6 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 
@@ -8,7 +8,6 @@ CHANNEL_INFO_URL = "http://api.plu.cn/tga/streams/%s"
 QQ_STREAM_INFO_URL = "http://info.zb.qq.com/?cnlid=%d&cmd=2&stream=%d&system=1&sdtfrom=113"
 PLU_STREAM_INFO_URL = "http://livestream.plu.cn/live/getlivePlayurl?roomId=%d"
 _quality_re = re.compile(r"\d+x(\d+)$")
-_url_re = re.compile(r"http://(star|y)\.longzhu\.(?:tv|com)/(m\/)?(?P<domain>[a-z0-9]+)")
 
 _channel_schema = validate.Schema(
     {
@@ -47,11 +46,10 @@ STREAM_WEIGHTS = {
 }
 
 
+@pluginmatcher(re.compile(
+    r"http?://(star|y)\.longzhu\.(?:tv|com)/(m/)?(?P<domain>[a-z0-9]+)"
+))
 class Tga(Plugin):
-    @classmethod
-    def can_handle_url(self, url):
-        return _url_re.match(url)
-
     @classmethod
     def stream_weight(cls, stream):
         if stream in STREAM_WEIGHTS:
@@ -99,8 +97,7 @@ class Tga(Plugin):
                 })
 
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        domain = match.group('domain')
+        domain = self.match.group('domain')
 
         vid, cid = self._get_channel_id(domain)
 

--- a/src/streamlink/plugins/theplatform.py
+++ b/src/streamlink/plugins/theplatform.py
@@ -1,23 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://player\.theplatform\.com/p/"
+))
 class ThePlatform(Plugin):
-    """
-    Plugin to support streaming videos hosted by thePlatform
-    """
-    url_re = re.compile(r"https?://player\.theplatform\.com/p/")
     release_re = re.compile(r'''tp:releaseUrl\s*=\s*"(.*?)"''')
     video_src_re = re.compile(r'''video.*?src="(.*?)"''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/tlctr.py
+++ b/src/streamlink/plugins/tlctr.py
@@ -1,21 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?tlctv\.com\.tr/canli-izle'
+))
 class TLCtr(Plugin):
-
-    _url_re = re.compile(r'https?://(?:www\.)?tlctv\.com\.tr/canli-izle')
     _hls_re = re.compile(
         r'''["'](?P<url>https?://[^/]+/live/hls/[^"']+)["']''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/turkuvaz.py
+++ b/src/streamlink/plugins/turkuvaz.py
@@ -1,32 +1,29 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
-class Turkuvaz(Plugin):
-    """
-    Plugin to support ATV/A2TV Live streams from www.atv.com.tr and www.a2tv.com.tr
-    """
-
-    _url_re = re.compile(r"""(?x)https?://(?:www\.)?
+@pluginmatcher(re.compile(r"""https?://(?:www\.)?
     (?:
         (?:
             (atvavrupa)\.tv
             |
             (atv|a2tv|ahaber|aspor|minikago|minikacocuk|anews)\.com\.tr
         )/webtv/(?:live-broadcast|canli-yayin)
-    |
+        |
         (ahaber)\.com\.tr/video/canli-yayin
-    |
+        |
         atv\.com\.tr/(a2tv)/canli-yayin
-    |
+        |
         sabah\.com\.tr/(apara)/canli-yayin
-    )""")
+    )
+""", re.VERBOSE))
+class Turkuvaz(Plugin):
     _hls_url = "https://trkvz-live.ercdn.net/{channel}/{channel}.m3u8"
     _token_url = "https://securevideotoken.tmgrup.com.tr/webtv/secure"
     _token_schema = validate.Schema(validate.all(
@@ -37,12 +34,8 @@ class Turkuvaz(Plugin):
         validate.get("Url"))
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        url_m = self._url_re.match(self.url)
+        url_m = self.match
         domain = url_m.group(1) or url_m.group(2) or url_m.group(3) or url_m.group(4) or url_m.group(5)
         # remap the domain to channel
         channel = {"atv": "atvhd",

--- a/src/streamlink/plugins/tv360.py
+++ b/src/streamlink/plugins/tv360.py
@@ -1,22 +1,20 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?tv360\.com\.tr/canli-yayin"
+))
 class TV360(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?tv360\.com\.tr/canli-yayin")
     hls_re = re.compile(r'''src="(http.*m3u8)"''')
 
     hls_schema = validate.Schema(
         validate.transform(hls_re.search),
         validate.any(None, validate.all(validate.get(1), validate.url()))
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         hls_url = self.session.http.get(self.url, schema=self.hls_schema)

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -2,32 +2,28 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?
+    (?:
+        tv4play\.se/program/[^?/]+
+        |
+        fotbollskanalen\.se/video
+    )
+    /(?P<video_id>\d+)
+""", re.VERBOSE))
 class TV4Play(Plugin):
-    """Plugin for TV4 Play, swedish TV channel TV4's streaming service."""
-
     title = None
     video_id = None
 
     api_url = "https://playback-api.b17g.net"
     api_assets = urljoin(api_url, "/asset/{0}")
-
-    _url_re = re.compile(r"""
-        https?://(?:www\.)?
-        (?:
-            tv4play.se/program/[^\?/]+
-            |
-            fotbollskanalen.se/video
-        )
-        /(?P<video_id>\d+)
-    """, re.VERBOSE)
 
     _meta_schema = validate.Schema(
         {
@@ -38,15 +34,10 @@ class TV4Play(Plugin):
         }
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     @property
     def get_video_id(self):
         if self.video_id is None:
-            match = self._url_re.match(self.url)
-            self.video_id = match.group("video_id")
+            self.video_id = self.match.group("video_id")
             log.debug("Found video ID: {0}".format(self.video_id))
         return self.video_id
 

--- a/src/streamlink/plugins/tv5monde.py
+++ b/src/streamlink/plugins/tv5monde.py
@@ -1,14 +1,16 @@
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugins.common_jwplayer import _js_to_json
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
 from streamlink.utils import parse_json
 
 
+@pluginmatcher(re.compile(
+    r'https?://([\w-]+\.)*(tv|tivi)5monde(plus(afrique)?)?\.com'
+))
 class TV5Monde(Plugin):
-    _url_re = re.compile(r'http://(.+\.)?(tv|tivi)5monde(plus(afrique)?)?\.com')
     _videos_re = re.compile(r'"?(?:files|sources)"?:\s*(?P<videos>\[.+?\])')
     _videos_embed_re = re.compile(r'(?:file:\s*|src=)"(?P<embed>.+?\.mp4|.+?/embed/.+?)"')
 
@@ -28,10 +30,6 @@ class TV5Monde(Plugin):
             )
         ])
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return TV5Monde._url_re.match(url)
 
     def _get_non_embed_streams(self, page):
         match = self._videos_re.search(page)

--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -1,15 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://www\.tv8\.com\.tr/canli-yayin'
+))
 class TV8(Plugin):
-    _url_re = re.compile(r'https?://www\.tv8\.com\.tr/canli-yayin')
     _player_schema = validate.Schema(validate.all({
         'servers': {
             validate.optional('manifest'): validate.url(),
@@ -18,10 +20,6 @@ class TV8(Plugin):
         validate.get('servers')))
 
     API_URL = 'https://static.personamedia.tv/player/config/tv8.json'
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def get_title(self):
         return 'TV8'

--- a/src/streamlink/plugins/tv999.py
+++ b/src/streamlink/plugins/tv999.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils.url import update_scheme
@@ -9,8 +9,10 @@ from streamlink.utils.url import update_scheme
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?tv999\.bg/live\.html'
+))
 class TV999(Plugin):
-    url_re = re.compile(r'https?://(?:www\.)?tv999\.bg/live\.html')
     iframe_re = re.compile(r'<iframe.*src="([^"]+)"')
     hls_re = re.compile(r'src="([^"]+)"\s+type="application/x-mpegURL"')
 
@@ -30,10 +32,6 @@ class TV999(Plugin):
             validate.url(),
         )),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         iframe_url = self.session.http.get(self.url, schema=self.iframe_schema)

--- a/src/streamlink/plugins/tvibo.py
+++ b/src/streamlink/plugins/tvibo.py
@@ -1,23 +1,20 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://player\.tvibo\.com/\w+/(?P<id>\d+)"
+))
 class Tvibo(Plugin):
-
-    _url_re = re.compile(r"https?://player\.tvibo\.com/\w+/(?P<id>\d+)")
     _api_url = "http://panel.tvibo.com/api/player/streamurl/{id}"
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        channel_id = self._url_re.match(self.url).group("id")
+        channel_id = self.match.group("id")
 
         api_response = self.session.http.get(
             self._api_url.format(id=channel_id),

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -1,27 +1,20 @@
 import logging
 import re
 
-from streamlink.exceptions import PluginError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.stream import HLSStream, HTTPStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://tvpstream\.vod\.tvp\.pl'
+))
 class TVP(Plugin):
-    '''Telewizja Polska S.A.
-       http://tvpstream.vod.tvp.pl
-    '''
-
     player_url = 'https://www.tvp.pl/sess/tvplayer.php?object_id={0}&autoplay=true'
 
-    _url_re = re.compile(r'https?://tvpstream\.vod\.tvp\.pl')
     _stream_re = re.compile(r'''src:["'](?P<url>[^"']+\.(?:m3u8|mp4))["']''')
     _video_id_re = re.compile(r'''class=["']tvp_player["'][^>]+data-video-id=["'](?P<video_id>\d+)["']''')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def get_embed_url(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -1,15 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?tvr\.by/televidenie/belarus"
+))
 class TVRBy(Plugin):
-    url_re = re.compile(r"""https?://(?:www\.)?tvr.by/televidenie/belarus""")
     file_re = re.compile(r"""(?P<url>https://stream\.hoster\.by[^"',]+\.m3u8[^"',]*)""")
     player_re = re.compile(r"""["'](?P<url>[^"']+tvr\.by/plugines/online-tv-main\.php[^"']+)["']""")
 
@@ -29,10 +31,6 @@ class TVRBy(Plugin):
         if not url.endswith("/"):
             url += "/"
         super().__init__(url)
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -1,15 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?tvrplus\.ro/live/"
+))
 class TVRPlus(Plugin):
-    url_re = re.compile(r"https?://(?:www\.)?tvrplus\.ro/live/")
     hls_file_re = re.compile(r"""["'](?P<url>[^"']+\.m3u8(?:[^"']+)?)["']""")
 
     stream_schema = validate.Schema(
@@ -18,10 +20,6 @@ class TVRPlus(Plugin):
             validate.any(None, [validate.text])
         ),
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def _get_streams(self):
         headers = {"Referer": self.url}

--- a/src/streamlink/plugins/tvtoya.py
+++ b/src/streamlink/plugins/tvtoya.py
@@ -1,19 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?tvtoya\.pl/live"
+))
 class TVToya(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?tvtoya\.pl/live")
     _playlist_re = re.compile(r'<source src="([^"]+)" type="application/x-mpegURL">')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         self.session.set_option('hls-live-edge', 10)

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -8,7 +8,7 @@ import websocket
 
 from streamlink import logger
 from streamlink.buffers import RingBuffer
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream.stream import Stream
 from streamlink.stream.stream import StreamIO
@@ -18,6 +18,9 @@ from streamlink.utils.url import update_qsd
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://twitcasting\.tv/(?P<channel>[^/]+)"
+))
 class TwitCasting(Plugin):
     arguments = PluginArguments(
         PluginArgument(
@@ -27,7 +30,6 @@ class TwitCasting(Plugin):
             help="Password for private Twitcasting streams."
         )
     )
-    _url_re = re.compile(r"http(s)?://twitcasting.tv/(?P<channel>[^/]+)", re.VERBOSE)
     _STREAM_INFO_URL = "https://twitcasting.tv/streamserver.php?target={channel}&mode=client"
     _STREAM_REAL_URL = "{proto}://{host}/ws.app/stream/{movie_id}/fmp4/bd/1/1500?mode={mode}"
 
@@ -45,14 +47,9 @@ class TwitCasting(Plugin):
     })
 
     def __init__(self, url):
-        Plugin.__init__(self, url)
-        match = self._url_re.match(url).groupdict()
-        self.channel = match.get("channel")
+        super().__init__(url)
+        self.channel = self.match.group("channel")
         self.session.http.headers.update({'User-Agent': useragents.CHROME})
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         stream_info = self._get_stream_info()

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -9,15 +9,16 @@ from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 from Crypto.Util.Padding import pad, unpad
 
-from streamlink import PluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?ustvnow\.com/live/(?P<scode>\w+)/-(?P<id>\d+)"
+))
 class USTVNow(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?ustvnow\.com/live/(?P<scode>\w+)/-(?P<id>\d+)")
     _main_js_re = re.compile(r"""src=['"](main\..*\.js)['"]""")
     _enc_key_re = re.compile(r'(?P<key>AES_(?:Key|IV))\s*:\s*"(?P<value>[^"]+)"')
 
@@ -47,10 +48,6 @@ class USTVNow(Plugin):
         super().__init__(url)
         self._encryption_config = {}
         self._token = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     @classmethod
     def encrypt_data(cls, data, key, iv):

--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -6,7 +6,7 @@ Plugin for vidio.com
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
@@ -14,8 +14,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?vidio\.com/(?:en/)?(?P<type>live|watch)/(?P<id>\d+)-(?P<name>[^/?#&]+)"
+))
 class Vidio(Plugin):
-    _url_re = re.compile(r"https?://(?:www\.)?vidio\.com/(?:en/)?(?P<type>live|watch)/(?P<id>\d+)-(?P<name>[^/?#&]+)")
     _playlist_re = re.compile(r'''hls-url=["'](?P<url>[^"']+)["']''')
     _data_id_re = re.compile(r'''meta\s+data-id=["'](?P<id>[^"']+)["']''')
 
@@ -24,10 +26,6 @@ class Vidio(Plugin):
     token_schema = validate.Schema(validate.transform(parse_json),
                                    {"token": validate.text},
                                    validate.get("token"))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     def get_csrf_tokens(self):
         return self.session.http.get(

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -3,7 +3,7 @@ import re
 from html import unescape as html_unescape
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -12,8 +12,10 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(player\.vimeo\.com/video/\d+|(www\.)?vimeo\.com/.+)"
+))
 class Vimeo(Plugin):
-    _url_re = re.compile(r"https?://(player\.vimeo\.com/video/\d+|(www\.)?vimeo\.com/.+)")
     _config_url_re = re.compile(r'(?:"config_url"|\bdata-config-url)\s*[:=]\s*(".+?")')
     _config_re = re.compile(r"var\s+config\s*=\s*({.+?})\s*;")
     _config_url_schema = validate.Schema(
@@ -53,10 +55,6 @@ class Vimeo(Plugin):
     arguments = PluginArguments(
         PluginArgument("mux-subtitles", is_global=True)
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     def _get_streams(self):
         if "player.vimeo.com" in self.url:

--- a/src/streamlink/plugins/vinhlongtv.py
+++ b/src/streamlink/plugins/vinhlongtv.py
@@ -1,19 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?thvli\.vn/live/(?P<channel>[^/]+)'
+))
 class VinhLongTV(Plugin):
-
     api_url = 'http://api.thvli.vn/backend/cm/detail/{0}/'
-
-    _url_re = re.compile(
-        r'https?://(?:www\.)?thvli\.vn/live/(?P<channel>[^/]+)')
 
     _data_schema = validate.Schema(
         {
@@ -22,12 +21,8 @@ class VinhLongTV(Plugin):
         validate.get('link_play')
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
-
     def _get_streams(self):
-        channel = self._url_re.match(self.url).group('channel')
+        channel = self.match.group('channel')
 
         res = self.session.http.get(self.api_url.format(channel))
         hls_url = self.session.http.json(res, schema=self._data_schema)

--- a/src/streamlink/plugins/viutv.py
+++ b/src/streamlink/plugins/viutv.py
@@ -4,19 +4,17 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://viu\.tv/ch/(\d+)"
+))
 class ViuTV(Plugin):
-    _url_re = re.compile(r"https?://viu\.tv/ch/(\d+)")
     api_url = "https://api.viu.now.com/p8/2/getLiveURL"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     @property
     def device_id(self):
@@ -24,7 +22,7 @@ class ViuTV(Plugin):
 
     @property
     def channel_id(self):
-        return self._url_re.match(self.url).group(1)
+        return self.match.group(1)
 
     def _get_streams(self):
         api_res = self.session.http.post(self.api_url,

--- a/src/streamlink/plugins/vrtbe.py
+++ b/src/streamlink/plugins/vrtbe.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import DASHStream, HLSStream
@@ -10,9 +10,10 @@ from streamlink.stream import DASHStream, HLSStream
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://www\.vrt\.be/vrtnu/(?:kanalen/(?P<channel>[^/]+)|\S+)"
+))
 class VRTbe(Plugin):
-    _url_re = re.compile(r'''https?://www\.vrt\.be/vrtnu/(?:kanalen/(?P<channel>[^/]+)|\S+)''')
-
     _stream_schema = validate.Schema(
         validate.any({
             "code": validate.text,
@@ -31,10 +32,6 @@ class VRTbe(Plugin):
     }, validate.get("vrtPlayerToken"))
 
     api_url = "https://api.vuplay.co.uk/"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
 
     def _get_api_info(self, page):
         for div in itertags(page.text, 'div'):

--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -10,10 +10,12 @@ from streamlink.utils import parse_json
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://vtvgo\.vn/xem-truc-tuyen-kenh-'
+))
 class VTVgo(Plugin):
     AJAX_URL = 'https://vtvgo.vn/ajax-get-stream'
 
-    _url_re = re.compile(r'https://vtvgo\.vn/xem-truc-tuyen-kenh-')
     _params_re = re.compile(r'''var\s+(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;''')
 
     _schema_params = validate.Schema(
@@ -32,10 +34,6 @@ class VTVgo(Plugin):
         validate.get("stream_url"),
         validate.get(0)
     )
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         self.session.http.headers.update({

--- a/src/streamlink/plugins/webcast_india_gov.py
+++ b/src/streamlink/plugins/webcast_india_gov.py
@@ -1,20 +1,17 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?webcast\.gov\.in/.+'
+))
 class WebcastIndiaGov(Plugin):
-    _url_re = re.compile(r'https?://(?:www\.)?webcast.gov.in/.+')
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url)
-
     def _get_streams(self):
         try:
             url_content = ""

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -5,7 +5,7 @@ import re
 
 from Crypto.Cipher import AES
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json, update_scheme
@@ -14,8 +14,10 @@ from streamlink.utils.crypto import unpad_pkcs5
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(\w+)\.web\.tv/?"
+))
 class WebTV(Plugin):
-    _url_re = re.compile(r"http(?:s)?://(\w+)\.web.tv/?")
     _sources_re = re.compile(r'"sources": (\[.*?\]),', re.DOTALL)
     _sources_schema = validate.Schema([
         {
@@ -31,10 +33,6 @@ class WebTV(Plugin):
             "label": validate.text
         }
     ])
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     @staticmethod
     def decrypt_stream_url(encoded_url):

--- a/src/streamlink/plugins/welt.py
+++ b/src/streamlink/plugins/welt.py
@@ -1,7 +1,7 @@
 import re
 from urllib.parse import quote
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
@@ -16,11 +16,10 @@ def get_json(text):
     return None
 
 
+@pluginmatcher(re.compile(
+    r"https?://(\w+\.)?welt\.de/?"
+))
 class Welt(Plugin):
-    _re_url = re.compile(
-        r"""https?://(\w+\.)?welt\.de/?""",
-        re.IGNORECASE
-    )
     _re_url_vod = re.compile(
         r"""mediathek""",
         re.IGNORECASE
@@ -35,13 +34,8 @@ class Welt(Plugin):
         validate.get(0)
     )
 
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._re_url.match(url) is not None
-
     def __init__(self, url):
-        Plugin.__init__(self, url)
-        self.url = url
+        super().__init__(url)
         self.isVod = self._re_url_vod.search(url) is not None
 
     def _get_streams(self):

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -4,8 +4,7 @@ import re
 from functools import lru_cache
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink import PluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 from streamlink.utils.times import seconds_to_hhmmss
@@ -13,8 +12,10 @@ from streamlink.utils.times import seconds_to_hhmmss
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://watch\.wwe\.com/(channel)?"
+))
 class WWENetwork(Plugin):
-    url_re = re.compile(r"https?://watch\.wwe\.com/(channel)?")
     site_config_re = re.compile(r'''">window.__data = (\{.*?\})</script>''')
     stream_url = "https://dce-frontoffice.imggaming.com/api/v2/stream/{id}"
     live_url = "https://dce-frontoffice.imggaming.com/api/v2/event/live"
@@ -48,10 +49,6 @@ class WWENetwork(Plugin):
         super().__init__(url)
         self.session.http.headers.update({"User-Agent": useragents.CHROME})
         self.auth_token = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls.url_re.match(url) is not None
 
     def get_title(self):
         return self.item_config['title']

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -2,15 +2,17 @@ import logging
 import re
 import time
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://(?:www\.)?yupptv\.com'
+))
 class YuppTV(Plugin):
-    _url_re = re.compile(r'https?://(?:www\.)?yupptv\.com')
     _m3u8_re = re.compile(r'''['"](http.+\.m3u8.*?)['"]''')
     _cookie_expiry = 3600 * 24 * 365
 
@@ -45,10 +47,6 @@ class YuppTV(Plugin):
         super().__init__(url)
         self._authed = (self.session.http.cookies.get("BoxId")
                         and self.session.http.cookies.get("YuppflixToken"))
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _login_using_box_id_and_yuppflix_token(self, box_id, yuppflix_token):
         time_now = time.time()

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -2,7 +2,7 @@ import logging
 import re
 from urllib.parse import urlparse, urlunparse
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream, HLSStream
 from streamlink.utils import parse_json
@@ -27,9 +27,6 @@ STREAMING_TYPES = {
     )
 }
 
-_url_re = re.compile(r"""
-    http(s)?://(\w+\.)?(zdf\.de|3sat\.de)/
-""", re.VERBOSE | re.IGNORECASE)
 _api_json_re = re.compile(r'''data-zdfplayer-jsb=["'](?P<json>{.+?})["']''', re.S)
 
 _api_schema = validate.Schema(
@@ -83,11 +80,10 @@ _schema = validate.Schema(
 )
 
 
+@pluginmatcher(re.compile(
+    r"https?://(\w+\.)?(zdf\.de|3sat\.de)/"
+))
 class ZDFMediathek(Plugin):
-    @classmethod
-    def can_handle_url(cls, url):
-        return _url_re.match(url)
-
     @classmethod
     def stream_weight(cls, key):
         weight = QUALITY_WEIGHTS.get(key)

--- a/src/streamlink/plugins/zeenews.py
+++ b/src/streamlink/plugins/zeenews.py
@@ -1,21 +1,18 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r'https?://zeenews\.india\.com/live-tv'
+))
 class ZeeNews(Plugin):
-    _url_re = re.compile(r'https?://zeenews\.india\.com/live-tv')
-
     HLS_URL = 'https://z5ams.akamaized.net/zeenews/index.m3u8{0}'
     TOKEN_URL = 'https://useraction.zee5.com/token/live.php'
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def get_title(self):
         return 'Zee News'

--- a/src/streamlink/plugins/zengatv.py
+++ b/src/streamlink/plugins/zengatv.py
@@ -1,24 +1,22 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
 
 
+@pluginmatcher(re.compile(
+    r"https?://(www\.)?zengatv\.com/\w+"
+))
 class ZengaTV(Plugin):
     """Streamlink Plugin for livestreams on zengatv.com"""
 
-    _url_re = re.compile(r"https?://(www\.)?zengatv\.com/\w+")
     _id_re = re.compile(r"""id=(?P<q>["'])dvrid(?P=q)\svalue=(?P=q)(?P<id>[^"']+)(?P=q)""")
     _id_2_re = re.compile(r"""LivePlayer\(.+["'](?P<id>D\d+)["']""")
 
     api_url = "http://www.zengatv.com/changeResulation/"
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._url_re.match(url) is not None
 
     def _get_streams(self):
         headers = {"Referer": self.url}

--- a/src/streamlink/plugins/zhanqi.py
+++ b/src/streamlink/plugins/zhanqi.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 
@@ -11,11 +11,6 @@ API_URL = "https://www.zhanqi.tv/api/static/v2.1/room/domain/{0}.json"
 
 STATUS_ONLINE = 4
 STATUS_OFFLINE = 0
-
-_url_re = re.compile(r"""
-    http(s)?://(www\.)?zhanqi.tv
-    /(?P<channel>[^/]+)
-""", re.VERBOSE)
 
 _room_schema = validate.Schema(
     {
@@ -31,14 +26,12 @@ _room_schema = validate.Schema(
 )
 
 
+@pluginmatcher(re.compile(
+    r"https?://(www\.)?zhanqi\.tv/(?P<channel>[^/]+)"
+))
 class Zhanqitv(Plugin):
-    @classmethod
-    def can_handle_url(self, url):
-        return _url_re.match(url)
-
     def _get_streams(self):
-        match = _url_re.match(self.url)
-        channel = match.group("channel")
+        channel = self.match.group("channel")
 
         res = self.session.http.get(API_URL.format(channel))
         room = self.session.http.json(res, schema=_room_schema)

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -15,7 +15,7 @@ from streamlink.exceptions import NoPluginError, PluginError
 from streamlink.logger import StreamlinkLogger
 from streamlink.options import Options
 from streamlink.plugin import Plugin, api
-from streamlink.plugin.plugin import Matcher, NO_PRIORITY
+from streamlink.plugin.plugin import Matcher, NORMAL_PRIORITY, NO_PRIORITY
 from streamlink.utils import load_module, update_scheme
 from streamlink.utils.l10n import Localization
 
@@ -398,6 +398,13 @@ class Streamlink:
                     if matcher.priority > priority and matcher.pattern.match(url) is not None:
                         candidate = plugin
                         priority = matcher.priority
+            # TODO: remove deprecated plugin resolver
+            elif hasattr(plugin, "can_handle_url") and callable(plugin.can_handle_url) and plugin.can_handle_url(url):
+                prio = plugin.priority(url) if hasattr(plugin, "priority") and callable(plugin.priority) else NORMAL_PRIORITY
+                if prio > priority:
+                    log.info(f"Resolved plugin {name} with deprecated can_handle_url API")
+                    candidate = plugin
+                    priority = prio
 
         if candidate:
             return candidate(url)

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -1,8 +1,9 @@
+import re
 from io import BytesIO
 
 from streamlink import NoStreamsError
 from streamlink.options import Options
-from streamlink.plugin import PluginArgument, PluginArguments
+from streamlink.plugin import PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugins import Plugin
 from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream, Stream
 
@@ -14,6 +15,9 @@ class TestStream(Stream):
         return BytesIO(b'x' * 8192 * 2)
 
 
+@pluginmatcher(re.compile(
+    r"https?://test\.se"
+))
 class TestPlugin(Plugin):
     arguments = PluginArguments(
         PluginArgument(
@@ -30,10 +34,6 @@ class TestPlugin(Plugin):
     options = Options({
         "a_option": "default"
     })
-
-    @classmethod
-    def can_handle_url(self, url):
-        return "test.se" in url
 
     def get_title(self):
         return "Test Title"

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -20,8 +20,8 @@ class PluginCanHandleUrl:
 
     # parametrized dynamically via conftest.py
     def test_can_handle_url_positive(self, url):
-        assert self.__plugin__.can_handle_url(url), "URL matches"
+        assert any(matcher.pattern.match(url) for matcher in self.__plugin__.matchers), "URL matches"
 
     # parametrized dynamically via conftest.py
     def test_can_handle_url_negative(self, url):
-        assert not self.__plugin__.can_handle_url(url), "URL does not match"
+        assert not any(matcher.pattern.match(url) for matcher in self.__plugin__.matchers), "URL does not match"

--- a/tests/plugins/test_abematv.py
+++ b/tests/plugins/test_abematv.py
@@ -15,8 +15,6 @@ class TestPluginCanHandleUrlAbemaTV(PluginCanHandleUrl):
     ]
 
     should_not_match = [
-        'http://abema.tv/now-on-air/abema-news',
-        'http://www.abema.tv/now-on-air/abema-news',
         'https://www.abema.tv/now-on-air/abema-news',
         'https://www.abema.tv/now-on-air/',
         'https://abema.tv/timetable',

--- a/tests/plugins/test_filmon.py
+++ b/tests/plugins/test_filmon.py
@@ -1,5 +1,8 @@
-import unittest
+from unittest.mock import Mock
 
+import pytest
+
+from streamlink.plugin import Plugin
 from streamlink.plugins.filmon import Filmon
 from tests.plugins import PluginCanHandleUrl
 
@@ -20,45 +23,20 @@ class TestPluginCanHandleUrlFilmon(PluginCanHandleUrl):
     ]
 
 
-class TestPluginFilmon(unittest.TestCase):
-    def _test_regex(self, url, expected):
-        m = Filmon.url_re.match(url)
-        self.assertIsNotNone(m, url)
-        # expected must return [is_group, channel, vod_id]
-        self.assertEqual(expected, list(m.groups()))
-
-    def test_regex_live_stream_channel(self):
-        self._test_regex('http://www.filmon.tv/channel/grandstand-show',
-                         [None, 'grandstand-show', None])
-
-    def test_regex_live_stream_index_popout(self):
-        self._test_regex('http://www.filmon.tv/index/popout?channel_id=5510&quality=low',
-                         [None, '5510', None])
-
-    def test_regex_live_stream_export(self):
-        self._test_regex('http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1',
-                         [None, '5510', None])
-
-    def test_regex_live_stream_tv_channel(self):
-        self._test_regex('http://www.filmon.tv/tv/channel/grandstand-show',
-                         [None, 'grandstand-show', None])
-
-    def test_regex_live_stream_tv(self):
-        self._test_regex('https://www.filmon.com/tv/bbc-news',
-                         [None, 'bbc-news', None])
-
-    def test_regex_live_stream_tv_with_channel_in_name(self):
-        self._test_regex('https://www.filmon.com/tv/channel-4',
-                         [None, 'channel-4', None])
-
-    def test_regex_live_stream_tv_number(self):
-        self._test_regex('https://www.filmon.tv/tv/55',
-                         [None, '55', None])
-
-    def test_regex_group(self):
-        self._test_regex('http://www.filmon.tv/group/comedy',
-                         ['group/', 'comedy', None])
-
-    def test_regex_vod(self):
-        self._test_regex('http://www.filmon.tv/vod/view/10250-0-crime-boss',
-                         [None, None, '10250'])
+@pytest.mark.parametrize('url,expected', [
+    ('http://www.filmon.tv/channel/grandstand-show', [None, "grandstand-show", None]),
+    ('http://www.filmon.tv/index/popout?channel_id=5510&quality=low', [None, '5510', None]),
+    ('http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1', [None, '5510', None]),
+    ('http://www.filmon.tv/tv/channel/grandstand-show', [None, 'grandstand-show', None]),
+    ('https://www.filmon.com/tv/bbc-news', [None, 'bbc-news', None]),
+    ('https://www.filmon.com/tv/channel-4', [None, 'channel-4', None]),
+    ('https://www.filmon.tv/tv/55', [None, '55', None]),
+    ('http://www.filmon.tv/group/comedy', ['group/', 'comedy', None]),
+    ('http://www.filmon.tv/vod/view/10250-0-crime-boss', [None, None, '10250'])
+])
+def test_match_url(url, expected):
+    Plugin.bind(Mock(), "tests.plugins.test_filmon")
+    plugin = Filmon(url)
+    assert plugin.match is not None
+    # expected must return [is_group, channel, vod_id]
+    assert list(plugin.match.groups()) == expected

--- a/tests/plugins/test_huomao.py
+++ b/tests/plugins/test_huomao.py
@@ -25,18 +25,6 @@ class TestPluginCanHandleUrlHuomao(PluginCanHandleUrl):
         "https://www.huomao.tv/video/v/123456",
         "https://huomao.com/video/v/123456",
         "https://huomao.tv/video/v/123456",
-
-        # Assert that an URL without the http(s):// prefix is correctly read.
-        "www.huomao.com/123456",
-        "www.huomao.tv/123456",
-        "www.huomao.com/video/v/123456",
-        "www.huomao.tv/video/v/123456",
-
-        # Assert that an URL without the www prefix is correctly read.
-        "huomao.com/123456",
-        "huomao.tv/123456",
-        "huomao.com/video/v/123456",
-        "huomao.tv/video/v/123456",
     ]
 
     should_not_match = [
@@ -49,8 +37,4 @@ class TestPluginCanHandleUrlHuomao(PluginCanHandleUrl):
         "https://www.huomao.tv/",
         "https://huomao.com/",
         "https://huomao.tv/",
-        "www.huomao.com/",
-        "www.huomao.tv/",
-        "huomao.tv/",
-        "huomao.tv/",
     ]

--- a/tests/plugins/test_qq.py
+++ b/tests/plugins/test_qq.py
@@ -1,5 +1,8 @@
-import unittest
+from unittest.mock import Mock
 
+import pytest
+
+from streamlink.plugin import Plugin
 from streamlink.plugins.qq import QQ
 from tests.plugins import PluginCanHandleUrl
 
@@ -23,19 +26,12 @@ class TestPluginCanHandleUrlQQ(PluginCanHandleUrl):
     ]
 
 
-class TestPluginQQ(unittest.TestCase):
-    def test_url_re(self):
-        regex_match_list = [
-            {
-                "data": "http://live.qq.com/10003715",
-                "result": "10003715"
-            },
-            {
-                "data": "http://m.live.qq.com/10039165",
-                "result": "10039165"
-            }
-        ]
-        for m_test in regex_match_list:
-            m = QQ._url_re.match(m_test.get("data"))
-            self.assertIsNotNone(m)
-            self.assertEqual(m_test.get("result"), m.group("room_id"))
+@pytest.mark.parametrize("url,group,expected", [
+    ("http://live.qq.com/10003715", "room_id", "10003715"),
+    ("http://m.live.qq.com/10039165", "room_id", "10039165")
+])
+def test_match_url(url, group, expected):
+    Plugin.bind(Mock(), "tests.plugins.test_qq")
+    plugin = QQ(url)
+    assert plugin.match is not None
+    assert plugin.match.group(group) == expected

--- a/tests/plugins/test_ruv.py
+++ b/tests/plugins/test_ruv.py
@@ -6,21 +6,20 @@ class TestPluginCanHandleUrlRuv(PluginCanHandleUrl):
     __plugin__ = Ruv
 
     should_match = [
-        "ruv.is/ruv",
+        "http://ruv.is/ruv",
         "http://ruv.is/ruv",
         "http://ruv.is/ruv/",
         "https://ruv.is/ruv/",
         "http://www.ruv.is/ruv",
         "http://www.ruv.is/ruv/",
-        "ruv.is/ruv2",
-        "ruv.is/ras1",
-        "ruv.is/ras2",
-        "ruv.is/rondo",
+        "http://ruv.is/ruv2",
+        "http://ruv.is/ras1",
+        "http://ruv.is/ras2",
+        "http://ruv.is/rondo",
         "http://www.ruv.is/spila/ruv/ol-2018-ishokki-karla/20180217",
         "http://www.ruv.is/spila/ruv/frettir/20180217"
     ]
 
     should_not_match = [
-        "rruv.is/ruv",
-        "ruv.is/ruvnew",
+        "http://ruv.is/ruvnew",
     ]

--- a/tests/plugins/test_showroom.py
+++ b/tests/plugins/test_showroom.py
@@ -17,8 +17,6 @@ class TestPluginCanHandleUrlShowroom(PluginCanHandleUrl):
     ]
 
     should_not_match = [
-        "https://www.showroom-live.com/mypage",
-        "https://www.showroom-live.com/ranking",
         "https://www.showroom-live.com/payment/payment_start",
         "https://www.showroom-live.com/s/licence",
     ]

--- a/tests/plugins/test_stream.py
+++ b/tests/plugins/test_stream.py
@@ -121,6 +121,7 @@ class TestPluginStream(unittest.TestCase):
                         "https://hostname.se/auth.php?key=a+value", dict(verify=False, params=dict(key='a value')))
 
     def test_parse_params(self):
+        self.assertEqual({}, parse_params())
         self.assertEqual(
             dict(verify=False, params=dict(key="a value")),
             parse_params("""verify=False params={'key': 'a value'}""")

--- a/tests/plugins/test_vk.py
+++ b/tests/plugins/test_vk.py
@@ -1,5 +1,8 @@
-import unittest
+from unittest.mock import Mock
 
+import pytest
+
+from streamlink.exceptions import NoStreamsError
 from streamlink.plugins.vk import VK
 from tests.plugins import PluginCanHandleUrl
 
@@ -22,28 +25,35 @@ class TestPluginCanHandleUrlVK(PluginCanHandleUrl):
     should_not_match = [
         "https://vk.com/",
         "https://vk.com/restore",
-        "https://www.vk.com/videos-24136539",
-        "http://vk.com/videos-24136539",
     ]
 
 
-class TestPluginVK(unittest.TestCase):
-    def test_follow_vk_redirect(self):
-        # should redirect
-        self.assertEqual(VK.follow_vk_redirect(
-            "https://vk.com/videos-24136539?z=video-24136539_456241176%2Fclub24136539%2Fpl_-24136539_-2"),
-            "https://vk.com/video-24136539_456241176"
-        )
-        self.assertEqual(VK.follow_vk_redirect(
-            "https://vk.com/videos-24136539?z=video-24136539_456241181%2Fpl_-24136539_-2"),
-            "https://vk.com/video-24136539_456241181"
-        )
-        self.assertEqual(VK.follow_vk_redirect(
-            "https://vk.com/videos132886594?z=video132886594_167211693"),
-            "https://vk.com/video132886594_167211693"
-        )
-
-        # shouldn't redirect
-        self.assertEqual(VK.follow_vk_redirect("http://vk.com/"), "http://vk.com/")
-        self.assertEqual(VK.follow_vk_redirect("http://vk.com/videos-24136539"), "http://vk.com/videos-24136539")
-        self.assertEqual(VK.follow_vk_redirect("http://www.youtube.com/"), "http://www.youtube.com/")
+@pytest.mark.parametrize("url,newurl,raises", [
+    ("https://vk.com/videos-24136539?z=video-24136539_456241176%2Fclub24136539%2Fpl_-24136539_-2",
+     "https://vk.com/video-24136539_456241176",
+     False),
+    ("https://vk.com/videos-24136539?z=video-24136539_456241181%2Fpl_-24136539_-2",
+     "https://vk.com/video-24136539_456241181",
+     False),
+    ("https://vk.com/videos132886594?z=video132886594_167211693",
+     "https://vk.com/video132886594_167211693",
+     False),
+    ("http://vk.com/",
+     "http://vk.com/",
+     False),
+    ("http://vk.com/videos-24136539",
+     "http://vk.com/videos-24136539",
+     True),
+    ("http://vk.com/videos-24136539?z=",
+     "http://vk.com/videos-24136539?z=",
+     True),
+])
+def test_url_redirect(url, newurl, raises):
+    VK.bind(Mock(), "tests.plugins.test_vk")
+    plugin = VK(url)
+    try:
+        plugin.follow_vk_redirect()
+        assert not raises
+    except NoStreamsError:
+        assert raises
+    assert plugin.url == newurl

--- a/tests/plugins/test_vtvgo.py
+++ b/tests/plugins/test_vtvgo.py
@@ -22,6 +22,4 @@ class TestPluginCanHandleUrlVTVgo(PluginCanHandleUrl):
     should_not_match = [
         # POST request will error with www.
         'https://www.vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
-        # POST request will error with http://
-        'http://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html',
     ]

--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import Mock
 
 import pytest
@@ -44,23 +43,16 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
     ]
 
 
-class TestPluginYouTube(unittest.TestCase):
-    def _test_regex(self, url, expected_string, expected_group):
-        m = YouTube._re_url.match(url)
-        self.assertIsNotNone(m)
-        self.assertEqual(expected_string, m.group(expected_group))
-
-    def test_regex_video_id_v(self):
-        self._test_regex("https://www.youtube.com/v/aqz-KE-bpKQ",
-                         "aqz-KE-bpKQ", "video_id")
-
-    def test_regex_video_id_embed(self):
-        self._test_regex("https://www.youtube.com/embed/aqz-KE-bpKQ",
-                         "aqz-KE-bpKQ", "video_id")
-
-    def test_regex_video_id_watch(self):
-        self._test_regex("https://www.youtube.com/watch?v=aqz-KE-bpKQ",
-                         "aqz-KE-bpKQ", "video_id")
+@pytest.mark.parametrize("url,group,expected", [
+    ("https://www.youtube.com/v/aqz-KE-bpKQ", "video_id", "aqz-KE-bpKQ"),
+    ("https://www.youtube.com/embed/aqz-KE-bpKQ", "video_id", "aqz-KE-bpKQ"),
+    ("https://www.youtube.com/watch?v=aqz-KE-bpKQ", "video_id", "aqz-KE-bpKQ"),
+])
+def test_match_url(url, group, expected):
+    Plugin.bind(Mock(), "tests.plugins.test_youtube")
+    plugin = YouTube(url)
+    assert plugin.match is not None
+    assert plugin.match.group(group) == expected
 
 
 @pytest.mark.parametrize("url,expected", [


### PR DESCRIPTION
Opening this as a draft, see #3814. 

The interesting commits are the first two and the last one, the rest are plugin updates, which are not that interesting and bloat up this diff a lot.

I've split up the plugin changes into multiple commits, based on the type of changes. Since the URL regexes had to be moved, I immediately applied fixes, as it would be duplicate work otherwise.

I'm not sure if I'm convinced with the regex pattern compilation in the decorator and the language injection annotations. After thinking about it again, it's probably better to just call `re.compile` in the decorator patameter.

Apart from that, the only thing that's missing is documentation.