### PR TITLE
vendor: bump lxml to >4.6.4,<5.0

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -9,14 +9,4 @@ python -m pip install --upgrade -r dev-requirements.txt
 python -m pip install pycountry
 # https://github.com/streamlink/streamlink/issues/4021
 python -m pip install brotli
-# temporary windows python 3.10 fix for missing 'lxml 4.6.3' wheel
-# https://github.com/streamlink/streamlink/issues/3971
-python -m pip install "https://github.com/back-to/tmp_wheel/raw/b237059b18110ca298e191340eebb6eb0aef8827/lxml-4.6.3-cp310-cp310-win_amd64.whl; \
-    '3.10' <= python_version \
-    and 'Windows' == platform_system \
-    and ('AMD64' == platform_machine or 'x86_64' == platform_machine)"
-python -m pip install "https://github.com/back-to/tmp_wheel/raw/b237059b18110ca298e191340eebb6eb0aef8827/lxml-4.6.3-cp310-cp310-win32.whl; \
-    '3.10' <= python_version \
-    and 'Windows' == platform_system \
-    and ('AMD64' != platform_machine and 'x86_64' != platform_machine)"
 python -m pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if "test" in argv:
 deps = [
     "requests>=2.26.0,<3.0",
     "isodate",
-    "lxml>=4.6.3",
+    "lxml>=4.6.4,<5.0",
     "websocket-client>=0.58.0",
     # Support for SOCKS proxies
     "PySocks!=1.5.7,>=1.5.6",


### PR DESCRIPTION
And remove the compat wheel installs on Windows for the CI runners, as
lxml 4.6.4 has fixed the missing python 3.10 wheels
https://pypi.org/project/lxml/4.6.4/#files

----

Resolves #4100 

The version requirement got bumped to ensure that everyone's up2date and will be able to find a matching wheel download, even though it's not strictly necessary. The lxml changes themselves are irrelevant for Streamlink.
https://github.com/lxml/lxml/blob/lxml-4.6.4-5/CHANGES.txt

I've also added the less than 5.0 constraint because we should do that on all dependencies, to prevent issues when breaking changes in dependencies are introduced. I will update the version of the websocket-client requirement once I'm done with my new websocket implementation. The other ones will need further review.
