### PR TITLE
cli.argparser: Fixed ValueError for streamlink --help

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -572,7 +572,7 @@ def build_parser():
         {{time}}
             The current timestamp, which can optionally be formatted via {{time:format}}.
             This format parameter string is passed to Python's datetime.strftime() method,
-            so all usual time directives are available. The default format is "%Y-%m-%d_%H-%M-%S".
+            so all usual time directives are available. The default format is "%%Y-%%m-%%d_%%H-%%M-%%S".
 
         Examples:
 


### PR DESCRIPTION
`ValueError: unsupported format character 'Y' (0x59) at index 2696`
