### PR TITLE
build: drop removed plugins file from package_data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,10 +50,6 @@ install_requires =
 [options.packages.find]
 where = src
 
-[options.package_data]
-streamlink.plugins =
-  .removed
-
 [versioneer]
 VCS = git
 style = pep440


### PR DESCRIPTION
Forgot to include this in #4405 