### PR TITLE
plugins.twitch: fix pluginmatcher regex

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -462,11 +462,11 @@ class TwitchAPI:
     (?:
         videos/(?P<videos_id>\d+)
         |
-        (?P<channel>[^/]+)
+        (?P<channel>[^/?]+)
         (?:
             /video/(?P<video_id>\d+)
             |
-            /clip/(?P<clip_name>[\w-]+)
+            /clip/(?P<clip_name>[^/?]+)
         )?
     )
 """, re.VERBOSE))


### PR DESCRIPTION
Resolves #4291 

Btw, this is a common problem in lots of other plugins where URL capture groups are used at the end. A proper fix would be not using a capture group for extracting the data but using urlparse and reading/parsing the result instead.