### PR TITLE
cli: override default signal handlers

### DIFF
--- a/src/streamlink_cli/__init__.py
+++ b/src/streamlink_cli/__init__.py
@@ -1,0 +1,12 @@
+from signal import SIGINT, SIGTERM, signal
+from sys import exit
+
+
+def _exit(*_):
+    # don't raise a KeyboardInterrupt until streamlink_cli has been fully initialized
+    exit(128 | 2)
+
+
+# override default SIGINT handler (and set SIGTERM handler) as early as possible
+signal(SIGINT, _exit)
+signal(SIGTERM, _exit)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -685,7 +685,9 @@ def setup_config_args(parser, ignore_unknown=False):
 
 
 def setup_signals():
-    # Handle SIGTERM just like SIGINT
+    # restore default behavior of raising a KeyboardInterrupt on SIGINT (and SIGTERM)
+    # so cleanup code can be run when the user stops execution
+    signal.signal(signal.SIGINT, signal.default_int_handler)
     signal.signal(signal.SIGTERM, signal.default_int_handler)
 
 
@@ -1005,8 +1007,6 @@ def main():
     log_file = args.logfile if log_level != "none" else None
     setup_logger_and_console(console_out, log_file, log_level, args.json)
 
-    setup_signals()
-
     setup_streamlink()
     # load additional plugins
     setup_plugins(args.plugin_dirs)
@@ -1024,6 +1024,8 @@ def main():
     log_root_warning()
     log_current_versions()
     log_current_arguments(streamlink, parser)
+
+    setup_signals()
 
     if args.version_check or args.auto_version_check:
         with ignored(Exception):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,17 @@
 import os
+import signal
 import warnings
 
 import pytest
+
+# import streamlink_cli as early as possible to execute its default signal overrides
+# noinspection PyUnresolvedReferences
+import streamlink_cli  # noqa: F401
+
+
+# immediately restore default signal handlers for the test runner
+signal.signal(signal.SIGINT, signal.default_int_handler)
+signal.signal(signal.SIGTERM, signal.default_int_handler)
 
 
 def catch_warnings(record=False, module=None):

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -20,7 +20,6 @@ from streamlink_cli.main import (
     format_valid_streams,
     handle_stream,
     handle_url,
-    log_current_arguments,
     resolve_stream_name,
     setup_config_args
 )
@@ -500,14 +499,13 @@ class _TestCLIMainLogging(unittest.TestCase):
         session = Streamlink()
         session.load_plugins(os.path.join(os.path.dirname(__file__), "plugin"))
 
-        def _log_current_arguments(*args, **kwargs):
-            log_current_arguments(*args, **kwargs)
-            raise SystemExit
+        # stop test execution at the setup_signals() call, as we're not interested in what comes afterwards
+        class StopTest(Exception):
+            pass
 
         with patch("streamlink_cli.main.streamlink", session), \
-             patch("streamlink_cli.main.log_current_arguments", side_effect=_log_current_arguments), \
+             patch("streamlink_cli.main.setup_signals", side_effect=StopTest), \
              patch("streamlink_cli.main.CONFIG_FILES", []), \
-             patch("streamlink_cli.main.setup_signals"), \
              patch("streamlink_cli.main.setup_streamlink"), \
              patch("streamlink_cli.main.setup_plugins"), \
              patch("streamlink_cli.main.setup_http_session"), \
@@ -516,7 +514,7 @@ class _TestCLIMainLogging(unittest.TestCase):
             mock_argv.__getitem__.side_effect = lambda x: argv[x]
             try:
                 streamlink_cli.main.main()
-            except SystemExit:
+            except StopTest:
                 pass
 
     def tearDown(self):


### PR DESCRIPTION
- Don't raise a KeyboardInterrupt until streamlink_cli has been fully
  initialized. This prevents a stack call from being printed to stderr
  when streamlink_cli gets interrupted early.
- Restore default signal handlers once streamlink_cli has finished its
  initialization, so that KeyboardInterrupt exceptions can be caught to
  perform clean up tasks.
- Restore default signal handlers in test immediately after importing
  streamlink_cli once as early as possible, to be able to cancel the
  test runners regularly via a KeyboardInterrupt.
- Refactor CLI logging tests, which test the log output of the
  initialization and need to stop execution at some point.

----

resolves #4188 

Both the regular entry script and invocation via `python -m streamlink{,_cli}` work.

```bash
$ /usr/bin/timeout --preserve-status --signal=SIGINT .1s streamlink twitch.tv/bobross
$ echo $?
130

$ /usr/bin/timeout --preserve-status --signal=SIGINT 1s streamlink twitch.tv/bobross
[cli][info] Found matching plugin twitch for URL twitch.tv/bobross
Interrupted! Exiting...
$ echo $?
130
```

This does not fix a `KeyboardInterrupt` from being raised and its call stack being printed to `stderr` if the user sends a `SIGINT` signal to the process even before the signal override happens. The signal overrides happen as early as possible, but python has to load parts of its standard library first, so there's a small time window here where we don't have any control.

There's also a secondary time window in the streamlink_cli.main.main code, as it restores the default signal handlers but then only catches KeyboardInterrupt exceptions in some cases. That shouldn't be too important though.