### PR TITLE
docs: use cross-reference instead of direct link

### DIFF
--- a/docs/cli/tutorial.rst
+++ b/docs/cli/tutorial.rst
@@ -32,7 +32,7 @@ This command will tell Streamlink to attempt to extract streams from the URL
 specified, and if it's successful, print out a list of available streams to choose
 from.
 
-In some cases (see `Supported streaming protocols <protocols>`_), local files are supported
+In some cases (see :ref:`cli/protocols:Supported streaming protocols`), local files are supported
 using the ``file://`` protocol, for example a local HLS playlist can be played.
 Relative file paths and absolute paths are supported. All path separators are ``/``,
 even on Windows.


### PR DESCRIPTION
rel #4506 

This should've been a cross reference to the specific section in the docs, not a direct link. The issue came up when the CLI tutorial was moved in #4415. Git-blame from before #4415:
https://github.com/streamlink/streamlink/blame/3.2.0/docs/cli.rst#L38