### PR TITLE
installer: move assets config to local JSON file

### DIFF
--- a/script/makeinstaller-assets.json
+++ b/script/makeinstaller-assets.json
@@ -1,0 +1,52 @@
+[
+    {
+        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/ffmpeg-4.2.2-win32-static.zip",
+        "sha256": "1f6adff50db6cad54fdab15013c4c95cb6f83d7fe6d1167f3896cf4550573565",
+        "filename": "ffmpeg-4.2.2-win32-static.zip",
+        "type": "zip",
+        "sourcedir": "ffmpeg-4.2.2-win32-static",
+        "targetdir": "ffmpeg",
+        "files": [
+            {
+                "from": "bin/ffmpeg.exe",
+                "to": "ffmpeg.exe"
+            },
+            {
+                "from": "LICENSE.txt",
+                "to": "LICENSE.txt"
+            }
+        ]
+    },
+    {
+        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/ffmpeg-4.2.2-win32-static-readme.txt",
+        "sha256": "6252abd8981ff3b61728bf58868c3dab2d4f96495907bae15ebbdad6b9bb9934",
+        "filename": "ffmpeg-4.2.2-win32-static-readme.txt",
+        "type": "file",
+        "sourcedir": null,
+        "targetdir": "ffmpeg",
+        "files": [
+            {
+                "from": "ffmpeg-4.2.2-win32-static-readme.txt",
+                "to": "BUILDINFO.txt"
+            }
+        ]
+    },
+    {
+        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/rtmpdump-2.3-windows.zip",
+        "sha256": "6948aa372f04952d5675917c6ca2c7c0bf6b109de21a4323adc93247fff0189f",
+        "filename": "rtmpdump-2.3-windows.zip",
+        "type": "zip",
+        "sourcedir": "rtmpdump-2.3",
+        "targetdir": "rtmpdump",
+        "files": [
+            {
+                "from": "rtmpdump.exe",
+                "to": "rtmpdump.exe"
+            },
+            {
+                "from": "COPYING",
+                "to": "LICENSE.txt"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
This is a preparation commit for the new FFmpeg asset files:
https://github.com/streamlink/FFmpeg-Builds

It moves the Windows installer assets JSON data from the remote streamlink-assets repo to here, which is more reliable, safe and secure. Assets data which verifies files shouldn't be loaded from a remote source.
https://github.com/streamlink/streamlink-assets/blob/2020.4.21/data.json

There's also a slight modification of the data structure (type + sha256) and file sources. Previously, the makeinstaller script read the latest tag from the streamlink-assets repo via the GH API, got the assets data from the JSON file of that tag and downloaded/verified the release files on that tag's release.

Now it has the URLs of the release files included directly instead of having to query the GH API. The previous method had the URLs of the external sources included because it was part of the streamlink-assets release script.

----

The new FFmpeg files can be included with this diff without having to create a new streamlink-assets release. I will open a separate PR for this afterwards.
```diff
diff --git a/script/makeinstaller-assets.json b/script/makeinstaller-assets.json
index a180a622..c5d50413 100644
--- a/script/makeinstaller-assets.json
+++ b/script/makeinstaller-assets.json
@@ -1,10 +1,10 @@
 [
     {
-        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/ffmpeg-4.2.2-win32-static.zip",
-        "sha256": "1f6adff50db6cad54fdab15013c4c95cb6f83d7fe6d1167f3896cf4550573565",
-        "filename": "ffmpeg-4.2.2-win32-static.zip",
+        "url": "https://github.com/streamlink/FFmpeg-Builds/releases/download/20210826-1/ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4.zip",
+        "sha256": "38af31a76b233cf0e83645e19c6dc758f8236981533ed3427424b9fb09285d29",
+        "filename": "ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4.zip",
         "type": "zip",
-        "sourcedir": "ffmpeg-4.2.2-win32-static",
+        "sourcedir": "ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4",
         "targetdir": "ffmpeg",
         "files": [
             {
@@ -14,19 +14,9 @@
             {
                 "from": "LICENSE.txt",
                 "to": "LICENSE.txt"
-            }
-        ]
-    },
-    {
-        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/ffmpeg-4.2.2-win32-static-readme.txt",
-        "sha256": "6252abd8981ff3b61728bf58868c3dab2d4f96495907bae15ebbdad6b9bb9934",
-        "filename": "ffmpeg-4.2.2-win32-static-readme.txt",
-        "type": "file",
-        "sourcedir": null,
-        "targetdir": "ffmpeg",
-        "files": [
+            },
             {
-                "from": "ffmpeg-4.2.2-win32-static-readme.txt",
+                "from": "BUILDINFO.txt",
                 "to": "BUILDINFO.txt"
             }
         ]
```