### PR TITLE
docs: fix GithubReferences transform, add external link icons

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -52,6 +52,22 @@ strong.command {
   font: normal var(--font-size--small) var(--font-stack--monospace);
 }
 
+a[href^="http://"],
+a[href^="https://"]:not([href^="https://streamlink.github.io/"]) {
+  display: inline-block;
+  word-break: break-word;
+}
+
+a[href^="http://"],
+a[href^="https://"]:not([href^="https://streamlink.github.io/"])::after {
+  content: "\f35d";
+  display: inline-block;
+  padding-left: .4em;
+  font: 900 .6em "Font Awesome 5 Free";
+  vertical-align: middle;
+  text-decoration: none;
+}
+
 /*
   Sidebar/Menubar and related
 */

--- a/docs/ext_github.py
+++ b/docs/ext_github.py
@@ -29,7 +29,7 @@ class GithubReferences(Transform):
 
         for node in self.document.traverse(nodes.Text):
             parent = node.parent
-            if isinstance(parent, (nodes.literal, nodes.FixedTextElement)):
+            if isinstance(parent, (nodes.reference, nodes.literal, nodes.FixedTextElement)):
                 continue
 
             text = str(node)


### PR DESCRIPTION
I was looking into adding icons to external links in the docs and found a bug in the custom `ext_github` sphinx extension, which generates lots of empty anchor elements while parsing `#issue`, `#pr` or `@username` notations in the document contents. This made the icons appear twice, on the actual link and on the empty one next to it. The fix is to ignore already parsed reference nodes in the extension while parsing the hashtag- and at-notations.

The only two lines in the docs where hashtags- and at-notations are used outside of links are this:
- https://github.com/streamlink/streamlink/blame/3.1.1/docs/cli.rst#L286
- https://github.com/streamlink/streamlink/blame/3.1.1/docs/players.rst#L78

While the changelog explicitly links to the issues and pull requests:
- https://github.com/streamlink/streamlink/blame/3.1.1/CHANGELOG.md#L7

----

The external link icons are based on Font Awesome 5 Free, which is already used by the docs.

----

While checking the entire docs for external links and potential issues, I found that the argparse output also generates nonsensical links, like `https://` or `http://hostname:port` for example. That would however need to get fixed by another Sphinx override, and I don't think it's worth spending time fixing that.