### PR TITLE
plugins.rtpa: add new plugin

### DIFF
--- a/docs/plugin_matrix.rst
+++ b/docs/plugin_matrix.rst
@@ -151,6 +151,7 @@ reuters                 - reuters.com        Yes   Yes
 rotana                  rotana.net           Yes   --    Streams are geo-restricted to Saudi Arabia.
 rtbf                    - rtbf.be/auvio      Yes   Yes   Streams may be geo-restricted to Belgium or Europe.
                         - rtbfradioplayer.be
+rtpa                    rtpa.es              Yes   Yes
 rtpplay                 rtp.pt/play          Yes   Yes   Streams may be geo-restricted to Portugal.
 rtve                    rtve.es              Yes   Yes   Streams may be geo-restricted to Spain.
 rtvs                    rtvs.sk              Yes   No    Streams may be geo-restricted to Slovakia.

--- a/src/streamlink/plugins/rtpa.py
+++ b/src/streamlink/plugins/rtpa.py
@@ -1,0 +1,21 @@
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+
+@pluginmatcher(re.compile(r"https?://(?:www\.)?rtpa\.es"))
+class RTPA(Plugin):
+    def _get_streams(self):
+        hls_url = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath_string(".//video/source[@src][@type='application/x-mpegURL'][1]/@src")
+        ))
+        if not hls_url:
+            return
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+
+__plugin__ = RTPA

--- a/tests/plugins/test_rtpa.py
+++ b/tests/plugins/test_rtpa.py
@@ -1,0 +1,11 @@
+from streamlink.plugins.rtpa import RTPA
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlRTPA(PluginCanHandleUrl):
+    __plugin__ = RTPA
+
+    should_match = [
+        "https://www.rtpa.es/tpa-television",
+        "https://www.rtpa.es/video:Ciencia%20en%2060%20segundos_551644582052.html",
+    ]


### PR DESCRIPTION
See #4341, #4343

Regional Spanish TV channel:
https://en.wikipedia.org/wiki/Radiotelevisi%C3%B3n_del_Principado_de_Asturias
https://www.rtpa.es/

Live:
```
$ streamlink 'https://www.rtpa.es/tpa-television' best
[cli][info] Found matching plugin rtpa for URL https://www.rtpa.es/tpa-television
[cli][info] Available streams: 500k (worst), 1500k (best)
[cli][info] Opening stream: 1500k (hls)
```

VOD:
```
$ streamlink 'https://www.rtpa.es/video:Ciencia%20en%2060%20segundos_551644582052.html' best
[cli][info] Found matching plugin rtpa for URL https://www.rtpa.es/video:Ciencia%20en%2060%20segundos_551644582052.html
[cli][info] Available streams: 240p (worst), 480p (best)
[cli][info] Opening stream: 480p (hls)
```