### PR TITLE
plugins.linelive: fix API URL

### DIFF
--- a/src/streamlink/plugins/linelive.py
+++ b/src/streamlink/plugins/linelive.py
@@ -15,7 +15,7 @@ from streamlink.stream.hls import HLSStream
     r"https?://live\.line\.me/channels/(?P<channel>\d+)/broadcast/(?P<broadcast>\d+)"
 ))
 class LineLive(Plugin):
-    _api_url = "https://live-api.line-apps.com/app/v3.2/channel/{0}/broadcast/{1}/player_status"
+    _api_url = "https://live-api.line-apps.com/web/v4.0/channel/{0}/broadcast/{1}/player_status"
 
     _player_status_schema = validate.Schema(
         {


### PR DESCRIPTION
The following error occurred due to a change in API URL.
```
$ streamlink https://live.line.me/channels/4120347/broadcast/18115135 best

error: Unable to open URL: https://live-api.line-apps.com/app/v3.2/channel/4120347/broadcast/18115135/player_status (404 Client Error: Not Found for url: https://live-api.line-apps.com/app/v3.2/channel/4120347/broadcast/18115135/player_status)
```

This pull request follows the current API URL.
