### PR TITLE
setup: drop pycrypto support

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -280,49 +280,51 @@ To install Streamlink from source you will need these dependencies.
 Name                                 Notes
 ==================================== ===========================================
 `Python`_                            At least version **3.6**.
-`python-setuptools`_
+`python-setuptools`_                 At least version **42.0.0**.
 
 **Automatically installed by the setup script**
 --------------------------------------------------------------------------------
-`python-requests`_                   At least version **2.26.0**
-`pycryptodome`_                      Required to play some encrypted streams
 `iso-639`_                           Used for localization settings, provides language information
 `iso3166`_                           Used for localization settings, provides country information
-`isodate`_                           Used for MPEG-DASH streams
+`isodate`_                           Used for parsing ISO8601 strings
 `lxml`_                              Used for processing HTML and XML data
+`pycryptodome`_                      Used for decrypting encrypted streams
 `PySocks`_                           Used for SOCKS Proxies
-`websocket-client`_                  At least version **0.58.0**. (used for some plugins)
+`requests`_                          Used for making any kind of HTTP/HTTPS request
+`websocket-client`_                  Used for making websocket connections
 
 **Optional**
 --------------------------------------------------------------------------------
-`ffmpeg`_                            Required to play streams that are made up of separate
-                                     audio and video streams, eg. YouTube 1080p+
+`ffmpeg`_                            Required for `muxing`_ multiple video/audio/subtitle streams into a single output stream.
+
+                                     - DASH streams with video and audio content always have to get remuxed.
+                                     - HLS streams optionally need to get remuxed depending on the stream selection.
 ==================================== ===========================================
 
-Using pycrypto and pycountry
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Alternative dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^
 
-With these two environment variables it is possible to use `pycrypto`_ instead of
-`pycryptodome`_ and `pycountry`_ instead of `iso-639`_ and `iso3166`_.
+With this environment variable it is possible to use `pycountry`_ instead of `iso-639`_ and `iso3166`_.
 
 .. code-block:: console
 
-    $ export STREAMLINK_USE_PYCRYPTO="true"
     $ export STREAMLINK_USE_PYCOUNTRY="true"
 
 .. _Python: https://www.python.org/
-.. _python-setuptools: https://pypi.org/project/setuptools/
-.. _python-requests: https://docs.python-requests.org/en/master/
-.. _pycountry: https://pypi.org/project/pycountry/
-.. _pycrypto: https://www.dlitz.net/software/pycrypto/
-.. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
-.. _ffmpeg: https://www.ffmpeg.org/
+.. _python-setuptools: https://setuptools.pypa.io/en/latest/
+
 .. _iso-639: https://pypi.org/project/iso-639/
 .. _iso3166: https://pypi.org/project/iso3166/
 .. _isodate: https://pypi.org/project/isodate/
 .. _lxml: https://lxml.de/
+.. _pycountry: https://pypi.org/project/pycountry/
+.. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
 .. _PySocks: https://github.com/Anorov/PySocks
+.. _requests: https://docs.python-requests.org/en/master/
 .. _websocket-client: https://pypi.org/project/websocket-client/
+
+.. _ffmpeg: https://www.ffmpeg.org/
+.. _muxing: https://en.wikipedia.org/wiki/Multiplexing#Video_processing
 
 
 Windows binaries

--- a/setup.py
+++ b/setup.py
@@ -39,20 +39,13 @@ if "test" in argv:
 
 
 deps = [
-    "requests>=2.26.0,<3.0",
     "isodate",
     "lxml>=4.6.4,<5.0",
-    "websocket-client>=1.2.1,<2.0",
-    # Support for SOCKS proxies
+    "pycryptodome>=3.4.3,<4",
     "PySocks!=1.5.7,>=1.5.6",
+    "requests>=2.26.0,<3.0",
+    "websocket-client>=1.2.1,<2.0",
 ]
-
-# for encrypted streams
-if environ.get("STREAMLINK_USE_PYCRYPTO"):
-    deps.append("pycrypto")
-else:
-    # this version of pycryptodome is known to work and has a Windows wheel for py2.7, py3.3-3.6
-    deps.append("pycryptodome>=3.4.3,<4")
 
 # for localization
 if environ.get("STREAMLINK_USE_PYCOUNTRY"):


### PR DESCRIPTION
- remove the `STREAMLINK_USE_PYCRYPTO` env var switch from setup.py
- sort dependencies list
- update dependencies section in install docs
  - sort dependencies table
  - rephrase notes column

----

ref #4170, #713

pycrypto has had its last update in 2013
https://pypi.org/project/pycrypto/#history

As I've shown in #4170, there are no streamlink packages (anymore) which depend on pycrypto. If I missed one, then they will have to upgrade.

I included the updates for the docs in this commit because I don't want to post two PRs. I also removed the versions of non-build-dependencies from the docs because they were never up2date and it doesn't make sense having two lists for this. The only dependency list that matters is the one in setup.py (or setup.cfg if we move to a declarative list). Please take a look at the rendered docs preview to see if everything's okay.
