### PR TITLE
chore: drop support for Python 3.6

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 10
+    after_n_builds: 8
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
           - ubuntu-20.04
           - windows-latest
         python:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -278,7 +278,7 @@ To install Streamlink from source you will need these dependencies.
 ==================================== ===========================================
 Name                                 Notes
 ==================================== ===========================================
-`Python`_                            At least version **3.6**.
+`Python`_                            At least version **3.7**.
 `python-setuptools`_                 At least version **42.0.0**.
 
 **Automatically installed by the setup script**

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
   Operating System :: Microsoft :: Windows
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.6
   Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def format_msg(text, *args, **kwargs):
 
 
 CURRENT_PYTHON = version_info[:2]
-REQUIRED_PYTHON = (3, 6)
+REQUIRED_PYTHON = (3, 7)
 
 # This check and everything above must remain compatible with older Python versions
 if CURRENT_PYTHON < REQUIRED_PYTHON:


### PR DESCRIPTION
Resolves #4277 

Required for #4441 