### PR TITLE
plugins.goltelevision: fix api url and update plugin url

### DIFF
--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -5,23 +5,27 @@ from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
 
+class GOLTelevisionHLSStream(HLSStream):
+    @classmethod
+    def _get_variant_playlist(cls, res):
+        res.encoding = "UTF-8"
+        return super()._get_variant_playlist(res)
+
+
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?goltelevision\.com/live"
+    r"https?://(?:www\.)?goltelevision\.com/en-directo"
 ))
 class GOLTelevision(Plugin):
-    api_url = "https://api.goltelevision.com/api/v1/media/hls/service/live"
-    api_schema = validate.Schema(validate.parse_json(), {
-        "code": 200,
-        "message": {
-            "success": {
-                "manifest": validate.url()
-            }
-        }
-    }, validate.get("message"), validate.get("success"), validate.get("manifest"))
-
     def _get_streams(self):
-        return HLSStream.parse_variant_playlist(self.session,
-                                                self.session.http.get(self.api_url, schema=self.api_schema))
+        url = self.session.http.get(
+            "https://www.goltelevision.com/api/manifest/live",
+            schema=validate.Schema(
+                validate.parse_json(),
+                {"manifest": validate.url()},
+                validate.get("manifest")
+            )
+        )
+        return GOLTelevisionHLSStream.parse_variant_playlist(self.session, url)
 
 
 __plugin__ = GOLTelevision

--- a/tests/plugins/test_goltelevision.py
+++ b/tests/plugins/test_goltelevision.py
@@ -6,8 +6,15 @@ class TestPluginCanHandleUrlEuronews(PluginCanHandleUrl):
     __plugin__ = GOLTelevision
 
     should_match = [
-        "http://www.goltelevision.com/live",
+        "http://goltelevision.com/en-directo",
+        "http://www.goltelevision.com/en-directo",
+        "https://goltelevision.com/en-directo",
+        "https://www.goltelevision.com/en-directo",
+    ]
+
+    should_not_match = [
         "http://goltelevision.com/live",
+        "http://www.goltelevision.com/live",
         "https://goltelevision.com/live",
         "https://www.goltelevision.com/live",
     ]


### PR DESCRIPTION
```
$ streamlink https://goltelevision.com/en-directo -l info
[cli][info] Found matching plugin goltelevision for URL https://goltelevision.com/en-directo
[cli][info] Available streams: 360p (worst), 480p, 576p, 720p (best)
[cli][info] Opening stream: 720p (hls-multi)
```