### PR TITLE
plugins.svtplay: oppetarkiv.se is not functional anymore

### DIFF
--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -1,7 +1,6 @@
 """
 $description Live TV channels and video on-demand service from SVT, a Swedish public, state-owned broadcaster.
 $url svtplay.se
-$url oppetarkiv.se
 $type live, vod
 $region Sweden
 """
@@ -20,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r'https?://(?:www\.)?(?:svtplay|oppetarkiv)\.se(/(kanaler/)?.*)'
+    r'https?://(?:www\.)?svtplay\.se(/(kanaler/)?.*)'
 ))
 class SVTPlay(Plugin):
     api_url = 'https://api.svt.se/videoplayer-api/video/{0}'

--- a/tests/plugins/test_svtplay.py
+++ b/tests/plugins/test_svtplay.py
@@ -15,12 +15,6 @@ class TestPluginCanHandleUrlSVTPlay(PluginCanHandleUrl):
         'https://www.svtplay.se/video/27794015/100-vaginor',
         'https://www.svtplay.se/video/28065172/motet/motet-sasong-1-det-skamtar-du-inte-om',
         'https://www.svtplay.se/dokument-inifran-att-radda-ett-barn',
-        'https://www.oppetarkiv.se/video/1399273/varfor-ar-det-sa-ont-om-q-avsnitt-1-av-5',
-        'https://www.oppetarkiv.se/video/2781201/karlekens-mirakel',
-        'https://www.oppetarkiv.se/video/10354325/studio-pop',
-        'https://www.oppetarkiv.se/video/5792180/studio-pop-david-bowie',
-        'https://www.oppetarkiv.se/video/2923832/hipp-hipp-sasong-2-avsnitt-3-av-7',
-        'https://www.oppetarkiv.se/video/3945501/cccp-hockey-cccp-hockey',
     ]
 
     should_not_match = [


### PR DESCRIPTION
Links to https://oppetarkiv.se are redirected to https://www.svtplay.se/kategori/oppet-arkiv

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
