### PR TITLE
plugins.htv: new plugin

### DIFF
--- a/src/streamlink/plugins/htv.py
+++ b/src/streamlink/plugins/htv.py
@@ -1,0 +1,99 @@
+"""
+$description Vietnamese live TV channels owned by the People's Committee of Ho Chi Minh City.
+$url htv.com.vn
+$type live
+$region Vietnam
+"""
+
+import logging
+import re
+from datetime import date
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?htv\.com\.vn/truc-tuyen(?:\?channel=(?P<channel>\w+)&?|$)"
+))
+class HTV(Plugin):
+    hls_url_re = re.compile(r'var\s+iosUrl\s*=\s*"([^"]+)"')
+
+    def get_channels(self):
+        data = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath(".//*[contains(@class,'channel-list')]//a[@data-id][@data-code]"),
+            [
+                validate.union_get("data-id", "data-code"),
+            ],
+        ))
+
+        return {k: v for k, v in data}
+
+    def _get_streams(self):
+        channels = self.get_channels()
+
+        if not channels:
+            log.error("No channels found")
+            return
+
+        log.debug(f"channels={channels}")
+
+        channel_id = self.match.group("channel")
+        if channel_id is None:
+            channel_id, channel_code = next(iter(channels.items()))
+        elif channel_id in channels:
+            channel_code = channels[channel_id]
+        else:
+            log.error(f"Unknown channel ID: {channel_id}")
+            return
+
+        log.info(f"Channel: {channel_code}")
+
+        json = self.session.http.post(
+            "https://www.htv.com.vn/HTVModule/Services/htvService.aspx",
+            data={
+                "method": "GetScheduleList",
+                "channelid": channel_id,
+                "template": "AjaxSchedules.xslt",
+                "channelcode": channel_code,
+                "date": date.today().strftime("%d-%m-%Y"),
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "success": bool,
+                    "chanelUrl": validate.url(),
+                },
+            ),
+        )
+
+        if not json["success"]:
+            log.error("API error: success not true")
+            return
+
+        hls_url = self.session.http.get(
+            json["chanelUrl"],
+            headers={"Referer": self.url},
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[contains(text(), 'playlist.m3u8')]/text()"),
+                validate.any(None, validate.all(
+                    validate.transform(self.hls_url_re.search),
+                    validate.any(None, validate.all(validate.get(1), validate.url())),
+                )),
+            ),
+        )
+
+        if hls_url:
+            return HLSStream.parse_variant_playlist(
+                self.session,
+                hls_url,
+                headers={"Referer": "https://hplus.com.vn/"},
+            )
+
+
+__plugin__ = HTV

--- a/tests/plugins/test_htv.py
+++ b/tests/plugins/test_htv.py
@@ -1,0 +1,24 @@
+from streamlink.plugins.htv import HTV
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlHTV(PluginCanHandleUrl):
+    __plugin__ = HTV
+
+    should_match_groups = [
+        ("https://htv.com.vn/truc-tuyen", {}),
+        ("https://htv.com.vn/truc-tuyen?channel=123", {"channel": "123"}),
+        ("https://htv.com.vn/truc-tuyen?channel=123&foo", {"channel": "123"}),
+        ("https://www.htv.com.vn/truc-tuyen", {}),
+        ("https://www.htv.com.vn/truc-tuyen?channel=123", {"channel": "123"}),
+        ("https://www.htv.com.vn/truc-tuyen?channel=123&foo", {"channel": "123"}),
+    ]
+
+    should_not_match = [
+        "https://htv.com.vn/",
+        "https://htv.com.vn/any/path",
+        "https://htv.com.vn/truc-tuyen?foo",
+        "https://www.htv.com.vn/",
+        "https://www.htv.com.vn/any/path",
+        "https://www.htv.com.vn/truc-tuyen?foo",
+    ]


### PR DESCRIPTION
~Nobody commented on https://github.com/streamlink/streamlink/issues/4225#issuecomment-1085268031, so...~

URLs:
```
$ streamlink htv.com.vn/truc-tuyen # defaults to first channel in list
$ streamlink htv.com.vn/truc-tuyen?channel=n # where n is valid channel ID
```
Channel IDs are discovered from the player page and can be shown in debug output:
```
$ streamlink --http-proxy 'socks4://localhost:9050' -l debug 'htv.com.vn/truc-tuyen'
[cli][debug] OS:         Linux-5.4.0-107-generic-x86_64-with-glibc2.29
[cli][debug] Python:     3.8.10
[cli][debug] Streamlink: 3.2.0+13.g59e847e
[cli][debug] Requests(2.27.1), Socks(1.7.1), Websocket(1.3.2)
[cli][debug] Arguments:
[cli][debug]  url=htv.com.vn/truc-tuyen
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --http-proxy=socks4://localhost:9050
[cli][info] Found matching plugin htv for URL htv.com.vn/truc-tuyen
[plugins.htv][debug] channels={'1': 'htv7', '3': 'htv9', '10': 'htvtt', '14': 'htv4'}
[utils.l10n][debug] Language code: en_GB
Available streams: 1080p (worst, best)
```
Valid channel ID URLs (at time of PR) in post below.

closes #4225
