### PR TITLE
utils.parse: fix encoding in parse_html

### DIFF
--- a/src/streamlink/utils/parse.py
+++ b/src/streamlink/utils/parse.py
@@ -48,12 +48,8 @@ def parse_html(
     """Wrapper around lxml.etree.HTML with some extras.
 
     Provides these extra features:
-     - Handles incorrectly encoded HTML
      - Wraps errors in custom exception with a snippet of the data in the message
     """
-    if isinstance(data, str):
-        data = bytes(data, "utf8")
-
     return _parse(HTML, data, name, exception, schema, *args, **kwargs)
 
 

--- a/tests/utils/test_parse.py
+++ b/tests/utils/test_parse.py
@@ -5,7 +5,7 @@ from lxml.etree import Element
 from streamlink.exceptions import PluginError
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.validate import xml_element
-from streamlink.utils.parse import parse_json, parse_qsd, parse_xml
+from streamlink.utils.parse import parse_html, parse_json, parse_qsd, parse_xml
 
 
 class TestUtilsParse(unittest.TestCase):
@@ -68,6 +68,26 @@ class TestUtilsParse(unittest.TestCase):
         )
         self.assertEqual(expected.tag, actual.tag)
         self.assertEqual(expected.attrib, actual.attrib)
+
+    def test_parse_xml_encoding(self):
+        tree = parse_xml("""<?xml version="1.0" encoding="UTF-8"?><test>ä</test>""")
+        self.assertEqual(tree.xpath(".//text()"), ["ä"])
+        tree = parse_xml("""<test>ä</test>""")
+        self.assertEqual(tree.xpath(".//text()"), ["ä"])
+        tree = parse_xml(b"""<?xml version="1.0" encoding="UTF-8"?><test>\xC3\xA4</test>""")
+        self.assertEqual(tree.xpath(".//text()"), ["ä"])
+        tree = parse_xml(b"""<test>\xC3\xA4</test>""")
+        self.assertEqual(tree.xpath(".//text()"), ["ä"])
+
+    def test_parse_html_encoding(self):
+        tree = parse_html("""<!DOCTYPE html><html><head><meta charset="utf-8"/></head><body>ä</body></html>""")
+        self.assertEqual(tree.xpath(".//body/text()"), ["ä"])
+        tree = parse_html("""<!DOCTYPE html><html><body>ä</body></html>""")
+        self.assertEqual(tree.xpath(".//body/text()"), ["ä"])
+        tree = parse_html(b"""<!DOCTYPE html><html><meta charset="utf-8"/><body>\xC3\xA4</body></html>""")
+        self.assertEqual(tree.xpath(".//body/text()"), ["ä"])
+        tree = parse_html(b"""<!DOCTYPE html><html><body>\xC3\xA4</body></html>""")
+        self.assertEqual(tree.xpath(".//body/text()"), ["Ã¤"])
 
     def test_parse_qsd(self):
         self.assertEqual(


### PR DESCRIPTION
This fixes the character encoding in parsed HTML documents. This should've been caught way sooner.

lxml's XML parser requires bytes as input, hence why strings must be encoded to bytes first (default utf8 encoding). The content is then decoded and parsed correctly as utf8 regardless whether the XML declaration with the document's encoding is missing or not.

The HTML parser on the other hand treats byte inputs differently, but only when the `<meta charset="utf8">` tag is missing in the first X bytes of the document. So if we encode input strings here to bytes as well (default utf8 encoding) and if the tag is missing too, then this will lead to decoding errors, as the parser won't treat the input as utf8 encoded data.

See the added tests.