### PR TITLE
ci: fix github deploy config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Github release
         env:
           RELEASES_API_KEY: ${{ secrets.RELEASES_API_KEY }}
-        run: ./script/github_releases.py "${STREAMLINK_DIST_DIR}/"*{.tar.gz{,.asc}}
+        run: ./script/github_releases.py "${STREAMLINK_DIST_DIR}"/*
       - name: PyPI release
         env:
           PYPI_USER: streamlink


### PR DESCRIPTION
Fixes #4502 

The unnoticed mistake was that BASH doesn't match anything in brace expansions if there's only one element.
```sh
$ bash -c 'ls dist/*{.tar.gz}'
ls: cannot access 'dist/*{.tar.gz}': No such file or directory

$ bash -c 'ls dist/*{.tar.gz,.exe}'
ls: cannot access 'dist/*.exe': No such file or directory
 dist/streamlink-4.0.0.tar.gz

$ bash -c 'shopt -s nullglob; ls dist/*{.tar.gz,.exe}'
dist/streamlink-4.0.0.tar.gz
```

As an alternative to this PR, I've got #4497 pretty much ready and validated multiple test releases in my test-repo using my test-account, but just apply this simple fix here and release 4.0.1.

----

Issue was introduced by #4405:
https://github.com/streamlink/streamlink/commit/2dd2f35930143946afe920c084ff910912a41547#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R153