### PR TITLE
http_session: override urllib3 percent-encoding

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -1,4 +1,5 @@
 import time
+from typing import Any, Callable, List, Pattern, Tuple
 
 import requests.adapters
 import urllib3
@@ -8,6 +9,9 @@ from streamlink.exceptions import PluginError
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.plugin.api import useragents
 from streamlink.utils import parse_json, parse_xml
+
+
+urllib3_version = tuple(map(int, urllib3.__version__.split(".")[:3]))
 
 
 try:
@@ -42,6 +46,44 @@ class _HTTPResponse(urllib3.response.HTTPResponse):
 # override all urllib3.response.HTTPResponse references in requests.adapters.HTTPAdapter.send
 urllib3.connectionpool.HTTPConnectionPool.ResponseCls = _HTTPResponse
 requests.adapters.HTTPResponse = _HTTPResponse
+
+
+# Never convert percent-encoded characters to uppercase in urllib3>=1.25.4.
+# This is required for sites which compare request URLs byte for byte and return different responses depending on that.
+# Older versions of urllib3 are not compatible with this override and will always convert to uppercase characters.
+#
+# https://datatracker.ietf.org/doc/html/rfc3986#section-2.1
+# > The uppercase hexadecimal digits 'A' through 'F' are equivalent to
+# > the lowercase digits 'a' through 'f', respectively.  If two URIs
+# > differ only in the case of hexadecimal digits used in percent-encoded
+# > octets, they are equivalent.  For consistency, URI producers and
+# > normalizers should use uppercase hexadecimal digits for all percent-
+# > encodings.
+if urllib3_version >= (1, 25, 4):
+    class Urllib3UtilUrlPercentReOverride:
+        _re_percent_encoding: Pattern = urllib3.util.url.PERCENT_RE
+
+        @classmethod
+        def _num_percent_encodings(cls, string) -> int:
+            return len(cls._re_percent_encoding.findall(string))
+
+        # urllib3>=1.25.8
+        # https://github.com/urllib3/urllib3/blame/1.25.8/src/urllib3/util/url.py#L219-L227
+        @classmethod
+        def subn(cls, repl: Callable, string: str) -> Tuple[str, int]:
+            return string, cls._num_percent_encodings(string)
+
+        # urllib3>=1.25.4,<1.25.8
+        # https://github.com/urllib3/urllib3/blame/1.25.4/src/urllib3/util/url.py#L218-L228
+        @classmethod
+        def findall(cls, string: str) -> List[Any]:
+            class _List(list):
+                def __len__(self) -> int:
+                    return cls._num_percent_encodings(string)
+
+            return _List()
+
+    urllib3.util.url.PERCENT_RE = Urllib3UtilUrlPercentReOverride
 
 
 def _parse_keyvalue_list(val):

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -1,11 +1,37 @@
 import unittest
 from unittest.mock import PropertyMock, call, patch
 
+import pytest
 import requests
 
 from streamlink.exceptions import PluginError
-from streamlink.plugin.api.http_session import HTTPSession
+from streamlink.plugin.api.http_session import HTTPSession, urllib3_version
 from streamlink.plugin.api.useragents import FIREFOX
+
+
+@pytest.mark.skipif(urllib3_version < (1, 25, 4), reason="test only applicable on urllib3 >=1.25.4")
+class TestUrllib3Overrides:
+    @pytest.fixture(scope="class")
+    def httpsession(self) -> HTTPSession:
+        return HTTPSession()
+
+    @pytest.mark.parametrize("url,expected,assertion", [
+        ("https://foo/bar%3F?baz%21", "https://foo/bar%3F?baz%21", "Keeps encoded reserved characters"),
+        ("https://foo/%62%61%72?%62%61%7A", "https://foo/bar?baz", "Decodes encoded unreserved characters"),
+        ("https://foo/bär?bäz", "https://foo/b%C3%A4r?b%C3%A4z", "Encodes other characters"),
+        ("https://foo/b%c3%a4r?b%c3%a4z", "https://foo/b%c3%a4r?b%c3%a4z", "Keeps percent-encodings with lowercase characters"),
+        ("https://foo/b%C3%A4r?b%C3%A4z", "https://foo/b%C3%A4r?b%C3%A4z", "Keeps percent-encodings with uppercase characters"),
+        ("https://foo/%?%", "https://foo/%25?%25", "Empty percent-encodings without valid encodings"),
+        ("https://foo/%0?%0", "https://foo/%250?%250", "Incomplete percent-encodings without valid encodings"),
+        ("https://foo/%zz?%zz", "https://foo/%25zz?%25zz", "Invalid percent-encodings without valid encodings"),
+        ("https://foo/%3F%?%3F%", "https://foo/%253F%25?%253F%25", "Empty percent-encodings with valid encodings"),
+        ("https://foo/%3F%0?%3F%0", "https://foo/%253F%250?%253F%250", "Incomplete percent-encodings with valid encodings"),
+        ("https://foo/%3F%zz?%3F%zz", "https://foo/%253F%25zz?%253F%25zz", "Invalid percent-encodings with valid encodings"),
+    ])
+    def test_encode_invalid_chars(self, httpsession: HTTPSession, url: str, expected: str, assertion: str):
+        req = requests.Request(method="GET", url=url)
+        prep = httpsession.prepare_request(req)
+        assert prep.url == expected, assertion
 
 
 class TestPluginAPIHTTPSession(unittest.TestCase):


### PR DESCRIPTION
According to [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.1), URLs are considered equal even if they differ in the case of the hexadecimal digits of percent-encoded characters, eg. `%FF` == `%ff`. URL normalizers **should** always use uppercase characters, which is why `urllib3` correctly transforms those lowercase digits to uppercase ones.

This is a problem though for sites which compare the request URL (or parts of it) byte for byte and return different responses depending on that. See https://github.com/streamlink/streamlink/issues/4002#issuecomment-916038530

This PR therefore adds overrides for `urllib3` which make it not transform hexadecimal digits of percent-encoded characters to uppercase. Since URLs are still considered equal, this shouldn't break anything and fix the problem mentioned above. If the original behavior is required, then request URLs can still be transformed manually. HTTP redirections could be a problem, but the risk is rather low.

Streamlink currently requires `urllib3>=1.21.1,<1.27`, as defined by [`requests>=2.26.0`](https://github.com/streamlink/streamlink/blob/2.4.0/setup.py#L13) here:
https://github.com/psf/requests/blob/v2.26.0/setup.py#L48

There are two different overrides for `urllib3>=1.25.8` and `urllib3>=1.25.4,<1.25.8`, as noted in the code comments, because `urllib3==1.25.8` had a minor revision of the string substitution. Versions of urllib3 prior to `1.25.4` unfortunately are using external libs for modifying the percent-encoding stuff and I'm not sure if the problem can be fixed there.

The added tests are working fine in both version ranges when the overrides are applied and will only fail in the lowercase test fixture when no override is applied, which is expected.

Should I add a test runner for `urllib3==1.25.4` so that it can test both version ranges?