### PR TITLE
docs: fix CLI argument line breaks

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -44,6 +44,10 @@ code.literal {
   font-size: var(--font-size--small);
 }
 
+code.literal.xref.std-option {
+  white-space: nowrap;
+}
+
 strong.command {
   padding: .1em .2em;
   border-radius: .2em;


### PR DESCRIPTION
Long CLI arguments with dashes should never wrap.