### PR TITLE
logger: change NONE loglevel to sys.maxsize

### DIFF
--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -48,6 +48,8 @@ class ConsoleOutput:
         return getpass(prompt, self.output)
 
     def msg(self, msg: str) -> None:
+        if self.json:
+            return
         self.output.write(f"{msg}\n")
 
     def msg_json(self, *objs: Any, **keywords: Any) -> None:
@@ -77,7 +79,7 @@ class ConsoleOutput:
             out.update(**keywords)
 
         msg = dumps(out, cls=JSONEncoder, indent=2)
-        self.msg(msg)
+        self.output.write(f"{msg}\n")
 
         if type(out) is dict and out.get("error"):
             sys.exit(1)

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -6,21 +6,17 @@ from streamlink_cli.console import ConsoleOutput
 
 
 class TestConsoleOutput(unittest.TestCase):
-    def test_msg_format(self):
+    def test_msg(self):
         output = StringIO()
         console = ConsoleOutput(output)
         console.msg("foo")
+        console.msg_json({"test": 1})
         self.assertEqual("foo\n", output.getvalue())
-
-    def test_msg_json_not_set(self):
-        output = StringIO()
-        console = ConsoleOutput(output)
-        self.assertEqual(None, console.msg_json({"test": 1}))
-        self.assertEqual("", output.getvalue())
 
     def test_msg_json(self):
         output = StringIO()
         console = ConsoleOutput(output, json=True)
+        console.msg("foo")
         console.msg_json({"test": 1})
         self.assertEqual('{\n  "test": 1\n}\n', output.getvalue())
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -15,6 +15,34 @@ class TestLogging(unittest.TestCase):
         logger.basicConfig(stream=output, format=format, style=style, **params)
         return logging.getLogger("streamlink.test"), output
 
+    def test_level_names(self):
+        self.assertEqual(logger.levels, [
+            "none", "critical", "error", "warning", "info", "debug", "trace"
+        ])
+        self.assertEqual(logging.getLevelName(logger.NONE), "none")
+        self.assertEqual(logging.getLevelName(logger.CRITICAL), "critical")
+        self.assertEqual(logging.getLevelName(logger.ERROR), "error")
+        self.assertEqual(logging.getLevelName(logger.WARNING), "warning")
+        self.assertEqual(logging.getLevelName(logger.INFO), "info")
+        self.assertEqual(logging.getLevelName(logger.DEBUG), "debug")
+        self.assertEqual(logging.getLevelName(logger.TRACE), "trace")
+
+        self.assertEqual(logging.getLevelName("none"), logger.NONE)
+        self.assertEqual(logging.getLevelName("critical"), logger.CRITICAL)
+        self.assertEqual(logging.getLevelName("error"), logger.ERROR)
+        self.assertEqual(logging.getLevelName("warning"), logger.WARNING)
+        self.assertEqual(logging.getLevelName("info"), logger.INFO)
+        self.assertEqual(logging.getLevelName("debug"), logger.DEBUG)
+        self.assertEqual(logging.getLevelName("trace"), logger.TRACE)
+
+        self.assertEqual(logging.getLevelName("NONE"), logger.NONE)
+        self.assertEqual(logging.getLevelName("CRITICAL"), logger.CRITICAL)
+        self.assertEqual(logging.getLevelName("ERROR"), logger.ERROR)
+        self.assertEqual(logging.getLevelName("WARNING"), logger.WARNING)
+        self.assertEqual(logging.getLevelName("INFO"), logger.INFO)
+        self.assertEqual(logging.getLevelName("DEBUG"), logger.DEBUG)
+        self.assertEqual(logging.getLevelName("TRACE"), logger.TRACE)
+
     def test_level(self):
         log, output = self._new_logger()
         logger.root.setLevel("info")
@@ -24,6 +52,17 @@ class TestLogging(unittest.TestCase):
         logger.root.setLevel("debug")
         log.debug("test")
         self.assertNotEqual(output.tell(), 0)
+
+    def test_level_none(self):
+        log, output = self._new_logger()
+        logger.root.setLevel("none")
+        log.critical("test")
+        log.error("test")
+        log.warning("test")
+        log.info("test")
+        log.debug("test")
+        log.trace("test")
+        self.assertEqual(output.tell(), 0)
 
     def test_output(self):
         log, output = self._new_logger()


### PR DESCRIPTION
Resolves #4235 

The reason why there are still log messages being written to stdout/stderr when any "silent" CLI argument is set (`--json`, `--quiet`, `--stream-url` or even `--loglevel=none`) is because of how Streamlink's `NONE` log level gets interpreted in Python's logging module.

Each logger instance (subclasses of `logging.Logger` or `streamlink.logger.StreamlinkLogger`) can optionally have their own log level. When a logger instance needs to check whether a certain message can be written to the output or not, it first tries to read its own log level value, and if it is set to `logging.UNSET` (which is the default and its value is 0), then it continues with its parent logger instance until it reaches `logging.root` (`RootLogger`). This RootLogger does have a default log level of 30, aka. "warning".
https://github.com/python/cpython/blame/3.10/Lib/logging/__init__.py#L1926-L1927

`logging.Logger.getEffectiveLevel()`:
https://github.com/python/cpython/blame/3.10/Lib/logging/__init__.py#L1701-L1713

> ```py
>     def getEffectiveLevel(self):
>         """
>         Get the effective level for this logger.
>         Loop through this logger and its parents in the logger hierarchy,
>         looking for a non-zero logging level. Return the first one found.
>         """
>         logger = self
>         while logger:
>             if logger.level:
>                 return logger.level
>             logger = logger.parent
>         return NOTSET
> ```

Since child loggers usually don't have their own log level set, the loggers like the one in the YouTube plugin for example look up the level of Streamlink's own root logger `streamlink.logger.root`. If the level of Streamlink's root logger however is set to `NONE` (0), then the level of the global RootLogger will be used ("warning"), which means everything equal to or above "warning", like error log messages for example, will still be logged.

----

The fix is to change the `streamlink.logger.NONE` value from 0 to `sys.maxsize`, so that `getEffectiveLevel()` doesn't continue with the next parent logger if one of the logger instance's level is set to `NONE`. This has been broken since the reimplementation of the logger module in 2018.

Please review carefully before merging, because I don't want to unintentionally break stuff.

The other changes are all optional. See the commit messages for details.

----

https://github.com/streamlink/streamlink/issues/4235#issue-1071382500
```
$ streamlink youtube.com/c/LudwigAhgren -j
{
  "error": "No playable streams found on this URL: youtube.com/c/LudwigAhgren"
}
```