### PR TITLE
tests.plugins: implement should_match_groups

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -464,7 +464,7 @@ class TwitchAPI:
         |
         (?P<channel>[^/?]+)
         (?:
-            /video/(?P<video_id>\d+)
+            /v(?:ideo)?/(?P<video_id>\d+)
             |
             /clip/(?P<clip_name>[^/?]+)
         )?

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,6 +14,11 @@ signal.signal(signal.SIGINT, signal.default_int_handler)
 signal.signal(signal.SIGTERM, signal.default_int_handler)
 
 
+# make pytest rewrite assertions in dynamically parametrized plugin tests
+# https://docs.pytest.org/en/stable/how-to/writing_plugins.html#assertion-rewriting
+pytest.register_assert_rewrite("tests.plugins")
+
+
 def catch_warnings(record=False, module=None):
     def _catch_warnings_wrapper(f):
         def _catch_warnings(*args, **kwargs):

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -11,18 +11,30 @@ generic_negative_matches = [
 class PluginCanHandleUrl:
     __plugin__ = None
 
+    # A list of URLs that should match any of the plugin's URL regexes.
+    #   ["https://foo", "https://bar"]
     should_match = []
+
+    # A list of URL+capturegroup tuples, where capturegroup can be a dict (re.Match.groupdict()) or a tuple (re.Match.groups()).
+    # URLs defined in this list automatically get appended to the should_match list.
+    # Values in capturegroup dictionaries that are None get ignored when comparing and can be omitted in the test fixtures.
+    #   [("https://foo", {"foo": "foo"}), ("https://bar", ("bar", None))]
+    should_match_groups = []
+
+    # A list of URLs that should not match any of the plugin's URL regexes.
+    #   ["https://foo", "https://bar"]
     should_not_match = []
 
     def test_class_setup(self):
         assert issubclass(self.__plugin__, Plugin), "Test has a __plugin__ that is a subclass of streamlink.plugin.Plugin"
-        assert len(self.should_match) > 0, "Test has at least one positive URL"
+        assert len(self.should_match + self.should_match_groups) > 0, "Test has at least one positive URL"
 
     def test_matchers(self):
+        should_match = self.should_match + [url for url, groups in self.should_match_groups]
         assert all(
             any(
                 matcher.pattern.match(url)
-                for url in self.should_match
+                for url in should_match
             )
             for matcher in self.__plugin__.matchers
         ), "All plugin matchers should match"
@@ -40,3 +52,17 @@ class PluginCanHandleUrl:
             matcher.pattern.match(url)
             for matcher in self.__plugin__.matchers
         ), "URL does not match"
+
+    # parametrized dynamically via conftest.py
+    def test_capture_groups(self, url, groups):
+        for matcher in self.__plugin__.matchers:
+            match = matcher.pattern.match(url)
+            if match:  # pragma: no branch
+                res = (
+                    # ignore None values in capture group dicts
+                    {k: v for k, v in match.groupdict().items() if v is not None}
+                    if type(groups) is dict else
+                    # capture group tuples
+                    match.groups()
+                )
+                assert res == groups, "URL capture groups match"

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,9 +1,24 @@
 from tests.plugins import PluginCanHandleUrl, generic_negative_matches
 
 
-def pytest_generate_tests(metafunc):
-    if metafunc.cls is not None and issubclass(metafunc.cls, PluginCanHandleUrl):  # pragma: no branch
+def pytest_collection_modifyitems(session, config, items):  # pragma: no cover
+    # remove empty parametrized tests
+    session.items = list(filter(lambda item: not any(
+        marker.name == "skip" and str(marker.kwargs.get("reason", "")).startswith("got empty parameter set")
+        for marker in item.own_markers
+    ), items))
+
+
+def pytest_generate_tests(metafunc):  # pragma: no cover
+    if metafunc.cls is not None and issubclass(metafunc.cls, PluginCanHandleUrl):
         if metafunc.function.__name__ == "test_can_handle_url_positive":
-            metafunc.parametrize("url", metafunc.cls.should_match)
+            metafunc.parametrize("url", metafunc.cls.should_match + [url for url, groups in metafunc.cls.should_match_groups])
+
         elif metafunc.function.__name__ == "test_can_handle_url_negative":
             metafunc.parametrize("url", metafunc.cls.should_not_match + generic_negative_matches)
+
+        elif metafunc.function.__name__ == "test_capture_groups":
+            metafunc.parametrize("url,groups", metafunc.cls.should_match_groups, ids=[
+                f"URL={url} GROUPS={groups}"
+                for url, groups in metafunc.cls.should_match_groups
+            ])

--- a/tests/plugins/test_filmon.py
+++ b/tests/plugins/test_filmon.py
@@ -1,7 +1,3 @@
-from unittest.mock import Mock
-
-import pytest
-
 from streamlink.plugins.filmon import Filmon
 from tests.plugins import PluginCanHandleUrl
 
@@ -21,24 +17,17 @@ class TestPluginCanHandleUrlFilmon(PluginCanHandleUrl):
         'http://www.filmon.tv/group/comedy',
     ]
 
-
-@pytest.mark.parametrize('url,expected', [
-    ('http://www.filmon.tv/channel/grandstand-show', [None, "grandstand-show", None]),
-    ('http://www.filmon.tv/index/popout?channel_id=5510&quality=low', [None, '5510', None]),
-    ('http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1', [None, '5510', None]),
-    ('http://www.filmon.tv/tv/channel/grandstand-show', [None, 'grandstand-show', None]),
-    ('https://www.filmon.com/tv/bbc-news', [None, 'bbc-news', None]),
-    ('https://www.filmon.com/tv/channel-4', [None, 'channel-4', None]),
-    ('https://www.filmon.tv/tv/55', [None, '55', None]),
-    ('http://www.filmon.tv/group/comedy', ['group/', 'comedy', None]),
-    ('http://www.filmon.tv/vod/view/10250-0-crime-boss', [None, None, '10250-0-crime-boss']),
-    ('http://www.filmon.tv/vod/view/10250-0-crime-boss/extra', [None, None, '10250-0-crime-boss']),
-    ('http://www.filmon.tv/vod/view/10250-0-crime-boss?extra', [None, None, '10250-0-crime-boss']),
-    ('http://www.filmon.tv/vod/view/10250-0-crime-boss&extra', [None, None, '10250-0-crime-boss'])
-])
-def test_match_url(url, expected):
-    Filmon.bind(Mock(), "tests.plugins.test_filmon")
-    plugin = Filmon(url)
-    assert plugin.match is not None
-    # expected must return [is_group, channel, vod_id]
-    assert list(plugin.match.groups()) == expected
+    should_match_groups = [
+        ('http://www.filmon.tv/channel/grandstand-show', (None, "grandstand-show", None)),
+        ('http://www.filmon.tv/index/popout?channel_id=5510&quality=low', (None, '5510', None)),
+        ('http://www.filmon.tv/tv/channel/export?channel_id=5510&autoPlay=1', (None, '5510', None)),
+        ('http://www.filmon.tv/tv/channel/grandstand-show', (None, 'grandstand-show', None)),
+        ('https://www.filmon.com/tv/bbc-news', (None, 'bbc-news', None)),
+        ('https://www.filmon.com/tv/channel-4', (None, 'channel-4', None)),
+        ('https://www.filmon.tv/tv/55', (None, '55', None)),
+        ('http://www.filmon.tv/group/comedy', ('group/', 'comedy', None)),
+        ('http://www.filmon.tv/vod/view/10250-0-crime-boss', (None, None, '10250-0-crime-boss')),
+        ('http://www.filmon.tv/vod/view/10250-0-crime-boss/extra', (None, None, '10250-0-crime-boss')),
+        ('http://www.filmon.tv/vod/view/10250-0-crime-boss?extra', (None, None, '10250-0-crime-boss')),
+        ('http://www.filmon.tv/vod/view/10250-0-crime-boss&extra', (None, None, '10250-0-crime-boss')),
+    ]

--- a/tests/plugins/test_qq.py
+++ b/tests/plugins/test_qq.py
@@ -1,7 +1,3 @@
-from unittest.mock import Mock
-
-import pytest
-
 from streamlink.plugins.qq import QQ
 from tests.plugins import PluginCanHandleUrl
 
@@ -18,19 +14,17 @@ class TestPluginCanHandleUrlQQ(PluginCanHandleUrl):
         "http://m.live.qq.com/10039165"
     ]
 
+    should_match_groups = [
+        ("http://live.qq.com/10003715", {
+            "room_id": "10003715"
+        }),
+        ("http://m.live.qq.com/10039165", {
+            "room_id": "10039165"
+        }),
+    ]
+
     should_not_match = [
         "http://live.qq.com/",
         "http://qq.com/",
         "http://www.qq.com/"
     ]
-
-
-@pytest.mark.parametrize("url,group,expected", [
-    ("http://live.qq.com/10003715", "room_id", "10003715"),
-    ("http://m.live.qq.com/10039165", "room_id", "10039165")
-])
-def test_match_url(url, group, expected):
-    QQ.bind(Mock(), "tests.plugins.test_qq")
-    plugin = QQ(url)
-    assert plugin.match is not None
-    assert plugin.match.group(group) == expected

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -13,13 +13,34 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlTwitch(PluginCanHandleUrl):
     __plugin__ = Twitch
 
-    should_match = [
-        'https://www.twitch.tv/twitch',
-        'https://www.twitch.tv/videos/150942279',
-        'https://clips.twitch.tv/ObservantBenevolentCarabeefPhilosoraptor',
-        'https://www.twitch.tv/weplaydota/clip/FurryIntelligentDonutAMPEnergyCherry-akPRxv7Y3w58WmFq'
-        'https://www.twitch.tv/twitch/video/292713971',
-        'https://www.twitch.tv/twitch/v/292713971',
+    should_match_groups = [
+        ("https://www.twitch.tv/twitch", {
+            "subdomain": "www",
+            "channel": "twitch",
+        }),
+        ("https://www.twitch.tv/videos/150942279", {
+            "subdomain": "www",
+            "videos_id": "150942279",
+        }),
+        ("https://clips.twitch.tv/ObservantBenevolentCarabeefPhilosoraptor", {
+            "subdomain": "clips",
+            "channel": "ObservantBenevolentCarabeefPhilosoraptor",
+        }),
+        ("https://www.twitch.tv/weplaydota/clip/FurryIntelligentDonutAMPEnergyCherry-akPRxv7Y3w58WmFq", {
+            "subdomain": "www",
+            "channel": "weplaydota",
+            "clip_name": "FurryIntelligentDonutAMPEnergyCherry-akPRxv7Y3w58WmFq",
+        }),
+        ("https://www.twitch.tv/twitch/video/292713971", {
+            "subdomain": "www",
+            "channel": "twitch",
+            "video_id": "292713971",
+        }),
+        ("https://www.twitch.tv/twitch/v/292713971", {
+            "subdomain": "www",
+            "channel": "twitch",
+            "video_id": "292713971",
+        }),
     ]
 
     should_not_match = [

--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -34,6 +34,19 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
         "https://youtu.be/0123456789A",
     ]
 
+    should_match_groups = [
+        ("https://www.youtube.com/v/aqz-KE-bpKQ", {
+            "video_id": "aqz-KE-bpKQ",
+        }),
+        ("https://www.youtube.com/embed/aqz-KE-bpKQ", {
+            "embed": "embed",
+            "video_id": "aqz-KE-bpKQ",
+        }),
+        ("https://www.youtube.com/watch?v=aqz-KE-bpKQ", {
+            "video_id": "aqz-KE-bpKQ",
+        }),
+    ]
+
     should_not_match = [
         "https://accounts.google.com/",
         "https://www.youtube.com",
@@ -45,18 +58,6 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
         "https://youtu.be/c/CHANNELNAME",
         "https://youtu.be/c/CHANNELNAME/live",
     ]
-
-
-@pytest.mark.parametrize("url,group,expected", [
-    ("https://www.youtube.com/v/aqz-KE-bpKQ", "video_id", "aqz-KE-bpKQ"),
-    ("https://www.youtube.com/embed/aqz-KE-bpKQ", "video_id", "aqz-KE-bpKQ"),
-    ("https://www.youtube.com/watch?v=aqz-KE-bpKQ", "video_id", "aqz-KE-bpKQ"),
-])
-def test_match_url(url, group, expected):
-    YouTube.bind(Mock(), "tests.plugins.test_youtube")
-    plugin = YouTube(url)
-    assert plugin.match is not None
-    assert plugin.match.group(group) == expected
 
 
 @pytest.mark.parametrize("url,expected", [


### PR DESCRIPTION
This should simplify testing plugin URL capture groups and make it more consistent between tests.

Please see the commit messages of both commits.