### PR TITLE
utils.parse: parse invalid XHTML5 documents

### DIFF
--- a/src/streamlink/utils/parse.py
+++ b/src/streamlink/utils/parse.py
@@ -48,8 +48,12 @@ def parse_html(
     """Wrapper around lxml.etree.HTML with some extras.
 
     Provides these extra features:
+     - Removes XML declarations of invalid XHTML5 documents
      - Wraps errors in custom exception with a snippet of the data in the message
     """
+    if isinstance(data, str) and data.lstrip().startswith("<?xml"):
+        data = re.sub(r"^\s*<\?xml.+?\?>", "", data)
+
     return _parse(HTML, data, name, exception, schema, *args, **kwargs)
 
 

--- a/tests/utils/test_parse.py
+++ b/tests/utils/test_parse.py
@@ -89,6 +89,12 @@ class TestUtilsParse(unittest.TestCase):
         tree = parse_html(b"""<!DOCTYPE html><html><body>\xC3\xA4</body></html>""")
         self.assertEqual(tree.xpath(".//body/text()"), ["Ã¤"])
 
+    def test_parse_html_xhtml5(self):
+        tree = parse_html("""<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html><body>ä?></body></html>""")
+        self.assertEqual(tree.xpath(".//body/text()"), ["ä?>"])
+        tree = parse_html(b"""<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE html><html><body>\xC3\xA4?></body></html>""")
+        self.assertEqual(tree.xpath(".//body/text()"), ["ä?>"])
+
     def test_parse_qsd(self):
         self.assertEqual(
             {"test": "1", "foo": "bar"},


### PR DESCRIPTION
Resolves #4209 

https://github.com/streamlink/streamlink/issues/4209#issuecomment-980173868