### PR TITLE
cli: add "overwrite" to --force help text

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -555,7 +555,7 @@ def build_parser():
         "-f", "--force",
         action="store_true",
         help="""
-        When using -o or -r, always write to file even if it already exists.
+        When using -o or -r, always write to file even if it already exists (overwrite).
         """
     )
     output.add_argument(


### PR DESCRIPTION
Hi. Today I'm going to download a stream. I tried multiple times and then encountered the following prompt:

```
File foo.ts already exists! Overwrite it? [y/N] 
```

Alright, I want to overwrite the existing file without confirmation, but what options should I specify? Searching for the "overwrite" word in [Command-Line Interface](https://streamlink.github.io/cli.html) turned up nothing, so I made this PR to improve the docs.

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
