### PR TITLE
plugins.pluzz: fix workflow value in API schema

### DIFF
--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -98,7 +98,7 @@ class Pluzz(Plugin):
             validate.parse_json(),
             {
                 "video": {
-                    "workflow": "token-akamai",
+                    "workflow": validate.any("token-akamai", "dai"),
                     "format": validate.any("dash", "hls"),
                     "token": validate.url(),
                     "url": validate.url()


### PR DESCRIPTION
Fixes #4325 

```
$ streamlink --http-proxy socks5://localhost:1920 'https://www.france.tv/beijing-h24/direct.html' best
[cli][info] Found matching plugin pluzz for URL https://www.france.tv/beijing-h24/direct.html
[cli][info] Available streams: 216p (worst), 360p, 432p, 540p, 720p (best)
[cli][info] Opening stream: 720p (hls)
[cli][info] Starting player: mpv
```