### PR TITLE
plugins.facebook: update onion address

### DIFF
--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -12,9 +12,11 @@ from streamlink.utils.parse import parse_json
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(re.compile(
-    r"https?://(?:www\.)?facebook(?:\.com|corewwwi\.onion)/[^/]+/(?:posts|videos)/(?P<video_id>\d+)"
-))
+@pluginmatcher(re.compile(r"""
+    https?://(?:www\.)?facebook
+    (?:\.com|wkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd\.onion)
+    /[^/]+/(?:posts|videos)/(?P<video_id>\d+)
+""", re.VERBOSE))
 class Facebook(Plugin):
     _src_re = re.compile(r'''(sd|hd)_src["']?\s*:\s*(?P<quote>["'])(?P<url>.+?)(?P=quote)''')
     _dash_manifest_re = re.compile(r'''dash_manifest["']?\s*:\s*["'](?P<manifest>.+?)["'],''')

--- a/tests/plugins/test_facebook.py
+++ b/tests/plugins/test_facebook.py
@@ -10,7 +10,7 @@ class TestPluginCanHandleUrlFacebook(PluginCanHandleUrl):
         "https://www.facebook.com/nytfood/videos/1485091228202006/",
         "https://www.facebook.com/SporTurkTR/videos/798553173631138/",
         "https://www.facebook.com/119555411802156/posts/500665313691162/",
-        "https://www.facebookcorewwwi.onion/SporTurkTR/videos/798553173631138/",
+        "https://www.facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/SporTurkTR/videos/798553173631138/",
     ]
 
     should_not_match = [


### PR DESCRIPTION
*In May 2021 it updated to an onion version 3 address at facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion.[1][2] This was due to the Tor Project's planned July 2021 deprecation of v2 addresses due to their inherent crackability by modern hardware that did not exist at the time of their introduction (many private keys are known to equal the same v2 address).[15]*

https://en.wikipedia.org/wiki/Facebook_onion_address

The v2 address still resolves to a Facebook page, but with a message and link indicating the new v3 address.  There is no redirect from the v2 to v3 address.
```
$ streamlink --https-proxy socks5h://localhost:9050 'https://www.facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/facebook/videos/1139465686465078'
[cli][info] Found matching plugin facebook for URL https://www.facebookwkhpilnemxj7asaniu7vnjjbiltxjqhye3mhbshg7kx5tfyd.onion/facebook/videos/1139465686465078
Available streams: vod (worst, best)
```
