### PR TITLE
docs: fix broken relative link

### DIFF
--- a/docs/cli/tutorial.rst
+++ b/docs/cli/tutorial.rst
@@ -32,7 +32,7 @@ This command will tell Streamlink to attempt to extract streams from the URL
 specified, and if it's successful, print out a list of available streams to choose
 from.
 
-In some cases (see `Supported streaming protocols <cli/protocols>`_), local files are supported
+In some cases (see `Supported streaming protocols <protocols>`_), local files are supported
 using the ``file://`` protocol, for example a local HLS playlist can be played.
 Relative file paths and absolute paths are supported. All path separators are ``/``,
 even on Windows.


### PR DESCRIPTION
live page with as of opening of this PR broken link: https://streamlink.github.io/cli/tutorial.html