### PR TITLE
stream.http: fix custom method argument

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -326,14 +326,15 @@ or they will be interpreted as Python literals:
 
 .. code-block:: console
 
-    $ streamlink "httpstream://https://streamingserver/path params={'abc':123} json=['foo','bar','baz']"
+    $ streamlink "httpstream://https://streamingserver/path method=POST params={'abc':123} json=['foo','bar','baz']"
 
 .. code-block:: python
 
+    method="POST"
     params={"key": 123}
     json=["foo", "bar", "baz"]
 
-The parameters from the example above are used to make an HTTP ``GET`` request with ``abc=123`` added
+The parameters from the example above are used to make an HTTP ``POST`` request with ``abc=123`` added
 to the query string and ``["foo", "bar", "baz"]`` used as the content of the HTTP request's body (the serialized JSON data).
 
 Some parameters allow you to configure the behavior of the streaming protocol implementation directly:


### PR DESCRIPTION
As mentioned in #4169, the method parameter was not working.

I've also changed `valid_args()` and hardcoded the supported args, because `requests.Request()` and `requests.Session.request()` don't share the same set of args and some args should not be set by the user anyway.

No tests, because there are no HTTPStream tests, and I don't want to add new ones. You can check the output of `--json` instead.