### PR TITLE
cli: prioritize --help and fix its output

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -548,7 +548,7 @@ def build_parser():
 
         Example:
 
-            %(prog)s --output "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
+            %(prog)s --output "~/recordings/{author}/{category}/{id}-{time:%%Y%%m%%d%%H%%M%%S}.ts" <URL> [STREAM]
         """
     )
     output.add_argument(
@@ -587,7 +587,7 @@ def build_parser():
 
         Example:
 
-            %(prog)s --record "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
+            %(prog)s --record "~/recordings/{author}/{category}/{id}-{time:%%Y%%m%%d%%H%%M%%S}.ts" <URL> [STREAM]
         """
     )
     output.add_argument(
@@ -604,7 +604,7 @@ def build_parser():
 
         Example:
 
-            %(prog)s --record-and-pipe "~/recordings/{author}/{category}/{id}-{time:%Y%m%d%H%M%S}.ts" <URL> [STREAM]
+            %(prog)s --record-and-pipe "~/recordings/{author}/{category}/{id}-{time:%%Y%%m%%d%%H%%M%%S}.ts" <URL> [STREAM]
         """
     )
     output.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1032,7 +1032,9 @@ def main():
         with ignored(Exception):
             check_version(force=args.version_check)
 
-    if args.plugins:
+    if args.help:
+        parser.print_help()
+    elif args.plugins:
         print_plugins()
     elif args.can_handle_url:
         try:
@@ -1065,8 +1067,6 @@ def main():
                     stream_fd.close()
                 except KeyboardInterrupt:
                     error_code = 130
-    elif args.help:
-        parser.print_help()
     else:
         usage = parser.format_usage()
         console.msg(


### PR DESCRIPTION
Fixes #4212 

Since this isn't the first time that the output of `--help` didn't get checked after modifying the argparse help texts, I've added some tests.

I've also moved the `if args.help` statement to the top of `main()` and prioritized `--help` by doing that, like it is common with other CLI applications. Streamlink shouldn't suppress the help text if there's an input URL set.