### PR TITLE
plugins.crunchyroll: add metadata attributes

### DIFF
--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -298,11 +298,6 @@ class Crunchyroll(Plugin):
 
         return Plugin.stream_weight(key)
 
-    def get_category(self):
-        if self.category:
-            self.category = self.category.capitalize()
-        return self.category
-
     def _get_streams(self):
         api = self._create_api()
         media_id = int(self.match.group("media_id"))

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -39,9 +39,9 @@ _api_schema = validate.Schema({
 })
 _media_schema = validate.Schema(
     {
-        "name": validate.text,
-        "series_name": validate.text,
-        "media_type": validate.text,
+        validate.optional("name"): validate.any(validate.text, None),
+        validate.optional("series_name"): validate.any(validate.text, None),
+        validate.optional("media_type"): validate.any(validate.text, None),
         "stream_data": validate.any(
             None,
             {
@@ -298,6 +298,11 @@ class Crunchyroll(Plugin):
 
         return Plugin.stream_weight(key)
 
+    def get_category(self):
+        if self.category:
+            self.category = self.category.capitalize()
+        return self.category
+
     def _get_streams(self):
         api = self._create_api()
         media_id = int(self.match.group("media_id"))
@@ -314,9 +319,9 @@ class Crunchyroll(Plugin):
 
         streams = {}
 
-        self.title = info["name"]
-        self.author = info["series_name"]
-        self.category = info["media_type"].capitalize()
+        self.title = info.get("name")
+        self.author = info.get("series_name")
+        self.category = info.get("media_type")
 
         info = info["stream_data"]
 


### PR DESCRIPTION
Currently, none of the metadata attributes is set, this PR adds them using 3 fields provided by the API

- `media.name` as _title_ is the title of the episode
- `media.series_name` as _author_ is the name of the anime/show
- `media.media_type` as _category_ is a more general category, like "anime" or "drama"