### PR TITLE
plugins.svtplay: fix live channel URL matching

### DIFF
--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r'https?://(?:www\.)?(?:svtplay|oppetarkiv)\.se(/(kanaler/)?)'
+    r'https?://(?:www\.)?(?:svtplay|oppetarkiv)\.se(/(kanaler/)?.*)'
 ))
 class SVTPlay(Plugin):
     api_url = 'https://api.svt.se/videoplayer-api/video/{0}'


### PR DESCRIPTION
Update to the new plugin URL matching API removed a couple of characters in the matching URL which broke the live channel matching.