### PR TITLE
utils.parse: fix ignore_ns in parse_xml

### DIFF
--- a/src/streamlink/utils/parse.py
+++ b/src/streamlink/utils/parse.py
@@ -76,7 +76,7 @@ def parse_xml(
     if isinstance(data, str):
         data = bytes(data, "utf8")
     if ignore_ns:
-        data = re.sub(br"[\t ]xmlns=\"(.+?)\"", b"", data)
+        data = re.sub(br"\s+xmlns=\"(.+?)\"", b"", data)
     if invalid_char_entities:
         data = re.sub(br"&(?!(?:#(?:[0-9]+|[Xx][0-9A-Fa-f]+)|[A-Za-z0-9]+);)", b"&amp;", data)
 

--- a/tests/utils/test_parse.py
+++ b/tests/utils/test_parse.py
@@ -29,9 +29,11 @@ class TestUtilsParse(unittest.TestCase):
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 
-    def test_parse_xml_ns_ignore_tab(self):
-        expected = Element("test", {"foo": "bar"})
         actual = parse_xml("""<test	foo="bar"	xmlns="foo:bar"/>""", ignore_ns=True)
+        self.assertEqual(expected.tag, actual.tag)
+        self.assertEqual(expected.attrib, actual.attrib)
+
+        actual = parse_xml("""<test\nfoo="bar"\nxmlns="foo:bar"/>""", ignore_ns=True)
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
 


### PR DESCRIPTION
Fixes #4074 

What's broken is the regex for removing the namespace data, which expects a leading space or tab character, which doesn't work when a new-line or a different whitespace character is used in the serialized XML content. I've added another test for that.

There's probably a better solution for stripping default namespace information than using a dirty regex substitution, but this simple fix should work for now (and I don't want to re-implement the parse_xml method).
https://lxml.de/parsing.html#parsers