### PR TITLE
plugins.youtube: Better API age-gate bypassing

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -253,11 +253,14 @@ class YouTube(Plugin):
             params={"key": _i_api_key},
             data=json.dumps({
                 "videoId": _i_video_id,
+                "contentCheckOk": True,
+                "racyCheckOk": True,
                 "context": {
                     "client": {
-                        "clientName": "WEB_EMBEDDED_PLAYER",
+                        "clientName": "WEB",
                         "clientVersion": _i_version,
                         "platform": "DESKTOP",
+                        "clientScreen": "EMBED",
                         "clientFormFactor": "UNKNOWN_FORM_FACTOR",
                         "browserName": "Chrome",
                     },

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -279,12 +279,13 @@ class YouTube(Plugin):
                 if videoId is not None:
                     return videoId
 
-    def _data_status(self, data):
+    def _data_status(self, data, errorlog=False):
         if not data:
             return False
         status, reason = self._schema_playabilitystatus(data)
         if status != "OK":
-            log.error(f"Could not get video info - {status}: {reason}")
+            if errorlog:
+                log.error(f"Could not get video info - {status}: {reason}")
             return False
         return True
 
@@ -303,7 +304,7 @@ class YouTube(Plugin):
         data = self._get_data_from_regex(res, self._re_ytInitialPlayerResponse, "initial player response")
         if not self._data_status(data):
             data = self._get_data_from_api(res)
-            if not self._data_status(data):
+            if not self._data_status(data, True):
                 return
 
         video_id, self.author, self.title, is_live = self._schema_videodetails(data)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
Based on https://github.com/yt-dlp/yt-dlp/issues/574#issuecomment-887171136

- Works in videos like https://www.youtube.com/watch?v=Tq92D6wQ1mg
- embedUrl is required for videos like https://www.youtube.com/watch?v=HsUATh_Nc2U but I can't find any examples that aren't protected so I left it out
- Still doesn't work for videos like https://www.youtube.com/watch?v=Cr381pDsSsA which seem to have embedding explicitly disabled (since it returns an `Playback on other websites has been disabled by the video owner.` error)
