### PR TITLE
stream.dash: sort video duplicated resolutions by bandwidth

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -249,6 +249,12 @@ class DASHStream(Stream):
         ret_new = {}
         for q in dict_value_list:
             items = dict_value_list[q]
+
+            try:
+                items = sorted(items, key=lambda k: k.video_representation.bandwidth, reverse=True)
+            except AttributeError:
+                pass
+
             for n in range(len(items)):
                 if n == 0:
                     ret_new[q] = items[n]


### PR DESCRIPTION
could be done differently, but this should work for a quick fix.

```
[stream.dash][debug] Available languages for DASH audio streams: sv-x-tal, sv (using: sv)
720p = 4590.0
720p_alt = 2995.0
[cli][info] Available streams: 234p (worst), 360p, 540p, 720p_alt, 720p (best)
```

closes https://github.com/streamlink/streamlink/issues/4217