### PR TITLE
cli: tell users the stream could be saved or piped

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -116,7 +116,9 @@ def create_output(formatter: Formatter):
         if not args.player:
             console.exit("The default player (VLC) does not seem to be "
                          "installed. You must specify the path to a player "
-                         "executable with --player.")
+                         "executable with --player, a filepath to save the "
+                         "stream with --output, or pipe the stream to "
+                         "another program with --stdout.")
 
         if args.player_fifo:
             try:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -110,15 +110,16 @@ def create_output(formatter: Formatter):
     elif args.record_and_pipe:
         record = check_file_output(formatter.path(args.record_and_pipe, args.fs_safe_rules), args.force)
         out = FileOutput(fd=stdout, record=record)
+    elif not args.player:
+        console.exit(
+            "The default player (VLC) does not seem to be "
+            "installed. You must specify the path to a player "
+            "executable with --player, a file path to save the "
+            "stream with --output, or pipe the stream to "
+            "another program with --stdout."
+        )
     else:
         http = namedpipe = record = None
-
-        if not args.player:
-            console.exit("The default player (VLC) does not seem to be "
-                         "installed. You must specify the path to a player "
-                         "executable with --player, a filepath to save the "
-                         "stream with --output, or pipe the stream to "
-                         "another program with --stdout.")
 
         if args.player_fifo:
             try:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -379,6 +379,22 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         create_output(formatter)
         console.exit.assert_called_with("Cannot use record options with other file output options.")
 
+    @patch("streamlink_cli.main.args")
+    @patch("streamlink_cli.main.console")
+    def test_create_output_no_default_player(self, console: Mock, args: Mock):
+        formatter = Formatter({})
+        args.output = None
+        args.stdout = False
+        args.record_and_pipe = False
+        args.player = None
+        console.exit.side_effect = SystemExit
+        with self.assertRaises(SystemExit):
+            create_output(formatter)
+        self.assertRegex(
+            console.exit.call_args_list[0][0][0],
+            r"^The default player \(\w+\) does not seem to be installed\."
+        )
+
 
 class TestCLIMainHandleStream(unittest.TestCase):
     @patch("streamlink_cli.main.output_stream")


### PR DESCRIPTION
Hi there!

For new CLI users (e.g., on Ubuntu Server), it is more friendly to tell them that this utility has the ability to save and pipe streams.  
I know they should "RTFM", but IMO, more detailed error messages might get them started sooner.

Original:

```console
$ streamlink ...
[cli][info] ...
[cli][info] ...
[cli][info] ...
error: The default player (VLC) does not seem to be installed. You must specify the path to a player executable with --player.
```

New:

```console
$ streamlink ...
[cli][info] ...
[cli][info] ...
[cli][info] ...
error: The default player (VLC) does not seem to be installed. You must specify the path to a player executable with --player, a filepath to save the stream with --output, or pipe the stream to another program with --stdout.
```