### PR TITLE
plugins.ard_live: fix live.daserste.de inputs

### DIFF
--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
     r"https?://((www|live)\.)?daserste\.de/"
 ))
 class ARDLive(Plugin):
+    _URL_DATA_BASE = "https://www.daserste.de/"
     _QUALITY_MAP = {
         4: "1080p",
         3: "720p",
@@ -36,7 +37,7 @@ class ARDLive(Plugin):
         except PluginError:
             return
 
-        data_url = urljoin(self.url, data_url)
+        data_url = urljoin(self._URL_DATA_BASE, data_url)
         log.debug(f"Player URL: '{data_url}'")
 
         self.title, media = self.session.http.get(data_url, schema=validate.Schema(


### PR DESCRIPTION
Fixes #4354 

```
$ streamlink 'https://live.daserste.de/' best -l debug
[cli][debug] OS:         Linux-5.16.10-1-git-x86_64-with-glibc2.35
[cli][debug] Python:     3.10.2
[cli][debug] Streamlink: 3.1.1+12.g2120481
[cli][debug] Requests(2.27.1), Socks(1.7.1), Websocket(1.2.3)
[cli][debug] Arguments:
[cli][debug]  url=https://live.daserste.de/
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin ard_live for URL https://live.daserste.de/
[plugins.ard_live][debug] Player URL: 'https://www.daserste.de/live-de-102~playerJson.json'
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 270p (worst), 360p, 540p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
```