### PR TITLE
plugins.nicolive: add support for community urls

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -25,7 +25,7 @@ _login_url_params = {
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?P<domain>live\d*\.nicovideo\.jp)/watch/lv\d*"
+    r"https?://(?P<domain>live\d*\.nicovideo\.jp)/watch/(lv|co)\d*"
 ))
 class NicoLive(Plugin):
     arguments = PluginArguments(

--- a/tests/plugins/test_nicolive.py
+++ b/tests/plugins/test_nicolive.py
@@ -10,4 +10,6 @@ class TestPluginCanHandleUrlNicoLive(PluginCanHandleUrl):
         'http://live2.nicovideo.jp/watch/lv534562961',
         'https://live.nicovideo.jp/watch/lv534562961',
         'https://live2.nicovideo.jp/watch/lv534562961?ref=rtrec&zroute=recent',
+        'https://live.nicovideo.jp/watch/co2467009?ref=community',
+        'https://live.nicovideo.jp/watch/co2619719',
     ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

There's a special type of nicovideo livestream URL that always points to the latest livestream of a community page which is really convenient. This PR adds support for that type of URLs.