### PR TITLE
docs: correct minor typo

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -314,7 +314,7 @@ with an optional list of parameters, like so:
     $ streamlink "protocol://https://streamingserver/path key1=value1 key2=value2"
 
 Depending on the input URL, the explicit protocol scheme may be omitted.
-The following example shows HLS streams (``.m3u8``) and DASH streams (``.mdp``):
+The following example shows HLS streams (``.m3u8``) and DASH streams (``.mpd``):
 
 .. code-block:: console
 


### PR DESCRIPTION
mdp -> mpd
