### PR TITLE
tests: fix partial coverage in can_handle_url

### DIFF
--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -18,10 +18,25 @@ class PluginCanHandleUrl:
         assert issubclass(self.__plugin__, Plugin), "Test has a __plugin__ that is a subclass of streamlink.plugin.Plugin"
         assert len(self.should_match) > 0, "Test has at least one positive URL"
 
+    def test_matchers(self):
+        assert all(
+            any(
+                matcher.pattern.match(url)
+                for url in self.should_match
+            )
+            for matcher in self.__plugin__.matchers
+        ), "All plugin matchers should match"
+
     # parametrized dynamically via conftest.py
     def test_can_handle_url_positive(self, url):
-        assert any(matcher.pattern.match(url) for matcher in self.__plugin__.matchers), "URL matches"
+        assert any(  # pragma: no branch
+            matcher.pattern.match(url)
+            for matcher in self.__plugin__.matchers
+        ), "URL matches"
 
     # parametrized dynamically via conftest.py
     def test_can_handle_url_negative(self, url):
-        assert not any(matcher.pattern.match(url) for matcher in self.__plugin__.matchers), "URL does not match"
+        assert not any(  # pragma: no branch
+            matcher.pattern.match(url)
+            for matcher in self.__plugin__.matchers
+        ), "URL does not match"

--- a/tests/plugins/test_mediavitrina.py
+++ b/tests/plugins/test_mediavitrina.py
@@ -9,6 +9,7 @@ class TestPluginCanHandleUrlMediaVitrina(PluginCanHandleUrl):
         "https://chetv.ru/online/",
         "https://ctc.ru/online/",
         "https://ctclove.ru/online/",
+        "https://ren.tv/live",
         "https://player.mediavitrina.ru/5tv/moretv_web/player.html",
         "https://player.mediavitrina.ru/che/che_web/player.html",
         "https://player.mediavitrina.ru/ctc_ext/moretv_web/player.html",

--- a/tests/plugins/test_orf_tvthek.py
+++ b/tests/plugins/test_orf_tvthek.py
@@ -6,5 +6,6 @@ class TestPluginCanHandleUrlORFTVThek(PluginCanHandleUrl):
     __plugin__ = ORFTVThek
 
     should_match = [
-        'http://tvthek.orf.at/live/Wetter/13953206',
+        "https://tvthek.orf.at/live/Christine-Lavant-Preis-2021/14139354",
+        "https://tvthek.orf.at/profile/Aktuell-nach-eins/13887636/Aktuell-nach-eins/14107576",
     ]


### PR DESCRIPTION
Fixes #4066 

The plugin URL test fixes are optional, but I noticed that they were missing, so I added them...