### PR TITLE
ci.github: check for unicode bidi control chars

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Lint (line terminators)
         if: startsWith(matrix.os, 'ubuntu')
         run: "! grep 'with CRLF line terminators' <(git ls-files | file -nNf-)"
+      - name: Lint (unicode bidirectional control characters)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: "! git grep -EIn $'[\\u2066\\u2067\\u2068\\u2069\\u202A\\u202B\\u202C\\u202D\\u202E]'"
       - name: Lint (file permissions)
         if: startsWith(matrix.os, 'ubuntu')
         run: "! grep -Ev '^644' <(git ls-files src/ tests/ | xargs stat '--format=%a %n')"


### PR DESCRIPTION
[CVE-2021-42574](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-42574) has been published a couple of days ago:

> An issue was discovered in the Bidirectional Algorithm in the Unicode Specification through 14.0. It permits the visual reordering of characters via control sequences, which can be used to craft source code that renders different logic than the logical ordering of tokens ingested by compilers and interpreters. Adversaries can leverage this to encode source code for compilers accepting Unicode such that targeted vulnerabilities are introduced invisibly to human reviewers.

Even though [Github has started showing a warning](https://github.blog/changelog/2021-10-31-warning-about-bidirectional-unicode-text/) about this vulnerability ([example](https://github.com/nickboucher/trojan-source/blob/be30965b7091c14bda65c1d82f582c8733779827/Python/commenting-out.py)), there's currently no linting config here to prevent unicode bidirectional control characters from being committed and merged. Projects with lots of different contributors should take care of this. We already have similar linting configs, so let's add one for this too, because why not, it's very simple...

The explicit control characters are listed here:
- https://www.unicode.org/reports/tr9/#Directional_Formatting_Characters
- https://developer.mozilla.org/en-US/docs/Web/Guide/Unicode_Bidrectional_Text_Algorithm

The regex of the grep command matches any of these characters in all of the tracked files by git and it returns status 1 if it finds one. This project doesn't need bidirectional text, neither in plugins for certain international sites or in the docs, so adding this global linting config is fine.