### PR TITLE
cli: include plugin metadata in --json output

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -430,6 +430,13 @@ class Plugin:
     def _get_streams(self):
         raise NotImplementedError
 
+    def get_metadata(self) -> Dict[str, Optional[str]]:
+        return dict(
+            author=self.get_author(),
+            category=self.get_category(),
+            title=self.get_title()
+        )
+
     def get_title(self) -> Optional[str]:
         return self.title
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -408,7 +408,10 @@ def handle_stream(plugin, streams, stream_name):
 
     # Print JSON representation of the stream
     elif args.json:
-        console.msg_json(stream)
+        console.msg_json(
+            stream,
+            metadata=plugin.get_metadata()
+        )
 
     elif args.stream_url:
         try:
@@ -583,11 +586,20 @@ def handle_url():
 
         err = f"The specified stream(s) '{', '.join(args.stream)}' could not be found"
         if args.json:
-            console.msg_json(plugin=plugin.module, streams=streams, error=err)
+            console.msg_json(
+                plugin=plugin.module,
+                metadata=plugin.get_metadata(),
+                streams=streams,
+                error=err
+            )
         else:
             console.exit(f"{err}.\n       Available streams: {validstreams}")
     elif args.json:
-        console.msg_json(plugin=plugin.module, streams=streams)
+        console.msg_json(
+            plugin=plugin.module,
+            metadata=plugin.get_metadata(),
+            streams=streams
+        )
     elif args.stream_url:
         try:
             console.msg(streams[list(streams)[-1]].to_manifest_url())


### PR DESCRIPTION
- Add `Plugin.get_metadata()` which returns a dict of all metadata.
- Add `metadata` property to list of all resolved streams, but merge
  all metadata properties with the specific stream output in order to
  not introduce a breaking change in the JSON output format.

----

Resolves #3941 