### PR TITLE
plugins.reuters: rewrite and fix using XPath

### DIFF
--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -1,9 +1,8 @@
 import logging
 import re
 
-from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
 from streamlink.utils import parse_json
 
@@ -14,81 +13,77 @@ log = logging.getLogger(__name__)
     r'https?://([\w-]+\.)*reuters\.(com|tv)'
 ))
 class Reuters(Plugin):
-    _id_re = re.compile(r'(/l/|id=)(?P<id>.*?)(/|\?|$)')
-    _iframe_url = 'https://www.reuters.tv/l/{0}/?nonav=true'
-    _hls_re = re.compile(r'''(?<!')https://[^"';!<>]+\.m3u8''')
-    _json_re = re.compile(r'''(?P<data>{.*});''')
-    _data_schema = validate.Schema(
-        validate.transform(_json_re.search),
-        validate.any(
-            None,
-            validate.all(
-                validate.get('data'),
-                validate.transform(parse_json),
-                {
-                    'title': validate.text,
-                    'items': [
-                        {
-                            'title': validate.text,
-                            'type': validate.text,
-                            'resources': [
-                                {
-                                    'mimeType': validate.text,
-                                    'uri': validate.url(),
-                                    validate.optional('protocol'): validate.text,
-                                    validate.optional('entityType'): validate.text,
-                                }
-                            ]
-                        }
-                    ],
-                }
-            )
-        )
-    )
-
-    def get_title(self):
-        if not self.title:
-            self._get_data()
-        return self.title
+    _re_fusion_global_content = re.compile(r"Fusion\s*\.\s*globalContent\s*=\s*(?P<json>{.+?})\s*;\s*Fusion\s*\.", re.DOTALL)
+    _re_fusion_content_cache = re.compile(r"Fusion\s*\.\s*contentCache\s*=\s*(?P<json>{.+?})\s*;\s*Fusion\s*\.", re.DOTALL)
 
     def _get_data(self):
-        res = self.session.http.get(self.url)
-        for script in itertags(res.text, 'script'):
-            if script.attributes.get('type') == 'text/javascript' and '#rtvIframe' in script.text:
-                m = self._id_re.search(self.url)
-                if m and m.group('id'):
-                    log.debug('ID: {0}'.format(m.group('id')))
-                    res = self.session.http.get(self._iframe_url.format(m.group('id')))
+        root = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html()
+        ))
 
-        for script in itertags(res.text, 'script'):
-            if script.attributes.get('type') == 'text/javascript' and 'RTVJson' in script.text:
-                data = self._data_schema.validate(script.text)
-                if not data:
-                    continue
-                self.title = data['title']
-                for item in data['items']:
-                    if data['title'] == item['title']:
-                        log.trace('{0!r}'.format(item))
-                        log.debug('Type: {0}'.format(item['type']))
-                        for res in item['resources']:
-                            if res['mimeType'] == 'application/x-mpegURL':
-                                return res['uri']
+        try:
+            log.debug("Trying to find source via meta tag")
+            schema = validate.Schema(
+                validate.xml_xpath_string(".//meta[@property='og:video'][1]/@content"),
+                validate.url()
+            )
+            return schema.validate(root)
+        except PluginError:
+            pass
 
-        # fallback
-        for title in itertags(res.text, 'title'):
-            self.title = title.text
-        m = self._hls_re.search(res.text)
-        if not m:
-            log.error('Unsupported PageType.')
-            return
-        return m.group(0)
+        try:
+            log.debug("Trying to find source via next-head")
+            schema = validate.Schema(
+                validate.xml_findtext(".//script[@type='application/ld+json'][@class='next-head']"),
+                validate.transform(parse_json),
+                {"contentUrl": validate.url()},
+                validate.get("contentUrl")
+            )
+            return schema.validate(root)
+        except PluginError:
+            pass
+
+        schema_fusion = validate.xml_findtext(".//script[@type='application/javascript'][@id='fusion-metadata']")
+        schema_video = validate.all(
+            {"source": {"hls": validate.url()}},
+            validate.get(("source", "hls"))
+        )
+        try:
+            log.debug("Trying to find source via fusion-metadata globalContent")
+            schema = validate.Schema(
+                schema_fusion,
+                validate.transform(self._re_fusion_global_content.search),
+                validate.get("json"),
+                validate.transform(parse_json),
+                {"result": {"related_content": {"videos": list}}},
+                validate.get(("result", "related_content", "videos", 0)),
+                schema_video
+            )
+            return schema.validate(root)
+        except PluginError:
+            pass
+
+        try:
+            log.debug("Trying to find source via fusion-metadata contentCache")
+            schema = validate.Schema(
+                schema_fusion,
+                validate.transform(self._re_fusion_content_cache.search),
+                validate.get("json"),
+                validate.transform(parse_json),
+                {"videohub-by-guid-v1": {str: {"data": {"result": {"videos": list}}}}},
+                validate.get("videohub-by-guid-v1"),
+                validate.transform(lambda obj: obj[list(obj.keys())[0]]),
+                validate.get(("data", "result", "videos", 0)),
+                schema_video
+            )
+            return schema.validate(root)
+        except PluginError:
+            pass
 
     def _get_streams(self):
         hls_url = self._get_data()
-        if not hls_url:
-            return
-        log.debug('URL={0}'.format(hls_url))
-        return HLSStream.parse_variant_playlist(self.session, hls_url)
+        if hls_url:
+            return HLSStream.parse_variant_playlist(self.session, hls_url)
 
 
 __plugin__ = Reuters


### PR DESCRIPTION
The plugin on the master branch is currently getting the HLS streams exclusively via the fallback method, which searches for HLS-like URLs in the entire content, and it's very slow. This PR improves the resolve time by at least 3x.

Front page
```
$ streamlink -l debug 'https://www.reuters.com/'
[cli][debug] OS:         Linux-5.13.12-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.6
[cli][debug] Streamlink: 2.3.0+37.g75ca640
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.1.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.reuters.com/
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin reuters for URL https://www.reuters.com/
[plugins.reuters][debug] Trying to find source via meta tag
[plugins.reuters][debug] Trying to find source via next-head
[plugins.reuters][debug] Trying to find source via fusion-metadata globalContent
[plugins.reuters][debug] Trying to find source via fusion-metadata contentCache
[utils.l10n][debug] Language code: en_US
Available streams: 180p (worst), 288p, 360p, 480p, 540p, 576p, 720p, 1080p (best)
```

News articles
```
$ streamlink -l debug 'https://www.reuters.com/world/india/rockets-fired-kabul-airport-us-troops-race-complete-evacuation-2021-08-30/'
[cli][debug] OS:         Linux-5.13.12-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.6
[cli][debug] Streamlink: 2.3.0+37.g75ca640
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.1.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.reuters.com/world/india/rockets-fired-kabul-airport-us-troops-race-complete-evacuation-2021-08-30/
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin reuters for URL https://www.reuters.com/world/india/rockets-fired-kabul-airport-us-troops-race-complete-evacuation-2021-08-30/
[plugins.reuters][debug] Trying to find source via meta tag
[plugins.reuters][debug] Trying to find source via next-head
[plugins.reuters][debug] Trying to find source via fusion-metadata globalContent
[utils.l10n][debug] Language code: en_US
Available streams: 180p (worst), 288p, 360p, 480p, 540p, 576p, 720p, 1080p (best)
```

Video font page
```
$ streamlink -l debug 'https://www.reuters.com/video'
[cli][debug] OS:         Linux-5.13.12-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.6
[cli][debug] Streamlink: 2.3.0+37.g75ca640
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.1.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.reuters.com/video
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin reuters for URL https://www.reuters.com/video
[plugins.reuters][debug] Trying to find source via meta tag
[utils.l10n][debug] Language code: en_US
Available streams: 110k (worst), 180p, 288p, 360p, 480p, 540p, 576p, 720p, 1080p (best)
```

Video ID
```
$ streamlink -l debug 'https://www.reuters.com/video/watch/idPxj1?now=true'
[cli][debug] OS:         Linux-5.13.12-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.6
[cli][debug] Streamlink: 2.3.0+37.g75ca640
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.1.0)
[cli][debug] Arguments:
[cli][debug]  url=https://www.reuters.com/video/watch/idPxj1?now=true
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin reuters for URL https://www.reuters.com/video/watch/idPxj1?now=true
[plugins.reuters][debug] Trying to find source via meta tag
[utils.l10n][debug] Language code: en_US
Available streams: 110k (worst), 180p, 288p, 360p, 480p, 540p, 576p, 720p, 1080p (best)
```

Can't find a video for the "next-head" extraction method now (see debug log), but it worked yesterday