### PR TITLE
setup: show error on older python versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pip>=6
+pip>=9
 pytest
 pytest-cov
 coverage

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,35 @@
 #!/usr/bin/env python
 import codecs
+import sys
 from os import environ, path
 from sys import argv, path as sys_path
 
 from setuptools import find_packages, setup
 
 import versioneer
+
+
+CURRENT_PYTHON = sys.version_info[:2]
+REQUIRED_PYTHON = (3, 6)
+
+# This check and everything above must remain compatible with older Python versions
+if CURRENT_PYTHON < REQUIRED_PYTHON:
+    # noinspection PyStringFormat
+    sys.exit(
+        """
+========================================================
+               Unsupported Python version
+========================================================
+This version of Streamlink requires at least Python {}.{},
+but you're trying to install it on Python {}.{}.
+
+This may be because you are using a version of pip that
+doesn't understand the python_requires classifier.
+Make sure you have pip >= 9.0 and setuptools >= 24.2
+        """
+        .strip(" \n")
+        .format(*(REQUIRED_PYTHON + CURRENT_PYTHON))
+    )
 
 
 data_files = []


### PR DESCRIPTION
Show an error message when the python_requires classifier of the
package gets ignored, so that users can't accidentally install
an incompatible version of Streamlink with their unsupported
Python version / environment.

Also bump the required version of pip to >=9 in dev-requirements.

----

I've seen this too many times now. We should add a check to setup.py which prevents installs of Streamlink in incompatible python environments when the python_requires package classifier gets ignored (eg. on older pip versions).

Copied from here and modified / reworded:
https://github.com/urllib3/urllib3/blob/327f871f5dc2dcb47d5a7eb17108fbafdabd3333/setup.py#L10-L35

----

I would also prefer having a clean `setup.cfg` with declarative package information instead of having package information defined programmatically in `setup.py`. That's a different issue though. Also a bit confusing for me since I don't know much of the history of python package management. It's pretty messy and everyone's doing their own thing (which the community is trying to change from what it looks like).
https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
