### PR TITLE
utils.url: make update_scheme always update target

### DIFF
--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -25,12 +25,12 @@ _re_uri_implicit_scheme = re.compile(r"""^[a-z0-9][a-z0-9.+-]*://""", re.IGNOREC
 
 def update_scheme(current: str, target: str) -> str:
     """
-    Take the scheme from the current URL and apply it to the
-    target URL if the target URL starts with // or is missing a scheme
+    Take the scheme from the current URL and apply it to the target URL
     :param current: current URL
     :param target: target URL
-    :return: target URL with the current URLs scheme
+    :return: target URL with the current URL's scheme
     """
+    current_p = urlparse(current)
     target_p = urlparse(target)
 
     if (
@@ -42,14 +42,10 @@ def update_scheme(current: str, target: str) -> str:
         # target URLs without scheme and netloc: ("http://", "foo.bar/foo") -> "http://foo.bar/foo"
         or not target_p.scheme and not target_p.netloc
     ):
-        return f"{urlparse(current).scheme}://{urlunparse(target_p)}"
-
-    # target URLs without scheme but with netloc: ("http://", "//foo.bar/foo") -> "http://foo.bar/foo"
-    if not target_p.scheme and target_p.netloc:
-        return f"{urlparse(current).scheme}:{urlunparse(target_p)}"
+        return f"{current_p.scheme}://{urlunparse(target_p)}"
 
     # target URLs with scheme
-    return target
+    return urlunparse(target_p._replace(scheme=current_p.scheme))
 
 
 def url_equal(first, second, ignore_scheme=False, ignore_netloc=False, ignore_path=False, ignore_params=False,

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -23,14 +23,17 @@ def test_prepend_www(url, expected):
     assert expected == prepend_www(url)
 
 
-def test_update_scheme():
-    assert update_scheme("https://other.com/bar", "//example.com/foo") == "https://example.com/foo", "should become https"
-    assert update_scheme("http://other.com/bar", "//example.com/foo") == "http://example.com/foo", "should become http"
-    assert update_scheme("https://other.com/bar", "http://example.com/foo") == "http://example.com/foo", "should remain http"
-    assert update_scheme("https://other.com/bar", "example.com/foo") == "https://example.com/foo", "should become https"
-    assert update_scheme("http://", "127.0.0.1:1234/foo") == "http://127.0.0.1:1234/foo", "implicit scheme with IPv4+port"
-    assert update_scheme("http://", "foo.bar:1234/foo") == "http://foo.bar:1234/foo", "implicit scheme with hostname+port"
-    assert update_scheme("http://", "foo.1+2-bar://baz") == "foo.1+2-bar://baz", "correctly parses all kinds of schemes"
+@pytest.mark.parametrize("current,target,expected,assertion", [
+    ("https://other.com/bar", "https://example.com/foo", "https://example.com/foo", "current scheme overrides target scheme"),
+    ("https://other.com/bar", "//example.com/foo", "https://example.com/foo", "current scheme gets applied to scheme-less URL"),
+    ("https://other.com/bar", "example.com/foo", "https://example.com/foo", "current scheme gets added to target string"),
+    ("http://", "127.0.0.1:1234/foo", "http://127.0.0.1:1234/foo", "implicit scheme with IPv4+port"),
+    ("http://", "foo.bar:1234/foo", "http://foo.bar:1234/foo", "implicit scheme with hostname+port"),
+    ("foo.1+2-bar://baz", "FOO.1+2-BAR://qux", "foo.1+2-bar://qux", "correctly parses all kinds of schemes"),
+    ("foo.1+2-bar://baz", "qux", "foo.1+2-bar://qux", "correctly parses all kinds of schemes"),
+])
+def test_update_scheme(current, target, expected, assertion):
+    assert update_scheme(current, target) == expected, assertion
 
 
 def test_url_equal():


### PR DESCRIPTION
The previous implementation of update_scheme only made it set schemes
on scheme-less URLs and it kept target URLs that include a scheme intact.

This is confusing for plugin implementers and it has already been used
incorrectly a lot of times when trying to force the https protocol on
unencrypted http URLs. Since the method is called update_scheme, it
should do exactly that, in all cases.

- always update target URL scheme with current URL scheme
- parametrize tests, re-order assertions and add new ones

----

ref #4047

It is possible that this could cause issues when this pattern is used where `self.url` is a `http://` URL and the target is a `https://` URL where `https` is required and the server doesn't redirect, meaning the target will be degraded from https to http:
```
update_scheme(self.url, target)
```

There are 13 matches when searching for `update_scheme(self.url` in `src/`:
```
$ grep -RHn 'update_scheme(self.url' src/ | sed -E 's/ +/ /g' | column -tl2
src/streamlink/plugins/nbc.py:20:          url = update_scheme(self.url, platform_url)
src/streamlink/plugins/nbcsports.py:20:    url = update_scheme(self.url, platform_url)
src/streamlink/plugins/albavision.py:89:   playlist_url = m and update_scheme(self.url, m.group(1))
src/streamlink/plugins/albavision.py:116:  playlist_url = m and update_scheme(self.url, m.group(1))
src/streamlink/plugins/cdnbg.py:65:        iframe_url = update_scheme(self.url, html_unescape(iframe_url))
src/streamlink/plugins/delfi.py:41:        src = update_scheme(self.url, x['src'])
src/streamlink/plugins/dogus.py:39:        mobile_url = mobile_url_m and update_scheme(self.url, mobile_url_m.group("url"))
src/streamlink/plugins/invintus.py:41:     return HLSStream.parse_variant_playlist(self.session, update_scheme(self.url, hls_url))
src/streamlink/plugins/mediaklikk.py:70:   validate.map(lambda p: update_scheme(self.url, p["file"]))
src/streamlink/plugins/streamable.py:33:   stream_url = update_scheme(self.url, info["url"])
src/streamlink/plugins/vk.py:56:           iframe_url = update_scheme(self.url, _i.attributes['src'])
src/streamlink/plugins/webtv.py:64:        url = update_scheme(self.url, source["src"])
src/streamlink/plugins/earthcam.py:61:     hls_url = update_scheme(self.url, f"{hls_domain}{hls_playpath}")
```

and 7 matches for `update_scheme("http://`:
```
$ grep -RHnE "update_scheme\([\"']http://" src/ | sed -E 's/ +/ /g' | column -tl2
src/streamlink/plugins/akamaihd.py:18:  url = update_scheme("http://", data.get("url"))
src/streamlink/plugins/hds.py:21:       url = update_scheme("http://", data.get("url"))
src/streamlink/plugins/hls.py:21:       url = update_scheme("http://", data.get("url"))
src/streamlink/plugins/http.py:18:      url = update_scheme("http://", data.get("url"))
src/streamlink/session.py:234:          self.http.proxies["http"] = update_scheme("http://", value)
src/streamlink/session.py:236:          self.http.proxies["https"] = update_scheme("http://", value)
src/streamlink/session.py:356:          url = update_scheme("http://", url)
```