### PR TITLE
tests: rewrite plugins tests

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,6 @@
 import pkgutil
 import re
+from pathlib import Path
 
 import pytest
 
@@ -68,3 +69,19 @@ class TestPluginTests:
     @pytest.mark.parametrize("plugintest", plugintests)
     def test_test_has_plugin(self, plugintest):
         assert plugintest in plugins, "Plugin exists for test module"
+
+
+class TestRemovedPluginsFile:
+    @pytest.fixture(scope="class")
+    def removedplugins(self):
+        with (Path(plugins_path) / ".removed").open() as handle:
+            return [line.strip() for line in handle.readlines() if not line.strip().startswith("#")]
+
+    @pytest.mark.parametrize("plugin", plugins)
+    def test_plugin_not_in_file(self, plugin, removedplugins):
+        assert plugin not in removedplugins, "Existing plugin is not in removed plugins list"
+
+    def test_is_sorted(self, removedplugins):
+        removedplugins_sorted = removedplugins.copy()
+        removedplugins_sorted.sort()
+        assert removedplugins_sorted == removedplugins, "Removed plugins list is sorted alphabetically"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,17 +1,36 @@
 import pkgutil
+import re
 
 import pytest
 
 import streamlink.plugins
+import tests.plugins
 from streamlink.plugin.plugin import Matcher, Plugin
 from streamlink.utils.module import load_module
 
 
 plugins_path = streamlink.plugins.__path__[0]
+plugintests_path = tests.plugins.__path__[0]
+
+protocol_plugins = [
+    "http",
+    "hls",
+    "dash",
+]
+plugintests_ignore = [
+    "test_stream",
+]
+
 plugins = [
     pname
     for finder, pname, ispkg in pkgutil.iter_modules([plugins_path])
     if not pname.startswith("common_")
+]
+plugins_no_protocols = [pname for pname in plugins if pname not in protocol_plugins]
+plugintests = [
+    re.sub(r"^test_", "", tname)
+    for finder, tname, ispkg in pkgutil.iter_modules([plugintests_path])
+    if tname.startswith("test_") and tname not in plugintests_ignore
 ]
 
 
@@ -39,3 +58,13 @@ class TestPlugins:
         assert not hasattr(pluginclass, "can_handle_url"), "Does not implement deprecated can_handle_url(url)"
         assert not hasattr(pluginclass, "priority"), "Does not implement deprecated priority(url)"
         assert callable(pluginclass._get_streams), "Implements _get_streams()"
+
+
+class TestPluginTests:
+    @pytest.mark.parametrize("plugin", plugins_no_protocols)
+    def test_plugin_has_tests(self, plugin):
+        assert plugin in plugintests, "Test module exists for plugin"
+
+    @pytest.mark.parametrize("plugintest", plugintests)
+    def test_test_has_plugin(self, plugintest):
+        assert plugintest in plugins, "Plugin exists for test module"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,47 +1,41 @@
-import os.path
 import pkgutil
-import unittest
+
+import pytest
 
 import streamlink.plugins
 from streamlink.plugin.plugin import Matcher, Plugin
 from streamlink.utils.module import load_module
 
 
-class PluginTestMeta(type):
-    def __new__(mcs, name, bases, dict):
-        plugin_path = os.path.dirname(streamlink.plugins.__file__)
-
-        def gentest(plugin):
-            def load_plugin_test(self):
-                assert hasattr(plugin, "__plugin__"), "It exports __plugin__"
-
-                pluginclass = plugin.__plugin__
-                assert issubclass(plugin.__plugin__, Plugin), "__plugin__ is an instance of the Plugin class"
-
-                classname = pluginclass.__name__
-                assert classname == classname[0].upper() + classname[1:], "__plugin__ class name starts with uppercase letter"
-                assert "_" not in classname, "__plugin__ class name does not contain underscores"
-
-                assert isinstance(pluginclass.matchers, list) and len(pluginclass.matchers) > 0, "Has at least one matcher"
-                assert all(isinstance(matcher, Matcher) for matcher in pluginclass.matchers), "Only has valid matchers"
-
-                assert not hasattr(pluginclass, "can_handle_url"), "Does not implement deprecated can_handle_url(url)"
-                assert not hasattr(pluginclass, "priority"), "Does not implement deprecated priority(url)"
-                assert callable(pluginclass._get_streams), "Implements _get_streams()"
-
-            return load_plugin_test
-
-        pname: str
-        for finder, pname, ispkg in pkgutil.iter_modules([plugin_path]):
-            if pname.startswith("common_"):
-                continue
-            plugin_module = load_module(f"streamlink.plugins.{pname}", plugin_path)
-            dict[f"test_{pname}_load"] = gentest(plugin_module)
-
-        return type.__new__(mcs, name, bases, dict)
+plugins_path = streamlink.plugins.__path__[0]
+plugins = [
+    pname
+    for finder, pname, ispkg in pkgutil.iter_modules([plugins_path])
+    if not pname.startswith("common_")
+]
 
 
-class TestPlugins(unittest.TestCase, metaclass=PluginTestMeta):
-    """
-    Test that each plugin can be loaded and does not fail when calling can_handle_url.
-    """
+class TestPlugins:
+    @pytest.fixture(scope="class", params=plugins)
+    def plugin(self, request):
+        return load_module(f"streamlink.plugins.{request.param}", plugins_path)
+
+    def test_exports_plugin(self, plugin):
+        assert hasattr(plugin, "__plugin__"), "Plugin module exports __plugin__"
+        assert issubclass(plugin.__plugin__, Plugin), "__plugin__ is an instance of the Plugin class"
+
+    def test_classname(self, plugin):
+        classname = plugin.__plugin__.__name__
+        assert classname == classname[0].upper() + classname[1:], "__plugin__ class name starts with uppercase letter"
+        assert "_" not in classname, "__plugin__ class name does not contain underscores"
+
+    def test_matchers(self, plugin):
+        pluginclass = plugin.__plugin__
+        assert isinstance(pluginclass.matchers, list) and len(pluginclass.matchers) > 0, "Has at least one matcher"
+        assert all(isinstance(matcher, Matcher) for matcher in pluginclass.matchers), "Only has valid matchers"
+
+    def test_plugin_api(self, plugin):
+        pluginclass = plugin.__plugin__
+        assert not hasattr(pluginclass, "can_handle_url"), "Does not implement deprecated can_handle_url(url)"
+        assert not hasattr(pluginclass, "priority"), "Does not implement deprecated priority(url)"
+        assert callable(pluginclass._get_streams), "Implements _get_streams()"

--- a/tests/test_plugins_meta.py
+++ b/tests/test_plugins_meta.py
@@ -1,7 +1,6 @@
 import os.path
 import re
 import unittest
-from glob import glob
 
 from streamlink import Streamlink, plugins as streamlinkplugins
 from streamlink_cli.argparser import build_parser
@@ -28,13 +27,8 @@ class TestPluginMeta(unittest.TestCase):
         with open(os.path.join(plugins_dir, ".removed")) as rmfh:
             cls.plugins_removed = [pname for pname in rmfh.read().split("\n") if pname and not pname.startswith("#")]
 
-        tests_plugins_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "plugins"))
-        tests_plugin_files = glob(os.path.join(tests_plugins_dir, "test_*.py"))
-
         cls.plugins = cls.session.plugins.keys()
-        cls.plugin_tests = [re.sub(r"^test_(.+)\.py$", r"\1", os.path.basename(file)) for file in tests_plugin_files]
         cls.plugins_no_protocols = [pname for pname in cls.plugins if pname not in cls.protocol_tests]
-        cls.plugin_tests_no_protocols = [pname for pname in cls.plugin_tests if pname not in cls.protocol_tests]
 
     def test_plugin_has_docs_matrix(self):
         for pname in self.plugins_no_protocols:
@@ -43,14 +37,6 @@ class TestPluginMeta(unittest.TestCase):
     def test_docs_matrix_has_plugin(self):
         for pname in self.plugins_in_docs:
             self.assertIn(pname, self.plugins_no_protocols, f"{pname} plugin does not exist")
-
-    def test_plugin_has_tests(self):
-        for pname in self.plugins_no_protocols:
-            self.assertIn(pname, self.plugin_tests, f"{pname} has no tests")
-
-    def test_unknown_plugin_has_tests(self):
-        for pname in self.plugin_tests_no_protocols:
-            self.assertIn(pname, self.plugins_no_protocols, f"{pname} is not a plugin but has tests")
 
     def test_plugin_not_in_removed_list(self):
         for pname in self.plugins:

--- a/tests/test_plugins_meta.py
+++ b/tests/test_plugins_meta.py
@@ -38,15 +38,6 @@ class TestPluginMeta(unittest.TestCase):
         for pname in self.plugins_in_docs:
             self.assertIn(pname, self.plugins_no_protocols, f"{pname} plugin does not exist")
 
-    def test_plugin_not_in_removed_list(self):
-        for pname in self.plugins:
-            self.assertNotIn(pname, self.plugins_removed, f"{pname} is in removed plugins list")
-
-    def test_removed_list_is_sorted(self):
-        plugins_removed_sorted = self.plugins_removed.copy()
-        plugins_removed_sorted.sort()
-        self.assertEqual(self.plugins_removed, plugins_removed_sorted, "Removed plugins list is not sorted alphabetically")
-
     def test_plugin_has_valid_global_args(self):
         parser = build_parser()
         global_arg_dests = [action.dest for action in parser._actions]

--- a/tests/test_plugins_meta.py
+++ b/tests/test_plugins_meta.py
@@ -2,8 +2,7 @@ import os.path
 import re
 import unittest
 
-from streamlink import Streamlink, plugins as streamlinkplugins
-from streamlink_cli.argparser import build_parser
+from streamlink import Streamlink
 
 
 class TestPluginMeta(unittest.TestCase):
@@ -18,14 +17,10 @@ class TestPluginMeta(unittest.TestCase):
     def setUpClass(cls):
         cls.session = Streamlink()
         docs_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../docs"))
-        plugins_dir = streamlinkplugins.__path__[0]
 
         with open(os.path.join(docs_dir, "plugin_matrix.rst")) as plfh:
             parts = re.split(r"\n[= ]+\n", plfh.read())
             cls.plugins_in_docs = list(re.findall(r"^([\w_]+)\s", parts[3], re.MULTILINE))
-
-        with open(os.path.join(plugins_dir, ".removed")) as rmfh:
-            cls.plugins_removed = [pname for pname in rmfh.read().split("\n") if pname and not pname.startswith("#")]
 
         cls.plugins = cls.session.plugins.keys()
         cls.plugins_no_protocols = [pname for pname in cls.plugins if pname not in cls.protocol_tests]
@@ -37,12 +32,3 @@ class TestPluginMeta(unittest.TestCase):
     def test_docs_matrix_has_plugin(self):
         for pname in self.plugins_in_docs:
             self.assertIn(pname, self.plugins_no_protocols, f"{pname} plugin does not exist")
-
-    def test_plugin_has_valid_global_args(self):
-        parser = build_parser()
-        global_arg_dests = [action.dest for action in parser._actions]
-        for pname, plugin in self.session.plugins.items():
-            for parg in plugin.arguments:
-                if not parg.is_global:  # pragma: no cover
-                    continue
-                self.assertIn(parg.dest, global_arg_dests, f"{parg.name} from plugins.{pname} is not a valid global argument")


### PR DESCRIPTION
This rewrites plugin meta tests using pytest, in preparation for my plugin matrix replacement (see #4369). The plugin matrix replacement will then remove the last remaining tests from `tests/test_plugin_meta.py` that have not been touched here.

The old tests were making test assertions inside for-loops while iterating plugin names, etc., which is bad. This PR parametrizes everything while using pytest fixtures, so this will increase the number of collected test and the test results by a lot due to the large number of plugins (see the pytest output), but it'll make reading and fixing test failures much more easy by doing so, especially when I add strict tests for plugin metadata. And reading the tests is much more easy with this change, too. Another bonus is that there's no negated assertion messages anymore due to to `longMessage = False` in `TestPluginMeta`.

Changes are split into multiple commits, so the individual diffs are preserved and make more sense when reviewing.