### PR TITLE
plugins.pluto: geo-restricted to USA

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -126,7 +126,7 @@ orf_tvthek              tvthek.orf.at        Yes   Yes
 picarto                 picarto.tv           Yes   Yes
 piczel                  piczel.tv            Yes   No
 pixiv                   sketch.pixiv.net     Yes   --
-pluto                   pluto.tv             Yes   Yes   geo-restricted to USA
+pluto                   pluto.tv             Yes   Yes   geo restricted to the Americas and Europe
 pluzz                   - france.tv          Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
                         - ludo.fr
                         - zouzous.fr

--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -126,7 +126,7 @@ orf_tvthek              tvthek.orf.at        Yes   Yes
 picarto                 picarto.tv           Yes   Yes
 piczel                  piczel.tv            Yes   No
 pixiv                   sketch.pixiv.net     Yes   --
-pluto                   pluto.tv             Yes   Yes
+pluto                   pluto.tv             Yes   Yes   geo-restricted to USA
 pluzz                   - france.tv          Yes   Yes   Streams may be geo-restricted to France, Andorra and Monaco.
                         - ludo.fr
                         - zouzous.fr


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

This plugin is working for me only with the USA proxy. BTW for a long time I am using static links without proxy. This may be a hint for the workaround.