### PR TITLE
plugins.tv4play: fix plugin URL regex

### DIFF
--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(r"""
     https?://(?:www\.)?
     (?:
-        tv4play\.se/program/[^?/]+
+        tv4play\.se/program/[^?/]+/[^?/]+
         |
         fotbollskanalen\.se/video
     )

--- a/tests/plugins/test_tv4play.py
+++ b/tests/plugins/test_tv4play.py
@@ -6,8 +6,8 @@ class TestPluginCanHandleUrlTV4Play(PluginCanHandleUrl):
     __plugin__ = TV4Play
 
     should_match = [
-        'https://www.tv4play.se/program/fridas-vm-resa/10000884',
-        'https://www.tv4play.se/program/monk/3938989',
-        'https://www.tv4play.se/program/nyheterna/10378590',
+        'https://www.tv4play.se/program/robinson/del-26-sasong-2021/13299862',
+        'https://www.tv4play.se/program/sverige-mot-norge/del-1-sasong-1/12490380',
+        'https://www.tv4play.se/program/nyheterna/live/10378590',
         'https://www.fotbollskanalen.se/video/10395484/ghoddos-fullbordar-vandningen---ger-ofk-ledningen/',
     ]


### PR DESCRIPTION
I tried to run for example the news stream from tv4play but it did not work. I know it worked in the past. So my guess is that they changed their URL convention recently.

Here is a current URL from their website: https://www.tv4play.se/program/nyheterna/live/13351122

The current plugin regex in master is: tv4play\.se/program/[^?/]+

But in order to support their new URL convention it needed to be updated to: tv4play\.se/program/[^?/]+/[^?/]+

Based on all URLs I can find on the tv4play website all follow this new pattern of /program/XX/YY/<video_id>

I updated the regex and the tests. Ran them and installed. Now it works.

Here are the changes.