### PR TITLE
plugins.nicolive: fix timeshift-offset option

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -196,7 +196,7 @@ class NicoLive(Plugin):
 
         offset = self.get_option("timeshift-offset")
         if offset and "timeshift" in wss_api_url:
-            hls_stream_url = update_qsd(self.hls_stream_url, {"start": offset})
+            hls_stream_url = update_qsd(hls_stream_url, {"start": offset})
 
         for quality, stream in NicoLiveHLSStream.parse_variant_playlist(self.session, hls_stream_url).items():
             stream.set_wsclient(self.wsclient)


### PR DESCRIPTION
Fix `AttributeError: 'NicoLive' object has no attribute 'hls_stream_url'` when `--niconico-timeshift-offset` option is used