### PR TITLE
plugins.sportschau: fix audio streams

### DIFF
--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream import HLSStream, HTTPStream
 from streamlink.utils import parse_json, update_scheme
 
 log = logging.getLogger(__name__)
@@ -16,33 +16,34 @@ class Sportschau(Plugin):
     _re_player = re.compile(r"https?:(//deviceids-medp.wdr.de/ondemand/\S+\.js)")
     _re_json = re.compile(r"\$mediaObject.jsonpHelper.storeAndPlay\(({.+})\);?")
 
-    _schema_player = validate.Schema(
-        validate.transform(_re_player.search),
-        validate.any(None, validate.Schema(
-            validate.get(1),
-            validate.transform(lambda url: update_scheme("https:", url))
-        ))
-    )
-    _schema_json = validate.Schema(
-        validate.transform(_re_json.match),
-        validate.get(1),
-        validate.transform(parse_json),
-        validate.get("mediaResource"),
-        validate.get("dflt"),
-        validate.get("videoURL"),
-        validate.transform(lambda url: update_scheme("https:", url))
-    )
-
     def _get_streams(self):
-        player_js = self.session.http.get(self.url, schema=self._schema_player)
+        player_js = self.session.http.get(self.url, schema=validate.Schema(
+            validate.transform(self._re_player.search),
+            validate.any(None, validate.Schema(
+                validate.get(1),
+                validate.transform(lambda url: update_scheme("https:", url))
+            ))
+        ))
         if not player_js:
             return
 
-        log.debug("Found player js {0}".format(player_js))
+        log.debug(f"Found player js {player_js}")
+        data = self.session.http.get(player_js, schema=validate.Schema(
+            validate.transform(self._re_json.match),
+            validate.get(1),
+            validate.transform(parse_json),
+            validate.get("mediaResource"),
+            validate.get("dflt"),
+            {
+                validate.optional("audioURL"): validate.url(),
+                validate.optional("videoURL"): validate.url()
+            }
+        ))
 
-        hls_url = self.session.http.get(player_js, schema=self._schema_json)
-
-        yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
+        if data.get("videoURL"):
+            yield from HLSStream.parse_variant_playlist(self.session, update_scheme("https:", data.get("videoURL"))).items()
+        if data.get("audioURL"):
+            yield "audio", HTTPStream(self.session, update_scheme("https:", data.get("audioURL")))
 
 
 __plugin__ = Sportschau


### PR DESCRIPTION
Resolves #3945
Not the focus of Streamlink to fix audio-only streams, I know, but the fix is simple and at least it doesn't raise any errors.

The olympics/paralympics section on the site still does not work with these changes, as they seem to be using some special stream setup with iframes just for the event (tokio2020.sportschau.de). It's not worth supporting this unless we know that similar setups will be kept for future events.