### PR TITLE
cli: remove the https-proxy option in favour of a single http-proxy option

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -367,10 +367,11 @@ Progressive HTTP, HTTPS, etc   httpstream:// [1]_
 Proxy Support
 -------------
 
-You can use the :option:`--http-proxy` or :option:`--https-proxy` options to
-change the proxy server that Streamlink will use for HTTP and HTTPS requests respectively.
-For convenience reasons, :option:`--http-proxy` will automatically set the
-value of :option:`--https-proxy` as well, if it has not been set by the user.
+You can use the :option:`--http-proxy` option to change the proxy server
+that Streamlink will use for HTTP and HTTPS requests. :option:`--http-proxy` sets
+the proxy for all HTTP and HTTPS requests, including WebSocket connections.
+If separate proxies for each protocol are required, they can be set using
+environment variables - see `Requests Proxies Documentation`_
 
 Both HTTP and SOCKS proxies are supported, as well as authentication in each of them.
 
@@ -381,8 +382,10 @@ Both HTTP and SOCKS proxies are supported, as well as authentication in each of 
 
 .. code-block:: console
 
-    $ streamlink --http-proxy "http://user:pass@10.10.1.10:3128/" --https-proxy "socks5://10.10.1.10:1242"
-    $ streamlink --http-proxy "socks4a://10.10.1.10:1235" --https-proxy "socks5h://10.10.1.10:1234"
+    $ streamlink --http-proxy "http://address:port"
+    $ streamlink --http-proxy "https://address:port"
+    $ streamlink --http-proxy "socks4a://address:port"
+    $ streamlink --http-proxy "socks5h://address:port"
 
 
 Command-line usage
@@ -396,3 +399,5 @@ Command-line usage
 .. argparse::
     :module: streamlink_cli.main
     :attr: parser_helper
+
+.. _Requests Proxies Documentation: https://2.python-requests.org/en/master/user/advanced/#proxies

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,16 @@
 Deprecations
 ============
 
+streamlink next
+---------------
+
+Removal of separate https-proxy option
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:ref:`HTTPS proxy CLI option <cli:HTTP options>` and the respective :ref:`Session options <api:Session>`
+have been deprecated in favor of a single :option:`--http-proxy` that sets the proxy for all HTTP and
+HTTPS requests, including WebSocket connections.
+
 streamlink 2.4.0
 ----------------
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -230,13 +230,11 @@ class Streamlink:
             else:
                 urllib3_connection.allowed_gai_family = allowed_gai_family
 
-        elif key == "http-proxy":
+        elif key in ("http-proxy", "https-proxy"):
             self.http.proxies["http"] = update_scheme("https://", value, force=False)
-            if "https" not in self.http.proxies:
-                self.http.proxies["https"] = update_scheme("https://", value, force=False)
-
-        elif key == "https-proxy":
-            self.http.proxies["https"] = update_scheme("https://", value, force=False)
+            self.http.proxies["https"] = self.http.proxies["http"]
+            if key == "https-proxy":
+                log.info("The https-proxy option has been deprecated in favour of a single http-proxy option")
 
         elif key == "http-cookies":
             if isinstance(value, dict):

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1162,21 +1162,12 @@ def build_parser():
         "--http-proxy",
         metavar="HTTP_PROXY",
         help="""
-        A HTTP proxy to use for all HTTP requests, including WebSocket connections.
-        By default this proxy will be used for all HTTPS requests too.
+        A HTTP proxy to use for all HTTP and HTTPS requests, including WebSocket connections.
 
         Example: "http://hostname:port/"
         """
     )
-    http.add_argument(
-        "--https-proxy",
-        metavar="HTTPS_PROXY",
-        help="""
-        A HTTPS capable proxy to use for all HTTPS requests.
-
-        Example: "https://hostname:port/"
-        """
-    )
+    http.add_argument("--https-proxy", help=argparse.SUPPRESS)
     http.add_argument(
         "--http-cookie",
         metavar="KEY=VALUE",

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -358,21 +358,21 @@ class TestSession(unittest.TestCase):
         session.set_option("http-proxy", "http://testproxy.com")
 
         self.assertEqual("http://testproxy.com", session.http.proxies['http'])
-        self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
+        self.assertEqual("http://testproxy.com", session.http.proxies['https'])
 
     def test_https_proxy_default_override(self):
         session = self.subject(load_plugins=False)
         session.set_option("http-proxy", "http://testproxy.com")
         session.set_option("https-proxy", "https://testhttpsproxy.com")
 
-        self.assertEqual("http://testproxy.com", session.http.proxies['http'])
+        self.assertEqual("https://testhttpsproxy.com", session.http.proxies['http'])
         self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
 
     def test_https_proxy_set_only(self):
         session = self.subject(load_plugins=False)
         session.set_option("https-proxy", "https://testhttpsproxy.com")
 
-        self.assertFalse("http" in session.http.proxies)
+        self.assertEqual("https://testhttpsproxy.com", session.http.proxies['http'])
         self.assertEqual("https://testhttpsproxy.com", session.http.proxies['https'])
 
     def test_http_proxy_socks(self):
@@ -386,5 +386,5 @@ class TestSession(unittest.TestCase):
         session = self.subject(load_plugins=False)
         session.set_option("https-proxy", "socks5://localhost:1234")
 
-        self.assertNotIn("http", session.http.proxies)
+        self.assertEqual("socks5://localhost:1234", session.http.proxies["http"])
         self.assertEqual("socks5://localhost:1234", session.http.proxies["https"])


### PR DESCRIPTION
I have made the `--https-proxy` command line argument in to an alias for `--http-proxy` and suppressed the help output for `--https-proxy`. `https-proxy` has been removed from the `get/set_option` methods, and it will have no effect if set. An `info` log level message is auto emitted if the `--https-proxy` option is used. 


resolves #4094