### PR TITLE
cli: add support for --record=-

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -538,7 +538,8 @@ def build_parser():
         "-o", "--output",
         metavar="FILENAME",
         help="""
-        Write stream data to FILENAME instead of playing it.
+        Write stream data to FILENAME instead of playing it. If FILENAME is set to - (dash), then the stream data will be
+        written to stdout, similar to the --stdout argument.
 
         You will be prompted if the file already exists.
 
@@ -577,7 +578,8 @@ def build_parser():
         "-r", "--record",
         metavar="FILENAME",
         help="""
-        Open the stream in the player, while at the same time writing it to FILENAME.
+        Open the stream in the player, while at the same time writing it to FILENAME. If FILENAME is set to - (dash), then the
+        stream data will be written to stdout, similar to the --stdout argument, while still opening the player.
 
         You will be prompted if the file already exists.
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -132,7 +132,10 @@ def create_output(formatter: Formatter):
             http = create_http_server()
 
         if args.record:
-            record = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
+            if args.record == "-":
+                record = FileOutput(fd=stdout)
+            else:
+                record = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
 
         log.info(f"Starting player: {args.player}")
 
@@ -1003,7 +1006,7 @@ def main():
 
     # Console output should be on stderr if we are outputting
     # a stream to stdout.
-    if args.stdout or args.output == "-" or args.record_and_pipe:
+    if args.stdout or args.output == "-" or args.record == "-" or args.record_and_pipe:
         console_out = sys.stderr
     else:
         console_out = sys.stdout

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -374,6 +374,33 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         self.assertIsNone(output.record.record)
 
     @patch("streamlink_cli.main.args")
+    @patch("streamlink_cli.main.DEFAULT_STREAM_METADATA", {"title": "bar"})
+    def test_create_output_record_stdout(self, args: Mock):
+        formatter = Formatter({
+            "author": lambda: "foo"
+        })
+        args.output = None
+        args.stdout = None
+        args.record = "-"
+        args.record_and_pipe = None
+        args.force = False
+        args.fs_safe_rules = None
+        args.title = "{author} - {title}"
+        args.url = "URL"
+        args.player = "mpv"
+        args.player_args = ""
+        args.player_fifo = None
+        args.player_http = None
+
+        output = create_output(formatter)
+        self.assertIsInstance(output, PlayerOutput)
+        self.assertEqual(output.title, "foo - bar")
+        self.assertIsInstance(output.record, FileOutput)
+        self.assertIsNone(output.record.filename)
+        self.assertEqual(output.record.fd, stdout)
+        self.assertIsNone(output.record.record)
+
+    @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.console")
     def test_create_output_record_and_other_file_output(self, console: Mock, args: Mock):
         formatter = Formatter({})
@@ -602,6 +629,36 @@ class TestCLIMainLoggingStreams(_TestCLIMainLogging):
         self.assertIs(streamlink_cli.main.log.parent.handlers[0].stream, stream)
         self.assertIs(childlogger.parent.handlers[0].stream, stream)
         self.assertIs(streamlink_cli.main.console.output, stream)
+
+    @patch("sys.stderr")
+    @patch("sys.stdout")
+    def test_stream_stdout(self, mock_stdout: Mock, mock_stderr: Mock):
+        self.subject(["streamlink", "--stdout"], mock_stderr)
+
+    @patch("sys.stderr")
+    @patch("sys.stdout")
+    def test_stream_output_eq_file(self, mock_stdout: Mock, mock_stderr: Mock):
+        self.subject(["streamlink", "--output=foo"], mock_stdout)
+
+    @patch("sys.stderr")
+    @patch("sys.stdout")
+    def test_stream_output_eq_dash(self, mock_stdout: Mock, mock_stderr: Mock):
+        self.subject(["streamlink", "--output=-"], mock_stderr)
+
+    @patch("sys.stderr")
+    @patch("sys.stdout")
+    def test_stream_record_eq_file(self, mock_stdout: Mock, mock_stderr: Mock):
+        self.subject(["streamlink", "--record=foo"], mock_stdout)
+
+    @patch("sys.stderr")
+    @patch("sys.stdout")
+    def test_stream_record_eq_dash(self, mock_stdout: Mock, mock_stderr: Mock):
+        self.subject(["streamlink", "--record=-"], mock_stderr)
+
+    @patch("sys.stderr")
+    @patch("sys.stdout")
+    def test_stream_record_and_pipe(self, mock_stdout: Mock, mock_stderr: Mock):
+        self.subject(["streamlink", "--record-and-pipe=foo"], mock_stderr)
 
     @patch("sys.stderr")
     @patch("sys.stdout")


### PR DESCRIPTION
Write stream to stdout while also opening it in the player.

----

Closes #4461 

Example

```
$ streamlink --record=- twitch.tv/esl_dota2 best | ffmpeg -hide_banner -i pipe:0 -c copy -f null /dev/null
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: mpv
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
Input #0, mpegts, from 'pipe:0':
  Duration: N/A, start: 17878.165000, bitrate: N/A
  Program 1 
  Stream #0:0[0x100]: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp, 191 kb/s
  Stream #0:1[0x101]: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(progressive), 1920x1080 [SAR 1:1 DAR 16:9], 59.94 fps, 59.94 tbr, 90k tbn
  Stream #0:2[0x102]: Data: timed_id3 (ID3  / 0x20334449)
Output #0, null, to '/dev/null':
  Metadata:
    encoder         : Lavf59.16.100
  Stream #0:0: Video: h264 (High) ([27][0][0][0] / 0x001B), yuv420p(progressive), 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 59.94 fps, 59.94 tbr, 90k tbn
  Stream #0:1: Audio: aac (LC) ([15][0][0][0] / 0x000F), 48000 Hz, stereo, fltp, 191 kb/s
Stream mapping:
  Stream #0:1 -> #0:0 (copy)
  Stream #0:0 -> #0:1 (copy)
[cli][info] Player closed0 size=N/A time=00:00:08.84 bitrate=N/A speed=2.33x    
[cli][info] Stream ended
[cli][info] Closing currently open stream...
frame=  534 fps=134 q=-1.0 Lsize=N/A time=00:00:08.88 bitrate=N/A speed=2.24x    
video:6220kB audio:208kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
```