### PR TITLE
plugin: support m4sport

### DIFF
--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -10,15 +10,40 @@ log = logging.getLogger(__name__)
 
 
 class Mediaklikk(Plugin):
-    PLAYER_URL = "https://player.mediaklikk.hu/playernew/player.php"
+    DEFAULT_PLAYER_URL = "https://player.mediaklikk.hu/playernew/player.php"
+    M4SPORT_PLAYER_URL = "https://m4sport.hu/playernew/player.php"
 
-    _url_re = re.compile(r"https?://(?:www\.)?(?:mediaklikk|m4sport)\.hu/(?:[\w\-]+\-)?elo/?")
+    _url_re = re.compile(r"https?://(?:www\.)?(?:mediaklikk|m4sport)\.hu/(?:elo/)?(?:[\w\-]+)?(live|-elo)?/?")
     _id_re = re.compile(r'"streamId":"(\w+)"')
-    _file_re = re.compile(r'"file":\s*"([\w\./\\=:\-\?]+)"')
+    _default_file_re = re.compile(r'"file":\s*"([\w\./\\=:\-\?]+)"')
+    # the m4sport site has multiple playlist item but it seems only the middle one with your own ip added works
+    _m4sport_file_re = re.compile(r'"file":\s*"([\w\./\\=:\-\?]+)ip:.*"')
 
     @classmethod
     def can_handle_url(cls, url):
         return cls._url_re.match(url) is not None
+
+    @property
+    def is_m4sport(self):
+        return "m4sport" in self.url
+
+    @property
+    def player_url(self):
+        if self.is_m4sport:
+            return self.M4SPORT_PLAYER_URL
+
+        return self.DEFAULT_PLAYER_URL
+
+    def get_playlist_url(self, content):
+        if self.is_m4sport:
+            m = self._m4sport_file_re.search(content)
+        else:
+            m = self._default_file_re.search(content)
+
+        if not m:
+            return None
+
+        return update_scheme("https://", m.group(1).replace("\\/", "/"))
 
     def _get_streams(self):
         # get the stream id
@@ -32,14 +57,12 @@ class Mediaklikk(Plugin):
             "video": m.group(1),
             "noflash": "yes",
         }
-        res = self.session.http.get(self.PLAYER_URL, params=params)
-        m = self._file_re.search(res.text)
-        if m:
-            url = update_scheme("https://",
-                                m.group(1).replace("\\/", "/"))
+        res = self.session.http.get(self.player_url, params=params)
 
-            log.debug("URL={0}".format(url))
-            return HLSStream.parse_variant_playlist(self.session, url)
+        playlist_url = self.get_playlist_url(res.text)
+        if playlist_url:
+            log.debug("URL={0}".format(playlist_url))
+            return HLSStream.parse_variant_playlist(self.session, playlist_url)
 
 
 __plugin__ = Mediaklikk

--- a/tests/plugins/test_mediaklikk.py
+++ b/tests/plugins/test_mediaklikk.py
@@ -13,6 +13,7 @@ class TestPluginCanHandleUrlMediaklikk(PluginCanHandleUrl):
         'https://m4sport.hu/elo/',
         'https://m4sport.hu/elo/?channelId=m4sport+',
         'https://m4sport.hu/elo/?showchannel=mtv4plus',
+        'https://m4sport.hu/elo/mtv4live/',
     ]
 
     should_not_match = [


### PR DESCRIPTION
Added support for m4sport, during the UEFA championship the page got moved from https://mediaklikk.hu/m4-elo/ to https://m4sport.hu/elo/mtv4live/
