### PR TITLE
plugin.api: implement WebsocketClient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ deps = [
     "requests>=2.26.0,<3.0",
     "isodate",
     "lxml>=4.6.4,<5.0",
-    "websocket-client>=0.58.0",
+    "websocket-client>=1.2.1,<2.0",
     # Support for SOCKS proxies
     "PySocks!=1.5.7,>=1.5.6",
 ]

--- a/src/streamlink/plugin/api/websocket.py
+++ b/src/streamlink/plugin/api/websocket.py
@@ -1,0 +1,132 @@
+import json
+import logging
+from threading import Thread
+from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import unquote_plus, urlparse
+
+from websocket import ABNF, STATUS_NORMAL, WebSocketApp, enableTrace
+
+from streamlink.logger import TRACE, root as rootlogger
+from streamlink.session import Streamlink
+
+
+log = logging.getLogger(__name__)
+
+
+class WebsocketClient(Thread):
+    _id: int = 0
+
+    def __init__(
+        self,
+        session: Streamlink,
+        url: str,
+        subprotocols: Optional[List[str]] = None,
+        header: Optional[Union[List, Dict]] = None,
+        cookie: Optional[str] = None,
+        sockopt: Optional[Tuple] = None,
+        sslopt: Optional[Dict] = None,
+        host: Optional[str] = None,
+        origin: Optional[str] = None,
+        suppress_origin: bool = False,
+        ping_interval: Union[int, float] = 0,
+        ping_timeout: Optional[Union[int, float]] = None,
+        ping_payload: str = ""
+    ):
+        if rootlogger.level <= TRACE:
+            enableTrace(True, log)
+
+        if not header:
+            header = []
+        if not any(True for h in header if h.startswith("User-Agent: ")):
+            header.append(f"User-Agent: {session.http.headers['User-Agent']}")
+
+        proxy_options = {}
+        http_proxy: Optional[str] = session.get_option("http-proxy")
+        if http_proxy:
+            p = urlparse(http_proxy)
+            proxy_options["proxy_type"] = p.scheme
+            proxy_options["http_proxy_host"] = p.hostname
+            if p.port:  # pragma: no branch
+                proxy_options["http_proxy_port"] = p.port
+            if p.username:  # pragma: no branch
+                proxy_options["http_proxy_auth"] = unquote_plus(p.username), unquote_plus(p.password or "")
+
+        self.session = session
+        self.ws = WebSocketApp(
+            url=url,
+            subprotocols=subprotocols,
+            header=header,
+            cookie=cookie,
+            on_open=self.on_open,
+            on_error=self.on_error,
+            on_close=self.on_close,
+            on_ping=self.on_ping,
+            on_pong=self.on_pong,
+            on_message=self.on_message,
+            on_cont_message=self.on_cont_message,
+            on_data=self.on_data
+        )
+        self._data = dict(
+            sockopt=sockopt,
+            sslopt=sslopt,
+            host=host,
+            origin=origin,
+            suppress_origin=suppress_origin,
+            ping_interval=ping_interval,
+            ping_timeout=ping_timeout,
+            ping_payload=ping_payload,
+            **proxy_options
+        )
+
+        self._id += 1
+        super().__init__(
+            name=f"Thread-{self.__class__.__name__}-{self._id}",
+            daemon=True
+        )
+
+    def run(self) -> None:
+        self.ws.run_forever(**self._data)
+
+    # ----
+
+    def close(self, status: int = STATUS_NORMAL, reason: Union[str, bytes] = "", timeout: int = 3) -> None:
+        self.ws.close(status=status, reason=bytes(reason, encoding="utf-8"), timeout=timeout)
+        if self.is_alive():  # pragma: no branch
+            self.join()
+
+    def send(self, data: Union[str, bytes], opcode: int = ABNF.OPCODE_TEXT) -> None:
+        return self.ws.send(data, opcode)
+
+    def send_json(self, data: Any) -> None:
+        return self.send(json.dumps(data, indent=None, separators=(",", ":")))
+
+    # ----
+
+    # noinspection PyMethodMayBeStatic
+    def on_open(self, wsapp: WebSocketApp) -> None:
+        log.debug(f"Connected: {wsapp.url}")  # pragma: no cover
+
+    # noinspection PyMethodMayBeStatic
+    # noinspection PyUnusedLocal
+    def on_error(self, wsapp: WebSocketApp, error: Exception) -> None:
+        log.error(error)  # pragma: no cover
+
+    # noinspection PyMethodMayBeStatic
+    # noinspection PyUnusedLocal
+    def on_close(self, wsapp: WebSocketApp, status: int, message: str) -> None:
+        log.debug(f"Closed: {wsapp.url}")  # pragma: no cover
+
+    def on_ping(self, wsapp: WebSocketApp, data: str) -> None:
+        pass  # pragma: no cover
+
+    def on_pong(self, wsapp: WebSocketApp, data: str) -> None:
+        pass  # pragma: no cover
+
+    def on_message(self, wsapp: WebSocketApp, data: str) -> None:
+        pass  # pragma: no cover
+
+    def on_cont_message(self, wsapp: WebSocketApp, data: str, cont: Any) -> None:
+        pass  # pragma: no cover
+
+    def on_data(self, wsapp: WebSocketApp, data: str, data_type: int, cont: Any) -> None:
+        pass  # pragma: no cover

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -14,8 +14,8 @@ from streamlink.compat import is_win32
 from streamlink.exceptions import NoPluginError, PluginError
 from streamlink.logger import StreamlinkLogger
 from streamlink.options import Options
-from streamlink.plugin import Plugin, api
-from streamlink.plugin.plugin import Matcher, NORMAL_PRIORITY, NO_PRIORITY
+from streamlink.plugin.api.http_session import HTTPSession
+from streamlink.plugin.plugin import Matcher, NORMAL_PRIORITY, NO_PRIORITY, Plugin
 from streamlink.utils.l10n import Localization
 from streamlink.utils.module import load_module
 from streamlink.utils.url import update_scheme
@@ -34,7 +34,7 @@ class Streamlink:
        options and log settings."""
 
     def __init__(self, options=None):
-        self.http = api.HTTPSession()
+        self.http = HTTPSession()
         self.options = Options({
             "interface": None,
             "ipv4": False,

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -1,0 +1,124 @@
+import unittest
+from threading import Event
+from unittest.mock import Mock, call, patch
+
+from websocket import ABNF, STATUS_NORMAL
+
+from streamlink.logger import DEBUG, TRACE
+from streamlink.plugin.api.websocket import WebsocketClient
+from streamlink.session import Streamlink
+
+
+class TestWebsocketClient(unittest.TestCase):
+    def setUp(self):
+        self.session = Streamlink()
+
+    def tearDown(self):
+        self.session = None
+
+    @patch("streamlink.plugin.api.websocket.enableTrace")
+    def test_log(self, mock_enable_trace: Mock):
+        with patch("streamlink.plugin.api.websocket.rootlogger", Mock(level=DEBUG)):
+            WebsocketClient(self.session, "wss://localhost:0")
+        self.assertFalse(mock_enable_trace.called)
+
+        with patch("streamlink.plugin.api.websocket.rootlogger", Mock(level=TRACE)):
+            WebsocketClient(self.session, "wss://localhost:0")
+        self.assertTrue(mock_enable_trace.called)
+
+    def test_user_agent(self):
+        client = WebsocketClient(self.session, "wss://localhost:0")
+        self.assertEqual(client.ws.header, [
+            f"User-Agent: {self.session.http.headers['User-Agent']}"
+        ])
+
+        client = WebsocketClient(self.session, "wss://localhost:0", header=["User-Agent: foo"])
+        self.assertEqual(client.ws.header, [
+            "User-Agent: foo"
+        ])
+
+    def test_args_and_proxy(self):
+        self.session.set_option("http-proxy", "https://username:password@hostname:1234")
+        client = WebsocketClient(
+            self.session,
+            "wss://localhost:0",
+            subprotocols=["sub1", "sub2"],
+            cookie="cookie",
+            sockopt=("sockopt1", "sockopt2"),
+            sslopt={"ssloptkey": "ssloptval"},
+            host="customhost",
+            origin="customorigin",
+            suppress_origin=True,
+            ping_interval=30,
+            ping_timeout=4,
+            ping_payload="ping"
+        )
+        self.assertEqual(client.ws.url, "wss://localhost:0")
+        self.assertEqual(client.ws.subprotocols, ["sub1", "sub2"])
+        self.assertEqual(client.ws.cookie, "cookie")
+        with patch.object(client.ws, "run_forever") as mock_ws_run_forever:
+            client.start()
+            client.join(1)
+        self.assertFalse(client.is_alive())
+        self.assertEqual(mock_ws_run_forever.call_args_list, [
+            call(
+                sockopt=("sockopt1", "sockopt2"),
+                sslopt={"ssloptkey": "ssloptval"},
+                host="customhost",
+                origin="customorigin",
+                suppress_origin=True,
+                ping_interval=30,
+                ping_timeout=4,
+                ping_payload="ping",
+                proxy_type="https",
+                http_proxy_host="hostname",
+                http_proxy_port=1234,
+                http_proxy_auth=("username", "password")
+            )
+        ])
+
+    def test_handlers(self):
+        client = WebsocketClient(self.session, "wss://localhost:0")
+        self.assertEqual(client.ws.on_open, client.on_open)
+        self.assertEqual(client.ws.on_error, client.on_error)
+        self.assertEqual(client.ws.on_close, client.on_close)
+        self.assertEqual(client.ws.on_ping, client.on_ping)
+        self.assertEqual(client.ws.on_pong, client.on_pong)
+        self.assertEqual(client.ws.on_message, client.on_message)
+        self.assertEqual(client.ws.on_cont_message, client.on_cont_message)
+        self.assertEqual(client.ws.on_data, client.on_data)
+
+    def test_send(self):
+        client = WebsocketClient(self.session, "wss://localhost:0")
+        with patch.object(client, "ws") as mock_ws:
+            client.send("foo")
+            client.send(b"foo", ABNF.OPCODE_BINARY)
+            client.send_json({"foo": "bar", "baz": "qux"})
+        self.assertEqual(mock_ws.send.call_args_list, [
+            call("foo", ABNF.OPCODE_TEXT),
+            call(b"foo", ABNF.OPCODE_BINARY),
+            call("{\"foo\":\"bar\",\"baz\":\"qux\"}", ABNF.OPCODE_TEXT),
+        ])
+
+    def test_close(self):
+        class WebsocketClientSubclass(WebsocketClient):
+            running = Event()
+            status = False
+
+            def run(self):
+                self.status = self.running.wait(4)
+
+        client = WebsocketClientSubclass(self.session, "wss://localhost:0")
+        with patch.object(client.ws, "close") as mock_ws_close:
+            mock_ws_close.side_effect = lambda *_, **__: client.running.set()
+            client.start()
+            client.close(reason="foo")
+        self.assertFalse(client.is_alive())
+        self.assertTrue(client.status)
+        self.assertEqual(mock_ws_close.call_args_list, [
+            call(
+                status=STATUS_NORMAL,
+                reason=b"foo",
+                timeout=3
+            )
+        ])

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -285,12 +285,12 @@ class TestSession(unittest.TestCase):
         self.assertEqual(session.localization.language.alpha2, "en")
         self.assertEqual(session.localization.language_code, "en_US")
 
-    @patch("streamlink.session.api")
-    def test_interface(self, mock_api):
+    @patch("streamlink.session.HTTPSession")
+    def test_interface(self, mock_httpsession):
         adapter_http = Mock(poolmanager=Mock(connection_pool_kw={}))
         adapter_https = Mock(poolmanager=Mock(connection_pool_kw={}))
         adapter_foo = Mock(poolmanager=Mock(connection_pool_kw={}))
-        mock_api.HTTPSession.return_value = Mock(adapters={
+        mock_httpsession.return_value = Mock(adapters={
             "http://": adapter_http,
             "https://": adapter_https,
             "foo://": adapter_foo


### PR DESCRIPTION
- bump websocket-client requirement to >=1.2.1,<2.0
- avoid circular import by importing HTTPSession in session directly
- implement a common WebsocketClient based on the WebSocketApp API of
  websocket-client, so that plugins don't have to re-implement basic
  boilerplate code
- automatically apply User-Agent header
- automatically apply proxy settings
- set websocket log level (globally)
- add tests

----

This is a simple wrapper for `websocket-client`'s `WebSocketApp` class, which sets the HTTP header of the initialization request and which sets the HTTP proxy options from the session instance. The tests therefore don't test any actual websocket functionality, only the correct usage of the `WebSocketApp` API.

- https://websocket-client.readthedocs.io/en/latest/
- https://github.com/websocket-client/websocket-client/blob/v1.2.1/websocket/_app.py#L89

Another important change is the update of the `websocket-client` version requirement from `>=0.58.0` to `>=1.2.1,<2.0`. Their 1.0.0 release dropped support for py2, so this won't affect Streamlink, but some parameters were added between 1.0.0 and 1.2.1, so I had to bump the requirement.

----

There are three plugins which are currently implementing websockets:

- `nicolive` - via the high level `WebSocketApp` API
  Retrieves the HLS URL from the websocket connection and needs to send custom pong/keep-alive responses
  https://github.com/streamlink/streamlink/compare/bastimeyer:plugin/api/websocket...bastimeyer:plugins/nicolive/rewrite
- `twitcasting` - via high level `WebSocketApp` API
  Stream data is served via the websocket connection
  https://github.com/streamlink/streamlink/compare/bastimeyer:plugin/api/websocket...bastimeyer:plugins/twitcasting/websocket
- `ustreamtv` - via the low level `create_connection` API
  Retrieves stream segment URLs from the websocket connection

This PR does not update the plugins. I will do this in separate PRs. I've already finished nicolive (complete rewrite) and twitcasting (websocket and custom stream class replacement). ustreamtv requires a complete rewrite as well and I'm still working on it (see #4040). I'm opening this PR now because I'm quite confident that ustreamtv won't require any further changes in the `WebsocketClient`.