### PR TITLE
stream: clean up imports

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -15,8 +15,7 @@ from requests.adapters import BaseAdapter
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
-from streamlink.stream.hls import HLSStreamReader, HLSStreamWriter
+from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWriter
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/abweb.py
+++ b/src/streamlink/plugins/abweb.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme, url_concat
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/adultswim.py
+++ b/src/streamlink/plugins/adultswim.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, urlunparse
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.stream.hls import HLSStreamReader, HLSStreamWriter
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import parse_params
-from streamlink.stream import AkamaiHDStream
+from streamlink.stream.akamaihd import AkamaiHDStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -12,7 +12,7 @@ import time
 from urllib.parse import quote, urlencode, urlparse
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/app17.py
+++ b/src/streamlink/plugins/app17.py
@@ -3,7 +3,9 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -4,7 +4,8 @@ from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 MEDIA_URL = "http://www.ardmediathek.de/play/media/{0}"

--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -4,7 +4,7 @@ from operator import itemgetter
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import DASHStream, HLSStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.data import search_dict
 from streamlink.utils.url import update_scheme
 

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -7,8 +7,9 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HDSStream, HLSStream
 from streamlink.stream.dash import DASHStream
+from streamlink.stream.hds import HDSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/bfmtv.py
+++ b/src/streamlink/plugins/bfmtv.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin, urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
 from streamlink.plugins.brightcove import BrightcovePlayer
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -5,7 +5,8 @@ from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -8,7 +8,9 @@ from streamlink.packages.flashmedia import AMFMessage, AMFPacket
 from streamlink.packages.flashmedia.types import AMF3ObjectBase
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -19,7 +19,8 @@ from urllib.parse import quote
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import DASHStream, HLSStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/cinergroup.py
+++ b/src/streamlink/plugins/cinergroup.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(r"""

--- a/src/streamlink/plugins/clubbingtv.py
+++ b/src/streamlink/plugins/clubbingtv.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -4,7 +4,8 @@ import re
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -9,7 +9,9 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import DASHStream, HLSStream, HTTPStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -4,7 +4,8 @@ from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/dlive.py
+++ b/src/streamlink/plugins/dlive.py
@@ -5,7 +5,7 @@ from urllib.parse import unquote_plus
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/dogus.py
+++ b/src/streamlink/plugins/dogus.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/drdk.py
+++ b/src/streamlink/plugins/drdk.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, RTMPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.rtmpdump import RTMPStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/egame.py
+++ b/src/streamlink/plugins/egame.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/eltrecetv.py
+++ b/src/streamlink/plugins/eltrecetv.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/euronews.py
+++ b/src/streamlink/plugins/euronews.py
@@ -3,7 +3,8 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -5,7 +5,8 @@ from urllib.parse import unquote_plus, urlencode
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import DASHStream, HTTPStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -6,8 +6,8 @@ from urllib.parse import urlparse, urlunparse
 from streamlink.exceptions import PluginError, StreamError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, hls_playlist
-from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker, Sequence
+from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker, Sequence
+from streamlink.stream.hls_playlist import load as load_hls_playlist
 
 log = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class FilmOnHLSStreamWorker(HLSStreamWorker):
             raise err
 
         try:
-            playlist = hls_playlist.load(res.text, res.url)
+            playlist = load_hls_playlist(res.text, res.url)
         except ValueError as err:
             raise StreamError(err)
 

--- a/src/streamlink/plugins/foxtr.py
+++ b/src/streamlink/plugins/foxtr.py
@@ -1,7 +1,7 @@
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -5,8 +5,9 @@ import re
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.l10n import Localization
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/galatasaraytv.py
+++ b/src/streamlink/plugins/galatasaraytv.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/garena.py
+++ b/src/streamlink/plugins/garena.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/googledrive.py
+++ b/src/streamlink/plugins/googledrive.py
@@ -3,7 +3,7 @@ import re
 from urllib.parse import parse_qsl
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import LOW_PRIORITY, parse_params
-from streamlink.stream import HDSStream
+from streamlink.stream.hds import HDSStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import LOW_PRIORITY, parse_params
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import parse_params
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/huajiao.py
+++ b/src/streamlink/plugins/huajiao.py
@@ -8,7 +8,8 @@ import uuid
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.useragents import CHROME as USER_AGENT
-from streamlink.stream import (HLSStream, HTTPStream)
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 HUAJIAO_URL = "http://www.huajiao.com/l/{}"
 LAPI_URL = "http://g2.live.360.cn/liveplay?stype=flv&channel={}&bid=huajiao&sn={}&sid={}&_rate=xd&ts={}&r={}" \

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -5,7 +5,7 @@ from html import unescape as html_unescape
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 

--- a/src/streamlink/plugins/invintus.py
+++ b/src/streamlink/plugins/invintus.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 

--- a/src/streamlink/plugins/kugou.py
+++ b/src/streamlink/plugins/kugou.py
@@ -4,7 +4,8 @@ import time
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/latina.py
+++ b/src/streamlink/plugins/latina.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/linelive.py
+++ b/src/streamlink/plugins/linelive.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/live_russia_tv.py
+++ b/src/streamlink/plugins/live_russia_tv.py
@@ -4,7 +4,8 @@ from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/liveme.py
+++ b/src/streamlink/plugins/liveme.py
@@ -5,7 +5,8 @@ from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/lrt.py
+++ b/src/streamlink/plugins/lrt.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote, urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 

--- a/src/streamlink/plugins/mediavitrina.py
+++ b/src/streamlink/plugins/mediavitrina.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import url_concat
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_qsd
 from streamlink.utils.url import update_qsd
 

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -8,7 +8,7 @@ from Crypto.Util.Padding import unpad
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/mrtmk.py
+++ b/src/streamlink/plugins/mrtmk.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/n13tv.py
+++ b/src/streamlink/plugins/n13tv.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin, urlunparse
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/nbcnews.py
+++ b/src/streamlink/plugins/nbcnews.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/nhkworld.py
+++ b/src/streamlink/plugins/nhkworld.py
@@ -1,7 +1,7 @@
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 API_URL = "http://{}.nhk.or.jp/nhkworld/app/tv/hlslive_web.json"
 

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -10,7 +10,7 @@ import websocket
 from streamlink import logger
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.times import hours_minutes_seconds
 from streamlink.utils.url import update_qsd
 

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/nownews.py
+++ b/src/streamlink/plugins/nownews.py
@@ -3,7 +3,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -4,7 +4,8 @@ from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ntv.py
+++ b/src/streamlink/plugins/ntv.py
@@ -1,7 +1,7 @@
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -5,7 +5,9 @@ from urllib.parse import unquote
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/olympicchannel.py
+++ b/src/streamlink/plugins/olympicchannel.py
@@ -6,7 +6,7 @@ from urllib.parse import urljoin, urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -6,7 +6,7 @@ from urllib.parse import unquote
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.plugin import stream_weight
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/orf_tvthek.py
+++ b/src/streamlink/plugins/orf_tvthek.py
@@ -2,7 +2,7 @@ import json
 import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 _json_re = re.compile(r'<div class="jsb_ jsb_VideoPlaylist" data-jsb="(?P<json>[^"]+)">')
 

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/piczel.py
+++ b/src/streamlink/plugins/piczel.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -4,7 +4,7 @@ import re
 from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -4,8 +4,8 @@ from uuid import uuid4
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -7,7 +7,8 @@ from isodate import LOCAL as LOCALTIMEZONE
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import DASHStream, HLSStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_qsd
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/qq.py
+++ b/src/streamlink/plugins/qq.py
@@ -4,7 +4,7 @@ import re
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -8,7 +8,7 @@ from urllib.parse import urlencode
 from lxml.etree import XML
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -4,7 +4,8 @@ from urllib.parse import urlparse, urlunparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, urlunparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/rotana.py
+++ b/src/streamlink/plugins/rotana.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/rtbf.py
+++ b/src/streamlink/plugins/rtbf.py
@@ -5,7 +5,9 @@ from html import unescape as html_unescape
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import DASHStream, HLSStream, HTTPStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/rtmp.py
+++ b/src/streamlink/plugins/rtmp.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import parse_params
-from streamlink.stream import RTMPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/rtpplay.py
+++ b/src/streamlink/plugins/rtpplay.py
@@ -4,7 +4,7 @@ from urllib.parse import unquote
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -7,8 +7,9 @@ from Crypto.Cipher import Blowfish
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/rtvs.py
+++ b/src/streamlink/plugins/rtvs.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.parse import parse_json
 
 

--- a/src/streamlink/plugins/ruv.py
+++ b/src/streamlink/plugins/ruv.py
@@ -3,7 +3,7 @@
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 # URL to the RUV LIVE API
 RUV_LIVE_API = """http://www.ruv.is/sites/all/themes/at_ruv/scripts/\

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -4,7 +4,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -4,7 +4,8 @@ from functools import partial
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/senategov.py
+++ b/src/streamlink/plugins/senategov.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qsl, urlparse
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -3,8 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, RTMPStream
-from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker
+from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker
+from streamlink.stream.rtmpdump import RTMPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/sportal.py
+++ b/src/streamlink/plugins/sportal.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/ssh101.py
+++ b/src/streamlink/plugins/ssh101.py
@@ -3,7 +3,7 @@ import re
 from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/stadium.py
+++ b/src/streamlink/plugins/stadium.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/streamable.py
+++ b/src/streamlink/plugins/streamable.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HTTPStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.crypto import decrypt_openssl
 from streamlink.utils.parse import parse_qsd
 

--- a/src/streamlink/plugins/stv.py
+++ b/src/streamlink/plugins/stv.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -4,8 +4,9 @@ from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import DASHStream, HTTPStream
+from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/swisstxt.py
+++ b/src/streamlink/plugins/swisstxt.py
@@ -3,7 +3,7 @@ import re
 from urllib.parse import parse_qsl, urlparse, urlunparse
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_json
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents
-from streamlink.stream import DASHStream, HLSStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tga.py
+++ b/src/streamlink/plugins/tga.py
@@ -2,7 +2,9 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 CHANNEL_INFO_URL = "http://api.plu.cn/tga/streams/%s"
 QQ_STREAM_INFO_URL = "http://info.zb.qq.com/?cnlid=%d&cmd=2&stream=%d&system=1&sdtfrom=113"

--- a/src/streamlink/plugins/theplatform.py
+++ b/src/streamlink/plugins/theplatform.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tlctr.py
+++ b/src/streamlink/plugins/tlctr.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/turkuvaz.py
+++ b/src/streamlink/plugins/turkuvaz.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv360.py
+++ b/src/streamlink/plugins/tv360.py
@@ -2,7 +2,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/tv3cat.py
+++ b/src/streamlink/plugins/tv3cat.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -4,7 +4,7 @@ from urllib.parse import urljoin
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv5monde.py
+++ b/src/streamlink/plugins/tv5monde.py
@@ -3,7 +3,9 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugins.common_jwplayer import _js_to_json
-from streamlink.stream import HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tv999.py
+++ b/src/streamlink/plugins/tv999.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/tvibo.py
+++ b/src/streamlink/plugins/tvibo.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -2,7 +2,8 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tvrplus.py
+++ b/src/streamlink/plugins/tvrplus.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/tvtoya.py
+++ b/src/streamlink/plugins/tvtoya.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -10,9 +10,9 @@ import requests
 from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
-from streamlink.stream.hls import HLSStreamReader, HLSStreamWorker, HLSStreamWriter
+from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker, HLSStreamWriter
 from streamlink.stream.hls_playlist import M3U8, M3U8Parser, load as load_hls_playlist
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_json, parse_qsd
 from streamlink.utils.times import hours_minutes_seconds
 from streamlink.utils.url import update_qsd

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -10,7 +10,7 @@ from Crypto.Hash import SHA256
 from Crypto.Util.Padding import pad, unpad
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/viasat.py
+++ b/src/streamlink/plugins/viasat.py
@@ -4,7 +4,9 @@ import re
 from streamlink import NoStreamsError
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import StreamMapper, validate
-from streamlink.stream import HDSStream, HLSStream, RTMPStream
+from streamlink.stream.hds import HDSStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.rtmpdump import RTMPStream
 from streamlink.utils.rtmp import rtmpparse
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -8,7 +8,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -5,8 +5,10 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import DASHStream, HLSStream, HTTPStream
+from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/vinhlongtv.py
+++ b/src/streamlink/plugins/vinhlongtv.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -7,7 +7,8 @@ from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/vlive.py
+++ b/src/streamlink/plugins/vlive.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/vrtbe.py
+++ b/src/streamlink/plugins/vrtbe.py
@@ -5,7 +5,8 @@ from urllib.parse import urljoin
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import DASHStream, HLSStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -4,7 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/wasd.py
+++ b/src/streamlink/plugins/wasd.py
@@ -3,7 +3,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -7,7 +7,7 @@ from Crypto.Cipher import AES
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.crypto import unpad_pkcs5
 from streamlink.utils.parse import parse_json
 from streamlink.utils.url import update_scheme

--- a/src/streamlink/plugins/welt.py
+++ b/src/streamlink/plugins/welt.py
@@ -3,7 +3,7 @@ from urllib.parse import quote
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -6,7 +6,7 @@ from urllib.parse import parse_qsl, urlparse
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.times import seconds_to_hhmmss
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -7,8 +7,9 @@ from urllib.parse import urlparse, urlunparse
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.utils import itertags
-from streamlink.stream import HLSStream, HTTPStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 from streamlink.utils.data import search_dict
 from streamlink.utils.parse import parse_json
 

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -4,7 +4,7 @@ import time
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import useragents
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -5,7 +5,8 @@ import uuid
 from streamlink.cache import Cache
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import DASHStream, HLSStream
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.args import comma_list_filter
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -4,7 +4,7 @@ from urllib.parse import urlparse, urlunparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import url_concat
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/zeenews.py
+++ b/src/streamlink/plugins/zeenews.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/zengatv.py
+++ b/src/streamlink/plugins/zengatv.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/zhanqi.py
+++ b/src/streamlink/plugins/zhanqi.py
@@ -3,7 +3,8 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream, HTTPStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/stream/hds.py
+++ b/src/streamlink/stream/hds.py
@@ -19,7 +19,7 @@ from streamlink.packages.flashmedia import F4V, F4VError
 from streamlink.packages.flashmedia.box import Box
 from streamlink.packages.flashmedia.tag import ScriptData, TAG_TYPE_SCRIPT, Tag
 from streamlink.stream.flvconcat import FLVTagConcat
-from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
+from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.stream.stream import Stream
 from streamlink.stream.wrappers import StreamIOIterWrapper
 from streamlink.utils.swf import swfdecompress

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -15,11 +15,10 @@ from requests import Response
 from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDecodingError
 
 from streamlink.exceptions import StreamError
-from streamlink.stream import hls_playlist
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, MuxedStream
-from streamlink.stream.hls_playlist import Key, M3U8, Map, Segment
+from streamlink.stream.hls_playlist import Key, M3U8, Map, Segment, load as load_hls_playlist
 from streamlink.stream.http import HTTPStream
-from streamlink.stream.segmented import (SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter)
+from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.utils.cache import LRUCache
 from streamlink.utils.formatter import Formatter
 
@@ -229,7 +228,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
             self.playlist_reload_time_override = 0
 
     def _reload_playlist(self, text, url):
-        return hls_playlist.load(text, url)
+        return load_hls_playlist(text, url)
 
     def reload_playlist(self):
         if self.closed:  # pragma: no cover
@@ -473,7 +472,7 @@ class HLSStream(HTTPStream):
 
     @classmethod
     def _get_variant_playlist(cls, res):
-        return hls_playlist.load(res.text, base_uri=res.url)
+        return load_hls_playlist(res.text, base_uri=res.url)
 
     @classmethod
     def parse_variant_playlist(cls, session_, url, name_key="name",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -24,7 +24,8 @@ from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __ve
 from streamlink.cache import Cache
 from streamlink.exceptions import FatalPluginError
 from streamlink.plugin import Plugin, PluginOptions
-from streamlink.stream import StreamIO, StreamProcess
+from streamlink.stream.stream import StreamIO
+from streamlink.stream.streamprocess import StreamProcess
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink_cli.argparser import build_parser
 from streamlink_cli.compat import DeprecatedPath, is_win32, stdout

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -5,7 +5,11 @@ from streamlink import NoStreamsError
 from streamlink.options import Options
 from streamlink.plugin import PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugins import Plugin
-from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream, Stream
+from streamlink.stream.akamaihd import AkamaiHDStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
+from streamlink.stream.stream import Stream
 
 
 class TestStream(Stream):

--- a/tests/plugins/test_rtpplay.py
+++ b/tests/plugins/test_rtpplay.py
@@ -4,7 +4,7 @@ import requests_mock
 
 from streamlink import Streamlink
 from streamlink.plugins.rtpplay import RTPPlay
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 from tests.plugins import PluginCanHandleUrl
 from tests.resources import text
 

--- a/tests/plugins/test_stream.py
+++ b/tests/plugins/test_stream.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 
 from streamlink import Streamlink
 from streamlink.plugin.plugin import parse_params, stream_weight
-from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.akamaihd import AkamaiHDStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 
 class TestPluginStream(unittest.TestCase):

--- a/tests/streams/test_dash.py
+++ b/tests/streams/test_dash.py
@@ -2,8 +2,7 @@ import unittest
 from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 from streamlink import PluginError
-from streamlink.stream import DASHStream
-from streamlink.stream.dash import DASHStreamWorker
+from streamlink.stream.dash import DASHStream, DASHStreamWorker
 from streamlink.stream.dash_manifest import MPD
 from tests.resources import text, xml
 

--- a/tests/streams/test_hls.py
+++ b/tests/streams/test_hls.py
@@ -10,7 +10,7 @@ from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 
 from streamlink.session import Streamlink
-from streamlink.stream import hls
+from streamlink.stream.hls import HLSStream, HLSStreamReader
 from tests.mixins.stream_hls import EventedHLSStreamWriter, Playlist, Segment, Tag, TestMixinStreamHLS
 from tests.resources import text
 
@@ -63,10 +63,10 @@ class TestHLSStreamRepr(unittest.TestCase):
     def test_repr(self):
         session = Streamlink()
 
-        stream = hls.HLSStream(session, "https://foo.bar/playlist.m3u8")
+        stream = HLSStream(session, "https://foo.bar/playlist.m3u8")
         self.assertEqual(repr(stream), "<HLSStream('https://foo.bar/playlist.m3u8', None)>")
 
-        stream = hls.HLSStream(session, "https://foo.bar/playlist.m3u8", "https://foo.bar/master.m3u8")
+        stream = HLSStream(session, "https://foo.bar/playlist.m3u8", "https://foo.bar/master.m3u8")
         self.assertEqual(repr(stream), "<HLSStream('https://foo.bar/playlist.m3u8', 'https://foo.bar/master.m3u8')>")
 
 
@@ -84,7 +84,7 @@ class TestHLSVariantPlaylist(unittest.TestCase):
 
             session = Streamlink(options)
 
-            return hls.HLSStream.parse_variant_playlist(session, url)
+            return HLSStream.parse_variant_playlist(session, url)
 
     def test_variant_playlist(self):
         streams = self.subject("hls/test_master.m3u8")
@@ -94,16 +94,16 @@ class TestHLSVariantPlaylist(unittest.TestCase):
             "Finds all streams in master playlist"
         )
         self.assertTrue(
-            all([isinstance(stream, hls.HLSStream) for stream in streams.values()]),
+            all([isinstance(stream, HLSStream) for stream in streams.values()]),
             "Returns HLSStream instances"
         )
 
 
-class EventedHLSReader(hls.HLSStreamReader):
+class EventedHLSReader(HLSStreamReader):
     __writer__ = EventedHLSStreamWriter
 
 
-class EventedHLSStream(hls.HLSStream):
+class EventedHLSStream(HLSStream):
     __reader__ = EventedHLSReader
 
 
@@ -432,7 +432,7 @@ class TestHlsExtAudio(unittest.TestCase):
         if audio_select:
             streamlink.set_option("hls-audio-select", audio_select)
 
-        master_stream = hls.HLSStream.parse_variant_playlist(streamlink, playlist)
+        master_stream = HLSStream.parse_variant_playlist(streamlink, playlist)
 
         return master_stream
 

--- a/tests/streams/test_stream_streamprocess.py
+++ b/tests/streams/test_stream_streamprocess.py
@@ -5,7 +5,7 @@ import pytest
 
 from streamlink import StreamError
 from streamlink import Streamlink
-from streamlink.stream import StreamProcess
+from streamlink.stream.streamprocess import StreamProcess
 
 
 @pytest.mark.parametrize("parameters,arguments,expected", [

--- a/tests/streams/test_stream_to_url.py
+++ b/tests/streams/test_stream_to_url.py
@@ -3,11 +3,11 @@ from unittest.mock import PropertyMock, patch
 
 from streamlink import Streamlink
 from streamlink.plugins.filmon import FilmOnHLS
-from streamlink.stream import AkamaiHDStream
-from streamlink.stream import HDSStream
-from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
-from streamlink.stream import RTMPStream
+from streamlink.stream.akamaihd import AkamaiHDStream
+from streamlink.stream.hds import HDSStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 from streamlink.stream.stream import Stream
 from streamlink_cli.utils import stream_to_url
 

--- a/tests/streams/test_stream_wrappers.py
+++ b/tests/streams/test_stream_wrappers.py
@@ -1,6 +1,6 @@
 import unittest
 
-from streamlink.stream import StreamIOIterWrapper
+from streamlink.stream.wrappers import StreamIOIterWrapper
 
 
 class TestPluginStream(unittest.TestCase):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,7 +8,10 @@ from requests.packages.urllib3.util.connection import allowed_gai_family
 
 from streamlink import NoPluginError, Streamlink
 from streamlink.plugin import HIGH_PRIORITY, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, Plugin, pluginmatcher
-from streamlink.stream import AkamaiHDStream, HLSStream, HTTPStream, RTMPStream
+from streamlink.stream.akamaihd import AkamaiHDStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 
 
 class EmptyPlugin(Plugin):

--- a/tests/test_stream_json.py
+++ b/tests/test_stream_json.py
@@ -4,11 +4,11 @@ import unittest
 from requests.utils import DEFAULT_ACCEPT_ENCODING
 
 from streamlink import Streamlink
-from streamlink.stream import AkamaiHDStream
-from streamlink.stream import HDSStream
-from streamlink.stream import HLSStream
-from streamlink.stream import HTTPStream
-from streamlink.stream import RTMPStream
+from streamlink.stream.akamaihd import AkamaiHDStream
+from streamlink.stream.hds import HDSStream
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.stream.rtmpdump import RTMPStream
 from streamlink.stream.stream import Stream
 
 


### PR DESCRIPTION
Follow up of 57046e0 and 24c59a2

Import from the various stream modules directly instead of importing every stream implementation at once. As mentioned, this will be beneficial when Streamlink eventually switches to a new plugin resolver/importer.

ctrl+f -> `from streamlink.stream import` -> "Nothing found."