### PR TITLE
plugins.mildom: get token for livestream

### DIFF
--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from uuid import uuid4
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -82,6 +83,34 @@ class Mildom(Plugin):
         for quality_info in data["body"]["ext"]["cmode_params"]:
             qualities.append((quality_info["name"], "_" + quality_info["cmode"] if quality_info["cmode"] != "raw" else ""))
 
+        # Get token
+        data = self.session.http.post(
+            "https://cloudac.mildom.com/nonolive/gappserv/live/token",
+            params={
+                "__platform": "web",
+                "__guest_id": "pc-gp-{}".format(uuid4()),
+            },
+            headers={"Accept-Language": "en"},
+            json={"host_id": channel_id, "type": "hls"},
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "code": int,
+                    validate.optional("message"): str,
+                    validate.optional("body"): {
+                        "data": [
+                            {"token": str, }
+                        ],
+                    }
+                }
+            )
+        )
+        log.trace(f"{data!r}")
+        if data["code"] != 0:
+            log.debug(data.get("message", "Mildom API returned an error"))
+            return
+        token = data["body"]["data"][0]["token"]
+        
         # Create stream URLs
         data = self.session.http.get(
             "https://cloudac.mildom.com/nonolive/gappserv/live/liveserver",
@@ -106,7 +135,7 @@ class Mildom(Plugin):
         if data["code"] != 0:
             log.debug(data.get("message", "Mildom API returned an error"))
             return
-        base_url = url_concat(data["body"]["stream_server"], f"{channel_id}{{}}.m3u8")
+        base_url = url_concat(data["body"]["stream_server"], f"{channel_id}{{}}.m3u8?{token}")
         self.session.http.headers.update({"Referer": "https://www.mildom.com/"})
         for quality in qualities:
             yield quality[0], HLSStream(self.session, base_url.format(quality[1]))

--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -110,7 +110,7 @@ class Mildom(Plugin):
             log.debug(data.get("message", "Mildom API returned an error"))
             return
         token = data["body"]["data"][0]["token"]
-        
+
         # Create stream URLs
         data = self.session.http.get(
             "https://cloudac.mildom.com/nonolive/gappserv/live/liveserver",


### PR DESCRIPTION
Issue: 403 error during livestream playback, unable to get m3u8

```
>streamlink -l debug https://www.mildom.com/10148036 best
[cli][debug] OS:         Windows 10
[cli][debug] Python:     3.7.5
[cli][debug] Streamlink: 3.1.1
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.2.1)
[cli][debug] Arguments:
[cli][debug]  url=https://www.mildom.com/10148036
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin mildom for URL https://www.mildom.com/10148036
[cli][info] Available streams: 144p (worst), 360p, 540p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: "C:\Program Files (x86)\VideoLAN\VLC\vlc.exe"
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][error] Unable to open URL: https://txlvb-play-hls.mildom.tv/live/10148036.m3u8 (403 Client Error: Forbidden for url: https://txlvb-play-hls.mildom.tv/live/10148036.m3u8)
```
↓
```
>streamlink -l debug https://www.mildom.com/10148036 best
[cli][debug] OS:         Windows 10
[cli][debug] Python:     3.7.5
[cli][debug] Streamlink: 3.1.1
[cli][debug] Requests(2.26.0), Socks(1.7.1), Websocket(1.2.1)
[cli][debug] Arguments:
[cli][debug]  url=https://www.mildom.com/10148036
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin mildom for URL https://www.mildom.com/10148036
[cli][info] Available streams: 144p (worst), 360p, 540p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: "C:\Program Files (x86)\VideoLAN\VLC\vlc.exe"
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 1342; Last Sequence: 1351
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 1349; End Sequence: None
```

