### PR TITLE
installer: set pynsist to 2.7 and distlib to 0.3.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
-          python -m pip install pynsist wheel
+          python -m pip install wheel pynsist==2.7 distlib==0.3.3
           sudo apt update
           sudo apt install -y nsis imagemagick inkscape
       - name: Installer file name


### PR DESCRIPTION
See #4307 

According to my locally built installers, downgrading distlib to 0.3.3 fixes the issue of the broken executables. This is not a long-term solution, but it should work for now.

I'd like to publish 3.1.1 as soon as possible, but I also want to see if the next nightly is working as intended once this gets merged.

As said in #4307, the executables are only broken when trying to run them from a non-command-line context on Windows, eg. from a GUI application and they immediately terminate with exit code 3221225477. I don't know how the executables work. I only know how pynsist concatenates the binaries built by the distlib project with a shebang and the application's entry script.