### PR TITLE
cli: player title and file output metadata vars

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -588,6 +588,9 @@ def build_parser():
         Write stream data to FILENAME instead of playing it.
 
         You will be prompted if the file already exists.
+
+        The formatting variables available for the --title option may be used.
+        Unsupported characters in substituted variables will be replaced with an underscore.
         """
     )
     output.add_argument(
@@ -619,6 +622,9 @@ def build_parser():
         Open the stream in the player, while at the same time writing it to FILENAME.
 
         You will be prompted if the file already exists.
+
+        The formatting variables available for the --title option may be used.
+        Unsupported characters in substituted variables will be replaced with an underscore.
         """
     )
     output.add_argument(
@@ -628,6 +634,28 @@ def build_parser():
         Write stream data to stdout, while at the same time writing it to FILENAME.
 
         You will be prompted if the file already exists.
+
+        The formatting variables available for the --title option may be used.
+        Unsupported characters in substituted variables will be replaced with an underscore.
+        """
+    )
+    output.add_argument(
+        "--fs-safe-rules",
+        choices=["POSIX", "Windows"],
+        type=str,
+        help="""
+        The rules used to make formatting variables filesystem-safe are chosen
+        automatically according to the type of system in use. This overrides
+        the automatic detection.
+
+        Intended for use when Streamlink is running on a UNIX-like OS but writing
+        to Windows filesystems such as NTFS; USB devices using VFAT or exFAT; CIFS
+        shares that are enforcing Windows filename limitations, etc.
+
+        These characters are replaced with an underscore for the rules in use:
+
+          POSIX  : \\x00-\\x1F /
+          Windows: \\x00-\\x1F \\x7F " * / : < > ? \\ |
         """
     )
 

--- a/src/streamlink_cli/utils/__init__.py
+++ b/src/streamlink_cli/utils/__init__.py
@@ -1,13 +1,14 @@
 import json
 from contextlib import contextmanager
 
+from streamlink_cli.utils.formatter import Formatter
 from streamlink_cli.utils.http_server import HTTPServer
 from streamlink_cli.utils.player import find_default_player
 from streamlink_cli.utils.progress import progress
 from streamlink_cli.utils.stream import stream_to_url
 
 __all__ = [
-    "HTTPServer", "JSONEncoder",
+    "Formatter", "HTTPServer", "JSONEncoder",
     "find_default_player", "ignored", "progress", "stream_to_url"
 ]
 

--- a/src/streamlink_cli/utils/formatter.py
+++ b/src/streamlink_cli/utils/formatter.py
@@ -1,0 +1,52 @@
+from typing import Callable, Dict, Optional, Type, Union
+
+from streamlink_cli.utils.path import replace_chars
+
+
+class _UNKNOWN:
+    pass
+
+
+class Formatter(dict):
+    def __init__(self, mapping: Dict[str, Callable]):
+        super().__init__()
+        self.mapping = mapping
+        self.cache = dict()
+
+    def __missing__(self, key: str) -> Union[Type[_UNKNOWN], None, str]:
+        if key not in self.mapping:
+            return _UNKNOWN
+
+        if key in self.cache:
+            return self.cache[key]
+
+        value = self.mapping[key]()
+        self.cache[key] = value
+
+        return value
+
+    def _format(self, string: str, wrapper: Callable[[str], str], defaults: Optional[Dict] = None) -> str:
+        return string.format_map(_Wrapper(self, wrapper, defaults))
+
+    def filename(self, filename: str, charmap: Optional[str] = None) -> str:
+        return self._format(filename, lambda s: replace_chars(s, charmap))
+
+    def title(self, title: str, defaults: Optional[Dict] = None) -> str:
+        return self._format(title, lambda s: s, defaults)
+
+
+class _Wrapper(dict):
+    def __init__(self, formatter: Formatter, wrapper: Callable[[str], str], defaults: Optional[Dict[str, str]] = None):
+        super().__init__()
+        self.formatter = formatter
+        self.wrapper = wrapper
+        self.defaults = defaults or {}
+
+    def __missing__(self, key: str) -> str:
+        value = self.formatter[key]
+        if value is _UNKNOWN:
+            value = str(self.defaults.get(key, f"{{{key}}}"))
+        elif value is None:
+            value = str(self.defaults.get(key, ""))
+
+        return self.wrapper(value)

--- a/src/streamlink_cli/utils/path.py
+++ b/src/streamlink_cli/utils/path.py
@@ -1,0 +1,33 @@
+import re
+from typing import Optional
+
+from streamlink_cli.compat import is_win32
+
+
+REPLACEMENT = "_"
+
+_UNPRINTABLE = "".join(chr(c) for c in range(32))
+_UNSUPPORTED_POSIX = "/"
+_UNSUPPORTED_WIN32 = "\x7f\"*/:<>?\\|"
+
+RE_CHARS_POSIX = re.compile(f"[{re.escape(_UNPRINTABLE + _UNSUPPORTED_POSIX)}]+")
+RE_CHARS_WIN32 = re.compile(f"[{re.escape(_UNPRINTABLE + _UNSUPPORTED_WIN32)}]+")
+if is_win32:
+    RE_CHARS = RE_CHARS_WIN32
+else:
+    RE_CHARS = RE_CHARS_POSIX
+
+
+def replace_chars(path, charmap: Optional[str] = None, replacement=REPLACEMENT):
+    if charmap is None:
+        pattern = RE_CHARS
+    else:
+        charmap = charmap.lower()
+        if charmap in ("posix", "unix"):
+            pattern = RE_CHARS_POSIX
+        elif charmap in ("windows", "win32"):
+            pattern = RE_CHARS_WIN32
+        else:
+            raise ValueError("Invalid charmap")
+
+    return pattern.sub(replacement, path)

--- a/tests/test_cli_utils_formatter.py
+++ b/tests/test_cli_utils_formatter.py
@@ -1,0 +1,47 @@
+import unittest
+from unittest.mock import Mock, call, patch
+
+from streamlink_cli.utils.formatter import Formatter
+
+
+class TestFormatter(unittest.TestCase):
+    def setUp(self):
+        self.prop = Mock(return_value="prop")
+        self.formatter = Formatter({
+            "prop": self.prop,
+            "empty": lambda: "",
+            "none": lambda: None
+        })
+
+    def test_unknown(self):
+        self.assertEqual(self.formatter.title("some {unknown} variable"), "some {unknown} variable")
+        self.assertEqual(self.formatter.title("some {unknown} variable", {"unknown": "known"}), "some known variable")
+        self.assertEqual(self.formatter.cache, dict())
+
+    def test_title(self):
+        self.assertEqual(self.formatter.title("text '{prop}' '{empty}' '{none}'"), "text 'prop' '' ''")
+        self.assertEqual(self.formatter.cache, dict(prop="prop", empty="", none=None))
+        self.assertEqual(self.prop.call_count, 1)
+
+        self.assertEqual(self.formatter.title("text '{prop}' '{empty}' '{none}'"), "text 'prop' '' ''")
+        self.assertEqual(self.prop.call_count, 1)
+
+    @patch("streamlink_cli.utils.formatter.replace_chars")
+    def test_filename(self, mock_replace_chars: Mock):
+        mock_replace_chars.side_effect = lambda s, *_: s.upper()
+
+        self.assertEqual(self.formatter.filename("text '{prop}' '{empty}' '{none}'"), "text 'PROP' '' ''")
+        self.assertEqual(self.formatter.cache, dict(prop="prop", empty="", none=None))
+        self.assertEqual(self.prop.call_count, 1)
+        self.assertEqual(mock_replace_chars.call_args_list, [
+            call("prop", None), call("", None), call("", None)
+        ])
+
+        mock_replace_chars.reset_mock()
+
+        self.assertEqual(self.formatter.filename("text '{prop}' '{empty}' '{none}'", "foo"), "text 'PROP' '' ''")
+        self.assertEqual(self.formatter.cache, dict(prop="prop", empty="", none=None))
+        self.assertEqual(self.prop.call_count, 1)
+        self.assertEqual(mock_replace_chars.call_args_list, [
+            call("prop", "foo"), call("", "foo"), call("", "foo")
+        ])

--- a/tests/test_cli_utils_path.py
+++ b/tests/test_cli_utils_path.py
@@ -1,0 +1,55 @@
+import pytest
+
+from streamlink_cli.utils.path import replace_chars
+from tests import posix_only, windows_only
+
+
+@pytest.mark.parametrize("char", [i for i in range(32)])
+def test_replace_chars_unprintable(char: int):
+    assert replace_chars(f"foo{chr(char)}{chr(char)}bar") == "foo_bar", "Replaces unprintable characters"
+
+
+@posix_only
+@pytest.mark.parametrize("char", "/".split())
+def test_replace_chars_posix(char: str):
+    assert replace_chars(f"foo{char}{char}bar") == "foo_bar", "Replaces multiple unsupported characters in a row"
+
+
+@windows_only
+@pytest.mark.parametrize("char", "\x7f\"*/:<>?\\|".split())
+def test_replace_chars_windows(char: str):
+    assert replace_chars(f"foo{char}{char}bar") == "foo_bar", "Replaces multiple unsupported characters in a row"
+
+
+@posix_only
+def test_replace_chars_posix_all():
+    assert replace_chars("".join(chr(i) for i in range(32)) + "/") == "_"
+
+
+@windows_only
+def test_replace_chars_windows_all():
+    assert replace_chars("".join(chr(i) for i in range(32)) + "\x7f\"*/:<>?\\|") == "_"
+
+
+@posix_only
+def test_replace_chars_posix_override():
+    all_chars = "".join(chr(i) for i in range(32)) + "\x7f\"*:/<>?\\|"
+    assert replace_chars(all_chars) == "_\x7f\"*:_<>?\\|"
+    assert replace_chars(all_chars, "posix") == "_\x7f\"*:_<>?\\|"
+    assert replace_chars(all_chars, "unix") == "_\x7f\"*:_<>?\\|"
+    assert replace_chars(all_chars, "windows") == "_"
+    assert replace_chars(all_chars, "win32") == "_"
+
+
+@windows_only
+def test_replace_chars_windows_override():
+    all_chars = "".join(chr(i) for i in range(32)) + "\x7f\"*:/<>?\\|"
+    assert replace_chars(all_chars) == "_"
+    assert replace_chars(all_chars, "posix") == "_\x7f\"*:_<>?\\|"
+    assert replace_chars(all_chars, "unix") == "_\x7f\"*:_<>?\\|"
+    assert replace_chars(all_chars, "windows") == "_"
+    assert replace_chars(all_chars, "win32") == "_"
+
+
+def test_replace_chars_replacement():
+    assert replace_chars("\x00", None, "+") == "+"


### PR DESCRIPTION
- support the same plugin metadata variables in `--output`, `--record`
  and `--record-and-pipe` like they already exist in `--title`:
  `{url}`, `{author}`, `{category}`/`{game}` and `{title}`
- substitute unsupported file name characters on specific OS-types
- add `--fs-safe-rules` CLI argument for overriding substitution logic
- add new Formatter class with caching and parameter translation
- create formatter instance in `handle_stream` and pass it to output
  methods where player titles or file names need to be formatted
- rewrite test_cli_main tests

Co-Authored-By: Ian Cameron <1661072+mkbloke@users.noreply.github.com>

----

Resolves #3898
Related #3954, #3933, #3913 

----

- ~~The critical code path where the formatter gets initialized is currently not tested because there weren't any test prior to these changes. I will try to add some tests tomorrow or so. This requires setting up ton of mocks, which is ugly.~~
- The new Formatter could be moved to the streamlink package and replace the LazyFormatter which is currently only used in the HLSWriter for the HLS key URI override stuff.
- There's currently no variable for the output stream's file container, which makes these variables not that useful IMO, but whatever.