### PR TITLE
cli: log resolved file output path

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -72,6 +72,7 @@ def check_file_output(path: Path, force):
     """Checks if file already exists and ask the user if it should
     be overwritten if it does."""
 
+    log.info(f"Writing output to\n{path.resolve()}")
     log.debug("Checking file output")
 
     if path.is_file() and not force:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -190,18 +190,22 @@ class TestCLIMainJsonAndStreamUrl(unittest.TestCase):
 
 class TestCLIMainCheckFileOutput(unittest.TestCase):
     @staticmethod
-    def mock_path(path, is_file=True):
+    def mock_path(path, is_file=True, resolve=""):
         return Mock(
             spec=Path(path),
             is_file=Mock(return_value=is_file),
+            resolve=Mock(return_value=resolve),
             __str__=Mock(return_value=path)
         )
 
-    def test_check_file_output(self):
-        path = self.mock_path("foo", is_file=False)
+    @patch("streamlink_cli.main.log")
+    def test_check_file_output(self, mock_log: Mock):
+        path = self.mock_path("foo", is_file=False, resolve="/path/to/foo")
         output = check_file_output(path, False)
         self.assertIsInstance(output, FileOutput)
         self.assertIs(output.filename, path)
+        self.assertEqual(mock_log.info.call_args_list, [call("Writing output to\n/path/to/foo")])
+        self.assertEqual(mock_log.debug.call_args_list, [call("Checking file output")])
 
     def test_check_file_output_exists_force(self):
         path = self.mock_path("foo", is_file=True)


### PR DESCRIPTION
Streamlink currently doesn't log the full path when writing the output to a file. This is an issue when the output path is dynamically generated from the input argument via the stream's metadata, because the user doesn't know where the data was actually written to. The output path gets already logged if the file already exists, but that's not really helpful.

The log message added by this PR does only get printed if the stream is written to a file, and not to stdout via `--stdout` or `--output=-`.

I'm not sure though if we should put the path into quotes and escape it (via shlex.quote), because if there are spaces, it's not perfectly clear. It is however on a separate line in the output, so maybe it is. The file path in the confirm message could also be removed, but that would require the "Writing output to" message to be printed via `console.msg` and not `log.info`, because log messages can be suppressed whereas console messages can not.

Thoughts?

```
$ streamlink -o '~/Downloads/{title}.ts' 'https://www.youtube.com/watch?v=tAHC3-dgzCo' best
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=tAHC3-dgzCo
[cli][info] Available streams: 144p (worst), 240p, 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Writing output to
/home/basti/Downloads/Liquicity Radio (24_7 stream).ts
[download][.. Radio (24_7 stream).ts] Written 1.4 MB (0s @ 2.3 MB/s)
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```

```
$ streamlink -o '~/Downloads/{title}.ts' 'https://www.youtube.com/watch?v=tAHC3-dgzCo' best
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=tAHC3-dgzCo
[cli][info] Available streams: 144p (worst), 240p, 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Writing output to
/home/basti/Downloads/Liquicity Radio (24_7 stream).ts
File /home/basti/Downloads/Liquicity Radio (24_7 stream).ts already exists! Overwrite it? [y/N] y
[download][.. Radio (24_7 stream).ts] Written 3.3 MB (2s @ 1.5 MB/s)
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```