### PR TITLE
plugins.twitch: calculate the average duration for prefetch segments

### DIFF
--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -296,6 +296,15 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             call("This is not a low latency stream")
         ])
 
+    def test_hls_low_latency_no_ads_reload_time(self):
+        self.subject([
+            Playlist(0, [Segment(0, duration=5), Segment(1, duration=7), Segment(2, duration=11), SegmentPrefetch(3)], end=True)
+        ], low_latency=True)
+
+        self.await_write(4)
+        self.await_read(read_all=True)
+        self.assertEqual(self.thread.reader.worker.playlist_reload_time, 23 / 3)
+
 
 class TestTwitchMetadata(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
A minor improvement for the prefetch segments in Twitch's HLS streams.

Prefetch segments don't include any information other than the URL of a segment that is available in the future. The parser therefore has to clone the last segment and replace its `uri` attribute.

If the segment durations however vary, which is the case for some streams, then the next playlist reload time can be either too short or too long, as it depends on the last queued segment in the worker, which is one of the prefetch segments. This change therefore calculates the average duration of all available segments for queued prefetch segments, so that the playlist reload time is neither too short or too long.

This PR also adds type annotations and refactors the TwitchSegment a bit.