### PR TITLE
Add parameters to DASH plugin and document protocol plugin parameters

### DIFF
--- a/docs/cli/protocols.rst
+++ b/docs/cli/protocols.rst
@@ -68,3 +68,24 @@ Some parameters allow you to configure the behavior of the streaming protocol im
 .. code-block:: console
 
     $ streamlink "hls://https://streamingserver/path start_offset=123 duration=321 force_restart=True"
+
+
+Available parameters
+--------------------
+
+Parameters are passed to the following methods of their respective stream implementations:
+
+.. rst-class:: table-custom-layout
+
+==================== =======================
+Protocol prefix      Method references
+==================== =======================
+``httpstream://``    - :py:meth:`streamlink.stream.HTTPStream`
+                     - :py:meth:`requests.request`
+``hls://``           - :py:meth:`streamlink.stream.HLSStream.parse_variant_playlist`
+                     - :py:meth:`streamlink.stream.HLSStream`
+                     - :py:meth:`streamlink.stream.MuxedHLSStream`
+                     - :py:meth:`requests.request`
+``dash://``          - :py:meth:`streamlink.stream.DASHStream.parse_manifest`
+                     - :py:meth:`requests.request`
+==================== =======================

--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -2,7 +2,7 @@ import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
-from streamlink.plugin.plugin import LOW_PRIORITY, stream_weight
+from streamlink.plugin.plugin import LOW_PRIORITY, parse_params, stream_weight
 from streamlink.stream.dash import DASHStream
 from streamlink.utils.url import update_scheme
 
@@ -10,10 +10,10 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"dash://(?P<url>.+)"
+    r"dash://(?P<url>\S+)(?:\s(?P<params>.+))?"
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-    r"(?P<url>.+\.mpd(?:\?.*)?)"
+    r"(?P<url>\S+\.mpd(?:\?\S*)?)(?:\s(?P<params>.+))?"
 ))
 class MPEGDASH(Plugin):
     @classmethod
@@ -29,10 +29,12 @@ class MPEGDASH(Plugin):
             return stream_weight(stream)
 
     def _get_streams(self):
-        url = update_scheme("https://", self.match.group(1), force=False)
-        log.debug(f"Parsing MPD URL: {url}")
+        data = self.match.groupdict()
+        url = update_scheme("https://", data.get("url"), force=False)
+        params = parse_params(data.get("params"))
+        log.debug(f"URL={url}; params={params}")
 
-        return DASHStream.parse_manifest(self.session, url)
+        return DASHStream.parse_manifest(self.session, url, **params)
 
 
 __plugin__ = MPEGDASH

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -582,7 +582,8 @@ class HLSStream(HTTPStream):
         :param name_fmt: A format string for the name, allowed format keys are: name, pixels, bitrate
         :param start_offset: Number of seconds to be skipped from the beginning
         :param duration: Number of second until ending the stream
-        :param request_params: Additional keyword arguments passed to :class:`HLSStream` or :py:meth:`requests.request`
+        :param request_params: Additional keyword arguments passed to :class:`HLSStream`, :class:`MuxedHLSStream`,
+                               or :py:meth:`requests.request`
         """
 
         locale = session_.localization


### PR DESCRIPTION
1. **plugins.dash: add support for parameters**
   This allows passing parameters to `DASHStream` and `requests.request`,
   similar to the HLS protocol plugin. See `DASHStream.parse_manifest`.
2. **docs: add protocol-plugin parameters documentation**
   and fix docstring of `HLSStream.parse_variant_playlist`