### PR TITLE
setup: add Python 3.10 to classifiers list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
+  Programming Language :: Python :: 3.10
   Topic :: Internet :: WWW/HTTP
   Topic :: Multimedia :: Sound/Audio
   Topic :: Multimedia :: Video


### PR DESCRIPTION
Now that the dependency issues are resolved, let's finally add Python 3.10 to the package classifiers lists.