### PR TITLE
plugins.zdf_mediathek: refactor plugin, drop HDS

### DIFF
--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -4,153 +4,88 @@ from urllib.parse import urlparse, urlunparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HDSStream, HLSStream
+from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 from streamlink.utils.url import url_concat
 
 log = logging.getLogger(__name__)
-
-QUALITY_WEIGHTS = {
-    "hd": 720,
-    "veryhigh": 480,
-    "high": 240,
-    "med": 176,
-    "low": 112
-}
-
-STREAMING_TYPES = {
-    "h264_aac_f4f_http_f4m_http": (
-        "HDS", HDSStream.parse_manifest
-    ),
-    "h264_aac_ts_http_m3u8_http": (
-        "HLS", HLSStream.parse_variant_playlist
-    )
-}
-
-_api_json_re = re.compile(r'''data-zdfplayer-jsb=["'](?P<json>{.+?})["']''', re.S)
-
-_api_schema = validate.Schema(
-    validate.transform(_api_json_re.search),
-    validate.any(
-        None,
-        validate.all(
-            validate.get("json"),
-            validate.transform(parse_json),
-            {
-                "content": validate.text,
-                "apiToken": validate.text
-            },
-        )
-    )
-)
-
-_documents_schema = validate.Schema(
-    {
-        "mainVideoContent": {
-            "http://zdf.de/rels/target": {
-                "http://zdf.de/rels/streams/ptmd-template": validate.text
-            },
-        },
-    }
-)
-
-_schema = validate.Schema(
-    {
-        "priorityList": [
-            {
-                "formitaeten": [
-                    {
-                        "type": validate.text,
-                        "qualities": [
-                            {
-                                "audio": {
-                                    "tracks": [
-                                        {
-                                            "uri": validate.text
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    }
-                ]
-            }
-        ]
-    }
-)
 
 
 @pluginmatcher(re.compile(
     r"https?://(\w+\.)?(zdf\.de|3sat\.de)/"
 ))
 class ZDFMediathek(Plugin):
-    @classmethod
-    def stream_weight(cls, key):
-        weight = QUALITY_WEIGHTS.get(key)
-        if weight:
-            return weight, "zdf_mediathek"
+    _re_api_json = re.compile(r"""data-zdfplayer-jsb=(["'])(?P<json>{.+?})\1""", re.DOTALL)
 
-        return Plugin.stream_weight(key)
-
-    def _extract_streams(self, response):
-        if "priorityList" not in response:
-            log.error("Invalid response! Contains no priorityList!")
-
-        for priority in response["priorityList"]:
-            for format_ in priority["formitaeten"]:
-                yield self._extract_from_format(format_)
-
-    def _parse_track(self, track, parser, name):
-        try:
-            return parser(self.session, track["uri"])
-        except OSError as err:
-            log.error("Failed to extract {0} streams: {1}".format(name, err))
-
-    def _extract_from_format(self, format_):
-        qualities = {}
-
-        if format_["type"] not in STREAMING_TYPES:
-            return qualities
-
-        name, parser = STREAMING_TYPES[format_["type"]]
-        for quality in format_["qualities"]:
-            for track in quality["audio"]["tracks"]:
-                option = self._parse_track(track, parser, name)
-                if option:
-                    qualities.update(option)
-
-        return qualities
+    PLAYER_ID = "ngplayer_2_4"
 
     def _get_streams(self):
-        zdf_json = self.session.http.get(self.url, schema=_api_schema)
+        zdf_json = self.session.http.get(self.url, schema=validate.Schema(
+            validate.transform(self._re_api_json.search),
+            validate.any(None, validate.all(
+                validate.get("json"),
+                validate.transform(parse_json),
+                {
+                    "apiToken": str,
+                    "content": validate.url()
+                },
+                validate.union_get("apiToken", "content")
+            ))
+        ))
         if zdf_json is None:
             return
 
+        apiToken, apiUrl = zdf_json
+
         headers = {
-            "Accept": "application/vnd.de.zdf.v1.0+json",
-            "Api-Auth": "Bearer {0}".format(zdf_json['apiToken']),
+            "Accept": "application/vnd.de.zdf.v1.0+json;charset=UTF-8",
+            "Api-Auth": f"Bearer {apiToken}",
             "Referer": self.url
         }
 
-        res = self.session.http.get(zdf_json['content'], headers=headers)
-        document = self.session.http.json(res, schema=_documents_schema)
+        pApiUrl = urlparse(apiUrl)
+        apiUrlBase = urlunparse((pApiUrl.scheme, pApiUrl.netloc, "", "", "", ""))
+        apiUrlPath = self.session.http.get(apiUrl, headers=headers, schema=validate.Schema(
+            validate.transform(parse_json),
+            {"mainVideoContent": {
+                "http://zdf.de/rels/target": {
+                    "http://zdf.de/rels/streams/ptmd-template": str
+                }
+            }},
+            validate.get(("mainVideoContent", "http://zdf.de/rels/target", "http://zdf.de/rels/streams/ptmd-template")),
+            validate.transform(lambda template: template.format(playerId=self.PLAYER_ID).replace(" ", ""))
+        ))
 
-        document_url_p = urlparse(zdf_json['content'])
-        api_url = urlunparse((document_url_p.scheme, document_url_p.netloc, "", "", "", ""))
+        stream_request_url = url_concat(apiUrlBase, apiUrlPath)
+        data = self.session.http.get(stream_request_url, headers=headers, schema=validate.Schema(
+            validate.transform(parse_json),
+            {"priorityList": [{
+                "formitaeten": validate.all(
+                    [{
+                        "type": str,
+                        "qualities": validate.all(
+                            [{
+                                "quality": str,
+                                "audio": {
+                                    "tracks": [{
+                                        "uri": validate.url()
+                                    }]
+                                }
+                            }],
+                            validate.filter(lambda obj: obj["quality"] == "auto")
+                        )
+                    }],
+                    validate.filter(lambda obj: obj["type"] == "h264_aac_ts_http_m3u8_http")
+                )
+            }]},
+            validate.get("priorityList")
+        ))
 
-        content = document["mainVideoContent"]
-        target = content["http://zdf.de/rels/target"]
-        template = target["http://zdf.de/rels/streams/ptmd-template"]
-        stream_request_url = url_concat(api_url, template.format(playerId="ngplayer_2_3").replace(" ", ""))
-
-        res = self.session.http.get(stream_request_url, headers=headers)
-        res = self.session.http.json(res, schema=_schema)
-
-        streams = {}
-        for format_ in self._extract_streams(res):
-            streams.update(format_)
-
-        return streams
+        for priority in data:
+            for formitaeten in priority["formitaeten"]:
+                for quality in formitaeten["qualities"]:
+                    for audio in quality["audio"]["tracks"]:
+                        yield from HLSStream.parse_variant_playlist(self.session, audio["uri"], headers=headers).items()
 
 
 __plugin__ = ZDFMediathek


### PR DESCRIPTION
- only use HLS streams (drop redundant HDS streams)
- update player ID from 'ngplayer_2_3' to 'ngplayer_2_4'
- remove custom stream weights
- move everything from global scope to plugin class
- update/improve validation schemas

----

It's probably a bit unnecessary, but the plugin currently yields way too many HLS streams when multiple master playlists exist for different languages. Similar issue with the Arte plugin.

Should this behavior be kept or should we just return the first stream? Or filter for the "main" stream maybe (not sure if this is properly flagged for every kind of content)?

----

```
$ streamlink 'https://www.zdf.de/live-tv'
[cli][info] Found matching plugin zdf_mediathek for URL https://www.zdf.de/live-tv
Available streams: 270p_alt (worst), 270p, 360p_alt, 360p, 540p_alt, 540p, 720p_alt, 720p (best)
```

```
$ streamlink 'https://www.zdf.de/sport/fussball-em/spiel-achtelfinale-england-deutschland-100.html'
[cli][info] Found matching plugin zdf_mediathek for URL https://www.zdf.de/sport/fussball-em/spiel-achtelfinale-england-deutschland-100.html
Available streams: 130k (worst), 270p, 360p, 540p, 720p (best)
```

```
$ streamlink 'https://www.zdf.de/serien/das-boot/das-boot-ii-folge-1-100.html'
[cli][info] Found matching plugin zdf_mediathek for URL https://www.zdf.de/serien/das-boot/das-boot-ii-folge-1-100.html
Available streams: 360p_alt2_alt, 360p_alt2_alt2, 130k_alt2 (worst), 130k_alt, 130k, 270p_alt2, 270p_alt, 270p, 360p_alt2, 360p_alt, 360p, 540p_alt2, 540p_alt, 540p, 720p_alt2, 720p_alt, 720p (best)
```

```
$ streamlink 'https://www.3sat.de/programm'
[cli][info] Found matching plugin zdf_mediathek for URL https://www.3sat.de/programm
Available streams: 270p_alt (worst), 270p, 360p_alt, 360p, 540p_alt, 540p (best)
```

```
$ streamlink 'https://www.3sat.de/dokumentation/natur/magie-des-monsuns-4-leben-mit-extremen-100.html'
[cli][info] Found matching plugin zdf_mediathek for URL https://www.3sat.de/dokumentation/natur/magie-des-monsuns-4-leben-mit-extremen-100.html
Available streams: 96k (worst), 176p, 272p, 360p, 480p, 576p, 720p (best)
```