### PR TITLE
plugins.booyah: add support for source stream

### DIFF
--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -67,7 +67,7 @@ class Booyah(Plugin):
 
     def get_title(self):
         return self.title
-        
+
     @classmethod
     def stream_weight(cls, stream):
         if stream == "source":

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, pluginmatcher
@@ -17,13 +18,6 @@ class Booyah(Plugin):
     vod_api_url = 'https://booyah.live/api/v3/playbacks/{0}'
     live_api_url = 'https://booyah.live/api/v3/channels/{0}'
     streams_api_url = 'https://booyah.live/api/v3/channels/{0}/streams'
-    
-    @classmethod
-    def stream_weight(cls, key):
-        if key.startswith("source"):
-            return 65535, "source"
-
-        return Plugin.stream_weight(key)
 
     auth_schema = validate.Schema({
         'expiry_time': int,
@@ -61,17 +55,6 @@ class Booyah(Plugin):
         },
     })
 
-    streams_schema = validate.Schema({
-        'stream_addr_list': [{
-            'resolution': str,
-            'url_path': str,
-        }],
-        'mirror_list': [{
-            'url_domain': validate.url(),
-        }],
-        'source_stream_url_path': str,
-    })
-
     author = None
     category = None
     title = None
@@ -84,6 +67,12 @@ class Booyah(Plugin):
 
     def get_title(self):
         return self.title
+        
+    @classmethod
+    def stream_weight(cls, stream):
+        if stream == "source":
+            return sys.maxsize, "source"
+        return super().stream_weight(stream)
 
     def do_auth(self):
         res = self.session.http.post(self.auth_api_url)
@@ -127,21 +116,32 @@ class Booyah(Plugin):
         self.title = user_data['channel']['name']
 
         res = self.session.http.get(self.streams_api_url.format(stream_id))
-        streams = self.session.http.json(res, schema=self.streams_schema)
+        streams = self.session.http.json(res, schema=validate.Schema({
+            "default_mirror": str,
+            "mirror_list": [{
+                "name": str,
+                "url_domain": validate.url(),
+            }],
+            "source_stream_url_path": str,
+            "stream_addr_list": [{
+                "resolution": str,
+                "url_path": str,
+            }],
+        }))
 
-        for stream in streams['stream_addr_list']:
-            if stream['resolution'] != 'Auto':
-                for mirror in streams['mirror_list']:
-                    yield stream['resolution'], HLSStream(
-                        self.session,
-                        urljoin(mirror['url_domain'], stream['url_path']),
-                    )
-                    
-        for mirror in streams['mirror_list']:
-            yield 'source', HLSStream(
-                self.session,
-                urljoin(mirror['url_domain'], streams['source_stream_url_path']),
-            )
+        mirror = (
+            next(filter(lambda item: item["name"] == streams["default_mirror"], streams["mirror_list"]), None)
+            or next(iter(streams["mirror_list"]), None)
+        )
+        if not mirror:
+            return
+
+        auto = next(filter(lambda item: item["resolution"] == "Auto", streams["stream_addr_list"]), None)
+        if auto:
+            yield from HLSStream.parse_variant_playlist(self.session, urljoin(mirror["url_domain"], auto["url_path"])).items()
+
+        if streams["source_stream_url_path"]:
+            yield "source", HLSStream(self.session, urljoin(mirror["url_domain"], streams["source_stream_url_path"]))
 
     def _get_streams(self):
         self.do_auth()

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -17,6 +17,13 @@ class Booyah(Plugin):
     vod_api_url = 'https://booyah.live/api/v3/playbacks/{0}'
     live_api_url = 'https://booyah.live/api/v3/channels/{0}'
     streams_api_url = 'https://booyah.live/api/v3/channels/{0}/streams'
+    
+    @classmethod
+    def stream_weight(cls, key):
+        if key.startswith("source"):
+            return 65535, "source"
+
+        return Plugin.stream_weight(key)
 
     auth_schema = validate.Schema({
         'expiry_time': int,
@@ -62,6 +69,7 @@ class Booyah(Plugin):
         'mirror_list': [{
             'url_domain': validate.url(),
         }],
+        'source_stream_url_path': str,
     })
 
     author = None
@@ -128,6 +136,12 @@ class Booyah(Plugin):
                         self.session,
                         urljoin(mirror['url_domain'], stream['url_path']),
                     )
+                    
+        for mirror in streams['mirror_list']:
+            yield 'source', HLSStream(
+                self.session,
+                urljoin(mirror['url_domain'], streams['source_stream_url_path']),
+            )
 
     def _get_streams(self):
         self.do_auth()


### PR DESCRIPTION
The current booyah plugin does not support the source quality. This PR adds support for it.