### PR TITLE
plugins.openrectv: update HLS URLs

### DIFF
--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -22,9 +22,11 @@ class OPENRECtv(Plugin):
         validate.optional("id"): validate.text,
         validate.optional("title"): validate.text,
         validate.optional("movie_type"): validate.text,
+        validate.optional("onair_status"): validate.any(None, int),
         validate.optional("media"): {
             "url": validate.any(None, validate.url()),
-            "url_public": validate.any(None, validate.url())
+            "url_public": validate.any(None, validate.url()),
+            "url_ull": validate.any(None, validate.url()),
         }
     })
 
@@ -99,14 +101,15 @@ class OPENRECtv(Plugin):
 
         if mdata:
             log.debug("Found video: {0} ({1})".format(mdata["title"], mdata["id"]))
+            m3u8_file = None
             # streaming
             if mdata["onair_status"] == 1:
                 m3u8_file = mdata["media"]["url_ull"]
             # archive
-            elif mdata["onair_status"] == 2:
+            elif mdata["onair_status"] == 2 and mdata["media"]["url_public"] is not None:
                 m3u8_file = mdata["media"]["url_public"].replace("public.m3u8", "playlist.m3u8")
             # uploaded video
-            elif mdata["onair_status"] is None and mdata["movie_type"] == 2:
+            elif mdata["onair_status"] is None and mdata["movie_type"] == "2":
                 m3u8_file = mdata["media"]["url"]
             else:
                 log.error("There is no video file.")

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -96,20 +96,29 @@ class OPENRECtv(Plugin):
         if self.get_option("email") and self.get_option("password"):
             self.login(self.get_option("email"), self.get_option("password"))
         mdata = self._get_movie_data()
+
         if mdata:
             log.debug("Found video: {0} ({1})".format(mdata["title"], mdata["id"]))
-            if mdata["media"]["url"]:
-                yield from HLSStream.parse_variant_playlist(
-                    self.session,
-                    mdata["media"]["url"]
-                ).items()
-            elif mdata["media"]["url_public"]:
-                yield from HLSStream.parse_variant_playlist(
-                    self.session,
-                    mdata["media"]["url_public"].replace("public.m3u8", "playlist.m3u8")
-                ).items()
+            # streaming
+            if mdata["onair_status"] == 1:
+                m3u8_file = mdata["media"]["url_ull"]
+            # archive
+            elif mdata["onair_status"] == 2:
+                m3u8_file = mdata["media"]["url_public"].replace("public.m3u8", "playlist.m3u8")
+            # uploaded video
+            elif mdata["onair_status"] is None and mdata["movie_type"] == 2:
+                m3u8_file = mdata["media"]["url"]
             else:
-                log.error("You don't have the authority.")
+                log.error("There is no video file.")
+
+            if m3u8_file is not None:
+                yield from HLSStream.parse_variant_playlist(
+                    self.session,
+                    m3u8_file
+                ).items()
+
+        else:
+            log.error("You don't have the authority or no video file.")
 
 
 __plugin__ = OPENRECtv


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
plugins.openrectv was unable to play the stream in media player due to an update to openrec.tv a few days ago.
So, I have made it possible and use low latency streaming video data.
I also added the feature to download uploaded videos.