### PR TITLE
plugin: add 'id' metadata property

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -203,6 +203,7 @@ class Plugin:
     match: Match
 
     # plugin metadata attributes
+    id: Optional[str] = None
     author: Optional[str] = None
     category: Optional[str] = None
     title: Optional[str] = None
@@ -432,10 +433,14 @@ class Plugin:
 
     def get_metadata(self) -> Dict[str, Optional[str]]:
         return dict(
+            id=self.get_id(),
             author=self.get_author(),
             category=self.get_category(),
             title=self.get_title()
         )
+
+    def get_id(self) -> Optional[str]:
+        return None if self.id is None else str(self.id).strip()
 
     def get_title(self) -> Optional[str]:
         return None if self.title is None else str(self.title).strip()

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -262,6 +262,7 @@ class TwitchAPI:
 
         return self.call(query, schema=validate.Schema(
             {"data": {"video": {
+                "id": str,
                 "owner": {
                     "displayName": str
                 },
@@ -272,9 +273,10 @@ class TwitchAPI:
             }}},
             validate.get(("data", "video")),
             validate.union_get(
+                "id",
                 ("owner", "displayName"),
-                "title",
-                ("game", "displayName")
+                ("game", "displayName"),
+                "title"
             )
         ))
 
@@ -305,16 +307,57 @@ class TwitchAPI:
                         "lastBroadcast": {
                             "title": str
                         },
-                        "stream": {"game": {
-                            "name": str
-                        }}
+                        "stream": {
+                            "id": str,
+                            "game": {
+                                "name": str
+                            }
+                        }
                     }}}
                 )
             ],
             validate.union_get(
+                (1, "data", "user", "stream", "id"),
                 (0, "data", "userOrError", "displayName"),
-                (1, "data", "user", "lastBroadcast", "title"),
-                (1, "data", "user", "stream", "game", "name")
+                (1, "data", "user", "stream", "game", "name"),
+                (1, "data", "user", "lastBroadcast", "title")
+            )
+        ))
+
+    def metadata_clips(self, clipname):
+        queries = [
+            self._gql_persisted_query(
+                "ClipsView",
+                "4480c1dcc2494a17bb6ef64b94a5213a956afb8a45fe314c66b0d04079a93a8f",
+                slug=clipname
+            ),
+            self._gql_persisted_query(
+                "ClipsTitle",
+                "f6cca7f2fdfbfc2cecea0c88452500dae569191e58a265f97711f8f2a838f5b4",
+                slug=clipname
+            )
+        ]
+
+        return self.call(queries, schema=validate.Schema(
+            [
+                validate.all(
+                    {"data": {"clip": {
+                        "id": str,
+                        "broadcaster": {"displayName": str},
+                        "game": {"name": str}
+                    }}},
+                    validate.get(("data", "clip"))
+                ),
+                validate.all(
+                    {"data": {"clip": {"title": str}}},
+                    validate.get(("data", "clip"))
+                )
+            ],
+            validate.union_get(
+                (0, "id"),
+                (0, "broadcaster", "displayName"),
+                (0, "game", "name"),
+                (1, "title")
             )
         ))
 
@@ -351,61 +394,37 @@ class TwitchAPI:
         ))
 
     def clips(self, clipname):
-        queries = [
-            self._gql_persisted_query(
-                "VideoAccessToken_Clip",
-                "36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11",
-                slug=clipname
-            ),
-            self._gql_persisted_query(
-                "ClipsView",
-                "4480c1dcc2494a17bb6ef64b94a5213a956afb8a45fe314c66b0d04079a93a8f",
-                slug=clipname
-            ),
-            self._gql_persisted_query(
-                "ClipsTitle",
-                "f6cca7f2fdfbfc2cecea0c88452500dae569191e58a265f97711f8f2a838f5b4",
-                slug=clipname
-            )
-        ]
+        query = self._gql_persisted_query(
+            "VideoAccessToken_Clip",
+            "36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11",
+            slug=clipname
+        )
 
-        return self.call(queries, schema=validate.Schema([
-            validate.all(
-                {"data": {"clip": {
-                    "playbackAccessToken": validate.all(
-                        {
-                            "signature": str,
-                            "value": str
-                        },
-                        validate.union_get("signature", "value")
-                    ),
-                    "videoQualities": [
-                        validate.all({
-                            "frameRate": validate.transform(int),
-                            "quality": str,
-                            "sourceURL": validate.url()
-                        }, validate.transform(lambda q: (
-                            f"{q['quality']}p{q['frameRate']}",
-                            q["sourceURL"]
-                        )))
-                    ]
-                }}},
-                validate.get(("data", "clip")),
-                validate.union_get("playbackAccessToken", "videoQualities")
-            ),
-            validate.all(
-                {"data": {"clip": {
-                    "broadcaster": {"displayName": str},
-                    "game": {"name": str}
-                }}},
-                validate.get(("data", "clip")),
-                validate.union_get(("broadcaster", "displayName"), ("game", "name"))
-            ),
-            validate.all(
-                {"data": {"clip": {"title": str}}},
-                validate.get(("data", "clip", "title"))
+        return self.call(query, schema=validate.Schema(
+            {"data": {"clip": {
+                "playbackAccessToken": {
+                    "signature": str,
+                    "value": str
+                },
+                "videoQualities": [validate.all(
+                    {
+                        "frameRate": validate.transform(int),
+                        "quality": str,
+                        "sourceURL": validate.url()
+                    },
+                    validate.transform(lambda q: (
+                        f"{q['quality']}p{q['frameRate']}",
+                        q["sourceURL"]
+                    ))
+                )]
+            }}},
+            validate.get(("data", "clip")),
+            validate.union_get(
+                ("playbackAccessToken", "signature"),
+                ("playbackAccessToken", "value"),
+                "videoQualities"
             )
-        ]))
+        ))
 
     def stream_metadata(self, channel):
         query = self._gql_persisted_query(
@@ -514,6 +533,7 @@ class Twitch(Plugin):
         self.video_id = None
         self.channel = None
         self.clip_name = None
+        self._checked_metadata = False
 
         if self.subdomain == "player":
             # pop-out player
@@ -531,29 +551,30 @@ class Twitch(Plugin):
         self.api = TwitchAPI(session=self.session)
         self.usher = UsherService(session=self.session)
 
-    def get_title(self):
-        if self.title is None:
-            self._get_metadata()
-        return self.title
+        def method_factory(parent_method):
+            def inner():
+                if not self._checked_metadata:
+                    self._checked_metadata = True
+                    self._get_metadata()
+                return parent_method()
+            return inner
 
-    def get_author(self):
-        if self.author is None:
-            self._get_metadata()
-        return self.author
-
-    def get_category(self):
-        if self.category is None:
-            self._get_metadata()
-        return self.category
+        parent = super()
+        for metadata in "id", "author", "category", "title":
+            method = f"get_{metadata}"
+            setattr(self, method, method_factory(getattr(parent, method)))
 
     def _get_metadata(self):
         try:
             if self.video_id:
-                (self.author, self.title, self.category) = self.api.metadata_video(self.video_id)
+                data = self.api.metadata_video(self.video_id)
             elif self.clip_name:
-                self._get_clips()
+                data = self.api.metadata_clips(self.clip_name)
             elif self.channel:
-                (self.author, self.title, self.category) = self.api.metadata_channel(self.channel)
+                data = self.api.metadata_channel(self.channel)
+            else:  # pragma: no cover
+                return
+            self.id, self.author, self.category, self.title = data
         except (PluginError, TypeError):
             pass
 
@@ -658,7 +679,7 @@ class Twitch(Plugin):
 
     def _get_clips(self):
         try:
-            (((sig, token), streams), (self.author, self.category), self.title) = self.api.clips(self.clip_name)
+            sig, token, streams = self.api.clips(self.clip_name)
         except (PluginError, TypeError):
             return
 

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -318,8 +318,8 @@ class YouTube(Plugin):
             if not self._data_status(data, True):
                 return
 
-        video_id, self.author, self.title, is_live = self._schema_videodetails(data)
-        log.debug(f"Using video ID: {video_id}")
+        self.id, self.author, self.title, is_live = self._schema_videodetails(data)
+        log.debug(f"Using video ID: {self.id}")
 
         if is_live:
             log.debug("This video is live.")

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -510,7 +510,7 @@ def build_parser():
     player.add_argument(
         "-t", "--title",
         metavar="TITLE",
-        help="""
+        help=f"""
         This option allows you to supply a title to be displayed in the
         title bar of the window that the video player is launched in.
 
@@ -518,7 +518,7 @@ def build_parser():
         {{ and }}. If you need to include a brace character, it can be escaped
         by doubling, e.g. {{{{ and }}}}.
 
-        This option is only supported for the following players: {0}.
+        This option is only supported for the following players: {', '.join(sorted(SUPPORTED_PLAYERS.keys()))}.
 
         VLC specific information:
             VLC has certain codes you can use inside your title.
@@ -533,13 +533,17 @@ def build_parser():
 
         Formatting variables available to use in --title:
 
+        {{id}}
+            If available, this is the unique ID of the stream.
+            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['id']}"
+
         {{title}}
             If available, this is the title of the stream.
-            Otherwise, it is the string "{1}"
+            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['title']}"
 
         {{author}}
             If available, this is the author of the stream.
-            Otherwise, it is the string "{2}"
+            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['author']}"
 
         {{category}}
             If available, this is the category the stream has been placed into.
@@ -547,7 +551,7 @@ def build_parser():
             - For Twitch, this is the game being played
             - For YouTube, it's the category e.g. Gaming, Sports, Music...
 
-            Otherwise, it is the string "{3}"
+            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['category']}"
 
         {{game}}
             This is just a synonym for {{category}} which may make more sense for
@@ -565,10 +569,7 @@ def build_parser():
         Examples:
 
             %(prog)s -p vlc --title "{{title}} -!- {{author}} -!- {{category}} \\$A" <url> [stream]
-        """.format(', '.join(sorted(SUPPORTED_PLAYERS.keys())),
-                   DEFAULT_STREAM_METADATA['title'],
-                   DEFAULT_STREAM_METADATA['author'],
-                   DEFAULT_STREAM_METADATA['category'])
+        """
     )
 
     output = parser.add_argument_group("File output options")

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -9,6 +9,7 @@ PLAYER_ARGS_INPUT_DEFAULT = "playerinput"
 PLAYER_ARGS_INPUT_FALLBACK = "filename"
 
 DEFAULT_STREAM_METADATA = {
+    "id": "Unknown ID",
     "title": "Unknown Title",
     "author": "Unknown Author",
     "category": "No Category",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -55,6 +55,7 @@ def get_formatter(plugin: Plugin):
     return Formatter(
         {
             "url": lambda: args.url,
+            "id": lambda: plugin.get_id(),
             "author": lambda: plugin.get_author(),
             "category": lambda: plugin.get_category(),
             "game": lambda: plugin.get_category(),

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -37,6 +37,7 @@ class TestPlugin(Plugin):
         "a_option": "default"
     })
 
+    id = "test-id-1234-5678"
     author = "Tѥst Āuƭhǿr"
     category = None
     title = "Test Title"

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -122,6 +122,7 @@ class TestCLIMainJsonAndStreamUrl(unittest.TestCase):
         self.assertEqual(console.msg_json.mock_calls, [call(
             stream,
             metadata=dict(
+                id="test-id-1234-5678",
                 author="Tѥst Āuƭhǿr",
                 category=None,
                 title="Test Title"
@@ -158,6 +159,7 @@ class TestCLIMainJsonAndStreamUrl(unittest.TestCase):
             self.assertEqual(console.msg_json.mock_calls, [call(
                 plugin="fake",
                 metadata=dict(
+                    id="test-id-1234-5678",
                     author="Tѥst Āuƭhǿr",
                     category=None,
                     title="Test Title"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -208,7 +208,7 @@ class TestPluginMatcher(unittest.TestCase):
         self.assertEqual(plugin.match, None)
 
 
-@pytest.mark.parametrize("attr", ["author", "category", "title"])
+@pytest.mark.parametrize("attr", ["id", "author", "category", "title"])
 def test_plugin_metadata(attr):
     plugin = FakePlugin("https://foo.bar/")
     getter = getattr(plugin, f"get_{attr}")


### PR DESCRIPTION
The `{id}` metadata is useful for writing unique file names to the filesystem when recording a stream.

This PR also adds the ID metadata to YouTube and Twitch.

The `--title` docs should ideally be rewritten and the available attributes moved to a different section. I will check this later today. After that I'd like to publish 3.0.2, because of the Twitch ads stuff.