### PR TITLE
docs: fix headline anchors on deprecations page

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,8 +1,8 @@
 Deprecations
 ============
 
-2.3.0
------
+streamlink 2.3.0
+----------------
 
 Plugin.can_handle_url() and Plugin.priority()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -84,8 +84,8 @@ message will be written to the info log output for the first plugin that gets re
    ``NoStreamsError`` when there are no streams to be found on that particular URL.
 
 
-2.2.0
------
+streamlink 2.2.0
+----------------
 
 Config file paths
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
https://streamlink.github.io/latest/deprecations.html#id1 (2.3.0)
and
https://streamlink.github.io/latest/deprecations.html#id2 (2.2.0)
are terrible anchor names and need to get fixed. It probably also makes sense distinguishing between streamlink and streamlink-cli on the deprecations page.

----

Let's also prepare the 2.3.0 release. We've had a lot of big changes, the new plugin matching API, fragmented HLS streams, a couple of fixes/improvements for high priority plugins (youtube), regular plugin fixes and a couple of plugin removals. Even if the commit log isn't that long yet, a minor release should be justified.

I'll be submitting the changelog tomorrow, so if there are further changes which should get included, post them.