### PR TITLE
revert: stream.hls: remove hls-segment-stream-data option

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -126,6 +126,7 @@ class TwitchHLSStreamReader(HLSStreamReader):
         if stream.low_latency:
             live_edge = max(1, min(LOW_LATENCY_MAX_LIVE_EDGE, stream.session.options.get("hls-live-edge")))
             stream.session.options.set("hls-live-edge", live_edge)
+            stream.session.options.set("hls-segment-stream-data", True)
             log.info(f"Low latency streaming (HLS live edge: {live_edge})")
         super().__init__(stream)
 
@@ -460,8 +461,8 @@ class Twitch(Plugin):
             action="store_true",
             help=f"""
             Enables low latency streaming by prefetching HLS segments.
-            Sets --hls-live-edge to {LOW_LATENCY_MAX_LIVE_EDGE}, if it is higher.
-            Reducing it to 1 will result in the lowest latency possible, but will most likely cause buffering.
+            Sets --hls-segment-stream-data to true and --hls-live-edge to {LOW_LATENCY_MAX_LIVE_EDGE}, if it is higher.
+            Reducing --hls-live-edge to 1 will result in the lowest latency possible, but will most likely cause buffering.
 
             In order to achieve true low latency streaming during playback, the player's caching/buffering settings will
             need to be adjusted and reduced to a value as low as possible, but still high enough to not cause any buffering.

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -42,6 +42,7 @@ class Streamlink:
             "hds-live-edge": 10.0,
             "hls-live-edge": 3,
             "hls-segment-ignore-names": [],
+            "hls-segment-stream-data": False,
             "hls-playlist-reload-attempts": 3,
             "hls-playlist-reload-time": "default",
             "hls-start-offset": 0,

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -40,6 +40,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
         self.key_data = None
         self.key_uri = None
         self.key_uri_override = options.get("hls-segment-key-uri")
+        self.stream_data = options.get("hls-segment-stream-data")
 
         self.ignore_names = False
         ignore_names = {*options.get("hls-segment-ignore-names")}
@@ -127,7 +128,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
     def fetch(self, sequence: Sequence) -> Optional[Response]:
         try:
-            return self._fetch(sequence.segment, not sequence.segment.key)
+            return self._fetch(sequence.segment, self.stream_data and not sequence.segment.key)
         except StreamError as err:  # pragma: no cover
             log.error(f"Failed to fetch segment {sequence.num}: {err}")
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -910,6 +910,13 @@ def build_parser():
         """
     )
     transport_hls.add_argument(
+        "--hls-segment-stream-data",
+        action="store_true",
+        help="""
+        Immediately write segment data into output buffer while downloading.
+        """
+    )
+    transport_hls.add_argument(
         "--hls-playlist-reload-attempts",
         type=num(int, min=0),
         metavar="ATTEMPTS",
@@ -1023,7 +1030,6 @@ def build_parser():
     transport_hls.add_argument("--hls-segment-attempts", help=argparse.SUPPRESS)
     transport_hls.add_argument("--hls-segment-threads", help=argparse.SUPPRESS)
     transport_hls.add_argument("--hls-segment-timeout", help=argparse.SUPPRESS)
-    transport_hls.add_argument("--hls-segment-stream-data", action="store_true", help=argparse.SUPPRESS)
     transport_hls.add_argument("--hls-timeout", help=argparse.SUPPRESS)
 
     transport.add_argument("--http-stream-timeout", help=argparse.SUPPRESS)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -772,6 +772,9 @@ def setup_options():
 
     if args.hls_live_edge:
         streamlink.set_option("hls-live-edge", args.hls_live_edge)
+    if args.hls_segment_stream_data:
+        streamlink.set_option("hls-segment-stream-data", args.hls_segment_stream_data)
+
     if args.hls_playlist_reload_attempts:
         streamlink.set_option("hls-playlist-reload-attempts", args.hls_playlist_reload_attempts)
     if args.hls_playlist_reload_time:

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -192,6 +192,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         ], disable_ads=False, low_latency=True)
 
         self.assertEqual(2, self.session.options.get("hls-live-edge"))
+        self.assertEqual(True, self.session.options.get("hls-segment-stream-data"))
 
         self.await_write(6)
         self.assertEqual(
@@ -213,6 +214,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         ], disable_ads=False, low_latency=False)
 
         self.assertEqual(4, self.session.options.get("hls-live-edge"))
+        self.assertEqual(False, self.session.options.get("hls-segment-stream-data"))
 
         self.await_write(8)
         self.assertEqual(


### PR DESCRIPTION
This reverts commit ccdd84bf769fab57f2c99816a726e1ae1d5cf4f8

- resolve merge conflicts
- keep stream=False parameter in HLSStreamWriter.fetch_map
- keep updated help text of --twitch-low-latency

----

closes #4126
closes #4146

Let's temporarily revert ccdd84bf until a fix has been found for the segment request issues when `stream` is set to `True`.
See https://github.com/streamlink/streamlink/issues/4126#issuecomment-955822923

TL;DR
Add back the suppressed `--hls-segment-stream-data` CLI parameter (and its according session option), with default value of `False`, so that HLS segments don't get downloaded with `stream=True` by default, which is causing issues since the 2.4.0 release.