### PR TITLE
Update GitHub release template and donations page in the docs

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,12 +1,16 @@
 {changelog}
 
-## Installation
+## ⚙️ Installation and configuration
 
-See the detailed [installation instructions](https://streamlink.github.io/install.html) on Streamlink's website.
+Please see the detailed [installation instructions](https://streamlink.github.io/install.html) and [CLI guide](https://streamlink.github.io/cli.html) on Streamlink's website.
 
-## Supporting Streamlink
+**⚠️ PLEASE NOTE ⚠️**  
+Streamlink's Windows installers have been moved to [streamlink/windows-installer](https://github.com/streamlink/windows-installer/releases).
 
-If you think that this application is helpful, please consider supporting the maintainers by [donating via the Open collective](https://opencollective.com/streamlink). Not only becoming a backer, but also a sponsor for the (open source) project.
+## ❤️ Support
+
+If you think that Streamlink is useful and if you want to keep the project alive, then please consider supporting its maintainers by sending a small and optionally recurring tip via the [available options](https://streamlink.github.io/donate.html).  
+Your support is very much appreciated, thank you!
 
 
 {gitlog}

--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -62,8 +62,8 @@ a[href^="https://"]:not([href^="https://streamlink.github.io/"]) {
   word-break: break-word;
 }
 
-a[href^="http://"],
-a[href^="https://"]:not([href^="https://streamlink.github.io/"])::after {
+a[href^="http://"]:not(.no-external-link-icon)::after,
+a[href^="https://"]:not(.no-external-link-icon):not([href^="https://streamlink.github.io/"])::after {
   content: "\f35d";
   display: inline-block;
   padding-left: .4em;

--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -18,6 +18,13 @@ as payment for future work.
 
 .. raw:: html
 
+   <a href="https://opencollective.com/streamlink" target="_blank" class="no-external-link-icon">
+     <img alt="Donate to our collective" src="https://opencollective.com/streamlink/donate/button@2x.png?color=white" width="300" height="50">
+   </a>
+
+
+.. raw:: html
+
    <h1>Individual team member donations</h1>
 
 Bastimeyer
@@ -33,7 +40,7 @@ Bastimeyer
       - `Github <https://github.com/bastimeyer>`__
       - `Github Sponsors <https://github.com/sponsors/bastimeyer>`__
       - `Paypal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=YUCGRLVALHS8C&item_name=Streamlink%20Twitch%20GUI>`__
-      - `Bitcoin <https://blockchain.info/qr?data=1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8>`__ :code:`1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8`
+      - `Bitcoin <https://www.blockchain.com/btc/address/1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8>`__ :code:`1EZg8eBz4RdPb8pEzYD9JEzr9Fyitzj8j8`
 
 Beardypig
 ^^^^^^^^^
@@ -46,7 +53,7 @@ Beardypig
    .. container::
 
       - `Github <https://github.com/beardypig>`__
-      - `Bitcoin <https://blockchain.info/qr?data=1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh>`__ :code:`1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh`
+      - `Bitcoin <https://www.blockchain.com/btc/address/1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh>`__ :code:`1Ey3KZ9SwTj6QyASE6vgJVebUiJsW1HuRh`
 
 Gravyboat
 ^^^^^^^^^
@@ -59,6 +66,5 @@ Gravyboat
    .. container::
 
       - `Github <https://github.com/gravyboat>`__
-      - `Bitcoin <https://blockchain.info/qr?data=1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`__ :code:`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`
+      - `Bitcoin <https://www.blockchain.com/btc/address/1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`__ :code:`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`
       - `Flattr <https://flattr.com/@gravyboat>`__
-      - `Gratipay <https://gratipay.com/~gravyboat/>`__


### PR DESCRIPTION
This updates the releases page and makes it consistent with the one in the streamlink/windows-installer repo:
https://github.com/streamlink/windows-installer/releases
Most importantly, it adds a warning message for people looking for the installers (which should be added temporarily).

Since it also changes the "support" section, I updated and fixed the donations page in the docs.