### PR TITLE
Refactor and improve HLS tests and HLS/Segmented stream classes

### DIFF
--- a/src/streamlink/buffers.py
+++ b/src/streamlink/buffers.py
@@ -103,10 +103,7 @@ class RingBuffer(Buffer):
 
     def read(self, size=-1, block=True, timeout=None):
         if block and not self.closed:
-            self.event_used.wait(timeout)
-
-            # If the event is still not set it's a timeout
-            if not self.event_used.is_set() and self.length == 0:
+            if not self.event_used.wait(timeout) and self.length == 0:
                 raise OSError("Read timeout")
 
         return self._read(size)

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -123,11 +123,11 @@ class HLSStreamWriter(SegmentedStreamWriter):
                 if future is None or sequence.segment.discontinuity:
                     future = self.executor.submit(self.fetch_map, sequence)
                     self.map_cache.set(sequence.segment.map.uri, future)
-                self.queue(future, sequence, True)
+                self.queue(sequence, future, True)
 
             # regular segment request
             future = self.executor.submit(self.fetch, sequence)
-            self.queue(future, sequence, False)
+            self.queue(sequence, future, False)
 
     def fetch(self, sequence: Sequence) -> Optional[Response]:
         try:

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -369,19 +369,20 @@ class HLSStreamReader(SegmentedStreamReader):
     __worker__ = HLSStreamWorker
     __writer__ = HLSStreamWriter
 
-    def __init__(self, stream, *args, **kwargs):
-        super().__init__(stream, *args, **kwargs)
+    def __init__(self, stream):
         self.request_params = dict(stream.args)
-        self.timeout = stream.session.options.get("hls-timeout")
-
-        self.filter_event = Event()
-        self.filter_event.set()
-
         # These params are reserved for internal use
         self.request_params.pop("exception", None)
         self.request_params.pop("stream", None)
         self.request_params.pop("timeout", None)
         self.request_params.pop("url", None)
+
+        self.filter_event = Event()
+        self.filter_event.set()
+
+        timeout = stream.session.options.get("hls-timeout")
+
+        super().__init__(stream, timeout)
 
     def read(self, size):
         while True:

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -231,25 +231,6 @@ class HLSStreamWorker(SegmentedStreamWorker):
         elif self.playlist_reload_time_override not in ["segment", "live-edge"]:
             self.playlist_reload_time_override = 0
 
-        self.reload_playlist()
-
-        if self.playlist_end is None:
-            if self.duration_offset_start > 0:
-                log.debug(f"Time offsets negative for live streams, skipping back {self.duration_offset_start} seconds")
-            # live playlist, force offset durations back to None
-            self.duration_offset_start = -self.duration_offset_start
-
-        if self.duration_offset_start != 0:
-            self.playlist_sequence = self.duration_to_sequence(self.duration_offset_start, self.playlist_sequences)
-
-        if self.playlist_sequences:
-            log.debug(f"First Sequence: {self.playlist_sequences[0].num}; "
-                      f"Last Sequence: {self.playlist_sequences[-1].num}")
-            log.debug(f"Start offset: {self.duration_offset_start}; "
-                      f"Duration: {self.duration_limit}; "
-                      f"Start Sequence: {self.playlist_sequence}; "
-                      f"End Sequence: {self.playlist_end}")
-
     def _reload_playlist(self, text, url):
         return hls_playlist.load(text, url)
 
@@ -341,6 +322,25 @@ class HLSStreamWorker(SegmentedStreamWorker):
         return default
 
     def iter_segments(self):
+        self.reload_playlist()
+
+        if self.playlist_end is None:
+            if self.duration_offset_start > 0:
+                log.debug(f"Time offsets negative for live streams, skipping back {self.duration_offset_start} seconds")
+            # live playlist, force offset durations back to None
+            self.duration_offset_start = -self.duration_offset_start
+
+        if self.duration_offset_start != 0:
+            self.playlist_sequence = self.duration_to_sequence(self.duration_offset_start, self.playlist_sequences)
+
+        if self.playlist_sequences:
+            log.debug(f"First Sequence: {self.playlist_sequences[0].num}; "
+                      f"Last Sequence: {self.playlist_sequences[-1].num}")
+            log.debug(f"Start offset: {self.duration_offset_start}; "
+                      f"Duration: {self.duration_limit}; "
+                      f"Start Sequence: {self.playlist_sequence}; "
+                      f"End Sequence: {self.playlist_end}")
+
         total_duration = 0
         while not self.closed:
             for sequence in filter(self.valid_sequence, self.playlist_sequences):

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -94,6 +94,16 @@ class EventedHLSStreamWriter(_HLSStreamWriter):
         self.write_done = Event()
         self.write_error = None
 
+    def _futures_put(self, item):
+        self.futures.put_nowait(item)
+
+    def _futures_get(self):
+        return self.futures.get_nowait()
+
+    @staticmethod
+    def _future_result(future):
+        return future.result(timeout=0)
+
     def write(self, *args, **kwargs):
         # only write once per step
         self.write_wait.wait()

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -248,6 +248,9 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
             Playlist(0, [key, SegmentEnc(0, aesKey, aesIv, padding=padding)], end=True)
         ])
 
+        # close read thread early
+        self.thread.close()
+
         with self.assertRaises(ValueError) as cm:
             self.await_write()
         self.assertEqual(str(cm.exception), "Padding is incorrect.", "Crypto.Util.Padding.unpad exception")
@@ -259,6 +262,9 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
         self.subject([
             Playlist(0, [key, SegmentEnc(0, aesKey, aesIv, padding=padding)], end=True)
         ])
+
+        # close read thread early
+        self.thread.close()
 
         with self.assertRaises(ValueError) as cm:
             self.await_write()


### PR DESCRIPTION
As mentioned in #3880, here are some improvements which I wrote while debugging #3868.
The changes are split into multiple logical commits, so please review them one by one.

There's one minor change in the HLSStreamReader in regards to `hls-timeout` and `stream-timeout`, where `stream-timeout` will be used when `hls-timeout` is falsy / zero, but that is also the case for the `hls-segment-attempts`, `hls-segment-threads` and `hls-segment-timeout` parameters in the HLSStreamWriter.

IMO, we don't need special `hls-` or `dash-` options/parameters when generic `stream-` ones already exist. The `dash-` ones which are read in the DASHStreamWriter aren't even defined as streamlink_cli arguments or on the Session's options.