### PR TITLE
tests: fix named pipe being created in CLI tests

### DIFF
--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -254,6 +254,7 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.stdout = None
         args.record = None
         args.record_and_pipe = None
+        args.player_fifo = False
         args.title = None
         args.url = "URL"
         args.player = "mpv"


### PR DESCRIPTION
**master**
```
$ ls /tmp/streamlinkpipe-*
fish: No matches for wildcard “/tmp/streamlinkpipe-*”. See `help expand`.
 ls /tmp/streamlinkpipe-*
$ pytest
$ ls /tmp/streamlinkpipe-*
/tmp/streamlinkpipe-1400506-1-5978  /tmp/streamlinkpipe-1400506-2-6981
```

**this PR**
```
$ ls /tmp/streamlinkpipe-*
fish: No matches for wildcard “/tmp/streamlinkpipe-*”. See `help expand`.
 ls /tmp/streamlinkpipe-*
$ pytest
$ ls /tmp/streamlinkpipe-*
fish: No matches for wildcard “/tmp/streamlinkpipe-*”. See `help expand`.
 ls /tmp/streamlinkpipe-*
```