### PR TITLE
vendor: downgrade requests to 2.25.1 on Windows

### DIFF
--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -92,13 +92,13 @@ format=bundled
 packages=pkg_resources
          iso639
 pypi_wheels=certifi==2021.5.30
-            charset-normalizer==2.0.1
-            idna==3.2
+            chardet==4.0.0
+            idna==2.10
             iso3166==1.0.1
             isodate==0.6.0
             pycryptodome==3.10.1
             PySocks==1.7.1
-            requests==2.26.0
+            requests==2.25.1
             six==1.16.0
             urllib3==1.26.6
             websocket-client==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ import versioneer
 
 data_files = []
 deps = [
-    "requests>=2.26.0,<3.0",
+    # Temporarily set requests to 2.25.1 on Windows to fix issues with randomly failing tests
+    # Don't force an older requests version on non-Windows systems due to packaging reasons
+    "requests>=2.26.0,<3.0 ; platform_system!='Windows'",
+    "requests==2.25.1      ; platform_system=='Windows'",
     "isodate",
     "websocket-client>=0.58.0",
     # Support for SOCKS proxies

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, call, patch
 import requests_mock
 
 from streamlink import Streamlink
-from streamlink.compat import is_win32
 from streamlink.plugin import PluginError
 from streamlink.plugins.twitch import Twitch, TwitchHLSStream, TwitchHLSStreamReader, TwitchHLSStreamWriter
 from tests.mixins.stream_hls import EventedHLSStreamWriter, Playlist, Segment as _Segment, Tag, TestMixinStreamHLS
@@ -76,7 +75,6 @@ class _TwitchHLSStream(TwitchHLSStream):
     __reader__ = _TwitchHLSStreamReader
 
 
-@unittest.skipIf(is_win32, "temporarily skip EventedHLSStreamWriter related tests on Windows")
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))
 class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = _TwitchHLSStream

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -7,7 +7,6 @@ import requests_mock
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
-from streamlink.compat import is_win32
 from streamlink.session import Streamlink
 from streamlink.stream import hls
 from tests.mixins.stream_hls import EventedHLSStreamWriter, Playlist, Segment, Tag, TestMixinStreamHLS
@@ -145,7 +144,6 @@ class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
         self.assertTrue(self.called(map2, once=True), "Downloads second map only once")
 
 
-@unittest.skipIf(is_win32, "temporarily skip EventedHLSStreamWriter related tests on Windows")
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", Mock(return_value=True))
 class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = EventedHLSStream

--- a/tests/streams/test_hls_filtered.py
+++ b/tests/streams/test_hls_filtered.py
@@ -2,7 +2,6 @@ import unittest
 from threading import Event
 from unittest.mock import MagicMock, call, patch
 
-from streamlink.compat import is_win32
 from streamlink.stream.hls import HLSStream, HLSStreamReader
 from tests.mixins.stream_hls import EventedHLSStreamWriter, Playlist, Segment, TestMixinStreamHLS
 
@@ -24,7 +23,6 @@ class _TestSubjectHLSStream(HLSStream):
     __reader__ = _TestSubjectHLSReader
 
 
-@unittest.skipIf(is_win32, "temporarily skip EventedHLSStreamWriter related tests on Windows")
 @patch("streamlink.stream.hls.HLSStreamWorker.wait", MagicMock(return_value=True))
 class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = _TestSubjectHLSStream


### PR DESCRIPTION
This temporarily fixes the issue of randomly failing tests on
Windows which seems to be related to the latest requests version
2.26 and requests-mock, where mocked request responses take an
random/arbitrary time to return data, which makes the
EventedHLSStreamWriter tests miss their time frames when writing
HLS segment data to the output buffer.

Since Windows builds of Streamlink don't rely on system python
packages like on most Linux distros for example, downgrading and
forcing an older version of requests on Windows should be fine.

This commit thus partly reverts 35cb8d9f and 29a25fc7 which fixed
the broken dependencies of the Windows installer and skipped the
randomly failing tests on Windows.

----

Resolves #3868 

Even if this resolves #3868 and will make the tests pass again, I'd like to improve/tweak the HLS tests a bit and refactor some of the HLS code. I will submit these changes later, but I'm not sure yet when. After that I'd like to prepare the 2.3.0 release like I've said last week before this whole ordeal began.