### PR TITLE
plugins.twitch: set playerType back to embed

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -298,7 +298,7 @@ class TwitchAPI:
             login=channel_or_vod if is_live else "",
             isVod=not is_live,
             vodID=channel_or_vod if not is_live else "",
-            playerType="site"
+            playerType="embed"
         )
         subschema = validate.any(None, validate.all(
             {
@@ -588,6 +588,10 @@ class Twitch(Plugin):
 
         # only get the token once the channel has been resolved
         log.debug(f"Getting live HLS streams for {self.channel}")
+        self.session.http.headers.update({
+            "referer": "https://player.twitch.tv",
+            "origin": "https://player.twitch.tv",
+        })
         sig, token, restricted_bitrates = self._access_token(True, self.channel)
         url = self.usher.channel(self.channel, sig=sig, token=token, fast_bread=True)
 


### PR DESCRIPTION
This partly reverts dfea62af0fd8cc2eeb9781e46583c613214a7c2c

----

#4156, #4106

`playerType=embed` seems to cause fewer ads and no midroll ads at all, at least from what I've seen so far.