### PR TITLE
stream.hls: remove hls-segment-stream-data option

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -124,7 +124,6 @@ class TwitchHLSStreamReader(HLSStreamReader):
         if stream.low_latency:
             live_edge = max(1, min(LOW_LATENCY_MAX_LIVE_EDGE, stream.session.options.get("hls-live-edge")))
             stream.session.options.set("hls-live-edge", live_edge)
-            stream.session.options.set("hls-segment-stream-data", True)
             log.info(f"Low latency streaming (HLS live edge: {live_edge})")
         super().__init__(stream)
 
@@ -436,18 +435,19 @@ class Twitch(Plugin):
         PluginArgument(
             "low-latency",
             action="store_true",
-            help="""
+            help=f"""
             Enables low latency streaming by prefetching HLS segments.
-            Sets --hls-segment-stream-data to true and --hls-live-edge to {live_edge}, if it is higher.
-            Reducing --hls-live-edge to 1 will result in the lowest latency possible.
+            Sets --hls-live-edge to {LOW_LATENCY_MAX_LIVE_EDGE}, if it is higher.
+            Reducing it to 1 will result in the lowest latency possible, but will most likely cause buffering.
 
-            Low latency streams have to be enabled by the broadcasters on Twitch themselves.
-            Regular streams can cause buffering issues with this option enabled.
+            In order to achieve true low latency streaming during playback, the player's caching/buffering settings will
+            need to be adjusted and reduced to a value as low as possible, but still high enough to not cause any buffering.
+            This depends on the stream's bitrate and the quality of the connection to Twitch's servers. Please refer to the
+            player's own documentation for the required configuration. Player parameters can be set via --player-args.
 
-            Note: The caching/buffering settings of the chosen player may need to be adjusted as well.
-            Please refer to the player's own documentation for the required parameters and its configuration.
-            Player parameters can be set via Streamlink's --player or --player-args parameters.
-            """.format(live_edge=LOW_LATENCY_MAX_LIVE_EDGE)
+            Note: Low latency streams have to be enabled by the broadcasters on Twitch themselves.
+            Regular streams can cause buffering issues with this option enabled due to the reduced --hls-live-edge value.
+            """
         )
     )
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -41,7 +41,6 @@ class Streamlink:
             "hds-live-edge": 10.0,
             "hls-live-edge": 3,
             "hls-segment-ignore-names": [],
-            "hls-segment-stream-data": False,
             "hls-playlist-reload-attempts": 3,
             "hls-playlist-reload-time": "default",
             "hls-start-offset": 0,

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -40,7 +40,6 @@ class HLSStreamWriter(SegmentedStreamWriter):
         self.key_data = None
         self.key_uri = None
         self.key_uri_override = options.get("hls-segment-key-uri")
-        self.stream_data = options.get("hls-segment-stream-data")
 
         self.ignore_names = False
         ignore_names = {*options.get("hls-segment-ignore-names")}
@@ -128,13 +127,13 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
     def fetch(self, sequence: Sequence) -> Optional[Response]:
         try:
-            return self._fetch(sequence.segment, self.stream_data and not sequence.segment.key)
+            return self._fetch(sequence.segment, not sequence.segment.key)
         except StreamError as err:  # pragma: no cover
             log.error(f"Failed to fetch segment {sequence.num}: {err}")
 
     def fetch_map(self, sequence: Sequence) -> Optional[Response]:
         try:
-            return self._fetch(sequence.segment.map, self.stream_data and not sequence.segment.key)
+            return self._fetch(sequence.segment.map, False)
         except StreamError as err:  # pragma: no cover
             log.error(f"Failed to fetch map for segment {sequence.num}: {err}")
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -781,13 +781,7 @@ def build_parser():
         Default is 3.
         """
     )
-    transport.add_argument(
-        "--hls-segment-stream-data",
-        action="store_true",
-        help="""
-        Immediately write segment data into output buffer while downloading.
-        """
-    )
+    transport.add_argument("--hls-segment-stream-data", action="store_true", help=argparse.SUPPRESS)
     transport.add_argument(
         "--hls-playlist-reload-attempts",
         type=num(int, min=0),

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -751,9 +751,6 @@ def setup_options():
     if args.hls_live_edge:
         streamlink.set_option("hls-live-edge", args.hls_live_edge)
 
-    if args.hls_segment_stream_data:
-        streamlink.set_option("hls-segment-stream-data", args.hls_segment_stream_data)
-
     if args.hls_playlist_reload_attempts:
         streamlink.set_option("hls-playlist-reload-attempts", args.hls_playlist_reload_attempts)
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -193,7 +193,6 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         ], disable_ads=False, low_latency=True)
 
         self.assertEqual(2, self.session.options.get("hls-live-edge"))
-        self.assertEqual(True, self.session.options.get("hls-segment-stream-data"))
 
         self.await_write(6)
         self.assertEqual(
@@ -215,7 +214,6 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         ], disable_ads=False, low_latency=False)
 
         self.assertEqual(4, self.session.options.get("hls-live-edge"))
-        self.assertEqual(False, self.session.options.get("hls-segment-stream-data"))
 
         self.await_write(8)
         self.assertEqual(


### PR DESCRIPTION
- always stream data from unencrypted segment downloads
- never stream data from cached initialization sections, as the
  response content can only be consumed once when stream=True
- update --twitch-low-latency plugin argument and its description

----

This also fixes a bug with the previous media initialization sections (segment maps) implementation, which raises an exception when stream is set to True, as the content can only be consumed once when iterating and writing chunks to the buffer.