### PR TITLE
installer: bump ffmpeg to n4.4.1

### DIFF
--- a/script/makeinstaller-assets.json
+++ b/script/makeinstaller-assets.json
@@ -1,10 +1,10 @@
 [
     {
-        "url": "https://github.com/streamlink/FFmpeg-Builds/releases/download/20210826-1/ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4.zip",
-        "sha256": "38af31a76b233cf0e83645e19c6dc758f8236981533ed3427424b9fb09285d29",
-        "filename": "ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4.zip",
+        "url": "https://github.com/streamlink/FFmpeg-Builds/releases/download/20211030-1/ffmpeg-n4.4.1-win32-gpl-4.4.zip",
+        "sha256": "cb92b2ff3caf5d2169f97006c44c8e702304b09b95a0a7d7f83d48f9ee3227e7",
+        "filename": "ffmpeg-n4.4.1-win32-gpl-4.4.zip",
         "type": "zip",
-        "sourcedir": "ffmpeg-n4.4-80-gbf87bdd3f6-win32-gpl-4.4",
+        "sourcedir": "ffmpeg-n4.4.1-win32-gpl-4.4",
         "targetdir": "ffmpeg",
         "files": [
             {


### PR DESCRIPTION
This upgrades FFmpeg to the latest version n4.4.1 and it upgrades some of the build dependencies as well:
https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4.1
https://github.com/streamlink/FFmpeg-Builds/compare/20210826-1...20211030-1
https://github.com/streamlink/FFmpeg-Builds/runs/4054376109?check_suite_focus=true#step:4:12

The previous version was a random commit on the 4.4 branch (latest at that time). The main intention of publishing a new build was cleaning up a merge conflict on the FFmpeg-Builds fork.