### PR TITLE
plugin.api.http_session: add class TLSSecLevel1Adapter()

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -1,3 +1,4 @@
+import ssl
 import time
 from typing import Any, Callable, List, Pattern, Tuple
 
@@ -220,4 +221,12 @@ class HTTPSession(Session):
         return res
 
 
-__all__ = ["HTTPSession"]
+class TLSSecLevel1Adapter(requests.adapters.HTTPAdapter):
+    def init_poolmanager(self, *args, **kwargs):
+        ctx = ssl.create_default_context()
+        ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
+        kwargs["ssl_context"] = ctx
+        return super().init_poolmanager(*args, **kwargs)
+
+
+__all__ = ["HTTPSession", "TLSSecLevel1Adapter"]


### PR DESCRIPTION
Creates an adapter with OpenSSL security level 1.  Example usage:

from streamlink.plugin.api.http_session import TLSSecLevel1Adapter

adapter = TLSSecLevel1Adapter()
self.session.http.mount("https://filmon.com", adapter)
self.session.http.mount("https://www.filmon.com", adapter)

---
~I have not added this to `__all__`, is that reasonable?~
There are no tests; I'm not really sure how to test it.

merge before #4335
