### PR TITLE
cli: refactor FileOutput and Formatter

### DIFF
--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,12 +1,13 @@
 import os
 import sys
 from pathlib import Path
+from typing import BinaryIO
 
 
 is_darwin = sys.platform == "darwin"
 is_win32 = os.name == "nt"
 
-stdout = sys.stdout.buffer
+stdout: BinaryIO = sys.stdout.buffer
 
 
 class DeprecatedPath(type(Path())):

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -67,22 +67,22 @@ def get_formatter(plugin: Plugin):
     )
 
 
-def check_file_output(filename, force):
+def check_file_output(path: Path, force):
     """Checks if file already exists and ask the user if it should
     be overwritten if it does."""
 
     log.debug("Checking file output")
 
-    if os.path.isfile(filename) and not force:
+    if path.is_file() and not force:
         if sys.stdin.isatty():
-            answer = console.ask(f"File {filename} already exists! Overwrite it? [y/N] ")
+            answer = console.ask(f"File {path} already exists! Overwrite it? [y/N] ")
             if answer.lower() != "y":
                 sys.exit()
         else:
-            log.error(f"File {filename} already exists, use --force to overwrite it.")
+            log.error(f"File {path} already exists, use --force to overwrite it.")
             sys.exit()
 
-    return FileOutput(filename)
+    return FileOutput(path)
 
 
 def create_output(formatter: Formatter):
@@ -103,11 +103,11 @@ def create_output(formatter: Formatter):
         if args.output == "-":
             out = FileOutput(fd=stdout)
         else:
-            out = check_file_output(formatter.filename(args.output, args.fs_safe_rules), args.force)
+            out = check_file_output(formatter.path(args.output, args.fs_safe_rules), args.force)
     elif args.stdout:
         out = FileOutput(fd=stdout)
     elif args.record_and_pipe:
-        record = check_file_output(formatter.filename(args.record_and_pipe, args.fs_safe_rules), args.force)
+        record = check_file_output(formatter.path(args.record_and_pipe, args.fs_safe_rules), args.force)
         out = FileOutput(fd=stdout, record=record)
     else:
         http = namedpipe = record = None
@@ -126,7 +126,7 @@ def create_output(formatter: Formatter):
             http = create_http_server()
 
         if args.record:
-            record = check_file_output(formatter.filename(args.record, args.fs_safe_rules), args.force)
+            record = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
 
         log.info(f"Starting player: {args.player}")
 

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -4,7 +4,9 @@ import re
 import shlex
 import subprocess
 import sys
+from pathlib import Path
 from time import sleep
+from typing import BinaryIO, Optional
 
 from streamlink_cli.compat import is_win32, stdout
 from streamlink_cli.constants import PLAYER_ARGS_INPUT_DEFAULT, PLAYER_ARGS_INPUT_FALLBACK, SUPPORTED_PLAYERS
@@ -47,7 +49,12 @@ class Output:
 
 
 class FileOutput(Output):
-    def __init__(self, filename=None, fd=None, record=None):
+    def __init__(
+        self,
+        filename: Optional[Path] = None,
+        fd: Optional[BinaryIO] = None,
+        record: Optional["FileOutput"] = None
+    ):
         super().__init__()
         self.filename = filename
         self.fd = fd
@@ -55,6 +62,7 @@ class FileOutput(Output):
 
     def _open(self):
         if self.filename:
+            self.filename.parent.mkdir(parents=True, exist_ok=True)
             self.fd = open(self.filename, "wb")
 
         if self.record:

--- a/src/streamlink_cli/utils/formatter.py
+++ b/src/streamlink_cli/utils/formatter.py
@@ -1,12 +1,19 @@
+from pathlib import Path
 from typing import Dict, Optional
 
 from streamlink.utils.formatter import Formatter as _BaseFormatter
-from streamlink_cli.utils.path import replace_chars
+from streamlink_cli.utils.path import replace_chars, replace_path
 
 
 class Formatter(_BaseFormatter):
-    def filename(self, filename: str, charmap: Optional[str] = None) -> str:
-        return self._format(filename, lambda s: replace_chars(s, charmap), {})
+    def path(self, pathlike: str, charmap: Optional[str] = None) -> Path:
+        def mapper(s):
+            return replace_chars(s, charmap)
+
+        def format_part(part):
+            return self._format(part, mapper, {})
+
+        return replace_path(pathlike, format_part)
 
     def title(self, title: str, defaults: Optional[Dict[str, str]] = None) -> str:
         return self.format(title, defaults)

--- a/tests/test_cli_utils_path.py
+++ b/tests/test_cli_utils_path.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 import pytest
 
-from streamlink_cli.utils.path import replace_chars
+from streamlink_cli.utils.path import replace_chars, replace_path
 from tests import posix_only, windows_only
 
 
@@ -53,3 +55,12 @@ def test_replace_chars_windows_override():
 
 def test_replace_chars_replacement():
     assert replace_chars("\x00", None, "+") == "+"
+
+
+def test_replace_path():
+    def mapper(s):
+        return dict(foo=".", bar="..").get(s, s)
+
+    path = Path("foo", ".", "bar", "..", "baz")
+    expected = Path("_", ".", "_", "..", "baz")
+    assert replace_path(path, mapper) == expected, "Only replaces mapped parts which are in the special parts tuple"


### PR DESCRIPTION
- add streamlink_cli.utils.path.replace_path
- refactor streamlink_cli.utils.formatter.Formatter
  - rename filename() to path() and return a pathlib.Path object
  - format path parts separately
  - replace dot and double-dot path parts if not explicit user input
  - replace unsupported chars in path parts (like before)
- refactor streamlink_cli.output.FileOutput
  - turn filename into a Path object
  - create parent directories before creating the file descriptor
- update streamlink_cli.main accordingly
- update and add new tests

----

resolves #4081 

```
$ streamlink -o '{author}/{category}/{title}.ts' twitch.tv/dota2ti best
[cli][info] Found matching plugin twitch for URL twitch.tv/dota2ti
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] Waiting for pre-roll ads to finish, be patient
[stream.hls][info] Filtering out segments and pausing stream output                                                                     [stream.hls][info] Resuming stream output
[download][.. - Group Stage Day 4.ts] Written 8.0 MB (9s @ 839.8 KB/s)                                                                          ^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...

$ ls dota2ti/Dota\ 2/Dota\ 2\ The\ International\ -\ Group\ Stage\ Day\ 4.ts 
'dota2ti/Dota 2/Dota 2 The International - Group Stage Day 4.ts'
```