### PR TITLE
plugins.goltelevision: fix API URL

### DIFF
--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -5,27 +5,20 @@ from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
 
-class GOLTelevisionHLSStream(HLSStream):
-    @classmethod
-    def _get_variant_playlist(cls, res):
-        res.encoding = "UTF-8"
-        return super()._get_variant_playlist(res)
-
-
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?goltelevision\.com/en-directo"
 ))
 class GOLTelevision(Plugin):
     def _get_streams(self):
         url = self.session.http.get(
-            "https://www.goltelevision.com/api/manifest/live",
+            "https://play.goltelevision.com/api/stream/live",
             schema=validate.Schema(
                 validate.parse_json(),
                 {"manifest": validate.url()},
                 validate.get("manifest")
             )
         )
-        return GOLTelevisionHLSStream.parse_variant_playlist(self.session, url)
+        return HLSStream.parse_variant_playlist(self.session, url)
 
 
 __plugin__ = GOLTelevision


### PR DESCRIPTION
and remove unneeded HLSStream subclass

----

Fixes #4367 

The master playlist can be accessed from any region, but individual streams are geo-blocked, so I can't fully verify the plugin. Shouldn't matter though.

```
$ streamlink -l debug 'https://www.goltelevision.com/en-directo'
[cli][debug] OS:         Linux-5.16.11-1-git-x86_64-with-glibc2.35
[cli][debug] Python:     3.10.2
[cli][debug] Streamlink: 3.1.1+15.g35f6fb7
[cli][debug] Requests(2.27.1), Socks(1.7.1), Websocket(1.2.3)
[cli][debug] Arguments:
[cli][debug]  url=https://www.goltelevision.com/en-directo
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin goltelevision for URL https://www.goltelevision.com/en-directo
[utils.l10n][debug] Language code: en_US
[stream.hls][debug] Using external audio tracks for stream 720p (language=spa, name=Spanish)
[stream.hls][debug] Using external audio tracks for stream 576p (language=spa, name=Spanish)
[stream.hls][debug] Using external audio tracks for stream 480p (language=spa, name=Spanish)
[stream.hls][debug] Using external audio tracks for stream 360p (language=spa, name=Spanish)
Available streams: 360p (worst), 480p, 576p, 720p (best)
```