### PR TITLE
plugins.tv5monde: re-implement plugin

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -189,6 +189,8 @@ tv3cat                  ccma.cat             Yes   Yes   Streams may be geo-rest
 tv4play                 - tv4play.se         Yes   Yes   Streams may be geo-restricted to Sweden.
                                                          Only non-premium streams currently supported.
                         - fotbollskanalen.se
+tv5monde                - tv5monde.com       Yes   Yes   Streams may be geo-restricted to France, Belgium or Switzerland
+                        - tivi5mondeplus.com
 tv8                     tv8.com.tr           Yes   No
 tv360                   tv360.com.tr         Yes   No
 tv999                   tv999.bg             Yes   --    Streams are geo-restricted to Bulgaria

--- a/src/streamlink/plugins/.removed
+++ b/src/streamlink/plugins/.removed
@@ -103,7 +103,6 @@ toya
 trt
 trtspor
 tv1channel
-tv5monde
 tv8cat
 tvcatchup
 tvnbg

--- a/src/streamlink/plugins/tv5monde.py
+++ b/src/streamlink/plugins/tv5monde.py
@@ -1,0 +1,74 @@
+import re
+from urllib.parse import urlparse
+
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+from streamlink.stream.http import HTTPStream
+from streamlink.utils.url import update_scheme
+
+
+@pluginmatcher(re.compile(r"""
+    https?://(?:[\w-]+\.)*(?:tv5monde|tivi5mondeplus)\.com/
+""", re.VERBOSE))
+class TV5Monde(Plugin):
+    def _get_hls(self, root):
+        schema_live = validate.Schema(
+            validate.xml_xpath_string(".//*[contains(@data-broadcast,'m3u8')]/@data-broadcast"),
+            str,
+            validate.parse_json(),
+            validate.any(
+                validate.all({"files": list}, validate.get("files")),
+                list
+            ),
+            [{
+                "url": validate.url(path=validate.endswith(".m3u8"))
+            }],
+            validate.get((0, "url")),
+            validate.transform(lambda content_url: update_scheme("https://", content_url))
+        )
+        try:
+            live = schema_live.validate(root)
+        except PluginError:
+            return
+
+        return HLSStream.parse_variant_playlist(self.session, live)
+
+    def _get_vod(self, root):
+        schema_vod = validate.Schema(
+            validate.xml_xpath_string(".//script[@type='application/ld+json'][contains(text(),'VideoObject')][1]/text()"),
+            str,
+            validate.transform(lambda jsonlike: re.sub(r"[\r\n]+", "", jsonlike)),
+            validate.parse_json(),
+            validate.any(
+                validate.all(
+                    {"@graph": [dict]},
+                    validate.get("@graph"),
+                    validate.filter(lambda obj: obj["@type"] == "VideoObject"),
+                    validate.get(0)
+                ),
+                dict
+            ),
+            {"contentUrl": validate.url()},
+            validate.get("contentUrl"),
+            validate.transform(lambda content_url: update_scheme("https://", content_url))
+        )
+        try:
+            vod = schema_vod.validate(root)
+        except PluginError:
+            return
+
+        if urlparse(vod).path.endswith(".m3u8"):
+            return HLSStream.parse_variant_playlist(self.session, vod)
+
+        return {"vod": HTTPStream(self.session, vod)}
+
+    def _get_streams(self):
+        root = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html()
+        ))
+
+        return self._get_hls(root) or self._get_vod(root)
+
+
+__plugin__ = TV5Monde

--- a/tests/plugins/test_tv5monde.py
+++ b/tests/plugins/test_tv5monde.py
@@ -1,0 +1,16 @@
+from streamlink.plugins.tv5monde import TV5Monde
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlTV5Monde(PluginCanHandleUrl):
+    __plugin__ = TV5Monde
+
+    should_match = [
+        "http://live.tv5monde.com/fbs.html",
+        "https://www.tv5monde.com/emissions/episode/version-francaise-vf-83",
+        "https://revoir.tv5monde.com/toutes-les-videos/cinema/je-ne-reve-que-de-vous",
+        "https://revoir.tv5monde.com/toutes-les-videos/documentaires/des-russes-blancs-des-russes-blancs",
+        "https://information.tv5monde.com/video/la-diplomatie-francaise-est-elle-en-crise",
+        "https://afrique.tv5monde.com/videos/exclusivites-web/les-tutos-de-magloire/season-1/episode-1",
+        "https://www.tivi5mondeplus.com/conte-nous/episode-25",
+    ]


### PR DESCRIPTION
This re-implements the plugin after the removal in #4076 

- The main live stream is only available via http, not via https.
- tv5mondeplus uses DRM via DASH and HLS and can't be re-implemented/fixed
- all URLs added in the tests should be working, either with a French IP address or a German one (some VODs were only available via one of them)
 
@melmorabity Could you please check and verify if everything's working for you?