### PR TITLE
tests: fix Accept-Encoding headers in stream_json

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -7,6 +7,8 @@ set -ex
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
 python -m pip install pycountry
+# https://github.com/streamlink/streamlink/issues/4021
+python -m pip install brotli
 # temporary windows python 3.10 fix for missing 'lxml 4.6.3' wheel
 # https://github.com/streamlink/streamlink/issues/3971
 python -m pip install "https://github.com/back-to/tmp_wheel/raw/b237059b18110ca298e191340eebb6eb0aef8827/lxml-4.6.3-cp310-cp310-win_amd64.whl; \

--- a/tests/test_stream_json.py
+++ b/tests/test_stream_json.py
@@ -1,5 +1,8 @@
 import unittest
 
+# noinspection PyUnresolvedReferences
+from requests.utils import DEFAULT_ACCEPT_ENCODING
+
 from streamlink import Streamlink
 from streamlink.stream import AkamaiHDStream
 from streamlink.stream import HDSStream
@@ -31,7 +34,7 @@ class TestStreamToJSON(unittest.TestCase):
              "headers": {
                  "User-Agent": "Test",
                  "Accept": "*/*",
-                 "Accept-Encoding": "gzip, deflate",
+                 "Accept-Encoding": DEFAULT_ACCEPT_ENCODING,
                  "Connection": "keep-alive",
              }},
             stream.__json__()
@@ -49,7 +52,7 @@ class TestStreamToJSON(unittest.TestCase):
                 "headers": {
                     "User-Agent": "Test",
                     "Accept": "*/*",
-                    "Accept-Encoding": "gzip, deflate",
+                    "Accept-Encoding": DEFAULT_ACCEPT_ENCODING,
                     "Connection": "keep-alive",
                 }
             },
@@ -64,7 +67,7 @@ class TestStreamToJSON(unittest.TestCase):
                 "headers": {
                     "User-Agent": "Test",
                     "Accept": "*/*",
-                    "Accept-Encoding": "gzip, deflate",
+                    "Accept-Encoding": DEFAULT_ACCEPT_ENCODING,
                     "Connection": "keep-alive",
                 },
                 "master": master


### PR DESCRIPTION
Fixes #4021 

----

requests `2.26.0`:
https://github.com/psf/requests/commit/5351469472eccee7ed1a6cae53341446c520d807#

> When the brotli or brotlicffi packages are installed,
> urllib3.util.make_headers() inserts ',br' in the Accept-Encoding header
> and decodes br from the answers.