### PR TITLE
ci.github: switch to codecov-action@v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           name: os:${{ matrix.os }} py:${{ matrix.python }}
 


### PR DESCRIPTION
https://github.com/codecov/codecov-action/tree/v2#%EF%B8%8F--deprecration-of-v1

TL;DR
The codecov uploader was previously a bash script, and the GH action was just a node wrapper for that bash script. v2 of the action uses a rewrite of the uploader script written in NodeJS (probably because of their hack earlier this year). v1 is now considered deprecated and will be dropped in February 2022. No other changed we're affected by AFAICT.