### PR TITLE
tests: remove mock from dev dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,6 @@ pip>=6
 pytest
 pytest-cov
 coverage
-mock
 requests-mock
 freezegun>=1.0.0
 flake8


### PR DESCRIPTION
Could have already been dropped with the removal of py2 (py>=3.3)