### PR TITLE
installer: switch to streamlink/FFmpeg-Builds

### DIFF
--- a/script/makeinstaller-assets.json
+++ b/script/makeinstaller-assets.json
@@ -1,10 +1,10 @@
 [
     {
-        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/ffmpeg-4.2.2-win32-static.zip",
-        "sha256": "1f6adff50db6cad54fdab15013c4c95cb6f83d7fe6d1167f3896cf4550573565",
-        "filename": "ffmpeg-4.2.2-win32-static.zip",
+        "url": "https://github.com/streamlink/FFmpeg-Builds/releases/download/20210826-1/ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4.zip",
+        "sha256": "38af31a76b233cf0e83645e19c6dc758f8236981533ed3427424b9fb09285d29",
+        "filename": "ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4.zip",
         "type": "zip",
-        "sourcedir": "ffmpeg-4.2.2-win32-static",
+        "sourcedir": "ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4",
         "targetdir": "ffmpeg",
         "files": [
             {
@@ -14,19 +14,9 @@
             {
                 "from": "LICENSE.txt",
                 "to": "LICENSE.txt"
-            }
-        ]
-    },
-    {
-        "url": "https://github.com/streamlink/streamlink-assets/releases/download/2020.4.21/ffmpeg-4.2.2-win32-static-readme.txt",
-        "sha256": "6252abd8981ff3b61728bf58868c3dab2d4f96495907bae15ebbdad6b9bb9934",
-        "filename": "ffmpeg-4.2.2-win32-static-readme.txt",
-        "type": "file",
-        "sourcedir": null,
-        "targetdir": "ffmpeg",
-        "files": [
+            },
             {
-                "from": "ffmpeg-4.2.2-win32-static-readme.txt",
+                "from": "BUILDINFO.txt",
                 "to": "BUILDINFO.txt"
             }
         ]


### PR DESCRIPTION
Resolves #3931 

Upgrades the bundled 3rd party FFmpeg build (Zeranoe) in Streamlink's Windows installer from 4.2 to 4.4, built here on GH actions:
https://github.com/streamlink/FFmpeg-Builds

FFmpeg build flags (chosen by the `win32 gpl 4.4` build flavor):
```
  --enable-gpl
  --enable-version3
  --disable-debug
  --disable-w32threads
  --enable-pthreads
  --enable-iconv
  --enable-libxml2
  --enable-zlib
  --enable-libfreetype
  --enable-libfribidi
  --enable-gmp
  --enable-lzma
  --enable-fontconfig
  --enable-libvorbis
  --enable-opencl
  --enable-libvmaf
  --enable-vulkan
  --disable-libxcb
  --disable-xlib
  --enable-amf
  --enable-libaom
  --enable-avisynth
  --enable-libdav1d
  --disable-libdavs2
  --disable-libfdk-aac
  --enable-ffnvcodec
  --enable-cuda-llvm
  --enable-frei0r
  --enable-libglslang
  --enable-libgme
  --enable-libass
  --enable-libbluray
  --enable-libmp3lame
  --enable-libopus
  --enable-libtheora
  --enable-libvpx
  --enable-libwebp
  --enable-lv2
  --enable-libmfx
  --enable-libopencore-amrnb
  --enable-libopencore-amrwb
  --enable-libopenjpeg
  --disable-librav1e
  --enable-librubberband
  --enable-schannel
  --enable-sdl2
  --enable-libsoxr
  --enable-libsrt
  --disable-libsvtav1
  --enable-libtwolame
  --disable-libuavs3d
  --disable-libdrm
  --disable-vaapi
  --enable-libvidstab
  --enable-libx264
  --enable-libx265
  --disable-libxavs2
  --enable-libxvid
  --enable-libzimg
  --enable-libzvbi
```