### PR TITLE
setup: include shell completions in sdist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,20 +13,23 @@ nbproject
 *.sublime-workspace
 .idea
 
+/build/
+/completions/
+/docs/_build/
+/dist/
+
 *.mo
 *.egg-info
 *.egg
 *.EGG
 *.EGG-INFO
 bin
-build
 build-win32
 develop-eggs
 downloads
 eggs
 fake-eggs
 parts
-dist
 .installed.cfg
 .mr.developer.cfg
 .hg
@@ -36,7 +39,6 @@ dist
 *.pyo
 *.tmp*
 *.swp
-docs/_build
 include/
 lib/
 local/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include src/streamlink/_version.py
 include src/streamlink/plugins/.removed
 include versioneer.py
 
+recursive-include completions *
 recursive-include docs *
 recursive-include examples *
 recursive-include tests *

--- a/script/build-shell-completions.sh
+++ b/script/build-shell-completions.sh
@@ -3,7 +3,7 @@ set -e
 
 ROOT=$(git rev-parse --show-toplevel 2>/dev/null || realpath "$(dirname "$(readlink -f "${0}")")/..")
 
-DIST="${ROOT}/build/shtab"
+DIST="${ROOT}/completions"
 PYTHON_DEPS=(streamlink_cli shtab)
 
 declare -A COMPLETIONS=(

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ data_files = [
     # shell completions
     #  requires pre-built completion files via shtab (dev-requirements.txt)
     #  `./script/build-shell-completions.sh`
-    ("share/bash-completion/completions", ["build/shtab/bash/streamlink"]),
-    ("share/zsh/site-functions", ["build/shtab/zsh/_streamlink"]),
+    ("share/bash-completion/completions", ["completions/bash/streamlink"]),
+    ("share/zsh/site-functions", ["completions/zsh/_streamlink"]),
     # man page
     #  requires pre-built man page file via sphinx (docs-requirements.txt)
     #  `make --directory=docs clean man`


### PR DESCRIPTION
- move build directory of the shell completions from /build/shtab to
  /completions due to an sdist restriction of setuptools and MANIFEST.in
- recursively include the /completions directory in MANIFEST.in
- update data_files path in setup.py (for inclusion in wheels)
- update .gitignore

----

https://github.com/streamlink/streamlink/pull/4177#issuecomment-969088309

```
$ rm -rf src/streamlink.egg-info build/lib
...

$ ./script/build-shell-completions.sh
Completions for bash written to /home/basti/repos/streamlink/completions/bash/streamlink
Completions for zsh written to /home/basti/repos/streamlink/completions/zsh/_streamlink

$ python setup.py clean sdist bdist_wheel
...

$ bsdtar tf dist/streamlink-2.4.0+92.g54356a0.tar.gz | grep -E 'bash|zsh'
streamlink-2.4.0+92.g54356a0/completions/bash/
streamlink-2.4.0+92.g54356a0/completions/bash/streamlink
streamlink-2.4.0+92.g54356a0/completions/zsh/
streamlink-2.4.0+92.g54356a0/completions/zsh/_streamlink

$ bsdtar tf dist/streamlink-2.4.0+92.g54356a0-py3-none-any.whl | grep -E 'bash|zsh'
streamlink-2.4.0+92.g54356a0.data/data/share/bash-completion/completions/streamlink
streamlink-2.4.0+92.g54356a0.data/data/share/zsh/site-functions/_streamlink
```