### PR TITLE
tests: fix unnecessary hostname lookup in cli_main

### DIFF
--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -475,14 +475,14 @@ class TestCLIMainLogging(_TestCLIMainLogging):
             "-p", "custom",
             "--testplugin-bool",
             "--testplugin-password=secret",
-            "website.tld/channel",
+            "test.se/channel",
             "best,worst"
         ])
         self.assertEqual(
             mock_log.debug.mock_calls[-7:],
             [
                 call("Arguments:"),
-                call(" url=website.tld/channel"),
+                call(" url=test.se/channel"),
                 call(" stream=['best', 'worst']"),
                 call(" --loglevel=debug"),
                 call(" --player=custom"),


### PR DESCRIPTION
I currently have limited internet access due to massive floods in my region :cloud_with_rain:. I've tried fixing #3868, but it's more complicated than I thought. We'll probably have to disable these affected tests until this is fixed.

This PR however fixes the tests while being offline.