### PR TITLE
plugins.cdnbg: rewrite plugin

### DIFF
--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -14,12 +14,10 @@ $region Bulgaria
 
 import logging
 import re
-from html import unescape as html_unescape
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.utils import itertags
 from streamlink.stream.hls import HLSStream
 from streamlink.utils.url import update_scheme
 
@@ -28,62 +26,83 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(re.compile(r"""
     https?://(?:www\.)?(?:
-        armymedia\.bg|
-        bgonair\.bg/tvonline|
-        bloombergtv\.bg/video|
-        (?:tv\.)?bnt\.bg/\w+(?:/\w+)?|
-        live\.bstv\.bg|
-        i\.cdn\.bg/live/|
-        nova\.bg/live|
+        armymedia\.bg
+        |
+        bgonair\.bg/tvonline
+        |
+        bloombergtv\.bg/video
+        |
+        (?:tv\.)?bnt\.bg/\w+(?:/\w+)?
+        |
+        live\.bstv\.bg
+        |
+        i\.cdn\.bg/live/
+        |
+        nova\.bg/live
+        |
         mu-vi\.tv/LiveStreams/pages/Live\.aspx
     )/?
 """, re.VERBOSE))
 class CDNBG(Plugin):
-    _re_frame = re.compile(r"'src',\s*'(https?://i\.cdn\.bg/live/\w+)'\);")
-    sdata_re = re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>http.*?)(?P=q)")
-    hls_file_re = re.compile(r"(src|file): (?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)")
-    hls_src_re = re.compile(r"video src=(?P<url>http[^ ]+m3u8[^ ]*)")
-    _re_source_src = re.compile(r"source src=\"(?P<url>[^\"]+m3u8[^\"]*)\"")
-    _re_geoblocked = re.compile(r"(?P<url>[^\"]+geoblock[^\"]+)")
-
-    stream_schema = validate.Schema(
-        validate.any(
-            validate.all(validate.transform(sdata_re.search), validate.get("url")),
-            validate.all(validate.transform(hls_file_re.search), validate.get("url")),
-            validate.all(validate.transform(hls_src_re.search), validate.get("url")),
-            validate.all(validate.transform(_re_source_src.search), validate.get("url")),
-            # GEOBLOCKED
-            validate.all(validate.transform(_re_geoblocked.search), validate.get("url")),
+    @staticmethod
+    def _find_url(regex: re.Pattern) -> validate.all:
+        return validate.all(
+            validate.transform(regex.search),
+            validate.get("url")
         )
-    )
 
     def _get_streams(self):
         if "cdn.bg" in urlparse(self.url).netloc:
             iframe_url = self.url
             h = self.session.get_option("http-headers")
-            if h and h.get("Referer"):
-                _referer = h.get("Referer")
-            else:
+            if not h or not h.get("Referer"):
                 log.error("Missing Referer for iframe URL, use --http-header \"Referer=URL\" ")
                 return
+            _referer = h.get("Referer")
         else:
             _referer = self.url
-            res = self.session.http.get(self.url)
-            m = self._re_frame.search(res.text)
-            if m:
-                iframe_url = m.group(1)
-            else:
-                for iframe in itertags(res.text, "iframe"):
-                    iframe_url = iframe.attributes.get("src")
-                    if iframe_url and "cdn.bg" in iframe_url:
-                        iframe_url = update_scheme("https://", html_unescape(iframe_url), force=False)
-                        break
-                else:
-                    return
+            iframe_url = self.session.http.get(self.url, schema=validate.Schema(
+                validate.any(
+                    self._find_url(
+                        re.compile(r"'src',\s*'(?P<url>https?://i\.cdn\.bg/live/\w+)'\);")
+                    ),
+                    validate.all(
+                        validate.parse_html(),
+                        validate.xml_xpath_string(".//iframe[contains(@src,'cdn.bg')][1]/@src")
+                    )
+                )
+            ))
+
+        if not iframe_url:
+            return
+
+        iframe_url = update_scheme("https://", iframe_url, force=False)
         log.debug(f"Found iframe: {iframe_url}")
 
-        res = self.session.http.get(iframe_url, headers={"Referer": _referer})
-        stream_url = self.stream_schema.validate(res.text)
+        stream_url = self.session.http.get(
+            iframe_url,
+            headers={"Referer": _referer},
+            schema=validate.Schema(
+                validate.any(
+                    self._find_url(
+                        re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>http.*?)(?P=q)")
+                    ),
+                    self._find_url(
+                        re.compile(r"(src|file): (?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)")
+                    ),
+                    self._find_url(
+                        re.compile(r"video src=(?P<url>http[^ ]+m3u8[^ ]*)")
+                    ),
+                    self._find_url(
+                        re.compile(r"source src=\"(?P<url>[^\"]+m3u8[^\"]*)\"")
+                    ),
+                    # GEOBLOCKED
+                    self._find_url(
+                        re.compile(r"(?P<url>[^\"]+geoblock[^\"]+)")
+                    ),
+                )
+            )
+        )
         if "geoblock" in stream_url:
             log.error("Geo-restricted content")
             return


### PR DESCRIPTION
- don't use suffix operators in pluginmatcher regex
- don't define validation schema and regexes as class attributes
- replace itertags with xpath query
- make validation schemas more legible by adding _find_url util method

----

ref #4455 

I've checked all the URLs defined in the plugin URL tests, and everything was working except for the ones with geo-restrictions or those which require additional HTTP headers.
