### PR TITLE
ci: fix netlify PR preview builds

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,3 +1,4 @@
 sphinx>=3.0
 furo==2021.09.08
 recommonmark>=0.5.0
+versioningit >=1.1.1, <2

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,22 +3,37 @@
 
 # https://docs.netlify.com/configure-builds/file-based-configuration/#build-settings
 [build]
-  command = "pip install -U pip setuptools && pip install -e . && pip install -U -r docs-requirements.txt && make --directory=docs clean html"
+  command = """\
+    git fetch --tags \
+      && pip install -U pip setuptools \
+      && pip install -e . \
+      && pip install -U -r docs-requirements.txt \
+      && make --directory=docs clean html
+  """
   publish = "docs/_build/html"
   # Since production builds can't be disabled without disabling PRs as well, pushes to the master branch need to be ignored.
   # Also ignore pull requests which don't include any changes that would alter the docs:
   # - CHANGELOG.md (symlinked from docs/changelog.md)
   # - docs/
   # - docs-requirements.txt
+  # - src/streamlink/plugins/
   # - src/streamlink_cli/argparser.py
   # https://docs.netlify.com/configure-builds/file-based-configuration/#ignore-builds
-  ignore = "[ $(git rev-parse --abbrev-ref HEAD) = master ] || git diff --quiet master HEAD CHANGELOG.md docs/ docs-requirements.txt src/streamlink_cli/argparser.py"
+  ignore = """\
+    [ $(git rev-parse --abbrev-ref HEAD) = master ] \
+      || git diff --quiet master HEAD \
+        CHANGELOG.md \
+        docs/ \
+        docs-requirements.txt \
+        src/streamlink/plugins/ \
+        src/streamlink_cli/argparser.py
+  """
 
 [build.environment]
-  # Set the latest natively available Python version in the Ubuntu env (currently 16.04 / Xenial)
+  # Set the latest natively available Python version in the Ubuntu env (currently 20.04 / Focal)
   # https://docs.netlify.com/configure-builds/manage-dependencies/#python
   # https://github.com/netlify/build-image/blob/xenial/included_software.md
-  PYTHON_VERSION = "3.7"
+  PYTHON_VERSION = "3.8"
 
 # Builds on untagged commits are always "latest", but since it's built on the root docs dir, actual "latest" links will cause 404 errors
 # https://docs.netlify.com/configure-builds/file-based-configuration/#redirects


### PR DESCRIPTION
- Add versioningit to docs-requirements.txt
  Needed dependency when Streamlink was installed in editable mode.
- Reformat netlify.toml
- Update PYTHON_VERSION env var (based on Ubuntu 20.04)
- Always fetch all tags to ensure correct version strings in docs builds
- Add plugins dir to ignore check

----

Changes made in the settings menu on netlify.com:
- Updated to Ubuntu 20.04
- Disabled embedded netlify feedback overlay stuff on rendered docs
