### PR TITLE
plugins.ardlive: rewrite plugin

### DIFF
--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -5,7 +5,6 @@ from importlib.util import module_from_spec
 from typing import Dict, Generic, Optional, TypeVar
 from urllib.parse import urljoin, urlparse
 
-from streamlink.exceptions import PluginError
 from streamlink.utils.lazy_formatter import LazyFormatter
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.parse import parse_html, parse_json, parse_qsd, parse_xml
@@ -30,16 +29,6 @@ def swfdecompress(data):
         data = b"F" + data[1:8] + zlib.decompress(data[8:])
 
     return data
-
-
-def verifyjson(json, key):
-    if not isinstance(json, dict):
-        raise PluginError("JSON result is not a dict")
-
-    if key not in json:
-        raise PluginError("Missing '{0}' key in JSON".format(key))
-
-    return json[key]
 
 
 def absolute_url(baseurl, url):
@@ -142,7 +131,6 @@ class LRUCache(Generic[TCacheKey, TCacheValue]):
 __all__ = [
     "load_module",
     "escape_librtmp", "rtmpparse", "swfdecompress",
-    "verifyjson",
     "absolute_url", "prepend_www",
     "search_dict",
     "LRUCache",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,6 @@ from streamlink.utils import (
     rtmpparse,
     search_dict,
     swfdecompress,
-    verifyjson,
 )
 
 # used in the import test to verify that this module was imported
@@ -26,13 +25,6 @@ __test_marker__ = "test_marker"
 
 
 class TestUtil(unittest.TestCase):
-    def test_verifyjson(self):
-        self.assertEqual(verifyjson({"test": 1}, "test"),
-                         1)
-
-        self.assertRaises(PluginError, verifyjson, None, "test")
-        self.assertRaises(PluginError, verifyjson, {}, "test")
-
     def test_absolute_url(self):
         self.assertEqual("http://test.se/test",
                          absolute_url("http://test.se", "/test"))


### PR DESCRIPTION
I've been trying to clean up the `streamlink.utils` module and from what it looks like, the `verifyjson` method seems to be only used by the `ARDLive` plugin which itself could use a rewrite / simplification. This PR rewrites the plugin and removes the unneeded utility method.

Even though I'm pretty sure that the entire content is available as HLS via the "auto" quality name, I left the HTTPStream stuff, but didn't merge both stream types together like before, because it's unnecessary and confusing. There's also a couple of simplifications of the validation schema due to changes on the site and its JSON data. And I've added the title metadata.

----

Live:
```
$ streamlink 'https://live.daserste.de/'
[cli][info] Found matching plugin ard_live for URL https://live.daserste.de/
Available streams: 270p (worst), 360p, 540p, 720p (best)
```

VOD:
```
$ streamlink 'https://www.daserste.de/information/nachrichten-wetter/tagesschau/videosextern/tagesschau-12-00-uhr-6262.html'
[cli][info] Found matching plugin ard_live for URL https://www.daserste.de/information/nachrichten-wetter/tagesschau/videosextern/tagesschau-12-00-uhr-6262.html
Available streams: 130k (worst), 180p, 270p, 288p, 360p, 540p, 720p (best)
```

No content:
```
$ streamlink 'https://www.daserste.de/unterhaltung/comedy-satire/comedy-satire/index.html'
[cli][info] Found matching plugin ard_live for URL https://www.daserste.de/unterhaltung/comedy-satire/comedy-satire/index.html
error: No playable streams found on this URL: https://www.daserste.de/unterhaltung/comedy-satire/comedy-satire/index.html
```