### PR TITLE
plugins: fix utils imports

### DIFF
--- a/src/streamlink/plugins/common_jwplayer.py
+++ b/src/streamlink/plugins/common_jwplayer.py
@@ -2,7 +2,7 @@ import re
 from functools import partial
 
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import parse_json
+from streamlink.utils import parse_json
 
 __all__ = ["parse_playlist"]
 

--- a/src/streamlink/plugins/euronews.py
+++ b/src/streamlink/plugins/euronews.py
@@ -3,9 +3,9 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import itertags, parse_json
+from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import update_scheme
+from streamlink.utils import parse_json, update_scheme
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -3,8 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/qq.py
+++ b/src/streamlink/plugins/qq.py
@@ -4,8 +4,8 @@ import re
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import parse_json
 from streamlink.stream import HLSStream
+from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -11,9 +11,10 @@ import streamlink
 from streamlink.exceptions import FatalPluginError
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import itertags, parse_json
+from streamlink.plugin.api.utils import itertags
 from streamlink.plugin.api.validate import Schema
 from streamlink.stream.dash import DASHStream
+from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -10,10 +10,10 @@ import requests
 from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import parse_json, parse_query
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker, HLSStreamWriter
 from streamlink.stream.hls_playlist import M3U8, M3U8Parser, load as load_hls_playlist
+from streamlink.utils import parse_json, parse_qsd
 from streamlink.utils.times import hours_minutes_seconds
 from streamlink.utils.url import update_qsd
 
@@ -458,7 +458,7 @@ class Twitch(Plugin):
         super().__init__(url)
         match = self.match.groupdict()
         parsed = urlparse(url)
-        self.params = parse_query(parsed.query)
+        self.params = parse_qsd(parsed.query)
         self.subdomain = match.get("subdomain")
         self.video_id = None
         self.channel = None


### PR DESCRIPTION
This makes all plugins import the `parse_*` utility methods from `streamlink.util` directly instead of `streamlink.plugin.api.util`.

https://github.com/streamlink/streamlink/pull/3972#issuecomment-909694571

Since these imports/exports have been there in `streamlink.plugin.api.util` since 2014, 3rd party plugins might use them, so we can't remove them yet.

I haven't marked them as deprecated yet because I want to do this once all imports of `itertags` have been removed as well, so the entire module can be deprecated as a whole.