### PR TITLE
plugin: metadata attributes

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -202,6 +202,11 @@ class Plugin:
     # a reference to the `re.Match` result of the first matching matcher
     match: Match
 
+    # plugin metadata attributes
+    author: Optional[str] = None
+    category: Optional[str] = None
+    title: Optional[str] = None
+
     cache = None
     logger = None
     module = "unknown"
@@ -425,14 +430,14 @@ class Plugin:
     def _get_streams(self):
         raise NotImplementedError
 
-    def get_title(self):
-        return None
+    def get_title(self) -> Optional[str]:
+        return self.title
 
-    def get_author(self):
-        return None
+    def get_author(self) -> Optional[str]:
+        return self.author
 
-    def get_category(self):
-        return None
+    def get_category(self) -> Optional[str]:
+        return self.category
 
     def save_cookies(self, cookie_filter=None, default_expires=60 * 60 * 24 * 7):
         """

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -55,19 +55,6 @@ class Booyah(Plugin):
         },
     })
 
-    author = None
-    category = None
-    title = None
-
-    def get_author(self):
-        return self.author
-
-    def get_category(self):
-        return self.category
-
-    def get_title(self):
-        return self.title
-
     @classmethod
     def stream_weight(cls, stream):
         if stream == "source":

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -19,15 +19,6 @@ class DeutscheWelle(Plugin):
     DEFAULT_CHANNEL = "1"
     API_URL = "https://www.dw.com/playersources/v-{media_id}?hls=true"
 
-    author = None
-    title = None
-
-    def get_author(self):
-        return self.author
-
-    def get_title(self):
-        return self.title
-
     def _find_metadata(self, elem: Element):
         self.author = elem.xpath("string(.//input[@name='channel_name'][1]/@value)") or None
         self.title = elem.xpath("string(.//input[@name='media_title'][1]/@value)") or None

--- a/src/streamlink/plugins/dlive.py
+++ b/src/streamlink/plugins/dlive.py
@@ -58,17 +58,9 @@ class DLive(Plugin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.author = None
-        self.title = None
 
         self.video = self.match.group("video")
         self.channel = self.match.group("channel")
-
-    def get_author(self):
-        return self.author
-
-    def get_title(self):
-        return self.title
 
     def _get_streams_video(self):
         log.debug("Getting video HLS streams for {0}".format(self.video))

--- a/src/streamlink/plugins/galatasaraytv.py
+++ b/src/streamlink/plugins/galatasaraytv.py
@@ -13,8 +13,7 @@ log = logging.getLogger(__name__)
 class GalatasarayTV(Plugin):
     playervars_re = re.compile(r"sources\s*:\s*\[\s*\{\s*type\s*:\s*\"(.*?)\",\s*src\s*:\s*\"(.*?)\"", re.DOTALL)
 
-    def get_title(self):
-        return "Galatasaray TV"
+    title = "Galatasaray TV"
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/latina.py
+++ b/src/streamlink/plugins/latina.py
@@ -13,8 +13,7 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?latina\.pe/tvenvivo"
 ))
 class Latina(Plugin):
-    def get_title(self):
-        return "Latina"
+    title = "Latina"
 
     def _get_streams(self):
         self.session.http.headers.update({

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -61,19 +61,6 @@ class Mjunoon(Plugin):
         'aes-256-cbc': AES.MODE_CBC,
     }
 
-    author = None
-    category = None
-    title = None
-
-    def get_author(self):
-        return self.author
-
-    def get_category(self):
-        return self.category
-
-    def get_title(self):
-        return self.title
-
     def get_data(self):
         js_data = {}
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/nbcnews.py
+++ b/src/streamlink/plugins/nbcnews.py
@@ -51,8 +51,7 @@ class NBCNews(Plugin):
         ))
     )
 
-    def get_title(self):
-        return 'NBC News Now'
+    title = "NBC News Now"
 
     def _get_streams(self):
         video_id = self.session.http.get(self.url, schema=self.json_data_schema)

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -16,10 +16,6 @@ class NimoTV(Plugin):
     data_url = 'https://m.nimo.tv/{0}'
     data_re = re.compile(r'<script>var G_roomBaseInfo = ({.*?});</script>')
 
-    author = None
-    category = None
-    title = None
-
     data_schema = validate.Schema(
         validate.transform(data_re.search),
         validate.any(None, validate.all(
@@ -46,15 +42,6 @@ class NimoTV(Plugin):
     _re_domain = re.compile(br'(https?:\/\/[A-Za-z]{2,3}.hls[A-Za-z\.\/]+)(?:V|&)')
     _re_id = re.compile(br'id=([^|\\]+)')
     _re_tp = re.compile(br'tp=(\d+)')
-
-    def get_author(self):
-        return self.author
-
-    def get_category(self):
-        return self.category
-
-    def get_title(self):
-        return self.title
 
     def _get_streams(self):
         username = self.match.group('username')

--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -15,14 +15,10 @@ log = logging.getLogger(__name__)
 ))
 class NOS(Plugin):
     _msg_live_offline = "This livestream is offline."
-    title = None
     vod_keys = {
         "pages/Collection/Video/Video": "item",
         "pages/Video/Video": "video",
     }
-
-    def get_title(self):
-        return self.title
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -48,15 +48,6 @@ class NRK(Plugin):
         },
     ))
 
-    category = None
-    title = None
-
-    def get_category(self):
-        return self.category
-
-    def get_title(self):
-        return self.title
-
     def _get_streams(self):
         # Construct manifest URL for this program.
         program_type, program_id = self.match.groups()

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -56,8 +56,6 @@ class OPENRECtv(Plugin):
 
     def __init__(self, url):
         super().__init__(url)
-        self.author = None
-        self.title = None
         self.video_id = None
 
     def login(self, email, password):

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -45,19 +45,6 @@ class Picarto(Plugin):
 
     HLS_URL = 'https://{origin}.picarto.tv/stream/hls/{file_name}/index.m3u8'
 
-    author = None
-    category = None
-    title = None
-
-    def get_author(self):
-        return self.author
-
-    def get_category(self):
-        return self.category
-
-    def get_title(self):
-        return self.title
-
     def get_live(self, username):
         res = self.session.http.get(f'https://ptvintern.picarto.tv/api/channel/detail/{username}')
         channel_data = self.session.http.json(res, schema=self.channel_schema)

--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -21,11 +21,6 @@ log = logging.getLogger(__name__)
     )
 ''', re.VERBOSE))
 class Pluto(Plugin):
-    title = None
-
-    def get_title(self):
-        return self.title
-
     def _schema_media(self, slug):
         return validate.Schema(
             [{

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -46,10 +46,6 @@ class Reuters(Plugin):
         )
     )
 
-    def __init__(self, url):
-        super().__init__(url)
-        self.title = None
-
     def get_title(self):
         if not self.title:
             self._get_data()

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -58,10 +58,6 @@ class Streann(Plugin):
 
     _device_id = None
     _domain = None
-    title = None
-
-    def get_title(self):
-        return self.title
 
     @property
     def device_id(self):

--- a/src/streamlink/plugins/stv.py
+++ b/src/streamlink/plugins/stv.py
@@ -13,8 +13,6 @@ log = logging.getLogger(__name__)
 class STV(Plugin):
     API_URL = 'https://player.api.stv.tv/v1/streams/stv/'
 
-    title = None
-
     def get_title(self):
         if self.title is None:
             self._get_api_results()

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -16,10 +16,6 @@ log = logging.getLogger(__name__)
 class SVTPlay(Plugin):
     api_url = 'https://api.svt.se/videoplayer-api/video/{0}'
 
-    author = None
-    category = None
-    title = None
-
     latest_episode_url_re = re.compile(r'''
         data-rt="top-area-play-button"\s+href="(?P<url>[^"]+)"
     ''', re.VERBOSE)
@@ -42,18 +38,6 @@ class SVTPlay(Plugin):
     arguments = PluginArguments(
         PluginArgument("mux-subtitles", is_global=True)
     )
-
-    def get_author(self):
-        if self.author is not None:
-            return self.author
-
-    def get_category(self):
-        if self.category is not None:
-            return self.category
-
-    def get_title(self):
-        if self.title is not None:
-            return self.title
 
     def _set_metadata(self, data, category):
         if 'programTitle' in data:

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -19,7 +19,6 @@ log = logging.getLogger(__name__)
     /(?P<video_id>\d+)
 """, re.VERBOSE))
 class TV4Play(Plugin):
-    title = None
     video_id = None
 
     api_url = "https://playback-api.b17g.net"

--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -14,8 +14,7 @@ log = logging.getLogger(__name__)
 class TV8(Plugin):
     _re_hls = re.compile(r"""file\s*:\s*(["'])(?P<hls_url>https?://.*?\.m3u8.*?)\1""")
 
-    def get_title(self):
-        return 'TV8'
+    title = "TV8"
 
     def _get_streams(self):
         hls_url = self.session.http.get(self.url, schema=validate.Schema(

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -463,9 +463,6 @@ class Twitch(Plugin):
         self.video_id = None
         self.channel = None
         self.clip_name = None
-        self.title = None
-        self.author = None
-        self.category = None
 
         if self.subdomain == "player":
             # pop-out player

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -83,15 +83,7 @@ class YouTube(Plugin):
         elif parsed.scheme != "https":
             self.url = urlunparse(parsed._replace(scheme="https"))
 
-        self.author = None
-        self.title = None
         self.session.http.headers.update({'User-Agent': useragents.CHROME})
-
-    def get_author(self):
-        return self.author
-
-    def get_title(self):
-        return self.title
 
     @classmethod
     def stream_weight(cls, stream):

--- a/src/streamlink/plugins/zeenews.py
+++ b/src/streamlink/plugins/zeenews.py
@@ -14,8 +14,7 @@ class ZeeNews(Plugin):
     HLS_URL = 'https://z5ams.akamaized.net/zeenews/index.m3u8{0}'
     TOKEN_URL = 'https://useraction.zee5.com/token/live.php'
 
-    def get_title(self):
-        return 'Zee News'
+    title = 'Zee News'
 
     def _get_streams(self):
         res = self.session.http.get(self.TOKEN_URL)

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -35,14 +35,9 @@ class TestPlugin(Plugin):
         "a_option": "default"
     })
 
-    def get_title(self):
-        return "Test Title"
-
-    def get_author(self):
-        return "Tѥst Āuƭhǿr"
-
-    def get_category(self):
-        return None
+    author = "Tѥst Āuƭhǿr"
+    category = None
+    title = "Test Title"
 
     def _get_streams(self):
         if "empty" in self.url:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -346,7 +346,10 @@ class TestCLIMainHandleStream(unittest.TestCase):
         args.player_continuous_http = False
         mock_output_stream.return_value = True
 
-        plugin = Mock(FakePlugin(""), get_author=lambda: "AUTHOR", get_category=lambda: "CATEGORY", get_title=lambda: "TITLE")
+        plugin = FakePlugin("")
+        plugin.author = "AUTHOR"
+        plugin.category = "CATEGORY"
+        plugin.title = "TITLE"
         stream = Stream(session=Mock())
         streams = {"best": stream}
 


### PR DESCRIPTION
- add author, category and title attributes to base Plugin class
- make getters return attributes instead of None
- remove unnecessary duplicate attributes and getters from plugins
- keep getters in plugins which use custom logic

----

This change makes it much easier to set the plugin metadata by simply setting the attributes instead of overriding the `get_{author,category,title}` methods every single time with different return values.

The `author`, `category` and `title` attributes are already a well established pattern, so making them part of the Plugin base class is the right choice.