### PR TITLE
setup: disable test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,15 @@ import codecs
 import sys
 from os import environ, path
 from sys import argv, path as sys_path
+from textwrap import dedent
 
 from setuptools import find_packages, setup
 
 import versioneer
+
+
+def format_msg(text, *args, **kwargs):
+    return dedent(text).strip(" \n").format(*args, **kwargs)
 
 
 CURRENT_PYTHON = sys.version_info[:2]
@@ -14,22 +19,25 @@ REQUIRED_PYTHON = (3, 6)
 
 # This check and everything above must remain compatible with older Python versions
 if CURRENT_PYTHON < REQUIRED_PYTHON:
-    # noinspection PyStringFormat
-    sys.exit(
-        """
-========================================================
-               Unsupported Python version
-========================================================
-This version of Streamlink requires at least Python {}.{},
-but you're trying to install it on Python {}.{}.
+    sys.exit(format_msg("""
+        ========================================================
+                       Unsupported Python version
+        ========================================================
+        This version of Streamlink requires at least Python {}.{},
+        but you're trying to install it on Python {}.{}.
 
-This may be because you are using a version of pip that
-doesn't understand the python_requires classifier.
-Make sure you have pip >= 9.0 and setuptools >= 24.2
-        """
-        .strip(" \n")
-        .format(*(REQUIRED_PYTHON + CURRENT_PYTHON))
-    )
+        This may be because you are using a version of pip that
+        doesn't understand the python_requires classifier.
+        Make sure you have pip >= 9.0 and setuptools >= 24.2
+    """, *(REQUIRED_PYTHON + CURRENT_PYTHON)))
+
+# Explicitly disable running tests via setuptools
+if "test" in sys.argv:
+    sys.exit(format_msg("""
+        Running `python setup.py test` has been deprecated since setuptools 41.5.0.
+        Streamlink requires pytest for collecting and running tests, via one of these commands:
+        `pytest` or `python -m pytest` (see the pytest docs for more infos about this)
+    """))
 
 
 data_files = []


### PR DESCRIPTION
See #4102
Let's keep that issue thread open though, so that package maintainers who are running tests incorrectly in their package configs can see it.

1. Is there a better way to disable this other than checking `"test" in sys.argv`?
2. Is the error message worded well enough? We could also add links to the respective docs for example.

----

- https://setuptools.pypa.io/en/stable/userguide/commands.html#test-build-package-and-run-a-unittest-suite
- https://github.com/pytest-dev/pytest-runner/
- https://docs.pytest.org/en/6.2.x/pythonpath.html#invoking-pytest-versus-python-m-pytest