### PR TITLE
plugins.brightcove: rewrite plugin

### DIFF
--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -1,178 +1,95 @@
 import logging
-import random
 import re
-from io import BytesIO
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import urlparse
 
-from streamlink.packages.flashmedia import AMFMessage, AMFPacket
-from streamlink.packages.flashmedia.types import AMF3ObjectBase
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
-from streamlink.plugin.api import useragents, validate
+from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
-from streamlink.stream.rtmpdump import RTMPStream
+from streamlink.utils.parse import parse_qsd
 
 log = logging.getLogger(__name__)
 
 
-@AMF3ObjectBase.register("com.brightcove.experience.ViewerExperienceRequest")
-class ViewerExperienceRequest(AMF3ObjectBase):
-    def __init__(self, experienceId, URL, playerKey, deliveryType, TTLToken, contentOverrides):
-        self.experienceId = experienceId
-        self.URL = URL
-        self.playerKey = playerKey
-        self.deliveryType = deliveryType
-        self.TTLToken = TTLToken
-        self.contentOverrides = contentOverrides
-
-
-@AMF3ObjectBase.register("com.brightcove.experience.ContentOverride")
-class ContentOverride(AMF3ObjectBase):
-    def __init__(self, featuredRefId, contentRefIds, contentId, target="videoPlayer", contentIds=None,
-                 contentType=0, featuredId=float('nan'), contentRefId=None):
-        self.featuredRefId = featuredRefId
-        self.contentRefIds = contentRefIds
-        self.contentId = contentId
-        self.target = target
-        self.contentIds = contentIds
-        self.contentType = contentType
-        self.featuredId = featuredId
-        self.contentRefId = contentRefId
-
-
 class BrightcovePlayer:
-    player_page = "http://players.brightcove.net/{account_id}/{player_id}/index.html"
-    api_url = "https://edge.api.brightcove.com/playback/v1/"
-    amf_broker = "http://c.brightcove.com/services/messagebroker/amf"
-
-    policy_key_re = re.compile(r'''policyKey\s*:\s*(?P<q>['"])(?P<key>.*?)(?P=q)''')
-
-    schema = validate.Schema({
-        "sources": [{
-            validate.optional("height"): validate.any(int, None),
-            validate.optional("avg_bitrate"): validate.any(int, None),
-            validate.optional("src"): validate.url(),
-            validate.optional("app_name"): validate.any(
-                validate.url(scheme="rtmp"),
-                validate.url(scheme="rtmpe")
-            ),
-            validate.optional("stream_name"): validate.text,
-            validate.optional("type"): validate.text
-        }]
-    })
+    URL_PLAYER = "https://players.brightcove.net/{account_id}/{player_id}/index.html?videoId={video_id}"
+    URL_API = "https://edge.api.brightcove.com/playback/v1/accounts/{account_id}/videos/{video_id}"
 
     def __init__(self, session, account_id, player_id="default_default"):
         self.session = session
-        log.debug("Creating player for account {0} (player_id={1})".format(account_id, player_id))
         self.account_id = account_id
         self.player_id = player_id
-
-    def player_url(self, video_id):
-        return self.player_page.format(account_id=self.account_id,
-                                       player_id=self.player_id,
-                                       params=dict(videoId=video_id))
-
-    def video_info(self, video_id, policy_key):
-        url = "{base}accounts/{account_id}/videos/{video_id}".format(base=self.api_url,
-                                                                     account_id=self.account_id,
-                                                                     video_id=video_id)
-        res = self.session.http.get(
-            url,
-            headers={
-                "User-Agent": useragents.CHROME,
-                "Referer": self.player_url(video_id),
-                "Accept": "application/json;pk={0}".format(policy_key)
-            }
-        )
-        return self.session.http.json(res, schema=self.schema)
-
-    def policy_key(self, video_id):
-        # Get the embedded player page
-        res = self.session.http.get(self.player_url(video_id))
-
-        policy_key_m = self.policy_key_re.search(res.text)
-        policy_key = policy_key_m and policy_key_m.group("key")
-        if not policy_key:
-            raise PluginError("Could not find Brightcove policy key")
-
-        return policy_key
+        self.title = None
+        log.debug(f"Creating player for account {account_id} (player_id={player_id})")
 
     def get_streams(self, video_id):
-        log.debug("Finding streams for video: {0}".format(video_id))
-        policy_key = self.policy_key(video_id)
-        log.debug("Found policy key: {0}".format(policy_key))
-        data = self.video_info(video_id, policy_key)
-        headers = {"Referer": self.player_url(video_id)}
+        log.debug(f"Finding streams for video: {video_id}")
 
-        for source in data.get("sources"):
-            # determine quality name
-            if source.get("height"):
-                q = "{0}p".format(source.get("height"))
-            elif source.get("avg_bitrate"):
-                q = "{0}k".format(source.get("avg_bitrate") // 1000)
-            else:
-                q = "live"
-            if ((source.get("type") == "application/x-mpegURL" and source.get("src"))
-                    or (source.get("src") and ".m3u8" in source.get("src"))):
-                yield from HLSStream.parse_variant_playlist(self.session, source.get("src"), headers=headers).items()
-            elif source.get("app_name"):
-                s = RTMPStream(self.session,
-                               {"rtmp": source.get("app_name"),
-                                "playpath": source.get("stream_name")})
-                yield q, s
-            elif source.get("src") and source.get("src").endswith(".mp4"):
-                yield q, HTTPStream(self.session, source.get("src"), headers=headers)
-
-    @classmethod
-    def from_url(cls, session, url):
-        purl = urlparse(url)
-        querys = dict(parse_qsl(purl.query))
-
-        account_id, player_id, _ = purl.path.lstrip("/").split("/", 3)
-        video_id = querys.get("videoId")
-
-        bp = cls(session, account_id=account_id, player_id=player_id)
-        return bp.get_streams(video_id)
-
-    @classmethod
-    def from_player_key(cls, session, player_id, player_key, video_id, url=None):
-        amf_message = AMFMessage("com.brightcove.experience.ExperienceRuntimeFacade.getDataForExperience",
-                                 "/1",
-                                 [
-                                     ''.join(["{0:02x}".format(random.randint(0, 255)) for _ in range(20)]),  # random id
-                                     ViewerExperienceRequest(experienceId=int(player_id),
-                                                             URL=url or "",
-                                                             playerKey=player_key,
-                                                             deliveryType=float('nan'),
-                                                             TTLToken="",
-                                                             contentOverrides=[ContentOverride(
-                                                                 featuredRefId=None,
-                                                                 contentRefIds=None,
-                                                                 contentId=int(video_id)
-                                                             )])
-                                 ])
-        amf_packet = AMFPacket(version=3)
-        amf_packet.messages.append(amf_message)
-
-        res = session.http.post(
-            cls.amf_broker,
-            headers={"Content-Type": "application/x-amf"},
-            data=amf_packet.serialize(),
-            params=dict(playerKey=player_key),
-            raise_for_status=False
+        player_url = self.URL_PLAYER.format(
+            account_id=self.account_id,
+            player_id=self.player_id,
+            video_id=video_id
         )
-        data = AMFPacket.deserialize(BytesIO(res.content))
-        result = data.messages[0].value
-        bp = cls(session=session, account_id=int(result.publisherId))
-        return bp.get_streams(video_id)
+
+        policy_key = self.session.http.get(
+            player_url,
+            params={"videoId": video_id},
+            schema=validate.Schema(
+                validate.transform(re.compile(r"""policyKey\s*:\s*(?P<q>['"])(?P<key>[\w-]+)(?P=q)""").search),
+                validate.any(None, validate.get("key"))
+            )
+        )
+        if not policy_key:
+            raise PluginError("Could not find Brightcove policy key")
+        log.debug(f"Found policy key: {policy_key}")
+
+        self.session.http.headers.update({"Referer": player_url})
+        sources, self.title = self.session.http.get(
+            self.URL_API.format(account_id=self.account_id, video_id=video_id),
+            headers={"Accept": f"application/json;pk={policy_key}"},
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "sources": [{
+                        "src": validate.url(),
+                        validate.optional("type"): str,
+                        validate.optional("container"): str,
+                        validate.optional("height"): int,
+                        validate.optional("avg_bitrate"): int,
+                    }],
+                    validate.optional("name"): str,
+                },
+                validate.union_get("sources", "name")
+            )
+        )
+
+        for source in sources:
+            if source.get("type") == "application/vnd.apple.mpegurl":
+                yield from HLSStream.parse_variant_playlist(self.session, source.get("src")).items()
+
+            elif source.get("container") == "MP4":
+                # determine quality name
+                if source.get("height"):
+                    q = f"{source.get('height')}p"
+                elif source.get("avg_bitrate"):
+                    q = f"{source.get('avg_bitrate') // 1000}k"
+                else:
+                    q = "live"
+
+                yield q, HTTPStream(self.session, source.get("src"))
 
 
 @pluginmatcher(re.compile(
-    r"https?://players\.brightcove\.net/.*?/index\.html"
+    r"https?://players\.brightcove\.net/(?P<account_id>[^/]+)/(?P<player_id>[^/]+)/index\.html"
 ))
 class Brightcove(Plugin):
     def _get_streams(self):
-        return BrightcovePlayer.from_url(self.session, self.url)
+        video_id = parse_qsd(urlparse(self.url).query).get("videoId")
+        player = BrightcovePlayer(self.session, self.match.group("account_id"), self.match.group("player_id"))
+        streams = dict(player.get_streams(video_id))
+        self.title = player.title
+
+        return streams
 
 
 __plugin__ = Brightcove

--- a/tests/plugins/test_brightcove.py
+++ b/tests/plugins/test_brightcove.py
@@ -6,6 +6,6 @@ class TestPluginCanHandleUrlBrightcove(PluginCanHandleUrl):
     __plugin__ = Brightcove
 
     should_match = [
-        'http://players.brightcove.net/123/default_default/index.html?videoId=456',
-        'http://players.brightcove.net/456/default_default/index.html?videoId=789',
+        "https://players.brightcove.net/123/default_default/index.html?videoId=456",
+        "https://players.brightcove.net/456/default_default/index.html?videoId=789",
     ]


### PR DESCRIPTION
- remove RTMP + flashmedia imports
- refactor `BrightcovePlayer` class
  - remove `from_url` and `from_player_key` class methods
  - simplify `get_streams`
  - update validation schemas
- update plugin URL matcher

----

ref #4040 

These changes do not affect the functionality of the BFMTV plugin, which is the only one currently importing the `BrightcovePlayer` class. Technically, this is a breaking change for custom plugin implementations (removal of the static class methods), but that doesn't matter, since it's not a stable API Streamlink provides.

I've only tested streams on the brightcove player page from BFMTV, but that should cover all the stream types which this plugin supports, namely HLS and MP4 VOD (httpstream).

----

HLS
```
$ streamlink -l debug --title '{title}' 'https://players.brightcove.net/876450610001/gJegCNYHm_default/index.html?videoId=5615950982001' best
[cli][debug] OS:         Linux-5.14.8-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.7
[cli][debug] Streamlink: 2.4.0+37.gf5a996a
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://players.brightcove.net/876450610001/gJegCNYHm_default/index.html?videoId=5615950982001
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --title={title}
[cli][info] Found matching plugin brightcove for URL https://players.brightcove.net/876450610001/gJegCNYHm_default/index.html?videoId=5615950982001
[plugins.brightcove][debug] Creating player for account 876450610001 (player_id=gJegCNYHm_default)
[plugins.brightcove][debug] Finding streams for video: 5615950982001
[plugins.brightcove][debug] Found policy key: BCpkADawqM1mYQgRZ1bxuC1RqjjVAz6C5FCwu-68h_fyxNd0Ib4DDhZVlqC94kInbBuHvqkHQku1mZ5cRoyB3ISThApOKNpQX3iRai4hfGNbXfMhEr_FvqmfDHw
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 270p (worst), 360p, 540p (best)
[cli][info] Opening stream: 540p (hls)
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 0; Last Sequence: 1
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 0; End Sequence: None
[stream.hls][debug] Adding segment 0 to queue
[stream.hls][debug] Adding segment 1 to queue
[cli][info] Starting player: mpv
[cli.output][debug] Opening subprocess: mpv "--force-media-title=le direct BFMTV WEB" -
```

HTTP/MP4
```
$ streamlink -l debug --title '{title}' 'https://players.brightcove.net/6093072304001/Ff8ZOjI1z_default/index.html?videoId=6275508909001' best
[cli][debug] OS:         Linux-5.14.8-1-git-x86_64-with-glibc2.33
[cli][debug] Python:     3.9.7
[cli][debug] Streamlink: 2.4.0+37.gf5a996a
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(0.58.0)
[cli][debug] Arguments:
[cli][debug]  url=https://players.brightcove.net/6093072304001/Ff8ZOjI1z_default/index.html?videoId=6275508909001
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --title={title}
[cli][info] Found matching plugin brightcove for URL https://players.brightcove.net/6093072304001/Ff8ZOjI1z_default/index.html?videoId=6275508909001
[plugins.brightcove][debug] Creating player for account 6093072304001 (player_id=Ff8ZOjI1z_default)
[plugins.brightcove][debug] Finding streams for video: 6275508909001
[plugins.brightcove][debug] Found policy key: BCpkADawqM3YTg3UJqzUZ_UrCd_LBNfHkj9mNxf7c1s8WPXVq4gndIjsdor9YUfk_Ra-MrCOdhIBhSLx4dvlEzuZ-m4tdW_MNUoaVWTst3PgqXzNU77dL6mNt9ib53_-ZSbVwDxeLTUAoEyA
[cli][info] Available streams: 720p (worst, best)
[cli][info] Opening stream: 720p (http)
[cli][debug] Pre-buffering 8192 bytes
[cli][info] Starting player: mpv
[cli.output][debug] Opening subprocess: mpv "--force-media-title=Lille: début des travaux sur la ligne 1" -
[cli][debug] Writing stream to output
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```