### PR TITLE
docs: add dedicated metadata variables section

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -381,6 +381,56 @@ Both HTTP and SOCKS proxies are supported, as well as authentication in each of 
     $ streamlink --http-proxy "socks4a://address:port"
     $ streamlink --http-proxy "socks5h://address:port"
 
+.. _Requests Proxies Documentation: https://2.python-requests.org/en/master/user/advanced/#proxies
+
+
+Metadata variables
+------------------
+
+Streamlink supports a number of metadata variables that can be used in the following CLI arguments:
+
+- :option:`--title`
+- :option:`--output`
+- :option:`--record`
+- :option:`--record-and-pipe`
+
+Metadata variables are surrounded by curly braces and can be escaped by doubling the curly brace characters,
+eg. ``{variable}`` and ``{{not-a-variable}}``.
+
+The availability of each variable depends on the used plugin and whether that plugin supports this kind of metadata.
+If a variable is unsupported or not available, then its substitution will either be a short placeholder text (:option:`--title`)
+or an empty string (:option:`--output`, :option:`--record`, :option:`--record-and-pipe`).
+
+The :option:`--json` argument always lists the standard plugin metadata: ``id``, ``author``, ``category`` and ``title``.
+
+.. rst-class:: table-custom-layout table-custom-layout-platform-locations
+
+============================== =================================================
+Variable                       Description
+============================== =================================================
+``id``                         The unique ID of the stream, eg. an internal numeric ID or randomized string.
+``title``                      The stream's title, usually a short descriptive text.
+``author``                     The stream's author, eg. a channel or broadcaster name.
+``category``                   The stream's category, eg. the name of a game being played, a music genre, etc.
+``game``                       Alias for ``category``.
+``url``                        The resolved URL of the stream.
+``time``                       The current timestamp. Can optionally be formatted via ``{time:format}``.
+
+                               The format parameter string is passed to Python's `datetime.strftime()`_ method,
+                               so all the usual time directives are available.
+
+                               The default format is ``%Y-%m-%d_%H-%M-%S``.
+============================== =================================================
+
+Examples:
+
+.. code-block:: console
+
+    $ streamlink --title "{author} - {category} - {title}" <URL> [STREAM]
+    $ streamlink --output "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
+
+.. _datetime.strftime(): https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+
 
 Command-line usage
 ------------------
@@ -393,5 +443,3 @@ Command-line usage
 .. argparse::
     :module: streamlink_cli.main
     :attr: parser_helper
-
-.. _Requests Proxies Documentation: https://2.python-requests.org/en/master/user/advanced/#proxies

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -10,7 +10,7 @@ from streamlink.utils.args import (
 )
 from streamlink.utils.times import hours_minutes_seconds
 from streamlink_cli.constants import (
-    DEFAULT_STREAM_METADATA, PLAYER_ARGS_INPUT_DEFAULT, PLAYER_ARGS_INPUT_FALLBACK, STREAM_PASSTHROUGH, SUPPORTED_PLAYERS
+    PLAYER_ARGS_INPUT_DEFAULT, PLAYER_ARGS_INPUT_FALLBACK, STREAM_PASSTHROUGH, SUPPORTED_PLAYERS
 )
 from streamlink_cli.utils import find_default_player
 
@@ -511,64 +511,25 @@ def build_parser():
         "-t", "--title",
         metavar="TITLE",
         help=f"""
-        This option allows you to supply a title to be displayed in the
-        title bar of the window that the video player is launched in.
+        Change the title of the video player's window.
 
-        This value can contain formatting variables surrounded by curly braces,
-        {{ and }}. If you need to include a brace character, it can be escaped
-        by doubling, e.g. {{{{ and }}}}.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
 
-        This option is only supported for the following players: {', '.join(sorted(SUPPORTED_PLAYERS.keys()))}.
+        This option is only supported for the following players: {', '.join(sorted(SUPPORTED_PLAYERS.keys()))}
 
         VLC specific information:
-            VLC has certain codes you can use inside your title.
-            These are accessible inside --title by using a backslash
-            before the dollar sign VLC uses to denote a format character.
-
-            e.g. to put the current date in your VLC window title,
-            the string "\\$A" could be inserted inside your --title string.
-
-            A full list of the format codes VLC uses is available here:
+            VLC does support special formatting variables on its own:
             https://wiki.videolan.org/Documentation:Format_String/
 
-        Formatting variables available to use in --title:
+            These variables are accessible in the --title option by adding a backslash
+            in front of the dollar sign which VLC uses as its formatting character.
 
-        {{id}}
-            If available, this is the unique ID of the stream.
-            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['id']}"
+            For example, to put the current date in your VLC window title,
+            the string "\\\\$A" could be inserted inside the --title string.
 
-        {{title}}
-            If available, this is the title of the stream.
-            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['title']}"
+        Example:
 
-        {{author}}
-            If available, this is the author of the stream.
-            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['author']}"
-
-        {{category}}
-            If available, this is the category the stream has been placed into.
-
-            - For Twitch, this is the game being played
-            - For YouTube, it's the category e.g. Gaming, Sports, Music...
-
-            Otherwise, it is the string "{DEFAULT_STREAM_METADATA['category']}"
-
-        {{game}}
-            This is just a synonym for {{category}} which may make more sense for
-            gaming oriented platforms. "Game being played" is a way to categorize
-            the stream, so it doesn't need its own separate handling.
-
-        {{url}}
-            URL of the stream.
-
-        {{time}}
-            The current timestamp, which can optionally be formatted via {{time:format}}.
-            This format parameter string is passed to Python's datetime.strftime() method,
-            so all usual time directives are available. The default format is "%%Y-%%m-%%d_%%H-%%M-%%S".
-
-        Examples:
-
-            %(prog)s -p vlc --title "{{title}} -!- {{author}} -!- {{category}} \\$A" <url> [stream]
+            %(prog)s -p mpv --title "{{author}} - {{category}} - {{title}}" <URL> [STREAM]
         """
     )
 
@@ -581,8 +542,13 @@ def build_parser():
 
         You will be prompted if the file already exists.
 
-        The formatting variables available for the --title option may be used.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+
         Unsupported characters in substituted variables will be replaced with an underscore.
+
+        Example:
+
+            %(prog)s --output "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
         """
     )
     output.add_argument(
@@ -615,8 +581,13 @@ def build_parser():
 
         You will be prompted if the file already exists.
 
-        The formatting variables available for the --title option may be used.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+
         Unsupported characters in substituted variables will be replaced with an underscore.
+
+        Example:
+
+            %(prog)s --record "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
         """
     )
     output.add_argument(
@@ -627,8 +598,13 @@ def build_parser():
 
         You will be prompted if the file already exists.
 
-        The formatting variables available for the --title option may be used.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+
         Unsupported characters in substituted variables will be replaced with an underscore.
+
+        Example:
+
+            %(prog)s --record-and-pipe "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
         """
     )
     output.add_argument(


### PR DESCRIPTION
- add dedicated metadata variables section to the CLI docs
- rewrite --title help text
- update --output, --record and --record-and-pipe help texts

----

ref #4205 

This moves the metadata variables from the argparse help texts into the CLI docs. This unfortunately means that the argparse help texts can't link to the metadata variables section. At least I don't know how to do this.

It also means that the metadata vars are currently not part of the man page anymore, because the man page only includes the argparse stuff and not the entire CLI document (because we don't want the CLI tutorial in the man page). This could be fixed in the future by splitting up the sections into their own documents and including those in the CLI document and man page.

https://deploy-preview-4207--streamlink.netlify.app/cli.html#metadata-variables
https://deploy-preview-4207--streamlink.netlify.app/cli.html#cmdoption-title