### PR TITLE
plugins.twitch: remove device-id headers

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -187,8 +187,6 @@ class UsherService:
 class TwitchAPI:
     headers = {
         "Client-ID": "kimne78kx3ncx6brgo4mv6wki5h1ko",
-        "Device-ID": "twitch-web-wall-mason",
-        "X-Device-Id": "twitch-web-wall-mason",
     }
 
     def __init__(self, session):


### PR DESCRIPTION
#4086 

`twitch-web-wall-mason` device-id headers are causing midroll ads now, which is bad for Streamlink's output.

The regular preroll ads may be annoying, but at least filtering out those via `--twitch-disable-ads` works without causing any issues.