### PR TITLE
chore: clean up some imports

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -9,8 +9,7 @@ import re
 
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream.hls import HLSStream
-from streamlink.stream.hls import HLSStreamReader, HLSStreamWriter
+from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWriter
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/ssh101.py
+++ b/src/streamlink/plugins/ssh101.py
@@ -9,7 +9,7 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream import HLSStream
+from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -12,8 +12,7 @@ from streamlink.buffers import RingBuffer
 from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.websocket import WebsocketClient
-from streamlink.stream.stream import Stream
-from streamlink.stream.stream import StreamIO
+from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.url import update_qsd
 
 


### PR DESCRIPTION
Some module imports that can be cleaned up which I noticed while trying to implement the list of stream types which each plugin returns for the plugins page in the docs. Parsing the plugin ASTs and checking the stream class imports unfortunately doesn't work well, because some plugins return the result of `self.session.streams(URL)`, implement their own stream types (like ustream for example), or subclass HLSStream with required custom logic, so it doesn't make sense implementing such a list if the results are not correct.