### PR TITLE
installer: update wheels to latest versions

### DIFF
--- a/script/makeinstaller-requirements.json
+++ b/script/makeinstaller-requirements.json
@@ -4,15 +4,15 @@
     },
     "wheels": {
         "certifi": "2021.10.8 --hash=sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569",
-        "charset-normalizer": "2.0.7 --hash=sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b",
+        "charset-normalizer": "2.0.12 --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df",
         "idna": "3.3 --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-        "isodate": "0.6.0 --hash=sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81",
-        "lxml": "4.6.4 --hash=sha256:ee9e4b07b0eba4b6a521509e9e1877476729c1243246b6959de697ebea739643",
-        "pycryptodome": "3.11.0 --hash=sha256:6db1f9fa1f52226621905f004278ce7bd90c8f5363ffd5d7ab3755363d98549a",
+        "isodate": "0.6.1 --hash=sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96",
+        "lxml": "4.7.1 --hash=sha256:59e7da839a1238807226f7143c68a479dee09244d1b3cf8c134f2fce777d12d0",
+        "pycryptodome": "3.14.1 --hash=sha256:53dedbd2a6a0b02924718b520a723e88bcf22e37076191eb9b91b79934fb2192",
         "PySocks": "1.7.1 --hash=sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5",
-        "requests": "2.26.0 --hash=sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
+        "requests": "2.27.1 --hash=sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d",
         "six": "1.16.0 --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
-        "urllib3": "1.26.7 --hash=sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844",
-        "websocket-client": "1.2.1 --hash=sha256:0133d2f784858e59959ce82ddac316634229da55b498aac311f1620567a710ec"
+        "urllib3": "1.26.8 --hash=sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed",
+        "websocket-client": "1.2.3 --hash=sha256:2eed4cc58e4d65613ed6114af2f380f7910ff416fc8c46947f6e76b6815f56c0"
     }
 }


### PR DESCRIPTION
closes #4329 

The main intention of this PR is bumping `charset-normalizer` to the latest version, which fixes the broken charset detection in HTTP requests without charset data in the content-type header, which has previously often lead to broken HLS playlist contents.

The pycountry source-dist tarball did not get bumped in this commit, because it would require additional changes in the installer's build script. Doesn't really matter though.

I will probably also publish a new AppImage release (3.1.1-2) with bumped dependencies. Deps get always bumped there on each release, but since charset-normalizer is a transitive dependency of streamlink, publishing a new patch release here would only make sense if we add it to streamlink's own dependencies list.