### PR TITLE
vendor: add lxml dependency

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -289,6 +289,7 @@ Name                                 Notes
 `iso-639`_                           Used for localization settings, provides language information
 `iso3166`_                           Used for localization settings, provides country information
 `isodate`_                           Used for MPEG-DASH streams
+`lxml`_                              Used for processing HTML and XML data
 `PySocks`_                           Used for SOCKS Proxies
 `websocket-client`_                  At least version **0.58.0**. (used for some plugins)
 
@@ -321,6 +322,7 @@ With these two environment variables it is possible to use `pycrypto`_ instead o
 .. _iso-639: https://pypi.org/project/iso-639/
 .. _iso3166: https://pypi.org/project/iso3166/
 .. _isodate: https://pypi.org/project/isodate/
+.. _lxml: https://lxml.de/
 .. _PySocks: https://github.com/Anorov/PySocks
 .. _websocket-client: https://pypi.org/project/websocket-client/
 

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -96,6 +96,7 @@ pypi_wheels=certifi==2021.5.30
             idna==3.2
             iso3166==1.0.1
             isodate==0.6.0
+            lxml==4.6.3
             pycryptodome==3.10.1
             PySocks==1.7.1
             requests==2.26.0

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ data_files = []
 deps = [
     "requests>=2.26.0,<3.0",
     "isodate",
+    "lxml>=4.6.3",
     "websocket-client>=0.58.0",
     # Support for SOCKS proxies
     "PySocks!=1.5.7,>=1.5.6",


### PR DESCRIPTION
Resolves #3944 

This adds the `lxml` dependency for parsing XML and HTML to Streamlink's `install_requires`.

There's also the `lxml-stubs` package available on pypi for adding type definitions which are lacking in the `lxml` package, but I don't know how this external package works. I'm using pycharm professional and it's generating types from the docs automatically (not that well though). `lxml-stubs` is supposed to go into `dev-requirements.txt` I think. Should this be added?

----

The validation methods and `parse_xml` utility method have not been modified yet and are still using the standard library methods for parsing XML. DASH streams and the validation methods (which are only called one single plugin - rtve) are therefore not affected.

I've tried to update the methods, but ran into encoding issues while reading XML from strings (utf-8) with a custom encoding set in the XML declaration (`<?xml version="..." encoding="..."?>`). This needs some refactoring first.

----

As an example on how XPath queries massively simplify plugins in a safe way, take a look at this diff:
https://github.com/bastimeyer/streamlink/compare/requirements/lxml...bastimeyer:plugins/deutschewelle/rewrite-xpath