### PR TITLE
ci: temporary windows python 3.10 fix for missing `lxml 4.6.3` wheel

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -7,4 +7,14 @@ set -ex
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
 python -m pip install pycountry
+# temporary windows python 3.10 fix for missing 'lxml 4.6.3' wheel
+# https://github.com/streamlink/streamlink/issues/3971
+python -m pip install "https://github.com/back-to/tmp_wheel/raw/b237059b18110ca298e191340eebb6eb0aef8827/lxml-4.6.3-cp310-cp310-win_amd64.whl; \
+    '3.10' <= python_version \
+    and 'Windows' == platform_system \
+    and ('AMD64' == platform_machine or 'x86_64' == platform_machine)"
+python -m pip install "https://github.com/back-to/tmp_wheel/raw/b237059b18110ca298e191340eebb6eb0aef8827/lxml-4.6.3-cp310-cp310-win32.whl; \
+    '3.10' <= python_version \
+    and 'Windows' == platform_system \
+    and ('AMD64' != platform_machine and 'x86_64' != platform_machine)"
 python -m pip install -e .


### PR DESCRIPTION
- Fix CI, don't fail on python 3.10
- temporary until lxml gets an update

closes https://github.com/streamlink/streamlink/issues/3971

---

Original files are downloaded from `the unofficial Windows binaries https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml`

- https://github.com/lxml/lxml/blob/ea954da3c87bd8f6874f6bf4203e2ef5269ea383/INSTALL.txt#L105-L115
- https://www.lfd.uci.edu/~gohlke/pythonlibs/#lxml

```text
556433cadf982a578ee74e989883a07aa9d2a59a04eb2b9f6397c0b4b471ecad  lxml-4.6.3-cp310-cp310-win_amd64.whl
f756d973f89dd0715b5e93301afb9ebdd612ef53ac8986516c1eb0bc6518d85f  lxml-4.6.3-cp310-cp310-win32.whl
```
