### PR TITLE
plugins: clean up imports of parse_* utils

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -8,7 +8,7 @@ from requests import Session
 from streamlink.exceptions import PluginError
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.plugin.api import useragents
-from streamlink.utils import parse_json, parse_xml
+from streamlink.utils.parse import parse_json, parse_xml
 
 
 urllib3_version = tuple(map(int, urllib3.__version__.split(".")[:3]))

--- a/src/streamlink/plugin/api/utils.py
+++ b/src/streamlink/plugin/api/utils.py
@@ -2,7 +2,7 @@
 import re
 from collections import namedtuple
 
-from streamlink.utils import parse_json, parse_qsd as parse_query, parse_xml
+from streamlink.utils.parse import parse_json, parse_qsd as parse_query, parse_xml
 
 __all__ = ["parse_json", "parse_xml", "parse_query"]
 

--- a/src/streamlink/plugins/adultswim.py
+++ b/src/streamlink/plugins/adultswim.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse, urlunparse
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream
-from streamlink.utils import parse_json, search_dict
+from streamlink.utils import search_dict
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ class AtresPlayer(Plugin):
             None,
             validate.all(
                 validate.get(1),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 validate.transform(search_dict, key="href"),
             )
         )
@@ -30,13 +30,13 @@ class AtresPlayer(Plugin):
         validate.any(
             None,
             validate.all(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 validate.transform(search_dict, key="urlVideo"),
             )
         )
     )
     stream_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {"sources": [
             validate.all({
                 "src": validate.url(),

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -9,7 +9,7 @@ from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginErr
 from streamlink.plugin.api import validate
 from streamlink.stream import HDSStream, HLSStream
 from streamlink.stream.dash import DASHStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class BBCiPlayer(Plugin):
         validate.get("id")
     )
     mediaselector_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {"media": [
             {"connection":
                 validate.all([{

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HDSStream, HLSStream, HTTPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ class Bloomberg(Plugin):
     )
 
     _schema_live_list = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.get("live"),
         validate.get("channels"),
         validate.get("byChannelId"),
@@ -54,7 +53,7 @@ class Bloomberg(Plugin):
     )
 
     _schema_vod_list = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.any(
             validate.all(
                 {"video": {"videoList": list}},

--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -3,7 +3,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 
 @pluginmatcher(re.compile(
@@ -16,7 +15,7 @@ class CBSNews(Plugin):
         validate.transform(_re_default_payload.search),
         validate.any(None, validate.all(
             validate.get(1),
-            validate.transform(parse_json),
+            validate.parse_json(),
             {"items": [validate.all({
                 "video": validate.url(),
                 "format": "application/x-mpegURL"

--- a/src/streamlink/plugins/cnews.py
+++ b/src/streamlink/plugins/cnews.py
@@ -2,7 +2,6 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.utils import parse_json
 
 
 @pluginmatcher(re.compile(
@@ -16,7 +15,7 @@ class CNEWS(Plugin):
         validate.transform(_json_data_re.search),
         validate.any(None, validate.all(
             validate.get(1),
-            validate.transform(parse_json),
+            validate.parse_json(),
             {
                 validate.optional('dm_player_live_dailymotion'): {
                     validate.optional('video_id'): str,

--- a/src/streamlink/plugins/common_jwplayer.py
+++ b/src/streamlink/plugins/common_jwplayer.py
@@ -2,7 +2,6 @@ import re
 from functools import partial
 
 from streamlink.plugin.api import validate
-from streamlink.utils import parse_json
 
 __all__ = ["parse_playlist"]
 
@@ -16,7 +15,7 @@ _playlist_schema = validate.Schema(
         validate.all(
             validate.get(1),
             validate.transform(_js_to_json),
-            validate.transform(parse_json),
+            validate.parse_json(),
             [{
                 "sources": [{
                     "file": validate.text,

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -5,7 +5,6 @@ from urllib.parse import parse_qsl, urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +46,7 @@ class DeutscheWelle(Plugin):
         self._find_metadata(root)
         api_url = self.API_URL.format(media_id=media_id)
         stream_url = self.session.http.get(api_url, schema=validate.Schema(
-            validate.transform(parse_json),
+            validate.parse_json(),
             [{"file": validate.url()}],
             validate.get((0, "file"))
         ))

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, RTMPStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ class EarthCam(Plugin):
             validate.all(
                 validate.get(1),
                 validate.transform(lambda d: d.replace("\\/", "/")),
-                validate.transform(parse_json),
+                validate.parse_json(),
             )
         )
     )

--- a/src/streamlink/plugins/egame.py
+++ b/src/streamlink/plugins/egame.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/eltrecetv.py
+++ b/src/streamlink/plugins/eltrecetv.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote_plus, urlencode
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import DASHStream, HTTPStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -3,7 +3,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 
 @pluginmatcher(re.compile(
@@ -11,7 +10,7 @@ from streamlink.utils import parse_json
 ))
 class GOLTelevision(Plugin):
     api_url = "https://api.goltelevision.com/api/v1/media/hls/service/live"
-    api_schema = validate.Schema(validate.transform(parse_json), {
+    api_schema = validate.Schema(validate.parse_json(), {
         "code": 200,
         "message": {
             "success": {

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -24,7 +23,7 @@ class Gulli(Plugin):
         validate.all(
             validate.transform(lambda x: re.sub(r'"?file"?:\s*[\'"](.+?)[\'"],?', r'"file": "\1"', x, flags=re.DOTALL)),
             validate.transform(lambda x: re.sub(r'"?\w+?"?:\s*function\b.*?(?<={).*(?=})', "", x, flags=re.DOTALL)),
-            validate.transform(parse_json),
+            validate.parse_json(),
             [
                 validate.Schema({
                     'file': validate.url()

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -6,7 +6,7 @@ from html import unescape as html_unescape
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -3,7 +3,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_scheme
 
 
@@ -25,7 +24,7 @@ class IDF1(Plugin):
     _player_url = 'http://ssl.p.jwpcdn.com/player/v/7.12.6/jwplayer.flash.swf'
 
     _api_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {
             validate.optional('html5'): validate.all(
                 [
@@ -43,7 +42,7 @@ class IDF1(Plugin):
     )
 
     _token_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {'token': validate.text},
         validate.get('token')
     )

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -5,7 +5,6 @@ from urllib.parse import unquote, urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_scheme
 
 
@@ -31,7 +30,7 @@ class Mediaklikk(Plugin):
             validate.transform(self._re_player_manager.search),
             validate.any(None, validate.all(
                 validate.get("json"),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {
                     "contentId": validate.any(str, int),
                     validate.optional("streamId"): str,
@@ -60,7 +59,7 @@ class Mediaklikk(Plugin):
             validate.transform(self._re_player_json.search),
             validate.any(None, validate.all(
                 validate.get("json"),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"playlist": [{
                     "file": validate.url(),
                     "type": str

--- a/src/streamlink/plugins/mediavitrina.py
+++ b/src/streamlink/plugins/mediavitrina.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)
@@ -52,14 +51,14 @@ class MediaVitrina(Plugin):
         res_token = self.session.http.get(
             "https://media.mediavitrina.ru/get_token",
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"result": {"token": str}},
                 validate.get("result"),
             ))
         url = self.session.http.get(
             update_qsd(f"https://media.mediavitrina.ru/api/v2/{path}/playlist/{channel}_as_array.json", qsd=res_token),
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"hls": [validate.url()]},
                 validate.get("hls"),
                 validate.get(0),

--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import url_concat
 
 log = logging.getLogger(__name__)
@@ -26,7 +25,7 @@ class Mildom(Plugin):
                 "__platform": "web",
                 "v_id": video_id,
             },
-            schema=validate.Schema(validate.transform(parse_json), {
+            schema=validate.Schema(validate.parse_json(), {
                 "code": int,
                 validate.optional("message"): str,
                 validate.optional("body"): {
@@ -53,7 +52,7 @@ class Mildom(Plugin):
             },
             headers={"Accept-Language": "en"},
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {
                     "code": int,
                     validate.optional("message"): str,
@@ -93,7 +92,7 @@ class Mildom(Plugin):
             },
             headers={"Accept-Language": "en"},
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {
                     "code": int,
                     validate.optional("message"): str,

--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json, parse_qsd
+from streamlink.utils.parse import parse_qsd
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ class Mitele(Plugin):
     gbx_url = "https://mab.mediaset.es/1.0.0/get?oid=mtmw&eid=%2Fapi%2Fmtmw%2Fv2%2Fgbx%2Fmtweb%2Flive%2Fmmc%2F{channel}"
 
     error_schema = validate.Schema({"code": int})
-    caronte_schema = validate.Schema(validate.transform(parse_json), validate.any(
+    caronte_schema = validate.Schema(validate.parse_json(), validate.any(
         {
             "cerbero": validate.url(),
             "bbx": str,
@@ -33,12 +33,12 @@ class Mitele(Plugin):
         error_schema,
     ))
     gbx_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {"gbx": str},
         validate.get("gbx")
     )
     cerbero_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.any(
             validate.all(
                 {"tokens": {str: {"cdn": str}}},

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -9,7 +9,7 @@ from Crypto.Util.Padding import unpad
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/nbcnews.py
+++ b/src/streamlink/plugins/nbcnews.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +19,8 @@ class NBCNews(Plugin):
     token_url = 'https://tokens.playmakerservices.com/'
 
     api_schema = validate.Schema(
-        validate.transform(parse_json), {
+        validate.parse_json(),
+        {
             'videoSources': [{
                 'sourceUrl': validate.url(),
                 'type': validate.text,
@@ -31,7 +31,7 @@ class NBCNews(Plugin):
     )
 
     token_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {'akamai': [{
             'tokenizedUrl': validate.url(),
         }]},
@@ -44,7 +44,7 @@ class NBCNews(Plugin):
         validate.transform(json_data_re.search),
         validate.any(None, validate.all(
             validate.get(1),
-            validate.transform(parse_json),
+            validate.parse_json(),
             {"embedUrl": validate.url()},
             validate.get("embedUrl"),
             validate.transform(lambda url: url.split("/")[-1])

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +19,7 @@ class NimoTV(Plugin):
         validate.transform(data_re.search),
         validate.any(None, validate.all(
             validate.get(1),
-            validate.transform(parse_json), {
+            validate.parse_json(), {
                 'title': str,
                 'nickname': str,
                 'game': str,

--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -5,7 +5,7 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -6,7 +6,6 @@ from urllib.parse import unquote
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ class OKru(Plugin):
     _data_re = re.compile(r'''data-options=(?P<q>["'])(?P<data>{[^"']+})(?P=q)''')
 
     _metadata_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.any({
             'videos': validate.any(
                 [],
@@ -40,7 +39,7 @@ class OKru(Plugin):
             validate.transform(_data_re.search),
             validate.get('data'),
             validate.transform(html_unescape),
-            validate.transform(parse_json),
+            validate.parse_json(),
             validate.get('flashvars'),
             validate.any({
                 'metadata': _metadata_schema

--- a/src/streamlink/plugins/olympicchannel.py
+++ b/src/streamlink/plugins/olympicchannel.py
@@ -7,7 +7,6 @@ from urllib.parse import urljoin, urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -18,7 +17,7 @@ log = logging.getLogger(__name__)
 class OlympicChannel(Plugin):
     _token_api_path = "/tokenGenerator?url={url}&domain={netloc}&_ts={time}"
     _api_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         [{
             validate.optional("src"): validate.url(),
             validate.optional("srcType"): "HLS",
@@ -41,7 +40,7 @@ class OlympicChannel(Plugin):
         validate.any(None, validate.transform(html_unescape)),
     )
     _stream_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.url(),
     )
 

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -7,7 +7,6 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.plugin import stream_weight
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)
@@ -26,7 +25,7 @@ class OneTV(Plugin):
             "https://stream.1tv.ru/api/playlist/1tvch_as_array.json",
             data={"r": random.randint(1, 100000)},
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"hls": [validate.url()]},
                 validate.get("hls"),
                 validate.get(0),
@@ -42,7 +41,7 @@ class OneTV(Plugin):
         hls_session = self.session.http.get(
             "https://stream.1tv.ru/get_hls_session",
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"s": validate.transform(unquote)},
             ))
         url = update_qsd(url, qsd=hls_session, safe="/:")

--- a/src/streamlink/plugins/qq.py
+++ b/src/streamlink/plugins/qq.py
@@ -5,7 +5,7 @@ from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse, urlunparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ class RadioNet(Plugin):
             None,
             validate.all(
                 validate.get(1),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {
                     'type': validate.text,
                     'streams': validate.all([{

--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse, urlunparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class RaiPlay(Plugin):
         validate.any(None, validate.get(1))
     )
     _schema_json = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.get("video"),
         validate.get("content_url"),
         validate.url()

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -35,7 +34,7 @@ class Reuters(Plugin):
             log.debug("Trying to find source via next-head")
             schema = validate.Schema(
                 validate.xml_findtext(".//script[@type='application/ld+json'][@class='next-head']"),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"contentUrl": validate.url()},
                 validate.get("contentUrl")
             )
@@ -54,7 +53,7 @@ class Reuters(Plugin):
                 schema_fusion,
                 validate.transform(self._re_fusion_global_content.search),
                 validate.get("json"),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"result": {"related_content": {"videos": list}}},
                 validate.get(("result", "related_content", "videos", 0)),
                 schema_video
@@ -69,7 +68,7 @@ class Reuters(Plugin):
                 schema_fusion,
                 validate.transform(self._re_fusion_content_cache.search),
                 validate.get("json"),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {"videohub-by-guid-v1": {str: {"data": {"result": {"videos": list}}}}},
                 validate.get("videohub-by-guid-v1"),
                 validate.transform(lambda obj: obj[list(obj.keys())[0]]),

--- a/src/streamlink/plugins/rtbf.py
+++ b/src/streamlink/plugins/rtbf.py
@@ -6,7 +6,6 @@ from html import unescape as html_unescape
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -53,7 +52,7 @@ class RTBF(Plugin):
             validate.all(
                 validate.get(1),
                 validate.transform(html_unescape),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {
                     'geoLocRestriction': validate.text,
                     validate.optional('isLive'): bool,

--- a/src/streamlink/plugins/rtpplay.py
+++ b/src/streamlink/plugins/rtpplay.py
@@ -5,7 +5,6 @@ from urllib.parse import unquote
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 
 @pluginmatcher(re.compile(
@@ -37,13 +36,15 @@ class RTPPlay(Plugin):
             validate.all(
                 validate.get("obfuscated"),
                 str,
-                validate.transform(lambda arr: unquote("".join(parse_json(arr)))),
+                validate.parse_json(),
+                validate.transform(lambda arr: unquote("".join(arr))),
                 validate.url()
             ),
             validate.all(
                 validate.get("obfuscated_b64"),
                 str,
-                validate.transform(lambda arr: unquote("".join(parse_json(arr)))),
+                validate.parse_json(),
+                validate.transform(lambda arr: unquote("".join(arr))),
                 validate.transform(lambda b64: b64decode(b64).decode("utf-8")),
                 validate.url()
             )

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -9,7 +9,6 @@ from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmat
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
-from streamlink.utils import parse_xml
 
 log = logging.getLogger(__name__)
 
@@ -56,7 +55,7 @@ class Rtve(Plugin):
     _re_idAsset = re.compile(r"\"idAsset\":\"(\d+)\"")
     secret_key = base64.b64decode("eWVMJmRhRDM=")
     cdn_schema = validate.Schema(
-        validate.transform(parse_xml, invalid_char_entities=True),
+        validate.parse_xml(invalid_char_entities=True),
         validate.xml_findall(".//preset"),
         [
             validate.union({

--- a/src/streamlink/plugins/rtvs.py
+++ b/src/streamlink/plugins/rtvs.py
@@ -3,7 +3,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -5,7 +5,6 @@ from functools import partial
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class Schoolism(Plugin):
                 validate.transform(js_to_json),
                 validate.transform(fix_brackets),  # remove invalid ,
                 validate.transform(fix_colon_in_title),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 [{
                     "sources": validate.all([{
                         validate.optional("playlistTitle"): validate.text,

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
@@ -32,7 +31,7 @@ class Sportschau(Plugin):
         data = self.session.http.get(player_js, schema=validate.Schema(
             validate.transform(self._re_json.match),
             validate.get(1),
-            validate.transform(parse_json),
+            validate.parse_json(),
             validate.get("mediaResource"),
             validate.get("dflt"),
             {

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -14,7 +14,7 @@ from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.plugin.api.validate import Schema
 from streamlink.stream.dash import DASHStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/streamable.py
+++ b/src/streamlink/plugins/streamable.py
@@ -3,7 +3,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HTTPStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import update_scheme
 
 
@@ -17,7 +16,7 @@ class Streamable(Plugin):
         validate.any(None,
                      validate.all(
                          validate.get(1),
-                         validate.transform(parse_json),
+                         validate.parse_json(),
                          {
                              "files": {validate.text: {"url": validate.url(),
                                                        "width": int,

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -10,8 +10,8 @@ from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmat
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_qsd
 from streamlink.utils.crypto import decrypt_openssl
+from streamlink.utils.parse import parse_qsd
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream, HTTPStream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv5monde.py
+++ b/src/streamlink/plugins/tv5monde.py
@@ -4,7 +4,6 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugins.common_jwplayer import _js_to_json
 from streamlink.stream import HLSStream, HTTPStream, RTMPStream
-from streamlink.utils import parse_json
 
 
 @pluginmatcher(re.compile(
@@ -16,7 +15,7 @@ class TV5Monde(Plugin):
 
     _videos_schema = validate.Schema(
         validate.transform(_js_to_json),
-        validate.transform(parse_json),
+        validate.parse_json(),
         validate.all([
             validate.any(
                 validate.Schema(

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -13,7 +13,7 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker, HLSStreamWriter
 from streamlink.stream.hls_playlist import M3U8, M3U8Parser, load as load_hls_playlist
-from streamlink.utils import parse_json, parse_qsd
+from streamlink.utils.parse import parse_json, parse_qsd
 from streamlink.utils.times import hours_minutes_seconds
 from streamlink.utils.url import update_qsd
 

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -19,7 +19,7 @@ from streamlink.stream.dash_manifest import sleep_until, utc
 from streamlink.stream.flvconcat import FLVTagConcat
 from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
 from streamlink.stream.stream import Stream
-from streamlink.utils import parse_json
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -9,7 +9,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +22,7 @@ class Vidio(Plugin):
 
     csrf_tokens_url = "https://www.vidio.com/csrf_tokens"
     tokens_url = "https://www.vidio.com/live/{id}/tokens"
-    token_schema = validate.Schema(validate.transform(parse_json),
+    token_schema = validate.Schema(validate.parse_json(),
                                    {"token": validate.text},
                                    validate.get("token"))
 

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -7,7 +7,6 @@ from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmat
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -24,14 +23,14 @@ class Vimeo(Plugin):
             None,
             validate.Schema(
                 validate.get(1),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 validate.transform(html_unescape),
                 validate.url(),
             ),
         ),
     )
     _config_schema = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {
             "request": {
                 "files": {

--- a/src/streamlink/plugins/vlive.py
+++ b/src/streamlink/plugins/vlive.py
@@ -4,7 +4,6 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +19,7 @@ class Vlive(Plugin):
         validate.transform(_page_info.search),
         validate.any(None, validate.all(
             validate.get(1),
-            validate.transform(parse_json),
+            validate.parse_json(),
             validate.any(
                 validate.all(
                     {"postDetail": {"post": {"officialVideo": {
@@ -37,7 +36,7 @@ class Vlive(Plugin):
     )
 
     _schema_stream = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {"result": {"adaptiveStreamUrl": validate.url()}},
         validate.get(("result", "adaptiveStreamUrl")),
     )

--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -5,7 +5,6 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 
 log = logging.getLogger(__name__)
 
@@ -29,7 +28,7 @@ class VTVgo(Plugin):
         ]
     )
     _schema_stream_url = validate.Schema(
-        validate.transform(parse_json),
+        validate.parse_json(),
         {"stream_url": [validate.url()]},
         validate.get("stream_url"),
         validate.get(0)

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -8,8 +8,8 @@ from Crypto.Cipher import AES
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.crypto import unpad_pkcs5
+from streamlink.utils.parse import parse_json
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -9,7 +9,8 @@ from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
 from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
-from streamlink.utils import parse_json, search_dict
+from streamlink.utils import search_dict
+from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -6,7 +6,6 @@ from streamlink.cache import Cache
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import DASHStream, HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.args import comma_list_filter
 
 log = logging.getLogger(__name__)
@@ -114,7 +113,7 @@ class Zattoo(Plugin):
         log.debug('_hello ...')
         app_token = self.session.http.get(
             f'{self.base_url}/token.json',
-            schema=validate.Schema(validate.transform(parse_json), {
+            schema=validate.Schema(validate.parse_json(), {
                 'success': bool,
                 'session_token': str,
             }, validate.get('session_token'))
@@ -138,7 +137,7 @@ class Zattoo(Plugin):
             headers=self.headers,
             data=params,
             schema=validate.Schema(
-                validate.transform(parse_json),
+                validate.parse_json(),
                 validate.any({'active': bool}, {'success': bool})
             )
         )
@@ -159,7 +158,7 @@ class Zattoo(Plugin):
                 'format': 'json',
             },
             acceptable_status=(200, 400),
-            schema=validate.Schema(validate.transform(parse_json), validate.any(
+            schema=validate.Schema(validate.parse_json(), validate.any(
                 {'active': bool, 'power_guide_hash': str},
                 {'success': bool},
             )),
@@ -212,7 +211,7 @@ class Zattoo(Plugin):
                 headers=self.headers,
                 data=params,
                 acceptable_status=(200, 402, 403, 404),
-                schema=validate.Schema(validate.transform(parse_json), validate.any({
+                schema=validate.Schema(validate.parse_json(), validate.any({
                     'success': validate.transform(bool),
                     'stream': {
                         'watch_urls': [{
@@ -328,7 +327,7 @@ class Zattoo(Plugin):
             log.debug('Session control for {0}'.format(self.domain))
             active = self.session.http.get(
                 f'{self.base_url}/zapi/v3/session',
-                schema=validate.Schema(validate.transform(parse_json),
+                schema=validate.Schema(validate.parse_json(),
                                        {'active': bool}, validate.get('active'))
             )
             if active:

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse, urlunparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
-from streamlink.utils import parse_json
 from streamlink.utils.url import url_concat
 
 log = logging.getLogger(__name__)
@@ -24,7 +23,7 @@ class ZDFMediathek(Plugin):
             validate.transform(self._re_api_json.search),
             validate.any(None, validate.all(
                 validate.get("json"),
-                validate.transform(parse_json),
+                validate.parse_json(),
                 {
                     "apiToken": str,
                     "content": validate.url()
@@ -46,7 +45,7 @@ class ZDFMediathek(Plugin):
         pApiUrl = urlparse(apiUrl)
         apiUrlBase = urlunparse((pApiUrl.scheme, pApiUrl.netloc, "", "", "", ""))
         apiUrlPath = self.session.http.get(apiUrl, headers=headers, schema=validate.Schema(
-            validate.transform(parse_json),
+            validate.parse_json(),
             {"mainVideoContent": {
                 "http://zdf.de/rels/target": {
                     "http://zdf.de/rels/streams/ptmd-template": str
@@ -58,7 +57,7 @@ class ZDFMediathek(Plugin):
 
         stream_request_url = url_concat(apiUrlBase, apiUrlPath)
         data = self.session.http.get(stream_request_url, headers=headers, schema=validate.Schema(
-            validate.transform(parse_json),
+            validate.parse_json(),
             {"priorityList": [{
                 "formitaeten": validate.all(
                     [{

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -14,8 +14,8 @@ from streamlink.stream.ffmpegmux import FFMPEGMuxer
 from streamlink.stream.http import normalize_key, valid_args
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.stream.stream import Stream
-from streamlink.utils import parse_xml
 from streamlink.utils.l10n import Language
+from streamlink.utils.parse import parse_xml
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
follow-up of 40b604e and de5b27b

- `validate.transform(parse_*, ...)` -> `validate.parse_*(...)`
- fix imports where parse methods are not used in a validation schema

----

The next thing I want to do is move the methods from `streamlink.utils.__init__.py` to logical submodules and fix the remaining imports in other modules, as already mentioned in https://github.com/streamlink/streamlink/pull/4016#issue-995838502