### PR TITLE
build: include bash and zsh completions in wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
       - name: Test
         continue-on-error: ${{ matrix.continue || false }}
         run: pytest -r a --cov --cov-branch --cov-report=xml --durations 10
+      - name: Build shell completions
+        run: bash ./script/build-shell-completions.sh
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}
@@ -78,7 +80,7 @@ jobs:
           ./script/install-dependencies.sh
           python -m pip install -r docs-requirements.txt
       - name: Build
-        run: make --directory=docs html
+        run: make --directory=docs html man
 
   windows-installer:
     name: Windows installer
@@ -158,6 +160,8 @@ jobs:
           ./script/install-dependencies.sh
           python -m pip install -r docs-requirements.txt
           python -m pip install --upgrade wheel twine
+      - name: Build shell completions
+        run: ./script/build-shell-completions.sh
       - name: Build man page
         run: make --directory=docs man
       - name: Installer file name

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,3 +6,4 @@ requests-mock
 freezegun>=1.0.0
 flake8
 flake8-import-order
+shtab

--- a/script/build-shell-completions.sh
+++ b/script/build-shell-completions.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$(readlink -f "${0}")")/..")
+
+DIST="${ROOT}/build/shtab"
+PYTHON_DEPS=(streamlink_cli shtab)
+
+declare -A COMPLETIONS=(
+  [bash]="streamlink"
+  # ZSH requires the file to be prefixed with an underscore
+  [zsh]="_streamlink"
+)
+
+for dep in "${PYTHON_DEPS[@]}"; do
+  python -c "import ${dep}" 2>&1 >/dev/null \
+    || { echo >&2 "${dep} could not be found in your python environment"; exit 1; }
+done
+
+for shell in "${!COMPLETIONS[@]}"; do
+  mkdir -p "${DIST}/${shell}"
+  dist="${DIST}/${shell}/${COMPLETIONS[${shell}]}"
+  python -m shtab \
+    "--shell=${shell}" \
+    --error-unimportable \
+    streamlink_cli.main.parser_helper \
+    > "${dist}"
+  echo "Completions for ${shell} written to ${dist}"
+done

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,16 @@ if is_wheel_for_windows():
     entry_points["gui_scripts"] = ["streamlinkw=streamlink_cli.main:main"]
 
 
+# optional data files
 additional_files = [
+    # shell completions
+    #  requires pre-built completion files via shtab (dev-requirements.txt)
+    #  `./script/build-shell-completions.sh`
+    ("share/bash-completion/completions", ["build/shtab/bash/streamlink"]),
+    ("share/zsh/site-functions", ["build/shtab/zsh/_streamlink"]),
+    # man page
+    #  requires pre-built man page file via sphinx (docs-requirements.txt)
+    #  `make --directory=docs clean man`
     ("share/man/man1", ["docs/_build/man/streamlink.1"])
 ]
 


### PR DESCRIPTION
Resolves #2993

This builds shell completions files for BASH and ZSH via `shtab`, which unlike other tools I've looked up in the past can parse an `argparse.ArgumentParser` object:
https://github.com/iterative/shtab

It's also only a simple build step and no runtime dependencies are required for implementing shell completions, which is the ideal solution.

Unfortunately, it currently does only support BASH and ZSH. I would love to see FISH support in the future as well.

----

The shell completion files get built via `./script/build-shell-completions.sh` and are optional in the `data_files` field in `setup.py`, just like the man pages.

This means the wheels will include these files when built prior to running setup.py, and pip will write them to

- `${XDG_DATA_HOME:-${HOME}/.local/share}/bash-completion/completions/streamlink`
- `${XDG_DATA_HOME:-${HOME}/.local/share}/zsh/site-functions/_streamlink`

or (if run as sudo - which shouldn't be done)

- `/usr/share/bash-completion/completions/streamlink`
- `/usr/share/zsh/site-functions/_streamlink`

when installing the wheel.

----

The `sdist` and `build` targets of setup.py don't include these optional data files.

Third party packagers of Streamlink can build the completion files via `shtab` themselves:

```bash
python -m shtab \
  "--shell=${shell}" \
  --error-unimportable \
  streamlink_cli.main.parser_helper \
  > "${dist}"
```

or

```bash
./script/build-shell-completions.sh
install -Dm644 build/shtab/bash/streamlink /usr/share/bash-completion/completions/streamlink
install -Dm644 build/shtab/zsh/_streamlink /usr/share/zsh/site-functions/_streamlink
```

----

For BASH, this requires the `bash-completion` package to be installed and it'll look up the completion files automatically.
https://github.com/scop/bash-completion/blob/master/README.md

For ZSH, the local completion path needs to be added to the config's `fpath` (I believe). I'm not a ZSH user, but the global path seems to be correct from what I can tell (according to Arch Linux's packaging at least). A confirmation would be appreciated.

----

```
[basti@basti-pc streamlink]$ streamlink -
Display all 102 possibilities? (y or n)

[basti@basti-pc streamlink]$ streamlink --player-
--player-args                --player-external-http       --player-fifo                --player-no-close
--player-continuous-http     --player-external-http-port  --player-http                --player-passthrough
```