### PR TITLE
chore: remove unnecessary collection.OrderedDict

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from typing import List, Optional
 
 
@@ -135,7 +134,7 @@ class Arguments:
     """
 
     def __init__(self, *args):
-        self.arguments = OrderedDict((arg.name, arg) for arg in args)
+        self.arguments = dict((arg.name, arg) for arg in args)
 
     def __iter__(self):
         return iter(self.arguments.values())

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -3,7 +3,6 @@ import logging
 import operator
 import re
 import time
-from collections import OrderedDict
 from functools import partial
 from typing import Any, Callable, ClassVar, Dict, List, Match, NamedTuple, Optional, Pattern, Sequence, Type
 
@@ -426,7 +425,7 @@ class Plugin:
         elif callable(sorting_excludes):
             sorted_streams = list(filter(sorting_excludes, sorted_streams))
 
-        final_sorted_streams = OrderedDict()
+        final_sorted_streams = {}
 
         for stream_name in sorted(streams, key=stream_weight_only):
             final_sorted_streams[stream_name] = streams[stream_name]

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -1,6 +1,5 @@
 import logging
 import pkgutil
-from collections import OrderedDict
 from functools import lru_cache
 from socket import AF_INET, AF_INET6
 from typing import Any, Dict, Optional, Tuple, Type
@@ -76,7 +75,7 @@ class Streamlink:
         })
         if options:
             self.options.update(options)
-        self.plugins: Dict[str, Type[Plugin]] = OrderedDict({})
+        self.plugins: Dict[str, Type[Plugin]] = {}
         self.load_builtin_plugins()
 
     def set_option(self, key: str, value: Any):

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import struct
-from collections import OrderedDict
 from concurrent.futures import Future
 from threading import Event
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
@@ -596,7 +595,7 @@ class HLSStream(HTTPStream):
         except ValueError as err:
             raise OSError("Failed to parse playlist: {0}".format(err))
 
-        streams = OrderedDict()
+        streams = {}
         for playlist in filter(lambda p: not p.is_iframe, parser.playlists):
             names = dict(name=None, pixels=None, bitrate=None)
             audio_streams = []

--- a/src/streamlink/utils/cache.py
+++ b/src/streamlink/utils/cache.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, Generic, Optional, TypeVar
+from typing import Generic, Optional, OrderedDict as TOrderedDict, TypeVar
 
 
 TCacheKey = TypeVar("TCacheKey")
@@ -8,21 +8,17 @@ TCacheValue = TypeVar("TCacheValue")
 
 class LRUCache(Generic[TCacheKey, TCacheValue]):
     def __init__(self, num: int):
-        # TODO: fix type after dropping py36
-        self.cache: Dict[TCacheKey, TCacheValue] = OrderedDict()
+        self.cache: TOrderedDict[TCacheKey, TCacheValue] = OrderedDict()
         self.num = num
 
     def get(self, key: TCacheKey) -> Optional[TCacheValue]:
         if key not in self.cache:
             return None
-        # noinspection PyUnresolvedReferences
         self.cache.move_to_end(key)
         return self.cache[key]
 
     def set(self, key: TCacheKey, value: TCacheValue) -> None:
         self.cache[key] = value
-        # noinspection PyUnresolvedReferences
         self.cache.move_to_end(key)
         if len(self.cache) > self.num:
-            # noinspection PyArgumentList
             self.cache.popitem(last=False)

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -1,5 +1,4 @@
 import re
-from collections import OrderedDict
 from urllib.parse import parse_qsl, quote_plus, urlencode, urljoin, urlparse, urlunparse
 
 
@@ -118,7 +117,7 @@ def update_qsd(url, qsd=None, remove=None, keep_blank_values=True, safe="", quot
 
     # parse current query string
     parsed = urlparse(url)
-    current_qsd = OrderedDict(parse_qsl(parsed.query, keep_blank_values=True))
+    current_qsd = dict(parse_qsl(parsed.query, keep_blank_values=True))
 
     # * removes all possible keys
     if remove == "*":

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -5,7 +5,6 @@ import os
 import platform
 import signal
 import sys
-from collections import OrderedDict
 from contextlib import closing
 from distutils.version import StrictVersion
 from functools import partial
@@ -861,7 +860,7 @@ def setup_plugin_args(session, parser):
 def setup_plugin_options(session: Streamlink, plugin: Type[Plugin]):
     """Sets Streamlink plugin options."""
     pname = plugin.module
-    required = OrderedDict({})
+    required = {}
 
     for parg in plugin.arguments:
         if parg.options.get("help") == argparse.SUPPRESS:

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -1,6 +1,5 @@
 import unittest
 from binascii import hexlify
-from collections import OrderedDict
 from functools import partial
 from threading import Event, Thread
 
@@ -279,7 +278,7 @@ class TestMixinStreamHLS(unittest.TestCase):
     def subject(self, playlists, options=None, streamoptions=None, threadoptions=None, start=True, *args, **kwargs):
         # filter out tags and duplicate segments between playlist responses while keeping index order
         segments_all = [item for playlist in playlists for item in playlist.items if isinstance(item, Segment)]
-        segments = OrderedDict([(segment.num, segment) for segment in segments_all])
+        segments = dict((segment.num, segment) for segment in segments_all)
 
         self.mock("GET", self.url(playlists[0]), [{"text": pl.build(self.id())} for pl in playlists])
         for segment in segments.values():

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,0 +1,28 @@
+from streamlink.utils.cache import LRUCache
+
+
+def test_lru_cache():
+    cache = LRUCache(num=3)
+    assert cache.get("foo") is None, "Getter returns None for unknown items"
+
+    cache.set("foo", "FOO")
+    assert list(cache.cache.items()) == [("foo", "FOO")], "Setter adds new items"
+
+    assert cache.get("foo") == "FOO", "Getter returns correct value of known items"
+
+    cache.set("bar", "BAR")
+    cache.set("baz", "BAZ")
+    cache.set("qux", "QUX")
+    assert list(cache.cache.items()) == [("bar", "BAR"), ("baz", "BAZ"), ("qux", "QUX")], "Setter respects max queue size"
+
+    cache.get("bar")
+    assert list(cache.cache.items()) == [("baz", "BAZ"), ("qux", "QUX"), ("bar", "BAR")], "Getter moves known items to the end"
+
+    cache.get("unknown")
+    assert list(cache.cache.items()) == [("baz", "BAZ"), ("qux", "QUX"), ("bar", "BAR")], "Getter keeps order on unknown items"
+
+    cache.set("foo", "FOO")
+    assert list(cache.cache.items()) == [("qux", "QUX"), ("bar", "BAR"), ("foo", "FOO")], "Setter moves new items to the end"
+
+    cache.set("qux", "QUUX")
+    assert list(cache.cache.items()) == [("bar", "BAR"), ("foo", "FOO"), ("qux", "QUUX")], "Setter moves known items to the end"

--- a/tests/utils/test_url.py
+++ b/tests/utils/test_url.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from urllib.parse import quote
 
 import pytest
@@ -86,7 +85,7 @@ def test_update_qsd():
     assert update_qsd("http://test.se?one=1&two=3", {"two": 2}) == "http://test.se?one=1&two=2"
     assert update_qsd("http://test.se?one=1&two=3", remove=["two"]) == "http://test.se?one=1"
     assert update_qsd("http://test.se?one=1&two=3", {"one": None}, remove="*") == "http://test.se?one=1"
-    assert update_qsd("http://test.se", OrderedDict([("one", ""), ("two", "")])) == "http://test.se?one=&two=", \
+    assert update_qsd("http://test.se", dict([("one", ""), ("two", "")])) == "http://test.se?one=&two=", \
         "should add empty params"
     assert update_qsd("http://test.se?one=", {"one": None}) == "http://test.se?one=", "should leave empty params unchanged"
     assert update_qsd("http://test.se?one=", keep_blank_values=False) == "http://test.se", "should strip blank params"


### PR DESCRIPTION
- Replace collection.OrderedDict with builtins.dict where possible:
  Python 3.7+ ensures the correct order in builtins.dict objects and is
  no longer an implementation detail of cpython.
- Fix OrderedDict type annotation in streamlink.utils.cache.LRUCache
- Add unit test for streamlink.utils.cache.LRUCache

----

https://docs.python.org/3.7/library/stdtypes.html#dict

> Changed in version 3.7: Dictionary order is guaranteed to be insertion order. This behavior was an implementation detail of CPython from 3.6.
