### PR TITLE
plugins.tviplayer: new plugin

### DIFF
--- a/src/streamlink/plugins/tviplayer.py
+++ b/src/streamlink/plugins/tviplayer.py
@@ -1,0 +1,59 @@
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import useragents, validate
+from streamlink.stream.hls import HLSStream
+
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
+
+
+@pluginmatcher(re.compile(  # Live
+    r'https://tviplayer.iol.pt/direto/(?P<channel>\w+)'
+))
+@pluginmatcher(re.compile(  # Episodes
+    r'https?://tviplayer.iol.pt/programa/(?P<sname>\S+)/(?P<sid>\w+)/video/(?P<eid>\w+)',
+))
+class TVIPlayer(Plugin):
+    _m3u8_re = re.compile(r'''"videoUrl":\s*"(?P<m3u8>[^"]+)"''')
+
+    _schema_token = validate.Schema(
+        validate.all(
+            str,
+            validate.any(
+                validate.length(0),
+            ),
+        ),
+    )
+    _schema_hls = validate.Schema(
+        validate.transform(lambda text: next(reversed(list(TVIPlayer._m3u8_re.finditer(text))), None)),
+        validate.all(
+            validate.get('m3u8'),
+            str,
+            validate.any(
+                validate.length(0),
+                validate.url()
+            ),
+        ),
+    )
+
+    def _get_streams(self):
+        self.session.http.headers.update({
+            "User-Agent": useragents.FIREFOX,
+            'Referer': 'https://tviplayer.iol.pt/',  # Homepage
+        })
+        # Get a wmsAuthSign
+        wmsAuthSign = self.session.http.get('https://services.iol.pt/matrix?userId=', schema=self._schema_token)
+
+        # Get the HLS
+        self.session.http.headers.update({'Referer': self.url})
+        hls_url = self.session.http.get(self.url, schema=self._schema_hls)
+        if hls_url:
+            # - Append the wmsAuthSign
+            raw_url = urlparse(hls_url)
+            qs = parse_qs(raw_url.query)
+            qs['wmsAuthSign'] = wmsAuthSign
+            new_hls_url = urlunparse(raw_url._replace(query=urlencode(qs, doseq=True)))
+            return HLSStream.parse_variant_playlist(self.session, new_hls_url)
+
+
+__plugin__ = TVIPlayer


### PR DESCRIPTION
This is really only the first pass, but it works.

I couldn't fully understand the schema stuff, so I did it in the oldschool imperative way below.

There are no tests yet, here is an example:

URL: https://tviplayer.iol.pt/programa/o-bairro/53c6b3b73004dc006243db2b/video/5ba580900cf282952f047ac9

Output (
[example1.txt](https://github.com/streamlink/streamlink/files/7360633/example1.txt)
):
```
jsonData = {"duration":2653,"cover":"https://www.iol.pt/multimedia/oratvi/multimedia/imagem/id/5bbe3c700cf2be35e247d2db/","videoUrl":"https://streaming-vod3.iol.pt/vod/_definst_/7/a/c/9/smil:5ba580900cf282952f047ac9-L/playlist.m3u8","videoType":"Clip","liveType":"VOD","description":"","id":"5ba580900cf282952f047ac9","program":{"name":"O Bairro","epNum":"Sem Episódio","season":"5be06fc00cf2223b6a7aec23","id":"53c6b3b73004dc006243db2b","ep":"Sem Episódio","seasonNum":1},"title":"Episódio 1"};
                                    head.ready(function () {
                                        var pub = '/130294768/tviplayer/web/bairro/video/VIDEO';
                                        var pub_patrocinado = false ? "" : pub;
                                        $('#player').iolplayer({
                                            video: [jsonData],
                                            pub: pub_patrocinado,
                                            smartToken: "A12FFAZ7B226964436F6E746575646F223A2022354241353830393030434632383239353246303437414339222C227469706F436F6E746575646F223A2022766964656F222C22706C617461666F726D61223A2022776562222C226F726967656D223A2022747669706C61796572222C2270726F6772616D61223A202262616972726F222C22696455736572223A2022227D",
                                            autostart: false,
                                            project: "tviplayer",
                                            pageContentType: "VIDEO",
                                            videoRedirect: true,
                                            "skin": {
                                                "timeslider": {
                                                    "progress": "#fab432"
                                                }
                                            }
                                        });
                                    });
```

"`videoUrl`" has the important stuff, but we also require a token to append to that URL as query string.