### PR TITLE
stream.hls: fix byterange parser

### DIFF
--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -27,7 +27,7 @@ class ExtInf(NamedTuple):
 # EXT-X-BYTERANGE
 class ByteRange(NamedTuple):  # version >= 4
     range: int
-    offset: int
+    offset: Optional[int]
 
 
 # EXT-X-DATERANGE
@@ -152,7 +152,7 @@ class M3U8:
 class M3U8Parser:
     _extinf_re = re.compile(r"(?P<duration>\d+(\.\d+)?)(,(?P<title>.+))?")
     _attr_re = re.compile(r"([A-Z\-]+)=(\d+\.\d+|0x[0-9A-z]+|\d+x\d+|\d+|\"(.+?)\"|[0-9A-z\-]+)")
-    _range_re = re.compile(r"(?P<range>\d+)(@(?P<offset>.+))?")
+    _range_re = re.compile(r"(?P<range>\d+)(?:@(?P<offset>\d+))?")
     _tag_re = re.compile(r"#(?P<tag>[\w-]+)(:(?P<value>.+))?")
     _res_re = re.compile(r"(\d+)x(\d+)")
 
@@ -214,7 +214,10 @@ class M3U8Parser:
 
     def parse_byterange(self, value: str) -> Optional[ByteRange]:
         match = self._range_re.match(value)
-        return None if match is None else ByteRange(int(match.group("range")), int(match.group("offset") or 0))
+        if match is None:
+            return None
+        _range, offset = match.groups()
+        return ByteRange(int(_range), int(offset) if offset is not None else None)
 
     def parse_extinf(self, value: str) -> Tuple[float, Optional[str]]:
         match = self._extinf_re.match(value)


### PR DESCRIPTION
Fixes #4300 

https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.2.2

> The EXT-X-BYTERANGE tag indicates that a Media Segment is a sub-range
> of the resource identified by its URI.  It applies only to the next
> URI line that follows it in the Playlist.  Its format is:
>
> `#EXT-X-BYTERANGE:<n>[@<o>]`
>
> where n is a decimal-integer indicating the length of the sub-range
> in bytes.  If present, o is a decimal-integer indicating the start of
> the sub-range, as a byte offset from the beginning of the resource.
> If o is not present, the sub-range begins at the next byte following
> the sub-range of the previous Media Segment.
>
> If o is not present, a previous Media Segment MUST appear in the
> Playlist file and MUST be a sub-range of the same media resource, or
> the Media Segment is undefined and the client MUST fail to parse the
> Playlist.

----

I'll take a look at writing some tests for this once I get the time. I'm currently busy with other stuff. There's also the other issue which I've talked about in #4300 which needs to be fixed too.