### PR TITLE
utils.url: make update_scheme always update target

### DIFF
--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class AkamaiHDPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"))
+        url = update_scheme("http://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -86,7 +86,7 @@ class Albavision(Plugin):
 
     def _get_streams(self):
         m = self._live_url_re.search(self.page.text)
-        playlist_url = m and update_scheme(self.url, m.group(1))
+        playlist_url = m and update_scheme("https://", m.group(1), force=False)
         player_url = self.url
         live_channel = None
         p = urlparse(player_url)
@@ -113,7 +113,7 @@ class Albavision(Plugin):
                 if "block access from your country." in page.text:
                     raise PluginError("Content is geo-locked")
                 m = self._playlist_re.search(page.text)
-                playlist_url = m and update_scheme(self.url, m.group(1))
+                playlist_url = m and update_scheme("https://", m.group(1), force=False)
             else:
                 log.error("Could not find the live channel")
 

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -62,7 +62,7 @@ class CDNBG(Plugin):
                 for iframe in itertags(res.text, "iframe"):
                     iframe_url = iframe.attributes.get("src")
                     if iframe_url and "cdn.bg" in iframe_url:
-                        iframe_url = update_scheme(self.url, html_unescape(iframe_url))
+                        iframe_url = update_scheme("https://", html_unescape(iframe_url), force=False)
                         break
                 else:
                     return

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -38,7 +38,7 @@ class Delfi(Plugin):
         data = self.session.http.json(res)
         if data["success"]:
             for x in itertools.chain(*data['data']['versions'].values()):
-                src = update_scheme(self.url, x['src'])
+                src = update_scheme("https://", x["src"], force=False)
                 if x['type'] == "application/x-mpegurl":
                     yield from HLSStream.parse_variant_playlist(self.session, src).items()
                 elif x['type'] == "application/dash+xml":

--- a/src/streamlink/plugins/dogus.py
+++ b/src/streamlink/plugins/dogus.py
@@ -36,7 +36,7 @@ class Dogus(Plugin):
 
         # Next check for HLS URL with token
         mobile_url_m = self.mobile_url_re.search(res.text)
-        mobile_url = mobile_url_m and update_scheme(self.url, mobile_url_m.group("url"))
+        mobile_url = mobile_url_m and update_scheme("https://", mobile_url_m.group("url"), force=False)
         if mobile_url:
             log.debug("Found mobile stream: {0}".format(mobile_url_m.group(0)))
 

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -58,7 +58,7 @@ class EarthCam(Plugin):
         self.title = cam_data["title"]
 
         if hls_playpath:
-            hls_url = update_scheme(self.url, f"{hls_domain}{hls_playpath}")
+            hls_url = update_scheme("https://", f"{hls_domain}{hls_playpath}")
             yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
 
 

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class HDSPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"))
+        url = update_scheme("http://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class HLSPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"))
+        url = update_scheme("http://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class HTTPStreamPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"))
+        url = update_scheme("http://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/invintus.py
+++ b/src/streamlink/plugins/invintus.py
@@ -38,7 +38,7 @@ class InvintusMedia(Plugin):
             return
 
         hls_url = api_response["data"]["streamingURIs"]["main"]
-        return HLSStream.parse_variant_playlist(self.session, update_scheme(self.url, hls_url))
+        return HLSStream.parse_variant_playlist(self.session, update_scheme("https://", hls_url))
 
 
 __plugin__ = InvintusMedia

--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -67,7 +67,7 @@ class Mediaklikk(Plugin):
                 validate.get("playlist"),
                 validate.filter(lambda p: p["type"] == "hls"),
                 validate.filter(lambda p: not skip_vods or "vod" not in p["file"]),
-                validate.map(lambda p: update_scheme(self.url, p["file"]))
+                validate.map(lambda p: update_scheme("https://", p["file"]))
             ))
         ))
 

--- a/src/streamlink/plugins/nbc.py
+++ b/src/streamlink/plugins/nbc.py
@@ -17,7 +17,7 @@ class NBC(Plugin):
         platform_url = m and m.group("url")
 
         if platform_url:
-            url = update_scheme(self.url, platform_url)
+            url = update_scheme("https://", platform_url)
             # hand off to ThePlatform plugin
             p = ThePlatform(url)
             p.bind(self.session, "plugin.nbc")

--- a/src/streamlink/plugins/nbcsports.py
+++ b/src/streamlink/plugins/nbcsports.py
@@ -17,7 +17,7 @@ class NBCSports(Plugin):
         platform_url = m and m.group("url")
 
         if platform_url:
-            url = update_scheme(self.url, platform_url)
+            url = update_scheme("https://", platform_url)
             # hand off to ThePlatform plugin
             p = ThePlatform(url)
             p.bind(self.session, "plugin.nbcsports")

--- a/src/streamlink/plugins/streamable.py
+++ b/src/streamlink/plugins/streamable.py
@@ -30,7 +30,7 @@ class Streamable(Plugin):
         data = self.session.http.get(self.url, schema=self.config_schema)
 
         for info in data["files"].values():
-            stream_url = update_scheme(self.url, info["url"])
+            stream_url = update_scheme("https://", info["url"])
             # pick the smaller of the two dimensions, for landscape v. portrait videos
             res = min(info["width"], info["height"])
             yield "{0}p".format(res), HTTPStream(self.session, stream_url)

--- a/src/streamlink/plugins/tv999.py
+++ b/src/streamlink/plugins/tv999.py
@@ -28,7 +28,7 @@ class TV999(Plugin):
         validate.transform(hls_re.search),
         validate.any(None, validate.all(
             validate.get(1),
-            validate.transform(lambda x: update_scheme('http:', x)),
+            validate.transform(lambda x: update_scheme("https://", x)),
             validate.url(),
         )),
     )

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -53,7 +53,7 @@ class VK(Plugin):
 
         for _i in itertags(res.text, 'iframe'):
             if _i.attributes.get('src'):
-                iframe_url = update_scheme(self.url, _i.attributes['src'])
+                iframe_url = update_scheme("https://", _i.attributes["src"])
                 log.debug('Found iframe: {0}'.format(iframe_url))
                 yield from self.session.streams(iframe_url).items()
 

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -61,7 +61,7 @@ class WebTV(Plugin):
             for source in sdata:
                 log.debug(f"Found stream of type: {source['type']}")
                 if source["type"] == "application/vnd.apple.mpegurl":
-                    url = update_scheme(self.url, source["src"])
+                    url = update_scheme("https://", source["src"], force=False)
 
                     try:
                         # try to parse the stream as a variant playlist

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -231,12 +231,13 @@ class Streamlink:
                 urllib3_connection.allowed_gai_family = allowed_gai_family
 
         elif key == "http-proxy":
-            self.http.proxies["http"] = update_scheme("http://", value)
+            self.http.proxies["http"] = update_scheme("http://", value, force=False)
             if "https" not in self.http.proxies:
-                self.http.proxies["https"] = update_scheme("http://", value)
+                self.http.proxies["https"] = update_scheme("http://", value, force=False)
 
         elif key == "https-proxy":
             self.http.proxies["https"] = update_scheme("https://", value)
+
         elif key == "http-cookies":
             if isinstance(value, dict):
                 self.http.cookies.update(value)
@@ -353,7 +354,7 @@ class Streamlink:
         :param follow_redirect: follow redirects
 
         """
-        url = update_scheme("http://", url)
+        url = update_scheme("http://", url, force=False)
 
         matcher: Matcher
         candidate: Optional[Type[Plugin]] = None

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -23,13 +23,13 @@ def prepend_www(url):
 _re_uri_implicit_scheme = re.compile(r"""^[a-z0-9][a-z0-9.+-]*://""", re.IGNORECASE)
 
 
-def update_scheme(current: str, target: str) -> str:
+def update_scheme(current: str, target: str, force: bool = True) -> str:
     """
-    Take the scheme from the current URL and apply it to the
-    target URL if the target URL starts with // or is missing a scheme
+    Take the scheme from the current URL and apply it to the target URL if it is missing
     :param current: current URL
     :param target: target URL
-    :return: target URL with the current URLs scheme
+    :param force: always apply the current scheme to the target, even if a target scheme exists
+    :return: target URL with the current URL's scheme
     """
     target_p = urlparse(target)
 
@@ -49,6 +49,11 @@ def update_scheme(current: str, target: str) -> str:
         return f"{urlparse(current).scheme}:{urlunparse(target_p)}"
 
     # target URLs with scheme
+    # override the target scheme
+    if force:
+        return urlunparse(target_p._replace(scheme=urlparse(current).scheme))
+
+    # keep the target scheme
     return target
 
 


### PR DESCRIPTION
Previously, update_scheme only added schemes on scheme-less URLs and
kept target URLs which included a scheme intact.

This is confusing for plugin implementers and it has already been used
incorrectly a lot of times when trying to force the HTTPS protocol on
unencrypted HTTP URLs. Since the method is called update_scheme, it
should do exactly that, in all cases.

However, always updating the target scheme will break those calls of
update_scheme where the scheme was previously only added if needed, eg.
on scheme-less URLs, partial URLs or URL paths.

An example of this are scheme-less input URLs passed to Streamlink's
`Session.resolve_url()`, which has to implicitly set the HTTP scheme.
Always overriding the scheme would turn explicit HTTPS schemes to HTTP,
which can break certain sites/plugins. The various stream-protocol
plugins have the same issue and have to implicitly set a scheme as well.

This change therefore introduces the `force=True` keyword, so that URL
schemes can be set implicitly again in the methods and plugins mentioned
above by setting force to False.

Another effect of forcing the scheme override by default is the pattern
currently used in many plugins, which often update (partial) URLs by
calling `update_scheme(self.url, target)`. Since `self.url` depends on
the user's input and since the input URL's scheme is implicitly set to
HTTP by the Session's URL resolver, target URLs can be downgraded from
HTTPS to HTTP, which is not desired. This is not a problem in cases
where the server will redirect, but it can be a problem where the server
returns an error instead.

These plugins will therefore need to be fixed so that they either set
the URL schemes implicitly or so that they force the according scheme.

Another solution (which will be done eventually) is the change of the
implicit input URL scheme from HTTP to HTTPS in `Session.resolve_url()`
and the various stream-protocol plugins, which will turn all scheme-less
input URLs to HTTPS by default, unless the user explicitly sets an HTTP
URL.

- always update target URL scheme with current URL scheme
- add force=True keyword and do not override scheme if force is False
- set force=False on all implicitly updated URL schemes
  - `Session.resolve_url`
  - `plugins.{akamaihd,hds,hls,http}`
- parametrize tests, re-order/re-format assertions and add new ones

----

ref #4047 

Here's a list of all `update_scheme` calls. As you can see, every call with "http://" as current URL have the force=False parameter set. The other ones are a mixture of "https://" (also via constants) and `self.url`. The `self.url` ones are problematic for the reasons mentioned above, but as I've also said, there's an upgrade path for that by switching from http by default to https (#4047).

Please don't merge unless this we're 100% sure that everything's good here.

```
$ grep -RHn 'update_scheme(' src/ | sort -V | sed -E 's/ +/ /g' | column -tl2 | head -n-2
src/streamlink/plugins/abweb.py:112:         iframe_url = update_scheme('https://', iframe_url)
src/streamlink/plugins/abweb.py:124:         hls_url = update_scheme('https://', m.group('url'))
src/streamlink/plugins/akamaihd.py:18:       url = update_scheme("http://", data.get("url"), force=False)
src/streamlink/plugins/albavision.py:89:     playlist_url = m and update_scheme(self.url, m.group(1))
src/streamlink/plugins/albavision.py:116:    playlist_url = m and update_scheme(self.url, m.group(1))
src/streamlink/plugins/ard_mediathek.py:45:  stream = HTTPStream(self.session, update_scheme("https://", url))
src/streamlink/plugins/ard_mediathek.py:49:  return HLSStream.parse_variant_playlist(self.session, update_scheme("https://", info["_stream"])).items()
src/streamlink/plugins/ard_mediathek.py:72:  stream_ = update_scheme("https://", stream_)
src/streamlink/plugins/atresplayer.py:50:    super().__init__(update_scheme("https://", url))
src/streamlink/plugins/cdnbg.py:65:          iframe_url = update_scheme(self.url, html_unescape(iframe_url))
src/streamlink/plugins/cdnbg.py:79:          update_scheme(iframe_url, stream_url),
src/streamlink/plugins/delfi.py:41:          src = update_scheme(self.url, x['src'])
src/streamlink/plugins/dogus.py:39:          mobile_url = mobile_url_m and update_scheme(self.url, mobile_url_m.group("url"))
src/streamlink/plugins/earthcam.py:61:       hls_url = update_scheme(self.url, f"{hls_domain}{hls_playpath}")
src/streamlink/plugins/euronews.py:47:       validate.transform(lambda url: update_scheme("https://", url))
src/streamlink/plugins/hds.py:21:            url = update_scheme("http://", data.get("url"), force=False)
src/streamlink/plugins/hls.py:21:            url = update_scheme("http://", data.get("url"), force=False)
src/streamlink/plugins/http.py:18:           url = update_scheme("http://", data.get("url"), force=False)
src/streamlink/plugins/idf1.py:40:           lambda x: [update_scheme(IDF1.DACAST_API_URL, x['hls']), x['hds']] + [y['src'] for y in x.get('html5', [])]
src/streamlink/plugins/invintus.py:41:       return HLSStream.parse_variant_playlist(self.session, update_scheme(self.url, hls_url))
src/streamlink/plugins/mediaklikk.py:70:     validate.map(lambda p: update_scheme(self.url, p["file"]))
src/streamlink/plugins/nbcsports.py:20:      url = update_scheme(self.url, platform_url)
src/streamlink/plugins/nbc.py:20:            url = update_scheme(self.url, platform_url)
src/streamlink/plugins/sportschau.py:25:     validate.transform(lambda url: update_scheme("https:", url))
src/streamlink/plugins/sportschau.py:45:     yield from HLSStream.parse_variant_playlist(self.session, update_scheme("https:", data.get("videoURL"))).items()
src/streamlink/plugins/sportschau.py:47:     yield "audio", HTTPStream(self.session, update_scheme("https:", data.get("audioURL")))
src/streamlink/plugins/streamable.py:33:     stream_url = update_scheme(self.url, info["url"])
src/streamlink/plugins/tv999.py:31:          validate.transform(lambda x: update_scheme('http:', x)),
src/streamlink/plugins/vk.py:56:             iframe_url = update_scheme(self.url, _i.attributes['src'])
src/streamlink/plugins/webtv.py:64:          url = update_scheme(self.url, source["src"])
src/streamlink/session.py:234:               self.http.proxies["http"] = update_scheme("http://", value, force=False)
src/streamlink/session.py:236:               self.http.proxies["https"] = update_scheme("http://", value, force=False)
src/streamlink/session.py:239:               self.http.proxies["https"] = update_scheme("https://", value)
```
