### PR TITLE
setup: drop iso-639/iso3166, default to pycountry

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -284,10 +284,9 @@ Name                                 Notes
 
 **Automatically installed by the setup script**
 --------------------------------------------------------------------------------
-`iso-639`_                           Used for localization settings, provides language information
-`iso3166`_                           Used for localization settings, provides country information
 `isodate`_                           Used for parsing ISO8601 strings
 `lxml`_                              Used for processing HTML and XML data
+`pycountry`_                         Used for localization settings, provides country and language data
 `pycryptodome`_                      Used for decrypting encrypted streams
 `PySocks`_                           Used for SOCKS Proxies
 `requests`_                          Used for making any kind of HTTP/HTTPS request
@@ -301,20 +300,9 @@ Name                                 Notes
                                      - HLS streams optionally need to get remuxed depending on the stream selection.
 ==================================== ===========================================
 
-Alternative dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-With this environment variable it is possible to use `pycountry`_ instead of `iso-639`_ and `iso3166`_.
-
-.. code-block:: console
-
-    $ export STREAMLINK_USE_PYCOUNTRY="true"
-
 .. _Python: https://www.python.org/
 .. _python-setuptools: https://setuptools.pypa.io/en/latest/
 
-.. _iso-639: https://pypi.org/project/iso-639/
-.. _iso3166: https://pypi.org/project/iso3166/
 .. _isodate: https://pypi.org/project/isodate/
 .. _lxml: https://lxml.de/
 .. _pycountry: https://pypi.org/project/pycountry/

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -6,7 +6,6 @@ set -ex
 
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
-python -m pip install pycountry
 # https://github.com/streamlink/streamlink/issues/4021
 python -m pip install brotli
 python -m pip install -e .

--- a/script/makeinstaller.sh
+++ b/script/makeinstaller.sh
@@ -89,11 +89,10 @@ format=bundled
 
 [Include]
 packages=pkg_resources
-         iso639
+         pycountry
 pypi_wheels=certifi==2021.5.30
             charset-normalizer==2.0.4
             idna==3.2
-            iso3166==1.0.1
             isodate==0.6.0
             lxml==4.6.4
             pycryptodome==3.10.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,14 @@ python_requires = >=3.6, <4
 package_dir =
   =src
 packages = find:
+install_requires =
+  isodate
+  lxml >=4.6.4,<5.0
+  pycountry
+  pycryptodome >=3.4.3,<4
+  PySocks !=1.5.7,>=1.5.6
+  requests >=2.26.0,<3.0
+  websocket-client >=1.2.1,<2.0
 
 [options.packages.find]
 where = src

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from os import environ, path
+from os import path
 from sys import argv, exit, version_info
 from textwrap import dedent
 
@@ -36,23 +36,6 @@ if "test" in argv:
         Streamlink requires pytest for collecting and running tests, via one of these commands:
         `pytest` or `python -m pytest` (see the pytest docs for more infos about this)
     """))
-
-
-deps = [
-    "isodate",
-    "lxml>=4.6.4,<5.0",
-    "pycryptodome>=3.4.3,<4",
-    "PySocks!=1.5.7,>=1.5.6",
-    "requests>=2.26.0,<3.0",
-    "websocket-client>=1.2.1,<2.0",
-]
-
-# for localization
-if environ.get("STREAMLINK_USE_PYCOUNTRY"):
-    deps.append("pycountry")
-else:
-    deps.append("iso-639")
-    deps.append("iso3166")
 
 
 def is_wheel_for_windows():
@@ -96,7 +79,6 @@ data_files = [
 setup(
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    install_requires=deps,
     entry_points=entry_points,
     data_files=data_files,
 )

--- a/tests/utils/test_l10n.py
+++ b/tests/utils/test_l10n.py
@@ -3,23 +3,8 @@ from unittest.mock import patch
 
 import streamlink.utils.l10n as l10n
 
-try:
-    import iso639  # noqa: F401
-    import iso3166  # noqa: F401
 
-    ISO639 = True
-except ImportError:  # pragma: no cover
-    ISO639 = False
-
-try:
-    import pycountry  # noqa: F401
-
-    PYCOUNTRY = True
-except ImportError:  # pragma: no cover
-    PYCOUNTRY = False
-
-
-class LocalizationTestsMixin:
+class TestLocalization(unittest.TestCase):
     def test_language_code_us(self):
         locale = l10n.Localization("en_US")
         self.assertEqual("en_US", locale.language_code)
@@ -116,29 +101,6 @@ class LocalizationTestsMixin:
         self.assertEqual(a.alpha3, "des")
         self.assertEqual(a.name, "Desano")
         self.assertEqual(a.bibliographic, "")
-
-
-@unittest.skipIf(not ISO639, "iso639+iso3166 modules are required to test iso639+iso3166 Localization")
-class TestLocalization(LocalizationTestsMixin, unittest.TestCase):
-    def setUp(self):
-        l10n.PYCOUNTRY = False
-
-    def test_pycountry(self):
-        self.assertEqual(False, l10n.PYCOUNTRY)
-
-
-@unittest.skipIf(not PYCOUNTRY, "pycountry module required to test pycountry Localization")
-class TestLocalizationPyCountry(LocalizationTestsMixin, unittest.TestCase):
-    """Duplicate of all the Localization tests but using PyCountry instead of the iso* modules"""
-
-    def setUp(self):
-        from pycountry import languages, countries
-        l10n.countries = countries
-        l10n.languages = languages
-        l10n.PYCOUNTRY = True
-
-    def test_pycountry(self):
-        self.assertEqual(True, l10n.PYCOUNTRY)
 
     # issue #3057: generic "en" lookups via pycountry yield the "En" language, but not "English"
     def test_language_en(self):


### PR DESCRIPTION
- drop iso-639 and iso3166 dependencies in favor of pycountry
- remove the `STREAMLINK_USE_PYCOUNTRY` env var switch from setup.py
- move dependencies list from setup.py to setup.cfg
- update utils.l10n and its tests
- update Windows installer config
- update docs

----

resolves #4170 