### PR TITLE
stream.hls: implement media initialization section

### DIFF
--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -2,68 +2,139 @@ import logging
 import math
 import re
 from binascii import unhexlify
-from collections import namedtuple
-from datetime import timedelta
+from datetime import datetime, timedelta
 from itertools import starmap
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type, Union
 from urllib.parse import urljoin, urlparse
 
-from isodate import parse_datetime
+# noinspection PyPackageRequirements
+from isodate import ISO8601Error, parse_datetime
 
 log = logging.getLogger(__name__)
 
-__all__ = ["load", "M3U8Parser"]
+
+class Resolution(NamedTuple):
+    width: int
+    height: int
+
+
+# EXTINF
+class ExtInf(NamedTuple):
+    duration: float  # version >= 3: float
+    title: Optional[str]
 
 
 # EXT-X-BYTERANGE
-ByteRange = namedtuple("ByteRange", "range offset")
+class ByteRange(NamedTuple):  # version >= 4
+    range: int
+    offset: int
+
 
 # EXT-X-DATERANGE
-DateRange = namedtuple("DateRange", "id classname start_date end_date duration planned_duration end_on_next x")
+class DateRange(NamedTuple):
+    id: Optional[str]
+    classname: Optional[str]
+    start_date: Optional[datetime]
+    end_date: Optional[datetime]
+    duration: Optional[timedelta]
+    planned_duration: Optional[timedelta]
+    end_on_next: bool
+    x: Dict[str, str]
+
 
 # EXT-X-KEY
-Key = namedtuple("Key", "method uri iv key_format key_format_versions")
+class Key(NamedTuple):
+    method: str
+    uri: str
+    iv: Optional[bytes]  # version >= 2
+    key_format: Optional[str]  # version >= 5
+    key_format_versions: Optional[str]  # version >= 5
+
 
 # EXT-X-MAP
-Map = namedtuple("Map", "uri byterange")
+class Map(NamedTuple):
+    uri: str
+    byterange: Optional[ByteRange]
+
 
 # EXT-X-MEDIA
-Media = namedtuple("Media", "uri type group_id language name default autoselect forced characteristics")
+class Media(NamedTuple):
+    uri: str
+    type: str
+    group_id: str
+    language: Optional[str]
+    name: str
+    default: bool
+    autoselect: bool
+    forced: bool
+    characteristics: Optional[str]
+
 
 # EXT-X-START
-Start = namedtuple("Start", "time_offset precise")
+class Start(NamedTuple):
+    time_offset: float
+    precise: bool
+
 
 # EXT-X-STREAM-INF
-StreamInfo = namedtuple("StreamInfo", "bandwidth program_id codecs resolution audio video subtitles")
+class StreamInfo(NamedTuple):
+    bandwidth: int
+    program_id: Optional[str]  # version < 6
+    codecs: List[str]
+    resolution: Optional[Resolution]
+    audio: Optional[str]
+    video: Optional[str]
+    subtitles: Optional[str]
+
 
 # EXT-X-I-FRAME-STREAM-INF
-IFrameStreamInfo = namedtuple("IFrameStreamInfo", "bandwidth program_id codecs resolution video")
+class IFrameStreamInfo(NamedTuple):
+    bandwidth: int
+    program_id: Optional[str]
+    codecs: List[str]
+    resolution: Optional[Resolution]
+    video: Optional[str]
 
-Playlist = namedtuple("Playlist", "uri stream_info media is_iframe")
-Resolution = namedtuple("Resolution", "width height")
-Segment = namedtuple("Segment", "uri duration title key discontinuity byterange date map")
+
+class Playlist(NamedTuple):
+    uri: str
+    stream_info: Union[StreamInfo, IFrameStreamInfo]
+    media: List[Media]
+    is_iframe: bool
+
+
+class Segment(NamedTuple):
+    uri: str
+    duration: float
+    title: Optional[str]
+    key: Optional[Key]
+    discontinuity: bool
+    byterange: Optional[ByteRange]
+    date: Optional[datetime]
+    map: Optional[Map]
 
 
 class M3U8:
     def __init__(self):
-        self.is_endlist = False
-        self.is_master = False
+        self.is_endlist: bool = False
+        self.is_master: bool = False
 
-        self.allow_cache = None
-        self.discontinuity_sequence = None
-        self.iframes_only = None
-        self.media_sequence = None
-        self.playlist_type = None
-        self.target_duration = None
-        self.start = None
-        self.version = None
+        self.allow_cache: Optional[bool] = None  # version < 7
+        self.discontinuity_sequence: Optional[int] = None
+        self.iframes_only: Optional[bool] = None  # version >= 4
+        self.media_sequence: Optional[int] = None
+        self.playlist_type: Optional[str] = None
+        self.target_duration: Optional[int] = None
+        self.start: Optional[Start] = None
+        self.version: Optional[int] = None
 
-        self.media = []
-        self.playlists = []
-        self.dateranges = []
-        self.segments = []
+        self.media: List[Media] = []
+        self.playlists: List[Playlist] = []
+        self.dateranges: List[DateRange] = []
+        self.segments: List[Segment] = []
 
     @classmethod
-    def is_date_in_daterange(cls, date, daterange):
+    def is_date_in_daterange(cls, date: Segment.date, daterange: DateRange):
         if date is None or daterange.start_date is None:
             return None
 
@@ -85,12 +156,12 @@ class M3U8Parser:
     _tag_re = re.compile(r"#(?P<tag>[\w-]+)(:(?P<value>.+))?")
     _res_re = re.compile(r"(\d+)x(\d+)")
 
-    def __init__(self, base_uri=None, m3u8=M3U8, **kwargs):
-        self.base_uri = base_uri
-        self.m3u8 = m3u8()
-        self.state = {}
+    def __init__(self, base_uri: Optional[str] = None, m3u8: Type[M3U8] = M3U8):
+        self.base_uri: Optional[str] = base_uri
+        self.m3u8: M3U8 = m3u8()
+        self.state: Dict[str, Any] = {}
 
-    def create_stream_info(self, streaminf, cls=None):
+    def create_stream_info(self, streaminf: Dict[str, Optional[str]], cls=None):
         program_id = streaminf.get("PROGRAM-ID")
 
         bandwidth = streaminf.get("BANDWIDTH")
@@ -101,19 +172,26 @@ class M3U8Parser:
         if resolution:
             resolution = self.parse_resolution(resolution)
 
-        codecs = streaminf.get("CODECS")
-        if codecs:
-            codecs = codecs.split(",")
-        else:
-            codecs = []
+        codecs = streaminf.get("CODECS", "").split(",")
 
         if cls == IFrameStreamInfo:
-            return IFrameStreamInfo(bandwidth, program_id, codecs, resolution,
-                                    streaminf.get("VIDEO"))
+            return IFrameStreamInfo(
+                bandwidth,
+                program_id,
+                codecs,
+                resolution,
+                streaminf.get("VIDEO")
+            )
         else:
-            return StreamInfo(bandwidth, program_id, codecs, resolution,
-                              streaminf.get("AUDIO"), streaminf.get("VIDEO"),
-                              streaminf.get("SUBTITLES"))
+            return StreamInfo(
+                bandwidth,
+                program_id,
+                codecs,
+                resolution,
+                streaminf.get("AUDIO"),
+                streaminf.get("VIDEO"),
+                streaminf.get("SUBTITLES")
+            )
 
     def split_tag(self, line):
         match = self._tag_re.match(line)
@@ -123,49 +201,48 @@ class M3U8Parser:
 
         return None, None
 
-    def parse_attributes(self, value):
-        def map_attribute(key, value, quoted):
-            return (key, quoted or value)
+    @staticmethod
+    def map_attribute(key: str, value: str, quoted: str) -> Tuple[str, str]:
+        return key, quoted or value
 
-        attr = self._attr_re.findall(value)
+    def parse_attributes(self, value: str) -> Dict[str, str]:
+        return dict(starmap(self.map_attribute, self._attr_re.findall(value)))
 
-        return dict(starmap(map_attribute, attr))
-
-    def parse_bool(self, value):
+    @staticmethod
+    def parse_bool(value: str) -> bool:
         return value == "YES"
 
-    def parse_byterange(self, value):
+    def parse_byterange(self, value: str) -> Optional[ByteRange]:
         match = self._range_re.match(value)
+        return None if match is None else ByteRange(int(match.group("range")), int(match.group("offset") or 0))
 
-        if match:
-            return ByteRange(int(match.group("range")),
-                             int(match.group("offset") or 0))
-
-    def parse_extinf(self, value):
+    def parse_extinf(self, value: str) -> Tuple[float, Optional[str]]:
         match = self._extinf_re.match(value)
-        if match:
-            return float(match.group("duration")), match.group("title")
-        return (0, None)
+        return ExtInf(0, None) if match is None else ExtInf(float(match.group("duration")), match.group("title"))
 
-    def parse_hex(self, value):
+    @staticmethod
+    def parse_hex(value: Optional[str]) -> Optional[bytes]:
+        if value is None:
+            return value
+
         value = value[2:]
         if len(value) % 2:
             value = "0" + value
 
         return unhexlify(value)
 
-    def parse_iso8601(self, value):
-        if value is None:
-            return None
+    @staticmethod
+    def parse_iso8601(value: Optional[str]) -> Optional[datetime]:
         try:
-            return parse_datetime(value)
-        except ValueError:
+            return None if value is None else parse_datetime(value)
+        except (ISO8601Error, ValueError):
             return None
 
-    def parse_timedelta(self, value):
-        return timedelta(seconds=float(value)) if value is not None else None
+    @staticmethod
+    def parse_timedelta(value: Optional[str]) -> Optional[timedelta]:
+        return None if value is None else timedelta(seconds=float(value))
 
-    def parse_resolution(self, value):
+    def parse_resolution(self, value: str) -> Resolution:
         match = self._res_re.match(value)
 
         if match:
@@ -191,13 +268,13 @@ class M3U8Parser:
 
     def parse_tag_ext_x_key(self, value):
         attr = self.parse_attributes(value)
-        iv = attr.get("IV")
-        if iv:
-            iv = self.parse_hex(iv)
-        self.state["key"] = Key(attr.get("METHOD"),
-                                self.uri(attr.get("URI")),
-                                iv, attr.get("KEYFORMAT"),
-                                attr.get("KEYFORMATVERSIONS"))
+        self.state["key"] = Key(
+            attr.get("METHOD"),
+            self.uri(attr.get("URI")),
+            self.parse_hex(attr.get("IV")),
+            attr.get("KEYFORMAT"),
+            attr.get("KEYFORMATVERSIONS")
+        )
 
     def parse_tag_ext_x_program_date_time(self, value):
         self.state["date"] = self.parse_iso8601(value)
@@ -216,7 +293,7 @@ class M3U8Parser:
         )
         self.m3u8.dateranges.append(daterange)
 
-    def parse_tag_ext_x_allow_cache(self, value):
+    def parse_tag_ext_x_allow_cache(self, value):  # version < 7
         self.m3u8.allow_cache = self.parse_bool(value)
 
     def parse_tag_ext_x_stream_inf(self, value):
@@ -226,6 +303,7 @@ class M3U8Parser:
     def parse_tag_ext_x_playlist_type(self, value):
         self.m3u8.playlist_type = value
 
+    # noinspection PyUnusedLocal
     def parse_tag_ext_x_endlist(self, value):
         self.m3u8.is_endlist = True
 
@@ -244,6 +322,7 @@ class M3U8Parser:
         )
         self.m3u8.media.append(media)
 
+    # noinspection PyUnusedLocal
     def parse_tag_ext_x_discontinuity(self, value):
         self.state["discontinuity"] = True
         self.state["map"] = None
@@ -251,13 +330,14 @@ class M3U8Parser:
     def parse_tag_ext_x_discontinuity_sequence(self, value):
         self.m3u8.discontinuity_sequence = int(value)
 
-    def parse_tag_ext_x_i_frames_only(self, value):
+    # noinspection PyUnusedLocal
+    def parse_tag_ext_x_i_frames_only(self, value):  # version >= 4
         self.m3u8.iframes_only = True
 
-    def parse_tag_ext_x_map(self, value):
+    def parse_tag_ext_x_map(self, value):  # version >= 5
         attr = self.parse_attributes(value)
         byterange = self.parse_byterange(attr.get("BYTERANGE", ""))
-        self.state["map"] = Map(attr.get("URI"), byterange)
+        self.state["map"] = Map(self.uri(attr.get("URI")), byterange)
 
     def parse_tag_ext_x_i_frame_stream_inf(self, value):
         attr = self.parse_attributes(value)
@@ -271,9 +351,10 @@ class M3U8Parser:
 
     def parse_tag_ext_x_start(self, value):
         attr = self.parse_attributes(value)
-        start = Start(attr.get("TIME-OFFSET"),
-                      self.parse_bool(attr.get("PRECISE", "NO")))
-        self.m3u8.start = start
+        self.m3u8.start = Start(
+            float(attr.get("TIME-OFFSET", 0)),
+            self.parse_bool(attr.get("PRECISE", "NO"))
+        )
 
     def parse_line(self, line):
         if line.startswith("#"):
@@ -291,7 +372,7 @@ class M3U8Parser:
             playlist = self.get_playlist(self.uri(line))
             self.m3u8.playlists.append(playlist)
 
-    def parse(self, data):
+    def parse(self, data: str) -> M3U8:
         lines = iter(filter(bool, data.splitlines()))
         try:
             line = next(lines)
@@ -319,7 +400,7 @@ class M3U8Parser:
 
         return self.m3u8
 
-    def uri(self, uri):
+    def uri(self, uri: str) -> str:
         if uri and urlparse(uri).scheme:
             return uri
         elif self.base_uri and uri:
@@ -327,32 +408,26 @@ class M3U8Parser:
         else:
             return uri
 
-    def get_segment(self, uri):
-        byterange = self.state.pop("byterange", None)
-        extinf = self.state.pop("extinf", (0, None))
-        date = self.state.pop("date", None)
-        map_ = self.state.get("map")
-        key = self.state.get("key")
-        discontinuity = self.state.pop("discontinuity", False)
-
+    def get_segment(self, uri: str) -> Segment:
+        extinf: ExtInf = self.state.pop("extinf", None) or ExtInf(0, None)
         return Segment(
             uri,
-            extinf[0],
-            extinf[1],
-            key,
-            discontinuity,
-            byterange,
-            date,
-            map_
+            extinf.duration,
+            extinf.title,
+            self.state.get("key"),
+            self.state.pop("discontinuity", False),
+            self.state.pop("byterange", None),
+            self.state.pop("date", None),
+            self.state.get("map")
         )
 
-    def get_playlist(self, uri):
+    def get_playlist(self, uri: str) -> Playlist:
         streaminf = self.state.pop("streaminf", {})
         stream_info = self.create_stream_info(streaminf)
         return Playlist(uri, stream_info, [], False)
 
 
-def load(data, base_uri=None, parser=M3U8Parser, **kwargs):
+def load(data: str, base_uri: Optional[str] = None, parser: Type[M3U8Parser] = M3U8Parser, **kwargs) -> M3U8:
     """Attempts to parse a M3U8 playlist from a string of data.
 
     If specified, *base_uri* is the base URI that relative URIs will

--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -1,9 +1,10 @@
 import logging
 import queue
 from concurrent import futures
-from concurrent.futures.thread import ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor
 from sys import version_info
 from threading import Event, Thread
+from typing import Any, Optional
 
 from streamlink.buffers import RingBuffer
 from streamlink.stream.stream import StreamIO
@@ -13,7 +14,7 @@ log = logging.getLogger(__name__)
 
 class CompatThreadPoolExecutor(ThreadPoolExecutor):
     if version_info < (3, 9):
-        def shutdown(self, wait=True, cancel_futures=False):
+        def shutdown(self, wait=True, cancel_futures=False):  # pragma: no cover
             with self._shutdown_lock:
                 self._shutdown = True
                 if cancel_futures:
@@ -51,8 +52,7 @@ class SegmentedStreamWorker(Thread):
 
         self._wait = None
 
-        Thread.__init__(self, name="Thread-{0}".format(self.__class__.__name__))
-        self.daemon = True
+        super().__init__(daemon=True, name=f"Thread-{self.__class__.__name__}")
 
     def close(self):
         """Shuts down the thread."""
@@ -118,8 +118,7 @@ class SegmentedStreamWriter(Thread):
         self.executor = CompatThreadPoolExecutor(max_workers=threads)
         self.futures = queue.Queue(size)
 
-        Thread.__init__(self, name="Thread-{0}".format(self.__class__.__name__))
-        self.daemon = True
+        super().__init__(daemon=True, name=f"Thread-{self.__class__.__name__}")
 
     def close(self):
         """Shuts down the thread."""
@@ -135,21 +134,20 @@ class SegmentedStreamWriter(Thread):
         if self.closed:
             return
 
-        if segment is not None:
-            future = self.executor.submit(self.fetch, segment,
-                                          retries=self.retries)
-        else:
+        if segment is None:
             future = None
+        else:
+            future = self.executor.submit(self.fetch, segment, retries=self.retries)
 
-        self.queue(self.futures, (segment, future))
+        self.queue(future, segment)
 
-    def queue(self, queue_, value):
-        """Puts a value into a queue but aborts if this thread is closed."""
+    def queue(self, future: Optional[Future], segment: Any, *data):
+        """Puts values into a queue but aborts if this thread is closed."""
         while not self.closed:
             try:
-                queue_.put(value, block=True, timeout=1)
+                self.futures.put((future, segment, *data), block=True, timeout=1)
                 return
-            except queue.Full:
+            except queue.Full:  # pragma: no cover
                 continue
 
     def fetch(self, segment):
@@ -159,7 +157,7 @@ class SegmentedStreamWriter(Thread):
         """
         pass
 
-    def write(self, segment, result):
+    def write(self, segment, result, *data):
         """Writes a segment to the buffer.
 
         Should be overridden by the inheriting class.
@@ -169,24 +167,24 @@ class SegmentedStreamWriter(Thread):
     def run(self):
         while not self.closed:
             try:
-                segment, future = self.futures.get(block=True, timeout=0.5)
-            except queue.Empty:
+                future, segment, *data = self.futures.get(block=True, timeout=0.5)
+            except queue.Empty:  # pragma: no cover
                 continue
 
             # End of stream
             if future is None:
                 break
 
-            while not self.closed:
+            while not self.closed:  # pragma: no branch
                 try:
                     result = future.result(timeout=0.5)
-                except futures.TimeoutError:
+                except futures.TimeoutError:  # pragma: no cover
                     continue
-                except futures.CancelledError:
+                except futures.CancelledError:  # pragma: no cover
                     break
 
-                if result is not None:
-                    self.write(segment, result)
+                if result is not None:  # pragma: no branch
+                    self.write(segment, result, *data)
 
                 break
 
@@ -198,7 +196,7 @@ class SegmentedStreamReader(StreamIO):
     __writer__ = SegmentedStreamWriter
 
     def __init__(self, stream, timeout=None):
-        StreamIO.__init__(self)
+        super().__init__()
         self.session = stream.session
         self.stream = stream
 

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -2,8 +2,10 @@ import json
 import re
 import xml.etree.ElementTree as ET
 import zlib
+from collections import OrderedDict
 from importlib.machinery import FileFinder, SOURCE_SUFFIXES, SourceFileLoader
 from importlib.util import module_from_spec
+from typing import Dict, Generic, Optional, TypeVar
 from urllib.parse import parse_qsl, urljoin, urlparse
 
 from streamlink.exceptions import PluginError
@@ -181,7 +183,33 @@ def escape_librtmp(value):  # pragma: no cover
     return value
 
 
+TCacheKey = TypeVar("TCacheKey")
+TCacheValue = TypeVar("TCacheValue")
+
+
+class LRUCache(Generic[TCacheKey, TCacheValue]):
+    def __init__(self, num: int):
+        # TODO: fix type after dropping py36
+        self.cache: Dict[TCacheKey, TCacheValue] = OrderedDict()
+        self.num = num
+
+    def get(self, key: TCacheKey) -> Optional[TCacheValue]:
+        if key not in self.cache:
+            return None
+        # noinspection PyUnresolvedReferences
+        self.cache.move_to_end(key)
+        return self.cache[key]
+
+    def set(self, key: TCacheKey, value: TCacheValue) -> None:
+        self.cache[key] = value
+        # noinspection PyUnresolvedReferences
+        self.cache.move_to_end(key)
+        if len(self.cache) > self.num:
+            # noinspection PyArgumentList
+            self.cache.popitem(last=False)
+
+
 __all__ = ["load_module", "swfdecompress", "update_scheme", "url_equal",
            "verifyjson", "absolute_url", "parse_qsd", "parse_json",
            "parse_xml", "rtmpparse", "prepend_www", "NamedPipe",
-           "escape_librtmp", "LazyFormatter"]
+           "escape_librtmp", "LRUCache", "LazyFormatter"]

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -200,14 +200,18 @@ class TestMixinStreamHLS(unittest.TestCase):
     def get_mock(self, item):
         return self.mocks[self.url(item)]
 
-    def called(self, item):
-        return self.get_mock(item).called
+    def called(self, item, once=False):
+        mock = self.get_mock(item)
+        return mock.called_once if once else mock.called
 
     def url(self, item):
         return item.url(self.id())
 
-    def content(self, segments, prop="content", cond=None):
-        return b"".join([getattr(segment, prop) for segment in segments.values() if cond is None or cond(segment)])
+    @staticmethod
+    def content(segments, prop="content", cond=None):
+        if isinstance(segments, dict):
+            segments = segments.values()
+        return b"".join([getattr(segment, prop) for segment in segments if cond is None or cond(segment)])
 
     # close read thread and make sure that all threads have terminated before moving on
     def close_thread(self):

--- a/tests/streams/test_hls_playlist.py
+++ b/tests/streams/test_hls_playlist.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timedelta
 
+# noinspection PyPackageRequirements
 from isodate import tzinfo
 
 from streamlink.stream.hls_playlist import DateRange, Media, Resolution, Segment, StreamInfo, load


### PR DESCRIPTION
Resolves #3328
Resolves #3403 

This implements the "Media Initialization Section" of HLS segments (via the `EXT-X-MAP` HLS tag) which is required for streams which use the fragmented MPEG-4 format (or MPEG2-TS with optional initialization sections). Think of it as segment headers which are loaded from an external source.

> [3.2 MPEG-2 Transport Streams](https://datatracker.ietf.org/doc/html/rfc8216#section-3.2)
> The Media Initialization Section of an MPEG-2 Transport Stream Segment is a Program Association Table (PAT) followed by a Program Map Table (PMT).
> 
> Transport Stream Segments MUST contain a single MPEG-2 Program; playback of Multi-Program Transport Streams is not defined. Each Transport Stream Segment MUST contain a PAT and a PMT, or have an EXT-X-MAP tag (Section 4.3.2.5) applied to it. The first two Transport Stream packets in a Segment without an EXT-X-MAP tag SHOULD be a PAT and a PMT.

> [3.3 Fragmented MPEG-4](https://datatracker.ietf.org/doc/html/rfc8216#section-3.3)
> MPEG-4 Fragments are specified by the ISO Base Media File Format [ISOBMFF].  Unlike regular MPEG-4 files that have a Movie Box ('moov') that contains sample tables and a Media Data Box ('mdat') containing the corresponding samples, an MPEG-4 Fragment consists of a Movie Fragment Box ('moof') containing a subset of the sample table and a Media Data Box containing those samples.  Use of MPEG-4 Fragments does require a Movie Box for initialization, but that Movie Box contains only non-sample-specific information such as track and sample descriptions.
> ...
> Each fMP4 Segment in a Media Playlist MUST have an EXT-X-MAP tag applied to it.

This simply means that if a map exists, we always have to write the map contents (the segment initialization section) to the output stream before writing the actual segment contents, regardless the used format.

----

Split into two commits:
1. type hints and clean up with some minor fixes of the M3U8 parser  
   All namedtuples are now typed, which makes referencing data much easier. What still needs to be done in the future is implementing all missing and new tag attributes from newer HLS versions according to RFC8216.
2. refactor of SegmentedStreamWriter and HLSStreamWriter, and feature implementation  
   The map content requests all get cached with a max cache number equal to the number of writer threads, so that it doesn't have to re-request the initialization section(s) every time when downloading a new segment.

The changes should also include a fix for the wonky test coverage results, which were unstable in the SegmentedStreamWriter due to the threading and queue polling. It simply disables coverage on those parts.

----

Other subclasses of SegmentedStreamWriter should not be affected by these changes unless they override `queue()` or `put()`, but that is not the case.