### PR TITLE
setup: switch to declarative package metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,49 @@
 [metadata]
-license_file = LICENSE
+name = streamlink
+author = Streamlink
+author_email = streamlink@protonmail.com
+description = Streamlink is a command-line utility that extracts streams from various services and pipes them into a video player of choice.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/streamlink/streamlink
+project_urls =
+  Documentation = https://streamlink.github.io/
+  Tracker = https://github.com/streamlink/streamlink/issues
+  Source = https://github.com/streamlink/streamlink
+  Funding = https://opencollective.com/streamlink
+license = Simplified BSD
+license_files = LICENSE
+classifiers =
+  Development Status :: 5 - Production/Stable
+  License :: OSI Approved :: BSD License
+  Environment :: Console
+  Intended Audience :: End Users/Desktop
+  Operating System :: POSIX
+  Operating System :: MacOS
+  Operating System :: Microsoft :: Windows
+  Programming Language :: Python :: 3
+  Programming Language :: Python :: 3 :: Only
+  Programming Language :: Python :: 3.6
+  Programming Language :: Python :: 3.7
+  Programming Language :: Python :: 3.8
+  Programming Language :: Python :: 3.9
+  Topic :: Internet :: WWW/HTTP
+  Topic :: Multimedia :: Sound/Audio
+  Topic :: Multimedia :: Video
+  Topic :: Utilities
+
+[options]
+python_requires = >=3.6, <4
+package_dir =
+  =src
+packages = find:
+
+[options.packages.find]
+where = src
+
+[options.package_data]
+streamlink.plugins =
+  .removed
 
 [versioneer]
 VCS = git

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
-import codecs
-import sys
 from os import environ, path
-from sys import argv, path as sys_path
+from sys import argv, exit, version_info
 from textwrap import dedent
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 import versioneer
 
@@ -14,12 +12,12 @@ def format_msg(text, *args, **kwargs):
     return dedent(text).strip(" \n").format(*args, **kwargs)
 
 
-CURRENT_PYTHON = sys.version_info[:2]
+CURRENT_PYTHON = version_info[:2]
 REQUIRED_PYTHON = (3, 6)
 
 # This check and everything above must remain compatible with older Python versions
 if CURRENT_PYTHON < REQUIRED_PYTHON:
-    sys.exit(format_msg("""
+    exit(format_msg("""
         ========================================================
                        Unsupported Python version
         ========================================================
@@ -32,15 +30,14 @@ if CURRENT_PYTHON < REQUIRED_PYTHON:
     """, *(REQUIRED_PYTHON + CURRENT_PYTHON)))
 
 # Explicitly disable running tests via setuptools
-if "test" in sys.argv:
-    sys.exit(format_msg("""
+if "test" in argv:
+    exit(format_msg("""
         Running `python setup.py test` has been deprecated since setuptools 41.5.0.
         Streamlink requires pytest for collecting and running tests, via one of these commands:
         `pytest` or `python -m pytest` (see the pytest docs for more infos about this)
     """))
 
 
-data_files = []
 deps = [
     "requests>=2.26.0,<3.0",
     "isodate",
@@ -69,13 +66,6 @@ else:
 if environ.get("NO_DEPS"):
     deps = []
 
-this_directory = path.abspath(path.dirname(__file__))
-srcdir = path.join(this_directory, "src/")
-sys_path.insert(0, srcdir)
-
-with codecs.open(path.join(this_directory, "README.md"), 'r', "utf8") as f:
-    long_description = f.read()
-
 
 def is_wheel_for_windows():
     if "bdist_wheel" in argv:
@@ -98,7 +88,7 @@ if is_wheel_for_windows():
 
 
 # optional data files
-additional_files = [
+data_files = [
     # shell completions
     #  requires pre-built completion files via shtab (dev-requirements.txt)
     #  `./script/build-shell-completions.sh`
@@ -109,57 +99,16 @@ additional_files = [
     #  `make --directory=docs clean man`
     ("share/man/man1", ["docs/_build/man/streamlink.1"])
 ]
-
-for destdir, srcfiles in additional_files:
-    files = []
-    for srcfile in srcfiles:
-        if path.exists(srcfile):
-            files.append(srcfile)
-    if files:
-        data_files.append((destdir, files))
+data_files = [
+    (destdir, [file for file in srcfiles if path.exists(file)])
+    for destdir, srcfiles in data_files
+]
 
 
-setup(name="streamlink",
-      version=versioneer.get_version(),
-      cmdclass=versioneer.get_cmdclass(),
-      description="Streamlink is a command-line utility that extracts streams "
-                  "from various services and pipes them into a video player of "
-                  "choice.",
-      long_description=long_description,
-      long_description_content_type="text/markdown",
-      url="https://github.com/streamlink/streamlink",
-      project_urls={
-          "Documentation": "https://streamlink.github.io/",
-          "Tracker": "https://github.com/streamlink/streamlink/issues",
-          "Source": "https://github.com/streamlink/streamlink",
-          "Funding": "https://opencollective.com/streamlink"
-      },
-      author="Streamlink",
-      # temp until we have a mailing list / global email
-      author_email="streamlink@protonmail.com",
-      license="Simplified BSD",
-      packages=find_packages("src"),
-      package_dir={"": "src"},
-      package_data={"streamlink.plugins": [".removed"]},
-      entry_points=entry_points,
-      data_files=data_files,
-      install_requires=deps,
-      test_suite="tests",
-      python_requires=">=3.6, <4",
-      classifiers=["Development Status :: 5 - Production/Stable",
-                   "License :: OSI Approved :: BSD License",
-                   "Environment :: Console",
-                   "Intended Audience :: End Users/Desktop",
-                   "Operating System :: POSIX",
-                   "Operating System :: Microsoft :: Windows",
-                   "Operating System :: MacOS",
-                   "Programming Language :: Python :: 3",
-                   "Programming Language :: Python :: 3 :: Only",
-                   "Programming Language :: Python :: 3.6",
-                   "Programming Language :: Python :: 3.7",
-                   "Programming Language :: Python :: 3.8",
-                   "Programming Language :: Python :: 3.9",
-                   "Topic :: Internet :: WWW/HTTP",
-                   "Topic :: Multimedia :: Sound/Audio",
-                   "Topic :: Multimedia :: Video",
-                   "Topic :: Utilities"])
+setup(
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+    install_requires=deps,
+    entry_points=entry_points,
+    data_files=data_files,
+)


### PR DESCRIPTION
- move static package metadata to setup.cfg
- rename deprecated license_file field to license_files

Remove setuptools arguments:
- test_suite:
  Unneeded, as we disable the deprecated setuptools test command

Keep dynamic setuptools arguments:
- version/cmdclass:
  For writing static version info via versioneer
- install_requires:
  Some dependencies still depend on special environment variables
  instead of package "extra" dependency fields
- entry_points:
  The `gui_scripts` entry point should only be set when building wheels
  for Windows via `--plat-name={win32,win-amd64,cygwin}`
- data_files:
  All data files are optional and should not cause the build to fail if
  they are missing, eg. when building from sdist

----

- https://packaging.python.org/tutorials/packaging-projects/
- https://packaging.python.org/guides/distributing-packages-using-setuptools/
- https://setuptools.pypa.io/en/latest/userguide/declarative_config.html

Static package metadata could've also been moved into pyproject.toml ([PEP 518](https://www.python.org/dev/peps/pep-0518/) / [PEP 621](https://www.python.org/dev/peps/pep-0621/)), but this [would've changed how Streamlink gets built from source by tools like pip](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/), and this causes issues with the integrated versioneer module that's required by setup.py.

----

TODO (in future PRs):

- Add the pyproject.toml file, at least with the `build-system` data, as it defines setuptools as build tool, which is currently only implied as a default.
  I had already added it but then ran into issues with installing in develop mode (pip install -e) because it couldn't import versioneer.
- Define [optional dependencies as `extras_require`](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies) instead of using env vars in setup.py
- Remove the `NO_DEPS` env var, as it's unused

----

Some quick checks:

### `python setup.py --version`

- outputs correct version (required by `script/build-and-sign.sh`)

### `python setup.py build`

- writes built project files (into `build/lib`)
- writes `streamlink/plugins/.removed` (via options.package_data)
- bakes version info via versioneer

### `python setup.py sdist`

- includes correct source tree
- includes correct metadata and entry_points in embedded egg-info
- includes `streamlink/plugins/.removed` (via MANIFEST.in)
- bakes version info via versioneer

### `python setup.py bdist_wheel`

- includes built project files
- includes correct metadata and entry_points (Windows wheels also have the gui_scripts entry point)
- includes `streamlink/plugins/.removed` (via options.package_data)
- includes optional data files (shell completions and man pages)
- bakes version info via versioneer

### `python setup.py install`

- writes built project files
- writes correct metadata and entry_points in egg-info directory
- writes `streamlink/plugins/.removed` (via options.package_data)
- writes optional data files (shell completions and man pages)
- bakes version info via versioneer

### `python setup.py develop` / `pip install -e .`

- works

### `./script/makeinstaller.sh`

- builds but didn't test it yet
- writes `streamlink/plugins/.removed` (via options.package_data)

----

Please don't merge unless carefully reviewed, as I might have missed something...