### PR TITLE
setup: remove NO_DEPS env var

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,6 @@ else:
     deps.append("iso-639")
     deps.append("iso3166")
 
-# When we build an egg for the Win32 bootstrap we don"t want dependency
-# information built into it.
-if environ.get("NO_DEPS"):
-    deps = []
-
 
 def is_wheel_for_windows():
     if "bdist_wheel" in argv:


### PR DESCRIPTION
Added by 080c1635 8 years ago.
https://github.com/streamlink/streamlink/blame/42ca168b27a71bba9812f6909923acaebbe5e1a1/setup.py#L64-L67

This was meant for the Windows installer which was based on the `bdist_egg` egg distribution back then. Totally outdated nowadays and the installer was rewritten after the fork anyway.

`NO_DEPS` is not needed when building Streamlink via setuptools' `build`/`install` commands, and nobody will use it for building sdist/bdist_wheel without any dependencies defined, so it can be removed safely.