### PR TITLE
session: deprecate options for spec. stream types

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,21 @@
 Deprecations
 ============
 
+streamlink 2.4.0
+----------------
+
+Stream-type related CLI arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:ref:`Stream-type related CLI arguments <cli:Stream transport options>` and the respective :ref:`Session options <api:Session>`
+have been deprecated in favor of existing generic arguments/options, to avoid redundancy and potential confusion.
+
+- use :option:`--stream-segment-attempts` instead of ``--{dash,hds,hls}-segment-attempts``
+- use :option:`--stream-segment-threads` instead of ``--{dash,hds,hls}-segment-threads``
+- use :option:`--stream-segment-timeout` instead of ``--{dash,hds,hls}-segment-timeout``
+- use :option:`--stream-timeout` instead of ``--{dash,hds,hls,rtmp,http-stream}-timeout``
+
+
 streamlink 2.3.0
 ----------------
 

--- a/docs/issues.rst
+++ b/docs/issues.rst
@@ -29,17 +29,9 @@ Multi-threaded streaming
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 On segmented streaming protocols (such as HLS and HDS) it's possible to use
-multiple threads to potentially increase the throughput.
-Each stream type has its own option, and these are the ones that are currently available:
-
-=================================== ============================================
-Option                              Used by these plugins
-=================================== ============================================
-:option:`--hls-segment-threads`     `twitch`, `youtube` and many more.
-:option:`--hds-segment-threads`     `dailymotion` and many more.
-:option:`--stream-segment-threads`  `ustreamtv` and any other plugins implementing
-                                    their own segmented streaming protocol.
-=================================== ============================================
+multiple threads for downloading multiple segments at the same time to
+potentially increase the throughput. This can be done via Streamlink's
+:option:`--stream-segment-threads` argument.
 
 .. note::
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -39,24 +39,14 @@ class Streamlink:
             "ipv4": False,
             "ipv6": False,
             "hds-live-edge": 10.0,
-            "hds-segment-attempts": 3,
-            "hds-segment-threads": 1,
-            "hds-segment-timeout": 10.0,
-            "hds-timeout": 60.0,
             "hls-live-edge": 3,
-            "hls-segment-attempts": 3,
             "hls-segment-ignore-names": [],
-            "hls-segment-threads": 1,
-            "hls-segment-timeout": 10.0,
             "hls-segment-stream-data": False,
-            "hls-timeout": 60.0,
             "hls-playlist-reload-attempts": 3,
             "hls-playlist-reload-time": "default",
             "hls-start-offset": 0,
             "hls-duration": None,
-            "http-stream-timeout": 60.0,
             "ringbuffer-size": 1024 * 1024 * 16,  # 16 MB
-            "rtmp-timeout": 60.0,
             "rtmp-rtmpdump": is_win32 and "rtmpdump.exe" or "rtmpdump",
             "rtmp-proxy": None,
             "stream-segment-attempts": 3,
@@ -101,39 +91,15 @@ class Streamlink:
                                  streams will start from the edge of
                                  stream, default: ``10.0``
 
-        hds-segment-attempts     (int) How many attempts should be done
-                                 to download each HDS segment, default: ``3``
-
-        hds-segment-threads      (int) The size of the thread pool used
-                                 to download segments, default: ``1``
-
-        hds-segment-timeout      (float) HDS segment connect and read
-                                 timeout, default: ``10.0``
-
-        hds-timeout              (float) Timeout for reading data from
-                                 HDS streams, default: ``60.0``
-
         hls-live-edge            (int) How many segments from the end
                                  to start live streams on, default: ``3``
-
-        hls-segment-attempts     (int) How many attempts should be done
-                                 to download each HLS segment, default: ``3``
 
         hls-segment-ignore-names (str[]) List of segment names without
                                  file endings which should get filtered out,
                                  default: ``[]``
 
-        hls-segment-threads      (int) The size of the thread pool used
-                                 to download segments, default: ``1``
-
         hls-segment-stream-data  (bool) Stream HLS segment downloads,
                                  default: ``False``
-
-        hls-segment-timeout      (float) HLS segment connect and read
-                                 timeout, default: ``10.0``
-
-        hls-timeout              (float) Timeout for reading data from
-                                 HLS streams, default: ``60.0``
 
         http-proxy               (str) Specify a HTTP proxy to use for
                                  all HTTP requests
@@ -170,9 +136,6 @@ class Streamlink:
                                  requests except the ones covered by
                                  other options, default: ``20.0``
 
-        http-stream-timeout      (float) Timeout for reading data from
-                                 HTTP streams, default: ``60.0``
-
         subprocess-errorlog      (bool) Log errors from subprocesses to
                                  a file located in the temp directory
 
@@ -189,9 +152,6 @@ class Streamlink:
         rtmp-rtmpdump            (str) Specify the location of the
                                  rtmpdump executable used by RTMP streams,
                                  e.g. ``/usr/local/bin/rtmpdump``
-
-        rtmp-timeout             (float) Timeout for reading data from
-                                 RTMP streams, default: ``60.0``
 
         ffmpeg-ffmpeg            (str) Specify the location of the
                                  ffmpeg executable use by Muxing streams
@@ -226,23 +186,15 @@ class Streamlink:
 
         stream-segment-attempts  (int) How many attempts should be done
                                  to download each segment, default: ``3``.
-                                 General option used by streams not
-                                 covered by other options.
 
         stream-segment-threads   (int) The size of the thread pool used
                                  to download segments, default: ``1``.
-                                 General option used by streams not
-                                 covered by other options.
 
         stream-segment-timeout   (float) Segment connect and read
                                  timeout, default: ``10.0``.
-                                 General option used by streams not
-                                 covered by other options.
 
         stream-timeout           (float) Timeout for reading data from
                                  stream, default: ``60.0``.
-                                 General option used by streams not
-                                 covered by other options.
 
         locale                   (str) Locale setting, in the RFC 1766 format
                                  eg. en_US or es_ES
@@ -317,6 +269,20 @@ class Streamlink:
             self.http.cert = value
         elif key == "http-timeout":
             self.http.timeout = value
+
+        # deprecated: {dash,hds,hls}-segment-attempts
+        elif key in ("dash-segment-attempts", "hds-segment-attempts", "hls-segment-attempts"):
+            self.options.set("stream-segment-attempts", int(value))
+        # deprecated: {dash,hds,hls}-segment-threads
+        elif key in ("dash-segment-threads", "hds-segment-threads", "hls-segment-threads"):
+            self.options.set("stream-segment-threads", int(value))
+        # deprecated: {dash,hds,hls}-segment-timeout
+        elif key in ("dash-segment-timeout", "hds-segment-timeout", "hls-segment-timeout"):
+            self.options.set("stream-segment-timeout", float(value))
+        # deprecated: {hds,hls,rtmp,dash,http-stream}-timeout
+        elif key in ("dash-timeout", "hds-timeout", "hls-timeout", "http-stream-timeout", "rtmp-timeout"):
+            self.options.set("stream-timeout", float(value))
+
         else:
             self.options.set(key, value)
 

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -21,13 +21,6 @@ log = logging.getLogger(__name__)
 
 
 class DASHStreamWriter(SegmentedStreamWriter):
-    def __init__(self, reader, *args, **kwargs):
-        options = reader.stream.session.options
-        kwargs["retries"] = options.get("dash-segment-attempts")
-        kwargs["threads"] = options.get("dash-segment-threads")
-        kwargs["timeout"] = options.get("dash-segment-timeout")
-        SegmentedStreamWriter.__init__(self, reader, *args, **kwargs)
-
     def fetch(self, segment, retries=None):
         if self.closed or not retries:
             return

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -43,12 +43,8 @@ Fragment = namedtuple("Fragment", "segment fragment duration url")
 
 
 class HDSStreamWriter(SegmentedStreamWriter):
-    def __init__(self, reader, *args, **kwargs):
-        options = reader.stream.session.options
-        kwargs["retries"] = options.get("hds-segment-attempts")
-        kwargs["threads"] = options.get("hds-segment-threads")
-        kwargs["timeout"] = options.get("hds-segment-timeout")
-        SegmentedStreamWriter.__init__(self, reader, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         duration, tags = None, []
         if self.stream.metadata:

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -31,15 +31,12 @@ class Sequence(NamedTuple):
 
 
 class HLSStreamWriter(SegmentedStreamWriter):
-    def __init__(self, reader, *args, **kwargs):
-        options = reader.stream.session.options
-        kwargs["retries"] = options.get("hls-segment-attempts")
-        kwargs["threads"] = options.get("hls-segment-threads")
-        kwargs["timeout"] = options.get("hls-segment-timeout")
-        super().__init__(reader, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        options = self.session.options
 
         self.byterange_offsets = defaultdict(int)
-        self.map_cache: LRUCache[Sequence.segment.map.uri, Future] = LRUCache(kwargs["threads"])
+        self.map_cache: LRUCache[Sequence.segment.map.uri, Future] = LRUCache(self.threads)
         self.key_data = None
         self.key_uri = None
         self.key_uri_override = options.get("hls-segment-key-uri")
@@ -380,9 +377,7 @@ class HLSStreamReader(SegmentedStreamReader):
         self.filter_event = Event()
         self.filter_event.set()
 
-        timeout = stream.session.options.get("hls-timeout")
-
-        super().__init__(stream, timeout)
+        super().__init__(stream)
 
     def read(self, size):
         while True:

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -66,7 +66,7 @@ class HTTPStream(Stream):
 
     def open(self):
         method = self.args.get("method", "GET")
-        timeout = self.session.options.get("http-timeout")
+        timeout = self.session.options.get("stream-timeout")
         res = self.session.http.request(method=method,
                                         stream=True,
                                         exception=StreamError,

--- a/src/streamlink/stream/rtmpdump.py
+++ b/src/streamlink/stream/rtmpdump.py
@@ -26,7 +26,7 @@ class RTMPStream(StreamProcess):
     def __init__(self, session, params, redirect=False, **kwargs):
         StreamProcess.__init__(self, session, params=params, **kwargs)
 
-        self.timeout = self.session.options.get("rtmp-timeout")
+        self.timeout = self.session.options.get("stream-timeout")
         self.redirect = redirect
 
         # set rtmpdump logging level

--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -115,7 +115,8 @@ class SegmentedStreamWriter(Thread):
 
         self.retries = retries
         self.timeout = timeout
-        self.executor = CompatThreadPoolExecutor(max_workers=threads)
+        self.threads = threads
+        self.executor = CompatThreadPoolExecutor(max_workers=self.threads)
         self.futures = queue.Queue(size)
 
         super().__init__(daemon=True, name=f"Thread-{self.__class__.__name__}")

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -764,48 +764,10 @@ def build_parser():
         Default is 10.0.
         """
     )
-    transport.add_argument(
-        "--hds-segment-attempts",
-        type=num(int, min=0),
-        metavar="ATTEMPTS",
-        help="""
-        How many attempts should be done to download each HDS segment before
-        giving up.
-
-        Default is 3.
-        """
-    )
-    transport.add_argument(
-        "--hds-segment-threads",
-        type=num(int, max=10),
-        metavar="THREADS",
-        help="""
-        The size of the thread pool used to download HDS segments. Minimum value
-        is 1 and maximum is 10.
-
-        Default is 1.
-        """
-    )
-    transport.add_argument(
-        "--hds-segment-timeout",
-        type=num(float, min=0),
-        metavar="TIMEOUT",
-        help="""
-        HDS segment connect and read timeout.
-
-        Default is 10.0.
-        """
-    )
-    transport.add_argument(
-        "--hds-timeout",
-        type=num(float, min=0),
-        metavar="TIMEOUT",
-        help="""
-        Timeout for reading data from HDS streams.
-
-        Default is 60.0.
-        """
-    )
+    transport.add_argument("--hds-segment-attempts", help=argparse.SUPPRESS)
+    transport.add_argument("--hds-segment-threads", help=argparse.SUPPRESS)
+    transport.add_argument("--hds-segment-timeout", help=argparse.SUPPRESS)
+    transport.add_argument("--hds-timeout", help=argparse.SUPPRESS)
     transport.add_argument(
         "--hls-live-edge",
         type=num(int, min=0),
@@ -824,17 +786,6 @@ def build_parser():
         action="store_true",
         help="""
         Immediately write segment data into output buffer while downloading.
-        """
-    )
-    transport.add_argument(
-        "--hls-segment-attempts",
-        type=num(int, min=0),
-        metavar="ATTEMPTS",
-        help="""
-        How many attempts should be done to download each HLS segment before
-        giving up.
-
-        Default is 3.
         """
     )
     transport.add_argument(
@@ -862,26 +813,9 @@ def build_parser():
         Default is default.
         """
     )
-    transport.add_argument(
-        "--hls-segment-threads",
-        type=num(int, max=10),
-        metavar="THREADS",
-        help="""
-        The size of the thread pool used to download HLS segments. Minimum value
-        is 1 and maximum is 10.
-
-        Default is 1.
-        """
-    )
-    transport.add_argument(
-        "--hls-segment-timeout",
-        type=num(float, min=0),
-        metavar="TIMEOUT",
-        help="""
-        HLS segment connect and read timeout.
-
-        Default is 10.0.
-        """)
+    transport.add_argument("--hls-segment-attempts", help=argparse.SUPPRESS)
+    transport.add_argument("--hls-segment-threads", help=argparse.SUPPRESS)
+    transport.add_argument("--hls-segment-timeout", help=argparse.SUPPRESS)
     transport.add_argument(
         "--hls-segment-ignore-names",
         metavar="NAMES",
@@ -936,16 +870,9 @@ def build_parser():
         Note: This is only useful in special circumstances where the regular
         locale option fails, such as when multiple sources of the same language
         exists.
-        """)
-    transport.add_argument(
-        "--hls-timeout",
-        type=num(float, min=0),
-        metavar="TIMEOUT",
-        help="""
-        Timeout for reading data from HLS streams.
-
-        Default is 60.0.
-        """)
+        """
+    )
+    transport.add_argument("--hls-timeout", help=argparse.SUPPRESS)
     transport.add_argument(
         "--hls-start-offset",
         type=hours_minutes_seconds,
@@ -956,7 +883,8 @@ def build_parser():
         streams, this is a negative offset from the end of the stream (rewind).
 
         Default is 00:00:00.
-        """)
+        """
+    )
     transport.add_argument(
         "--hls-duration",
         type=hours_minutes_seconds,
@@ -968,22 +896,16 @@ def build_parser():
         nearest HLS segment.
 
         Default is unlimited.
-        """)
+        """
+    )
     transport.add_argument(
         "--hls-live-restart",
         action="store_true",
         help="""
         Skip to the beginning of a live stream, or as far back as possible.
-        """)
-    transport.add_argument(
-        "--http-stream-timeout",
-        type=num(float, min=0),
-        metavar="TIMEOUT",
-        help="""
-        Timeout for reading data from HTTP streams.
-
-        Default is 60.0.
-        """)
+        """
+    )
+    transport.add_argument("--http-stream-timeout", help=argparse.SUPPRESS)
     transport.add_argument(
         "--ringbuffer-size",
         metavar="SIZE",
@@ -1008,7 +930,8 @@ def build_parser():
         Note: A smaller size is recommended on lower end systems (such as
         Raspberry Pi) when playing stream types that require some extra
         processing (such as HDS) to avoid unnecessary background processing.
-        """)
+        """
+    )
     transport.add_argument(
         "--rtmp-proxy",
         metavar="PROXY",
@@ -1029,26 +952,15 @@ def build_parser():
         """
     )
     transport.add_argument("--rtmpdump", help=argparse.SUPPRESS)
-    transport.add_argument(
-        "--rtmp-timeout",
-        type=num(float, min=0),
-        metavar="TIMEOUT",
-        help="""
-        Timeout for reading data from RTMP streams.
-
-        Default is 60.0.
-        """
-    )
+    transport.add_argument("--rtmp-timeout", help=argparse.SUPPRESS)
     transport.add_argument(
         "--stream-segment-attempts",
         type=num(int, min=0),
         metavar="ATTEMPTS",
         help="""
-        How many attempts should be done to download each segment before giving
-        up.
+        How many attempts should be done to download each segment before giving up.
 
-        This is generic option used by streams not covered by other options,
-        such as stream protocols specific to plugins, e.g. UStream.
+        This applies to all different kinds of segmented stream types, such as DASH, HDS, HLS, etc.
 
         Default is 3.
         """
@@ -1058,11 +970,9 @@ def build_parser():
         type=num(int, max=10),
         metavar="THREADS",
         help="""
-        The size of the thread pool used to download segments. Minimum value is
-        1 and maximum is 10.
+        The size of the thread pool used to download segments. Minimum value is 1 and maximum is 10.
 
-        This is generic option used by streams not covered by other options,
-        such as stream protocols specific to plugins, e.g. UStream.
+        This applies to all different kinds of segmented stream types, such as DASH, HDS, HLS, etc.
 
         Default is 1.
         """
@@ -1074,11 +984,11 @@ def build_parser():
         help="""
         Segment connect and read timeout.
 
-        This is generic option used by streams not covered by other options,
-        such as stream protocols specific to plugins, e.g. UStream.
+        This applies to all different kinds of segmented stream types, such as DASH, HDS, HLS, etc.
 
         Default is 10.0.
-        """)
+        """
+    )
     transport.add_argument(
         "--stream-timeout",
         type=num(float, min=0),
@@ -1086,11 +996,11 @@ def build_parser():
         help="""
         Timeout for reading data from streams.
 
-        This is generic option used by streams not covered by other options,
-        such as stream protocols specific to plugins, e.g. UStream.
+        This applies to all different kinds of stream types, such as DASH, HDS, HLS, HTTP, RTMP, etc.
 
         Default is 60.0.
-        """)
+        """
+    )
     transport.add_argument(
         "--subprocess-cmdline",
         action="store_true",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -754,29 +754,17 @@ def setup_options():
     if args.hls_segment_stream_data:
         streamlink.set_option("hls-segment-stream-data", args.hls_segment_stream_data)
 
-    if args.hls_segment_attempts:
-        streamlink.set_option("hls-segment-attempts", args.hls_segment_attempts)
-
     if args.hls_playlist_reload_attempts:
         streamlink.set_option("hls-playlist-reload-attempts", args.hls_playlist_reload_attempts)
 
     if args.hls_playlist_reload_time:
         streamlink.set_option("hls-playlist-reload-time", args.hls_playlist_reload_time)
 
-    if args.hls_segment_threads:
-        streamlink.set_option("hls-segment-threads", args.hls_segment_threads)
-
-    if args.hls_segment_timeout:
-        streamlink.set_option("hls-segment-timeout", args.hls_segment_timeout)
-
     if args.hls_segment_ignore_names:
         streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
 
     if args.hls_segment_key_uri:
         streamlink.set_option("hls-segment-key-uri", args.hls_segment_key_uri)
-
-    if args.hls_timeout:
-        streamlink.set_option("hls-timeout", args.hls_timeout)
 
     if args.hls_audio_select:
         streamlink.set_option("hls-audio-select", args.hls_audio_select)
@@ -793,21 +781,6 @@ def setup_options():
     if args.hds_live_edge:
         streamlink.set_option("hds-live-edge", args.hds_live_edge)
 
-    if args.hds_segment_attempts:
-        streamlink.set_option("hds-segment-attempts", args.hds_segment_attempts)
-
-    if args.hds_segment_threads:
-        streamlink.set_option("hds-segment-threads", args.hds_segment_threads)
-
-    if args.hds_segment_timeout:
-        streamlink.set_option("hds-segment-timeout", args.hds_segment_timeout)
-
-    if args.hds_timeout:
-        streamlink.set_option("hds-timeout", args.hds_timeout)
-
-    if args.http_stream_timeout:
-        streamlink.set_option("http-stream-timeout", args.http_stream_timeout)
-
     if args.ringbuffer_size:
         streamlink.set_option("ringbuffer-size", args.ringbuffer_size)
 
@@ -819,18 +792,35 @@ def setup_options():
     elif args.rtmpdump:
         streamlink.set_option("rtmp-rtmpdump", args.rtmpdump)
 
+    # deprecated
+    if args.hds_segment_attempts:
+        streamlink.set_option("hds-segment-attempts", args.hds_segment_attempts)
+    if args.hds_segment_threads:
+        streamlink.set_option("hds-segment-threads", args.hds_segment_threads)
+    if args.hds_segment_timeout:
+        streamlink.set_option("hds-segment-timeout", args.hds_segment_timeout)
+    if args.hds_timeout:
+        streamlink.set_option("hds-timeout", args.hds_timeout)
+    if args.hls_segment_attempts:
+        streamlink.set_option("hls-segment-attempts", args.hls_segment_attempts)
+    if args.hls_segment_threads:
+        streamlink.set_option("hls-segment-threads", args.hls_segment_threads)
+    if args.hls_segment_timeout:
+        streamlink.set_option("hls-segment-timeout", args.hls_segment_timeout)
+    if args.hls_timeout:
+        streamlink.set_option("hls-timeout", args.hls_timeout)
+    if args.http_stream_timeout:
+        streamlink.set_option("http-stream-timeout", args.http_stream_timeout)
     if args.rtmp_timeout:
         streamlink.set_option("rtmp-timeout", args.rtmp_timeout)
 
+    # generic stream- arguments take precedence over deprecated stream-type arguments
     if args.stream_segment_attempts:
         streamlink.set_option("stream-segment-attempts", args.stream_segment_attempts)
-
     if args.stream_segment_threads:
         streamlink.set_option("stream-segment-threads", args.stream_segment_threads)
-
     if args.stream_segment_timeout:
         streamlink.set_option("stream-segment-timeout", args.stream_segment_timeout)
-
     if args.stream_timeout:
         streamlink.set_option("stream-timeout", args.stream_timeout)
 


### PR DESCRIPTION
Having multiple session options and CLI arguments for different stream
types which are already covered by generic options/arguments is not only
redundant, but also confusing.

A distinction between different stream types does only make sense when
multiple different stream types are available and the user needs to
explicitly set different values for each of them, but since it's not
always clear which stream type is returned when a stream is selected
via the "best" stream name synonym for example, this makes it even more
confusing. And it's redundant as well, since only one stream can be
selected anyway.

- deprecate `{dash,hds,hls}-segment-attempts`
  in favor of `stream-segment-attempts`
- deprecate `{dash,hds,hls}-segment-threads`
  in favor of `stream-segment-threads`
- deprecate `{dash,hds,hls}-segment-timeout`
  in favor of `stream-segment-timeout`
- deprecate `{dash,hds,hls,rtmp,http-stream}-timeout`
  in favor of `stream-timeout` (dash/http-stream were never used)
- fix `HTTPStream` and use `stream-timeout` instead of `http-timeout`
- suppress deprecated CLI arguments
- update help texts of generic CLI arguments
- fix docs and add entry to deprecations page

----

1. Do we need tests for the option/argument name translations?
2. The "Stream transport options" section in the docs needs to be reordered/improved. In a separate PR.
3. `hls-segment-stream-data` should be removed as well and just set to `True`. In a separate PR.
