### PR TITLE
streams.hls: fix playlist_reload_time

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -270,7 +270,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
             return sequences[-1].segment.duration
         if self.playlist_reload_time_override == "live-edge" and sequences:
             return sum([s.segment.duration for s in sequences[-max(1, self.live_edge - 1):]])
-        if self.playlist_reload_time_override > 0:
+        if type(self.playlist_reload_time_override) is float and self.playlist_reload_time_override > 0:
             return self.playlist_reload_time_override
         if playlist.target_duration:
             return playlist.target_duration

--- a/tests/streams/test_hls_filtered.py
+++ b/tests/streams/test_hls_filtered.py
@@ -132,7 +132,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
     @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_sequence", new=filter_sequence)
     def test_filtered_closed(self):
-        thread, reader, writer, segments = self.subject([
+        thread, reader, writer, segments = self.subject(start=False, playlists=[
             Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)], end=True)
         ])
 
@@ -145,6 +145,8 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
             return orig_wait(*args, **kwargs)
 
         with patch.object(reader.filter_event, "wait", side_effect=mocked_wait):
+            self.start()
+
             # write first filtered segment and trigger the filter_event's lock
             self.assertTrue(reader.filter_event.is_set(), "Doesn't let the reader wait if not filtering")
             self.await_write()


### PR DESCRIPTION
If hls-playlist-reload-time is set to "segment" or "live-edge" and
no segments are available, return the playlist's targetduration
instead of continuing with checking other input values.

Make immediately starting the HLS stream and reader thread optional
in TestMixinStreamHLS and fix subclasses of HLSStream (eg. Twitch)
which have custom open() logic due to the change of starting logic,
so that certain methods on the HLS classes can be mocked.

----

Fixes #3884 

```
$ streamlink -l debug --hls-playlist-reload-time=segment 'https://hakk.in/crash.m3u8' best
[cli][debug] OS:         Linux-5.13.1-2-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.6
[cli][debug] Streamlink: 2.2.0+47.gf57fea8
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.1.0)
[cli][debug] Arguments:
[cli][debug]  url=https://hakk.in/crash.m3u8
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --hls-playlist-reload-time=segment
[cli][info] Found matching plugin hls for URL https://hakk.in/crash.m3u8
[plugins.hls][debug] URL=https://hakk.in/crash.m3u8; params={}
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (hls)
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
^CInterrupted! Exiting...
[cli][info] Closing currently open stream...
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
```

```
$ streamlink -l debug --hls-playlist-reload-time=live-edge 'https://hakk.in/crash.m3u8' best
[cli][debug] OS:         Linux-5.13.1-2-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.6
[cli][debug] Streamlink: 2.2.0+47.gf57fea8
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.1.0)
[cli][debug] Arguments:
[cli][debug]  url=https://hakk.in/crash.m3u8
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --hls-playlist-reload-time=live-edge
[cli][info] Found matching plugin hls for URL https://hakk.in/crash.m3u8
[plugins.hls][debug] URL=https://hakk.in/crash.m3u8; params={}
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (hls)
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
^CInterrupted! Exiting...
[cli][info] Closing currently open stream...
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
```