### PR TITLE
session: move from http to https as default scheme

### DIFF
--- a/src/streamlink/plugins/akamaihd.py
+++ b/src/streamlink/plugins/akamaihd.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class AkamaiHDPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"), force=False)
+        url = update_scheme("https://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -4,6 +4,7 @@ import re
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.plugin import LOW_PRIORITY, stream_weight
 from streamlink.stream.dash import DASHStream
+from streamlink.utils.url import update_scheme
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class MPEGDASH(Plugin):
             return stream_weight(stream)
 
     def _get_streams(self):
-        url = self.match.group(1)
+        url = update_scheme("https://", self.match.group(1), force=False)
         log.debug(f"Parsing MPD URL: {url}")
 
         return DASHStream.parse_manifest(self.session, url)

--- a/src/streamlink/plugins/hds.py
+++ b/src/streamlink/plugins/hds.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class HDSPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"), force=False)
+        url = update_scheme("https://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class HLSPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"), force=False)
+        url = update_scheme("https://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class HTTPStreamPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("http://", data.get("url"), force=False)
+        url = update_scheme("https://", data.get("url"), force=False)
         params = parse_params(data.get("params"))
         log.debug(f"URL={url}; params={params}")
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -231,9 +231,9 @@ class Streamlink:
                 urllib3_connection.allowed_gai_family = allowed_gai_family
 
         elif key == "http-proxy":
-            self.http.proxies["http"] = update_scheme("http://", value, force=False)
+            self.http.proxies["http"] = update_scheme("https://", value, force=False)
             if "https" not in self.http.proxies:
-                self.http.proxies["https"] = update_scheme("http://", value, force=False)
+                self.http.proxies["https"] = update_scheme("https://", value, force=False)
 
         elif key == "https-proxy":
             self.http.proxies["https"] = update_scheme("https://", value)
@@ -354,7 +354,7 @@ class Streamlink:
         :param follow_redirect: follow redirects
 
         """
-        url = update_scheme("http://", url, force=False)
+        url = update_scheme("https://", url, force=False)
 
         matcher: Matcher
         candidate: Optional[Type[Plugin]] = None

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -81,27 +81,50 @@ class TestSession(unittest.TestCase):
         self.assertTrue(isinstance(plugin, plugins["testplugin"]))
         self.assertTrue(hasattr(session.resolve_url, "cache_info"), "resolve_url has a lookup cache")
 
+    def test_resolve_url_scheme(self):
+        @pluginmatcher(re.compile("http://insecure"))
+        class PluginHttp(EmptyPlugin):
+            pass
+
+        @pluginmatcher(re.compile("https://secure"))
+        class PluginHttps(EmptyPlugin):
+            pass
+
+        session = self.subject(load_plugins=False)
+        session.plugins = {
+            "insecure": PluginHttp,
+            "secure": PluginHttps,
+        }
+
+        self.assertRaises(NoPluginError, session.resolve_url, "insecure")
+        self.assertIsInstance(session.resolve_url("http://insecure"), PluginHttp)
+        self.assertRaises(NoPluginError, session.resolve_url, "https://insecure")
+
+        self.assertIsInstance(session.resolve_url("secure"), PluginHttps)
+        self.assertRaises(NoPluginError, session.resolve_url, "http://secure")
+        self.assertIsInstance(session.resolve_url("https://secure"), PluginHttps)
+
     def test_resolve_url_priority(self):
         @pluginmatcher(priority=HIGH_PRIORITY, pattern=re.compile(
-            "http://(high|normal|low|no)$"
+            "https://(high|normal|low|no)$"
         ))
         class HighPriority(EmptyPlugin):
             pass
 
         @pluginmatcher(priority=NORMAL_PRIORITY, pattern=re.compile(
-            "http://(normal|low|no)$"
+            "https://(normal|low|no)$"
         ))
         class NormalPriority(EmptyPlugin):
             pass
 
         @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-            "http://(low|no)$"
+            "https://(low|no)$"
         ))
         class LowPriority(EmptyPlugin):
             pass
 
         @pluginmatcher(priority=NO_PRIORITY, pattern=re.compile(
-            "http://(no)$"
+            "https://(no)$"
         ))
         class NoPriority(EmptyPlugin):
             pass
@@ -133,7 +156,7 @@ class TestSession(unittest.TestCase):
     @patch("streamlink.session.log")
     def test_resolve_deprecated(self, mock_log: Mock):
         @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-            "http://low"
+            "https://low"
         ))
         class LowPriority(EmptyPlugin):
             pass


### PR DESCRIPTION
Apply the https scheme to all input URLs if the scheme is missing:
- session:
  - Session.resolve_url()
  - session option `http-proxy` (`--http-proxy` CLI argument)
- plugins.akamaihd: `akamaihd://URL`
- plugins.dash: `dash://URL` or `URL.mpd`
- plugins.hds: `hds://URL` or `URL.f4m`
- plugins.hls: `hls://URL` or `URL.m3u8`
- plugins.http: `httpstream://URL`

Regular http URLs (non-https/TLS) will need to be set explicitly now.

Also
- update/fix test_session
- refactor/fix test_dash
- refactor/fix test_stream

----

Resolves #4047 
Follow-up of #4053

- **Does this introduce a breaking change?**
  This changes the way user input is handled. In almost all cases, this simply avoids the initial insecure http request when no scheme was defined, which then gets redirected by the server to a secure connection, so no breaking change here. For sites though which don't support https/TLS, setting the http scheme is now mandatory, which is the reason why I'm not sure if this is a breaking change. It probably is...
- **Does updating the `http-proxy` option make sense?**
  If we change the stream URL input, then we should change this too, IMO.
  Also, having two separate options for http and https is stupid and we should merge this at some point.