### PR TITLE
tests: increase TIMEOUT_AWAIT_WRITE and update requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         run: "! grep -Ev '^644' <(git ls-files src/ tests/ | xargs stat '--format=%a %n')"
       - name: Test
         continue-on-error: ${{ matrix.continue || false }}
-        run: pytest -r a --cov --cov-branch --cov-report=xml
+        run: pytest -r a --cov --cov-branch --cov-report=xml --durations 10
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -284,8 +284,7 @@ Name                                 Notes
 
 **Automatically installed by the setup script**
 --------------------------------------------------------------------------------
-`python-requests`_                   At least version **2.26.0** |br|
-                                     Temporarily pinpointed to **2.25.1** on Windows (see `#3880`_)
+`python-requests`_                   At least version **2.26.0**
 `pycryptodome`_                      Required to play some encrypted streams
 `iso-639`_                           Used for localization settings, provides language information
 `iso3166`_                           Used for localization settings, provides country information
@@ -313,7 +312,7 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 
 .. _Python: https://www.python.org/
 .. _python-setuptools: https://pypi.org/project/setuptools/
-.. _python-requests: https://requests.readthedocs.io/en/master/
+.. _python-requests: https://docs.python-requests.org/en/master/
 .. _RTMPDump: https://rtmpdump.mplayerhq.hu/
 .. _pycountry: https://pypi.org/project/pycountry/
 .. _pycrypto: https://www.dlitz.net/software/pycrypto/
@@ -324,7 +323,6 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 .. _isodate: https://pypi.org/project/isodate/
 .. _PySocks: https://github.com/Anorov/PySocks
 .. _websocket-client: https://pypi.org/project/websocket-client/
-.. _#3880: https://github.com/streamlink/streamlink/pull/3880
 
 
 Windows binaries

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -92,16 +92,16 @@ format=bundled
 packages=pkg_resources
          iso639
 pypi_wheels=certifi==2021.5.30
-            chardet==4.0.0
-            idna==2.10
+            charset-normalizer==2.0.4
+            idna==3.2
             iso3166==1.0.1
             isodate==0.6.0
             pycryptodome==3.10.1
             PySocks==1.7.1
-            requests==2.25.1
+            requests==2.26.0
             six==1.16.0
             urllib3==1.26.6
-            websocket-client==1.1.0
+            websocket-client==1.2.1
 
 files=${ROOT}/win32/THIRD-PARTY.txt > \$INSTDIR
       ${ROOT}/build/lib/streamlink > \$INSTDIR\pkgs

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,7 @@ import versioneer
 
 data_files = []
 deps = [
-    # Temporarily set requests to 2.25.1 on Windows to fix issues with randomly failing tests
-    # Don't force an older requests version on non-Windows systems due to packaging reasons
-    "requests>=2.26.0,<3.0 ; platform_system!='Windows'",
-    "requests==2.25.1      ; platform_system=='Windows'",
+    "requests>=2.26.0,<3.0",
     "isodate",
     "websocket-client>=0.58.0",
     # Support for SOCKS proxies

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -12,7 +12,7 @@ from streamlink.stream.hls import HLSStream, HLSStreamWriter as _HLSStreamWriter
 
 TIMEOUT_AWAIT_READ = 5
 TIMEOUT_AWAIT_READ_ONCE = 5
-TIMEOUT_AWAIT_WRITE = 5
+TIMEOUT_AWAIT_WRITE = 60  # https://github.com/streamlink/streamlink/issues/3868
 TIMEOUT_AWAIT_CLOSE = 5
 
 


### PR DESCRIPTION
### tests.mixins.stream_hls: increase TIMEOUT_AWAIT_WRITE timeout, use --durations 10 for pytest

`self.rebuild_proxies(request, self.proxies))` seems to slow down `requests`

https://github.com/psf/requests/commit/60ea7f0c2def461a9ddc20e7af0fc90b68dbe0de#diff-c80d84057edadb04b5615f7169c55f88ccda358d7c20af966afb20c0d0d1056a

which results in a pytest timeout, because 5 seconds is not enough on windows

```
with kwargs.setdefault('proxies', self.proxies)

============================================================================================ slowest 10 durations =============================================================================================
0.86s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128
0.53s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_key_uri_override
0.43s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_with_map
0.36s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_incorrect_padding_content
0.30s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_incorrect_padding_length
0.30s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_incorrect_block_length
```

```
with kwargs.setdefault('proxies', self.rebuild_proxies(request, self.proxies))

============================================================================================ slowest 10 durations =============================================================================================
10.01s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128
9.80s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_key_uri_override
5.63s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_incorrect_padding_length
5.22s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_with_map
2.97s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_incorrect_block_length
2.95s call     tests/streams/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_aes128_incorrect_padding_content
```

---

also show the 10 slowest tests on pytest

---

### setup: update requests version >=2.26.0 and makeinstaller.sh

revert https://github.com/streamlink/streamlink/pull/3880