### PR TITLE
plugins.artetv: rewrite plugin using v2 API

### DIFF
--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -1,5 +1,3 @@
-"""Plugin for Arte.tv, bi-lingual art and culture channel."""
-
 import logging
 import re
 from operator import itemgetter
@@ -9,25 +7,6 @@ from streamlink.plugin.api import validate
 from streamlink.stream import HLSStream
 
 log = logging.getLogger(__name__)
-JSON_VOD_URL = "https://api.arte.tv/api/player/v1/config/{0}/{1}?platform=ARTE_NEXT"
-JSON_LIVE_URL = "https://api.arte.tv/api/player/v1/livestream/{0}"
-
-_video_schema = validate.Schema({
-    "videoJsonPlayer": {
-        "VSR": validate.any(
-            [],
-            {
-                validate.text: {
-                    "height": int,
-                    "mediaType": validate.text,
-                    "url": validate.text,
-                    "versionProg": int,
-                    "versionLibelle": validate.text
-                },
-            },
-        )
-    }
-})
 
 
 @pluginmatcher(re.compile(r"""
@@ -40,34 +19,49 @@ _video_schema = validate.Schema({
     )
 """, re.VERBOSE))
 class ArteTV(Plugin):
-    def _create_stream(self, streams):
-        variant, variantname = min([(stream["versionProg"], stream["versionLibelle"]) for stream in streams.values()],
-                                   key=itemgetter(0))
-        log.debug(f"Using the '{variantname}' stream variant")
-        for sname, stream in streams.items():
-            if stream["versionProg"] == variant:
-                if stream["mediaType"] == "hls":
-                    try:
-                        streams = HLSStream.parse_variant_playlist(self.session, stream["url"])
-                        yield from streams.items()
-                    except OSError as err:
-                        log.warning(f"Failed to extract HLS streams for {sname}/{stream['versionLibelle']}: {err}")
+    API_URL = "https://api.arte.tv/api/player/v2/config/{0}/{1}"
+    API_TOKEN = "MzYyZDYyYmM1Y2Q3ZWRlZWFjMmIyZjZjNTRiMGY4MzY4NzBhOWQ5YjE4MGQ1NGFiODJmOTFlZDQwN2FkOTZjMQ"
 
     def _get_streams(self):
-        language = self.match.group('language')
-        video_id = self.match.group('video_id')
-        if video_id is None:
-            json_url = JSON_LIVE_URL.format(language)
-        else:
-            json_url = JSON_VOD_URL.format(language, video_id)
-        res = self.session.http.get(json_url)
-        video = self.session.http.json(res, schema=_video_schema)
+        language = self.match.group("language")
+        video_id = self.match.group("video_id")
 
-        if not video["videoJsonPlayer"]["VSR"]:
+        json_url = self.API_URL.format(language, video_id or "LIVE")
+        headers = {
+            "Authorization": f"Bearer {self.API_TOKEN}"
+        }
+        streams, metadata = self.session.http.get(json_url, headers=headers, schema=validate.Schema(
+            validate.parse_json(),
+            {"data": {"attributes": {
+                "streams": validate.any(
+                    [],
+                    [
+                        validate.all(
+                            {
+                                "url": validate.url(),
+                                "slot": int,
+                                "protocol": validate.any("HLS", "HLS_NG"),
+                            },
+                            validate.union_get("slot", "protocol", "url")
+                        )
+                    ]
+                ),
+                "metadata": {
+                    "title": str,
+                    "subtitle": validate.any(None, str)
+                }
+            }}},
+            validate.get(("data", "attributes")),
+            validate.union_get("streams", "metadata")
+        ))
+
+        if not streams:
             return
 
-        vsr = video["videoJsonPlayer"]["VSR"]
-        return self._create_stream(vsr)
+        self.title = f"{metadata['title']} - {metadata['subtitle']}" if metadata["subtitle"] else metadata["title"]
+
+        for slot, protocol, url in sorted(streams, key=itemgetter(0)):
+            return HLSStream.parse_variant_playlist(self.session, url)
 
 
 __plugin__ = ArteTV


### PR DESCRIPTION
Resolves #4026 
Closes #4027 

----

I had already implemented stream version selection for all the available languages/sub-streams (see #3167) when I noticed that Streamlink currently doesn't support HLS media items of the type `SUBTITLES` (aka. "non-external subtitles"):
- https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.1
- https://github.com/streamlink/streamlink/blob/24c59a23103922977991acc28741a323d8efa7a1/src/streamlink/stream/hls.py#L512-L516

This unfortunately means that adding a sub-stream selection via `--artetv-stream-version` for example or via an optional URL hash doesn't make sense, as the different stream versions are mostly just including different subtitles. Once this feature gets implemented, the stream version selection can be added very easily.

----

```
$ streamlink https://www.arte.tv/de/live
[cli][info] Found matching plugin artetv for URL https://www.arte.tv/de/live
Available streams: 180p_alt (worst), 180p, 240p_alt, 240p, 360p_alt, 360p, 540p_alt, 540p, 720p_alt, 720p (best)
```

```
$ streamlink https://www.arte.tv/fr/live
[cli][info] Found matching plugin artetv for URL https://www.arte.tv/fr/live
Available streams: 180p_alt (worst), 180p, 240p_alt, 240p, 360p_alt, 360p, 540p_alt, 540p, 720p_alt, 720p (best)
```

```
$ streamlink https://www.arte.tv/en/videos/098391-000-A/fifty-years-of-greenpeace/
[cli][info] Found matching plugin artetv for URL https://www.arte.tv/en/videos/098391-000-A/fifty-years-of-greenpeace/
Available streams: 216p (worst), 360p, 432p, 720p (best)
```