### PR TITLE
stream.hls: handle exception StreamError in Thread-HLSStreamWorker - iter_segments

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -318,7 +318,11 @@ class HLSStreamWorker(SegmentedStreamWorker):
         return default
 
     def iter_segments(self):
-        self.reload_playlist()
+        try:
+            self.reload_playlist()
+        except StreamError as err:
+            log.error(f'{err}')
+            return
 
         if self.playlist_end is None:
             if self.duration_offset_start > 0:


### PR DESCRIPTION
Streamlink can crash with `streamlink.exceptions.StreamError` since
https://github.com/streamlink/streamlink/commit/193c5c6eb9147a56df25de160f4d35d6f230733a

---

Test URL

https://gist.githubusercontent.com/back-to/514946aad6ce17586d992d05ee42673c/raw/521fe8dd25200042c71f1756b3f61cdd66093a8d/hlsva.m3u8

---

streamlink 2.2.0

```
[cli][debug] Streamlink: 2.2.0
[cli][info] Found matching plugin hls for URL hlsva.m3u8
[cli][info] Available streams: 180p (worst, best)
[cli][info] Opening stream: 180p (hls)
[cli][error] Try 1/1: Could not open stream <HLSStream('test_1.m3u8', 'hlsva.m3u8')>
(Could not open stream: Attempted to play a variant playlist, use 'hls://test_1.m3u8' instead)
error: Could not open stream <HLSStream('test_1.m3u8', 'hlsva.m3u8')>, tried 1 times, exiting
```

streamlink 2.3.0

Ref https://github.com/streamlink/streamlink/issues/3895

```
[cli][debug] Streamlink: 2.3.0
[cli][info] Found matching plugin hls for URL hlsva.m3u8
[cli][info] Available streams: 180p (worst, best)
[cli][info] Opening stream: 180p (hls)
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
Exception in thread Thread-HLSStreamWorker:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "src/streamlink/stream/segmented.py", line 84, in run
    for segment in self.iter_segments():
  File "src/streamlink/stream/hls.py", line 325, in iter_segments
    self.reload_playlist()
  File "src/streamlink/stream/hls.py", line 253, in reload_playlist
    raise StreamError("Attempted to play a variant playlist, use "
streamlink.exceptions.StreamError: Attempted to play a variant playlist, use 'hls://test_1.m3u8' instead
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][error] Try 1/1: Could not open stream <HLSStream('test_1.m3u8', 'hlsva.m3u8')>
(Failed to read data from stream: Read timeout)
error: Could not open stream <HLSStream('test_1.m3u8', 'hlsva.m3u8')>, tried 1 times, exiting
[cli][info] Closing currently open stream...
```

After PR

```
[cli][debug] Streamlink: 2.3.0+4.gc3f390a.dirty
[cli][info] Found matching plugin hls for URL hlsva.m3u8
[cli][info] Available streams: 180p (worst, best)
[cli][info] Opening stream: 180p (hls)
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][error] Attempted to play a variant playlist, use 'hls://test_1.m3u8' instead
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][error] Try 1/1: Could not open stream <HLSStream('test_1.m3u8', 'hlsva.m3u8')> (No data returned from stream)
error: Could not open stream <HLSStream('test_1.m3u8', 'hlsva.m3u8')>, tried 1 times, exiting
[cli][info] Closing currently open stream...
```

```
streamlink https://www.raiplay.it/dirette/raiyoyo

[cli][debug] Streamlink: 2.3.0+4.gc3f390a.dirty
[cli][info] Found matching plugin raiplay for URL https://www.raiplay.it/dirette/raiyoyo
[plugins.raiplay][debug] Found JSON URL: https://www.raiplay.it/dirette/raiyoyo.json
[plugins.raiplay][debug] Found stream URL: https://mediapolis.rai.it/relinker/relinkerServlet.htm?cont=746899
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 396p (worst), 504p, 576p (best)
[cli][info] Opening stream: 576p (hls)
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][error] Unable to open URL: ... (403 Client Error: Forbidden for url: ...)
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][error] Try 1/1: Could not open stream <HLSStream('...', '...')> (No data returned from stream)
error: Could not open stream <HLSStream('...', '...')>, tried 1 times, exiting
[cli][info] Closing currently open stream...
```

---

Ref https://github.com/streamlink/streamlink/issues/3895#issuecomment-891262491 for error 1