### PR TITLE
docs: add intersphinx config

### DIFF
--- a/docs/cli/protocols.rst
+++ b/docs/cli/protocols.rst
@@ -81,11 +81,11 @@ Parameters are passed to the following methods of their respective stream implem
 Protocol prefix      Method references
 ==================== =======================
 ``httpstream://``    - :py:meth:`streamlink.stream.HTTPStream`
-                     - :py:meth:`requests.request`
+                     - :py:meth:`requests.Session.request`
 ``hls://``           - :py:meth:`streamlink.stream.HLSStream.parse_variant_playlist`
                      - :py:meth:`streamlink.stream.HLSStream`
                      - :py:meth:`streamlink.stream.MuxedHLSStream`
-                     - :py:meth:`requests.request`
+                     - :py:meth:`requests.Session.request`
 ``dash://``          - :py:meth:`streamlink.stream.DASHStream.parse_manifest`
-                     - :py:meth:`requests.request`
+                     - :py:meth:`requests.Session.request`
 ==================== =======================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ needs_sphinx = '3.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
+    'sphinx.ext.intersphinx',
     'ext_argparse',
     'ext_github',
     'ext_plugins',
@@ -98,6 +99,16 @@ autodoc_default_options = {
 }
 autodoc_inherit_docstrings = False
 autodoc_typehints = "description"
+
+
+# -- Options for intersphinx ---------------------------------------------------
+
+intersphinx_mapping = {
+    # "python": ("https://docs.python.org/3", None),
+    "requests": ("https://docs.python-requests.org/en/stable/", None),
+}
+
+intersphinx_timeout = 60
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -162,7 +162,7 @@ class DASHStream(Stream):
         :param video_representation: Video representation
         :param audio_representation: Audio representation
         :param period: Update period
-        :param args: Additional keyword arguments passed to :meth:`requests.request`
+        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
         super().__init__(session)
@@ -191,7 +191,7 @@ class DASHStream(Stream):
 
         :param streamlink.Streamlink session: Streamlink session instance
         :param url_or_manifest: URL of the manifest file or an XML manifest string
-        :param args: Additional keyword arguments passed to :meth:`requests.request`
+        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
         if url_or_manifest.startswith('<?xml'):

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -519,7 +519,7 @@ class HLSStream(HTTPStream):
         :param force_restart: Start from the beginning after reaching the playlist's end
         :param start_offset: Number of seconds to be skipped from the beginning
         :param duration: Number of seconds until ending the stream
-        :param args: Additional keyword arguments passed to :meth:`requests.request`
+        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
         super().__init__(session_, url, **args)
@@ -583,7 +583,7 @@ class HLSStream(HTTPStream):
         :param start_offset: Number of seconds to be skipped from the beginning
         :param duration: Number of second until ending the stream
         :param request_params: Additional keyword arguments passed to :class:`HLSStream`, :class:`MuxedHLSStream`,
-                               or :py:meth:`requests.request`
+                               or :py:meth:`requests.Session.request`
         """
 
         locale = session_.localization

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -29,7 +29,7 @@ class HTTPStream(Stream):
     __shortname__ = "http"
 
     args: Dict
-    """A dict of keyword arguments passed to :meth:`requests.request`, such as method, headers, cookies, etc."""
+    """A dict of keyword arguments passed to :meth:`requests.Session.request`, such as method, headers, cookies, etc."""
 
     def __init__(
         self,
@@ -42,7 +42,7 @@ class HTTPStream(Stream):
         :param streamlink.Streamlink session_: Streamlink session instance
         :param url: The URL of the HTTP stream
         :param buffered: Wrap stream output in an additional reader-thread
-        :param args: Additional keyword arguments passed to :meth:`requests.request`
+        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
         super().__init__(session_)


### PR DESCRIPTION
- add intersphinx mapping for `requests`, skip Python standard library
- fix `requests.Session.request` references in docs and docstrings

----

https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html

I didn't include references to the Python standard library, because it adds external links everywhere, which is annoying.

Since this downloads data from external sites, packages like Debian will probably patch out these changes, but that's nothing we care about here.