### PR TITLE
tests: fix typo in pytest skipif marker

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,7 @@ def catch_warnings(record=False, module=None):
     return _catch_warnings_wrapper
 
 
-windows_only = pytest.mark.skipif(os.name != "nt", reason="test only applicable on Window")
+windows_only = pytest.mark.skipif(os.name != "nt", reason="test only applicable on Windows")
 posix_only = pytest.mark.skipif(os.name != "posix", reason="test only applicable on a POSIX OS")
 
 


### PR DESCRIPTION
This annoys me every time