### PR TITLE
Support -t/--title formatting vars in -o/--output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ deps = [
     "requests>=2.26.0,<3.0 ; platform_system!='Windows'",
     "requests==2.25.1      ; platform_system=='Windows'",
     "isodate",
+    "pathvalidate",
     "websocket-client>=0.58.0",
     # Support for SOCKS proxies
     "PySocks!=1.5.7,>=1.5.6",

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -588,6 +588,10 @@ def build_parser():
         Write stream data to FILENAME instead of playing it.
 
         You will be prompted if the file already exists.
+
+        The formatting variables available for the -t/--title option may be used.
+        Invalid characters (cross platform) are replaced with an underscore.
+        Filenames are truncated to 255 characters (cross platform limit).
         """
     )
     output.add_argument(
@@ -619,6 +623,10 @@ def build_parser():
         Open the stream in the player, while at the same time writing it to FILENAME.
 
         You will be prompted if the file already exists.
+
+        The formatting variables available for the -t/--title option may be used.
+        Invalid characters (cross platform) are replaced with an underscore.
+        Filenames are truncated to 255 characters (cross platform limit).
         """
     )
     output.add_argument(
@@ -628,6 +636,10 @@ def build_parser():
         Write stream data to stdout, while at the same time writing it to FILENAME.
 
         You will be prompted if the file already exists.
+
+        The formatting variables available for the -t/--title option may be used.
+        Invalid characters (cross platform) are replaced with an underscore.
+        Filenames are truncated to 255 characters (cross platform limit).
         """
     )
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -28,6 +28,8 @@ from streamlink_cli.output import FileOutput, PlayerOutput
 
 
 class FakePlugin:
+    url = "url"
+
     @classmethod
     def stream_weight(cls, stream):
         return Plugin.stream_weight(stream)


### PR DESCRIPTION
I thought I'd have a go at this, as it's been requested/mentioned a few times...

Things to note:

This adds a new dependency: [pathvalidate](https://github.com/thombashi/pathvalidate).  I think this is probably a worthwhile dep to add to ensure compatible and consistent filenames across supported platforms and there's little point in trying to reimplement it locally, I would have thought.  The pathvalidate module seems to be reasonably well maintained.

I've chosen to use pathvalidate in universal mode as this will result in consistent filenames across platforms (although that does impose undue limitations - e.g. on Linux), which seems a reasonable way to go.  One result of this is that filename length is truncated beyond 255 characters.

I've chosen to use underscore (`_`) as a replacement character rather than the default of just removing invalid characters, as it seems like it might be a bit more obvious as to what is going on.

closes #3898
