### PR TITLE
plugins.youtube: detect Livestreams with 'isLive'

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -129,12 +129,19 @@ class YouTube(Plugin):
                 "videoId": str,
                 "author": str,
                 "title": str,
-                validate.optional("isLiveContent"): validate.transform(bool)
+                validate.optional("isLive"): validate.transform(bool),
+                validate.optional("isLiveContent"): validate.transform(bool),
+                validate.optional("isLiveDvrEnabled"): validate.transform(bool),
+                validate.optional("isLowLatencyLiveStream"): validate.transform(bool),
+                validate.optional("isPrivate"): validate.transform(bool),
             }},
             validate.get("videoDetails"),
-            validate.union_get("videoId", "author", "title", "isLiveContent")
         )
-        return validate.validate(schema, data)
+        videoDetails = validate.validate(schema, data)
+        log.trace(f"videoDetails = {videoDetails!r}")
+        return validate.validate(
+            validate.union_get("videoId", "author", "title", "isLive"),
+            videoDetails)
 
     @classmethod
     def _schema_streamingdata(cls, data):


### PR DESCRIPTION
- Revert `isLiveContent` from https://github.com/streamlink/streamlink/pull/3797 use `isLive`
- Added more log details for `videoDetails`

basically same as https://github.com/streamlink/streamlink/pull/3026

closes https://github.com/streamlink/streamlink/issues/3872
