### PR TITLE
plugin.api.validate: switch to lxml.etree

### DIFF
--- a/src/streamlink/plugin/api/validate.py
+++ b/src/streamlink/plugin/api/validate.py
@@ -20,14 +20,15 @@ from copy import copy as copy_obj
 from functools import singledispatch
 from typing import Any, Tuple, Union
 from urllib.parse import urlparse
-from xml.etree import ElementTree as ET
+
+from lxml.etree import Element, iselement
 
 from streamlink.exceptions import PluginError
 
 __all__ = [
     "any", "all", "filter", "get", "getattr", "hasattr", "length", "optional",
     "transform", "text", "union", "union_get", "url", "startswith", "endswith", "contains",
-    "xml_element", "xml_find", "xml_findall", "xml_findtext",
+    "xml_element", "xml_find", "xml_findall", "xml_findtext", "xml_xpath", "xml_xpath_string",
     "validate", "Schema", "SchemaContainer"
 ]
 
@@ -164,8 +165,8 @@ def get(item: Union[Any, Tuple[Any]], default: Any = None, strict: bool = False)
         idx = 0
         try:
             for key in item:
-                if ET.iselement(value):
-                    value = value.attrib
+                if iselement(value):
+                    value = value.attrib[key]
                 # Use .group() if this is a regex match object
                 elif _is_re_match(value):
                     value = value.group(key)
@@ -275,12 +276,12 @@ def url(**attributes):
 def xml_find(xpath):
     """Find a XML element via xpath."""
     def xpath_find(value):
-        validate(ET.iselement, value)
+        validate(iselement, value)
         value = value.find(xpath)
         if value is None:
-            raise ValueError("XPath '{0}' did not return an element".format(xpath))
+            raise ValueError(f"XPath '{xpath}' did not return an element")
 
-        return validate(ET.iselement, value)
+        return validate(iselement, value)
 
     return transform(xpath_find)
 
@@ -288,7 +289,7 @@ def xml_find(xpath):
 def xml_findall(xpath):
     """Find a list of XML elements via xpath."""
     def xpath_findall(value):
-        validate(ET.iselement, value)
+        validate(iselement, value)
         return value.findall(xpath)
 
     return transform(xpath_findall)
@@ -300,6 +301,18 @@ def xml_findtext(xpath):
         xml_find(xpath),
         getattr("text"),
     )
+
+
+def xml_xpath(xpath):
+    def transform_xpath(value):
+        validate(iselement, value)
+        return value.xpath(xpath) or None
+
+    return transform(transform_xpath)
+
+
+def xml_xpath_string(xpath):
+    return xml_xpath(f"string({xpath})")
 
 
 @singledispatch
@@ -393,27 +406,31 @@ def validate_type(schema, value):
 
 @validate.register(xml_element)
 def validate_xml_element(schema, value):
-    validate(ET.iselement, value)
-    new = ET.Element(value.tag, attrib=value.attrib)
+    validate(iselement, value)
+    _tag = value.tag
+    _attrib = value.attrib
+    _text = value.text
 
     if schema.attrib is not None:
         try:
-            new.attrib = validate(schema.attrib, value.attrib)
+            _attrib = validate(schema.attrib, dict(value.attrib))
         except ValueError as err:
-            raise ValueError("Unable to validate XML attributes: {0}".format(err))
+            raise ValueError(f"Unable to validate XML attributes: {err}")
 
     if schema.tag is not None:
         try:
-            new.tag = validate(schema.tag, value.tag)
+            _tag = validate(schema.tag, value.tag)
         except ValueError as err:
-            raise ValueError("Unable to validate XML tag: {0}".format(err))
+            raise ValueError(f"Unable to validate XML tag: {err}")
 
     if schema.text is not None:
         try:
-            new.text = validate(schema.text, value.text)
+            _text = validate(schema.text, value.text)
         except ValueError as err:
-            raise ValueError("Unable to validate XML text: {0}".format(err))
+            raise ValueError(f"Unable to validate XML text: {err}")
 
+    new = Element(_tag, _attrib)
+    new.text = _text
     for child in value:
         new.append(child)
 

--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -3,8 +3,9 @@ import datetime
 import hashlib
 import random
 import re
-import xml.etree.ElementTree as ET
 from urllib.parse import urlencode
+
+from lxml.etree import XML
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
@@ -96,7 +97,7 @@ class Radiko(Plugin):
             date = today.strftime('%Y%m%d')
         api = 'http://radiko.jp/v3/program/station/date/{}/{}.xml'.format(date, station_id)
         r = self.session.http.get(api)
-        tree = ET.XML(r.content)
+        tree = XML(r.content)
         for x in tree[2][0][1].findall('prog'):
             if x.attrib['ft'] == start_at:
                 return x.attrib['to']

--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,17 +1,18 @@
 import codecs
 import os.path
-import xml.etree.ElementTree as ET
 from contextlib import contextmanager
 from io import BytesIO
+
+from lxml.etree import iterparse
 
 
 __here__ = os.path.abspath(os.path.dirname(__file__))
 
 
 def _parse_xml(data, strip_ns=False):
-    data = bytearray(data, "utf8")
+    data = bytes(data, "utf8")
     try:
-        it = ET.iterparse(BytesIO(data))
+        it = iterparse(BytesIO(data))
         for _, el in it:
             if '}' in el.tag and strip_ns:  # pragma: no branch
                 # strip all namespaces

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1,11 +1,12 @@
 import re
 import unittest
-from xml.etree.ElementTree import Element
+
+from lxml.etree import Element
 
 from streamlink.plugin.api.validate import (
     all, any, attr, endswith, filter, get, getattr, hasattr,
     length, map, optional, startswith, text, transform, union, union_get, url,
-    validate, xml_element, xml_find, xml_findall, xml_findtext
+    validate, xml_element, xml_find, xml_findall, xml_findtext, xml_xpath, xml_xpath_string
 )
 
 
@@ -94,6 +95,7 @@ class TestPluginAPIValidate(unittest.TestCase):
         assert validate(get("invalidkey"), {"key": "value"}) is None
         assert validate(get("invalidkey", "default"), {"key": "value"}) == "default"
         assert validate(get(3, "default"), [0, 1, 2]) == "default"
+        assert validate(get("attr"), Element("foo", {"attr": "value"})) == "value"
 
         with self.assertRaisesRegex(ValueError, "'NoneType' object is not subscriptable"):
             validate(get("key"), None)
@@ -134,12 +136,33 @@ class TestPluginAPIValidate(unittest.TestCase):
         self.assertRaises(ValueError, invalid_length)
 
     def test_xml_element(self):
-        el = Element("tag", attrib={"key": "value"})
+        el = Element("tag")
+        el.set("key", "value")
         el.text = "test"
+        childA = Element("childA")
+        childB = Element("childB")
+        el.append(childA)
+        el.append(childB)
 
-        assert validate(xml_element("tag"), el).tag == "tag"
-        assert validate(xml_element(text="test"), el).text == "test"
-        assert validate(xml_element(attrib={"key": text}), el).attrib == {"key": "value"}
+        upper = transform(str.upper)
+        newelem: Element = validate(xml_element(tag=upper, text=upper, attrib={upper: upper}), el)
+
+        assert newelem.tag == "TAG"
+        assert newelem.text == "TEST"
+        assert newelem.attrib == {"KEY": "VALUE"}
+        assert list(newelem.iterchildren()) == [childA, childB]
+
+        with self.assertRaises(ValueError) as cm:
+            validate(xml_element(tag="invalid"), el)
+        assert str(cm.exception).startswith("Unable to validate XML tag: ")
+
+        with self.assertRaises(ValueError) as cm:
+            validate(xml_element(text="invalid"), el)
+        assert str(cm.exception).startswith("Unable to validate XML text: ")
+
+        with self.assertRaises(ValueError) as cm:
+            validate(xml_element(attrib={"key": "invalid"}), el)
+        assert str(cm.exception).startswith("Unable to validate XML attributes: ")
 
     def test_xml_find(self):
         el = Element("parent")
@@ -147,6 +170,10 @@ class TestPluginAPIValidate(unittest.TestCase):
         el.append(Element("bar"))
 
         assert validate(xml_find("bar"), el).tag == "bar"
+
+        with self.assertRaises(ValueError) as cm:
+            validate(xml_find("baz"), el)
+        assert str(cm.exception) == "XPath 'baz' did not return an element"
 
     def test_xml_findtext(self):
         el = Element("foo")
@@ -161,6 +188,37 @@ class TestPluginAPIValidate(unittest.TestCase):
             el.append(child)
 
         assert validate(xml_findall("child"), el) == children
+
+    def test_xml_xpath(self):
+        root = Element("root")
+        foo = Element("foo")
+        bar = Element("bar")
+        baz = Element("baz")
+        root.append(foo)
+        root.append(bar)
+        foo.append(baz)
+
+        assert validate(xml_xpath("./descendant-or-self::node()"), root) == [root, foo, baz, bar], "Returns correct node set"
+        assert validate(xml_xpath("./child::qux"), root) is None, "Returns None when node set is empty"
+        assert validate(xml_xpath("name(.)"), root) == "root", "Returns function values instead of node sets"
+        self.assertRaises(ValueError, validate, xml_xpath("."), "not an Element")
+
+    def test_xml_xpath_string(self):
+        root = Element("root")
+        foo = Element("foo")
+        bar = Element("bar")
+        root.set("attr", "")
+        foo.set("attr", "FOO")
+        bar.set("attr", "BAR")
+        root.append(foo)
+        root.append(bar)
+
+        assert validate(xml_xpath_string("./baz"), root) is None, "Returns None if nothing was found"
+        assert validate(xml_xpath_string("./@attr"), root) is None, "Returns None if string is empty"
+        assert validate(xml_xpath_string("./foo/@attr"), root) == "FOO", "Returns the attr value of foo"
+        assert validate(xml_xpath_string("./bar/@attr"), root) == "BAR", "Returns the attr value of bar"
+        assert validate(xml_xpath_string("count(./*)"), root) == "2", "Wraps arbitrary functions"
+        assert validate(xml_xpath_string("./*/@attr"), root) == "FOO", "Returns the first item of a set of nodes"
 
     def test_attr(self):
         el = Element("foo")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,11 +2,12 @@ import base64
 import os.path
 import sys
 import unittest
-import xml.etree.ElementTree as ET
+
+from lxml.etree import Element
 
 from streamlink.exceptions import PluginError
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.validate import text, xml_element
+from streamlink.plugin.api.validate import xml_element
 from streamlink.utils import (
     absolute_url,
     load_module,
@@ -53,25 +54,25 @@ class TestUtil(unittest.TestCase):
         self.assertRaises(PluginError, parse_json, """{"test: 1}""" * 10)
 
     def test_parse_xml(self):
-        expected = ET.Element("test", {"foo": "bar"})
+        expected = Element("test", {"foo": "bar"})
         actual = parse_xml("""<test foo="bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_ns_ignore(self):
-        expected = ET.Element("test", {"foo": "bar"})
+        expected = Element("test", {"foo": "bar"})
         actual = parse_xml("""<test foo="bar" xmlns="foo:bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_ns_ignore_tab(self):
-        expected = ET.Element("test", {"foo": "bar"})
+        expected = Element("test", {"foo": "bar"})
         actual = parse_xml("""<test	foo="bar"	xmlns="foo:bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
     def test_parse_xml_ns(self):
-        expected = ET.Element("{foo:bar}test", {"foo": "bar"})
+        expected = Element("{foo:bar}test", {"foo": "bar"})
         actual = parse_xml("""<h:test foo="bar" xmlns:h="foo:bar"/>""")
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
@@ -83,9 +84,9 @@ class TestUtil(unittest.TestCase):
                           parse_xml, "1" * 1000, exception=IOError)
 
     def test_parse_xml_validate(self):
-        expected = ET.Element("test", {"foo": "bar"})
+        expected = Element("test", {"foo": "bar"})
         actual = parse_xml("""<test foo="bar"/>""",
-                           schema=validate.Schema(xml_element(tag="test", attrib={"foo": text})))
+                           schema=validate.Schema(xml_element(tag="test", attrib={"foo": str})))
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
@@ -94,9 +95,9 @@ class TestUtil(unittest.TestCase):
                           parse_xml, """<test foo="bar &"/>""")
 
     def test_parse_xml_entities(self):
-        expected = ET.Element("test", {"foo": "bar &"})
+        expected = Element("test", {"foo": "bar &"})
         actual = parse_xml("""<test foo="bar &"/>""",
-                           schema=validate.Schema(xml_element(tag="test", attrib={"foo": text})),
+                           schema=validate.Schema(xml_element(tag="test", attrib={"foo": str})),
                            invalid_char_entities=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
@@ -104,7 +105,7 @@ class TestUtil(unittest.TestCase):
     def test_parse_qsd(self):
         self.assertEqual(
             {"test": "1", "foo": "bar"},
-            parse_qsd("test=1&foo=bar", schema=validate.Schema({"test": validate.text, "foo": "bar"})))
+            parse_qsd("test=1&foo=bar", schema=validate.Schema({"test": str, "foo": "bar"})))
 
     def test_rtmpparse(self):
         self.assertEqual(


### PR DESCRIPTION
- replace xml.etree from standard library with lxml.etree in
  plugin.api.validate, utils.parse_xml, plugins and tests
- add validate.xml_xpath() and validate.xml_xpath_string() methods
- fix validate.get() and return attribute value for given attribute key
- refactor validate.xml_element() validation method
- fix and add tests

----

#3952 