### PR TITLE
vendor: set requests to >=2.26.0,<3

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -89,36 +89,19 @@ version=${STREAMLINK_PYTHON_VERSION}
 format=bundled
 
 [Include]
-; dep tree
-;   streamlink+streamlink_cli
-;       - pkg-resources (indirect)
-;           - pyparsing
-;           - packaging
-;           - six
-;       - iso639
-;       - iso3166
-;       - pycryptodome
-;       - requests
-;           - certifi
-;           - idna
-;           - urllib3
-;           - socks / sockshandler
-;       - websocket-client
-;       - isodate
 packages=pkg_resources
-         six
          iso639
-         iso3166
-         requests
-         urllib3
-         idna
-         chardet
-         certifi
-         websocket
-         socks
-         sockshandler
-         isodate
-pypi_wheels=pycryptodome==3.9.9
+pypi_wheels=certifi==2021.5.30
+            charset-normalizer==2.0.1
+            idna==3.2
+            iso3166==1.0.1
+            isodate==0.6.0
+            pycryptodome==3.10.1
+            PySocks==1.7.1
+            requests==2.26.0
+            six==1.16.0
+            urllib3==1.26.6
+            websocket-client==1.1.0
 
 files=${ROOT}/win32/THIRD-PARTY.txt > \$INSTDIR
       ${ROOT}/build/lib/streamlink > \$INSTDIR\pkgs

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import versioneer
 
 data_files = []
 deps = [
-    "requests>=2.21.0,<3.0",
+    "requests>=2.26.0,<3.0",
     "isodate",
     "websocket-client>=0.58.0",
     # Support for SOCKS proxies


### PR DESCRIPTION
- Bump requests to latest version:
  This replaces transitive dependency chardet with charset-normalizer
- Fix Windows installer dependencies:
  List dependencies as wheels with strict versions where possible.
  pynsist unfortunately doesn't support additional wheel checksums.

----

This pinpoints the dependency versions to strict values (all up2date), similar to the appimages, except for wheel checksums ("dependency lockfile"), as it's not supported by pynsist:
https://github.com/streamlink/streamlink-appimage/blob/2.2.0-1/config.json

The `iso639` dependency is not a wheel, so it has to be kept in the `packages` directive.

Tested a locally built installer in my Win10 VM...

----

#3862, #3863 