### PR TITLE
utils: move all URL methods to utils.url

### DIFF
--- a/src/streamlink/plugins/abweb.py
+++ b/src/streamlink/plugins/abweb.py
@@ -4,8 +4,7 @@ import re
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
-from streamlink.utils.url import url_concat
+from streamlink.utils.url import update_scheme, url_concat
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import parse_params
 from streamlink.stream import AkamaiHDStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -13,7 +13,7 @@ from urllib.parse import quote, urlencode, urlparse
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 MEDIA_URL = "http://www.ardmediathek.de/play/media/{0}"
 QUALITY_MAP = {

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -4,7 +4,8 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream
-from streamlink.utils import parse_json, search_dict, update_scheme
+from streamlink.utils import parse_json, search_dict
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -7,7 +7,7 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -10,7 +10,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/dogus.py
+++ b/src/streamlink/plugins/dogus.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -4,7 +4,8 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
-from streamlink.utils import parse_json, update_scheme
+from streamlink.utils import parse_json
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/euronews.py
+++ b/src/streamlink/plugins/euronews.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import LOW_PRIORITY, parse_params
 from streamlink.stream import HDSStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import LOW_PRIORITY, parse_params
 from streamlink.stream import HLSStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import parse_params
 from streamlink.stream import HTTPStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -3,7 +3,8 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json, update_scheme
+from streamlink.utils import parse_json
+from streamlink.utils.url import update_scheme
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -5,7 +5,8 @@ from urllib.parse import unquote, urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json, update_scheme
+from streamlink.utils import parse_json
+from streamlink.utils.url import update_scheme
 
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/nbc.py
+++ b/src/streamlink/plugins/nbc.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugins.theplatform import ThePlatform
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/nbcsports.py
+++ b/src/streamlink/plugins/nbcsports.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugins.theplatform import ThePlatform
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -4,7 +4,8 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json, update_scheme
+from streamlink.utils import parse_json
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/streamable.py
+++ b/src/streamlink/plugins/streamable.py
@@ -3,7 +3,8 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
-from streamlink.utils import parse_json, update_scheme
+from streamlink.utils import parse_json
+from streamlink.utils.url import update_scheme
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -8,7 +8,7 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import update_scheme
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -8,8 +8,9 @@ from Crypto.Cipher import AES
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json, update_scheme
+from streamlink.utils import parse_json
 from streamlink.utils.crypto import unpad_pkcs5
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -16,8 +16,9 @@ from streamlink.logger import StreamlinkLogger
 from streamlink.options import Options
 from streamlink.plugin import Plugin, api
 from streamlink.plugin.plugin import Matcher, NORMAL_PRIORITY, NO_PRIORITY
-from streamlink.utils import load_module, update_scheme
+from streamlink.utils import load_module
 from streamlink.utils.l10n import Localization
+from streamlink.utils.url import update_scheme
 
 # Ensure that the Logger class returned is Streamslink's for using the API (for backwards compatibility)
 logging.setLoggerClass(StreamlinkLogger)

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -22,7 +22,8 @@ from streamlink.stream.flvconcat import FLVTagConcat
 from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
 from streamlink.stream.stream import Stream
 from streamlink.stream.wrappers import StreamIOIterWrapper
-from streamlink.utils import absolute_url, swfdecompress
+from streamlink.utils import swfdecompress
+from streamlink.utils.url import absolute_url
 
 log = logging.getLogger(__name__)
 # Akamai HD player verification key

--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -3,12 +3,12 @@ from collections import OrderedDict
 from importlib.machinery import FileFinder, SOURCE_SUFFIXES, SourceFileLoader
 from importlib.util import module_from_spec
 from typing import Dict, Generic, Optional, TypeVar
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
 from streamlink.utils.formatter import Formatter
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.parse import parse_html, parse_json, parse_qsd, parse_xml
-from streamlink.utils.url import update_scheme, url_equal
+from streamlink.utils.url import absolute_url, prepend_www, update_qsd, update_scheme, url_concat, url_equal
 
 
 _loader_details = [(SourceFileLoader, SOURCE_SUFFIXES)]
@@ -29,22 +29,6 @@ def swfdecompress(data):
         data = b"F" + data[1:8] + zlib.decompress(data[8:])
 
     return data
-
-
-def absolute_url(baseurl, url):
-    if not url.startswith("http"):
-        return urljoin(baseurl, url)
-    else:
-        return url
-
-
-def prepend_www(url):
-    """Changes google.com to www.google.com"""
-    parsed = urlparse(url)
-    if parsed.netloc.split(".")[0] != "www":
-        return parsed.scheme + "://www." + parsed.netloc + parsed.path
-    else:
-        return url
 
 
 def rtmpparse(url):
@@ -131,11 +115,10 @@ class LRUCache(Generic[TCacheKey, TCacheValue]):
 __all__ = [
     "load_module",
     "escape_librtmp", "rtmpparse", "swfdecompress",
-    "absolute_url", "prepend_www",
     "search_dict",
     "LRUCache",
     "Formatter",
     "NamedPipe",
     "parse_html", "parse_json", "parse_qsd", "parse_xml",
-    "update_scheme", "url_equal",
+    "absolute_url", "prepend_www", "update_qsd", "update_scheme", "url_concat", "url_equal",
 ]

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -3,6 +3,23 @@ from collections import OrderedDict
 from urllib.parse import parse_qsl, quote_plus, urlencode, urljoin, urlparse, urlunparse
 
 
+def absolute_url(baseurl, url):
+    parsed = urlparse(url)
+    if not parsed.scheme:
+        url = urljoin(baseurl, url)
+
+    return url
+
+
+def prepend_www(url):
+    parsed = urlparse(url)
+    if not parsed.netloc.startswith("www."):
+        # noinspection PyProtectedMember
+        parsed = parsed._replace(netloc=f"www.{parsed.netloc}")
+
+    return parsed.geturl()
+
+
 _re_uri_implicit_scheme = re.compile(r"""^[a-z0-9][a-z0-9.+-]*://""", re.IGNORECASE)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,12 +9,10 @@ from streamlink.exceptions import PluginError
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.validate import xml_element
 from streamlink.utils import (
-    absolute_url,
     load_module,
     parse_json,
     parse_qsd,
     parse_xml,
-    prepend_www,
     rtmpparse,
     search_dict,
     swfdecompress,
@@ -25,18 +23,6 @@ __test_marker__ = "test_marker"
 
 
 class TestUtil(unittest.TestCase):
-    def test_absolute_url(self):
-        self.assertEqual("http://test.se/test",
-                         absolute_url("http://test.se", "/test"))
-        self.assertEqual("http://test2.se/test",
-                         absolute_url("http://test.se", "http://test2.se/test"))
-
-    def test_prepend_www(self):
-        self.assertEqual("http://www.test.se/test",
-                         prepend_www("http://test.se/test"))
-        self.assertEqual("http://www.test.se",
-                         prepend_www("http://www.test.se"))
-
     def test_parse_json(self):
         self.assertEqual({}, parse_json("{}"))
         self.assertEqual({"test": 1}, parse_json("""{"test": 1}"""))

--- a/tests/test_utils_url.py
+++ b/tests/test_utils_url.py
@@ -1,7 +1,26 @@
 from collections import OrderedDict
 from urllib.parse import quote
 
-from streamlink.utils.url import update_qsd, update_scheme, url_concat, url_equal
+import pytest
+
+from streamlink.utils.url import absolute_url, prepend_www, update_qsd, update_scheme, url_concat, url_equal
+
+
+@pytest.mark.parametrize("baseurl,url,expected", [
+    ("http://test.se", "/test", "http://test.se/test"),
+    ("http://test.se", "http/test.se/test", "http://test.se/http/test.se/test"),
+    ("http://test.se", "http://test2.se/test", "http://test2.se/test"),
+])
+def test_absolute_url(baseurl, url, expected):
+    assert expected == absolute_url(baseurl, url)
+
+
+@pytest.mark.parametrize("url,expected", [
+    ("http://test.se/test", "http://www.test.se/test"),
+    ("http://www.test.se", "http://www.test.se"),
+])
+def test_prepend_www(url, expected):
+    assert expected == prepend_www(url)
 
 
 def test_update_scheme():


### PR DESCRIPTION
This is part of another clean-up of the utils module (there's still much to do)

- `absolute_url` and `prepend_www` (unused) belong into the `streamlink.utils.url` module.
  I've also improved the logic a big and fixed the tests.
- Modules should not import from `streamlink.utils` but instead from the specific submodules.
  Once a new regex-based plugin resolver will get added in the future, this will avoid unnecessary imports of the entire utils module.