### PR TITLE
tests: mock user euid to be able to run tests as root

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -893,7 +893,7 @@ def setup_plugin_options(session: Streamlink, plugin: Type[Plugin]):
 
 
 def log_root_warning():
-    if hasattr(os, "getuid"):
+    if hasattr(os, "geteuid"):  # pragma: no branch
         if os.geteuid() == 0:
             log.info("streamlink is running as root! Be careful!")
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -572,7 +572,8 @@ class _TestCLIMainLogging(unittest.TestCase):
         class StopTest(Exception):
             pass
 
-        with patch("streamlink_cli.main.streamlink", session), \
+        with patch("streamlink_cli.main.os.geteuid", create=True, new=Mock(return_value=kwargs.get("euid", 1000))), \
+             patch("streamlink_cli.main.streamlink", session), \
              patch("streamlink_cli.main.setup_signals", side_effect=StopTest), \
              patch("streamlink_cli.main.CONFIG_FILES", []), \
              patch("streamlink_cli.main.setup_streamlink"), \
@@ -694,9 +695,8 @@ class TestCLIMainLoggingStreams(_TestCLIMainLogging):
 class TestCLIMainLoggingInfos(_TestCLIMainLogging):
     @unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
     @patch("streamlink_cli.main.log")
-    @patch("streamlink_cli.main.os.geteuid", Mock(return_value=0))
     def test_log_root_warning(self, mock_log):
-        self.subject(["streamlink"])
+        self.subject(["streamlink"], euid=0)
         self.assertEqual(mock_log.info.mock_calls, [call("streamlink is running as root! Be careful!")])
 
     @patch("streamlink_cli.main.log")
@@ -902,7 +902,8 @@ class TestCLIMainPrint(unittest.TestCase):
              patch.object(Streamlink, "resolve_url_no_redirect") as mock_resolve_url_no_redirect:
             session = Streamlink()
             session.load_plugins(os.path.join(os.path.dirname(__file__), "plugin"))
-            with patch("streamlink_cli.main.streamlink", session), \
+            with patch("streamlink_cli.main.os.geteuid", create=True, new=Mock(return_value=1000)), \
+                 patch("streamlink_cli.main.streamlink", session), \
                  patch("streamlink_cli.main.CONFIG_FILES", []), \
                  patch("streamlink_cli.main.setup_streamlink"), \
                  patch("streamlink_cli.main.setup_plugins"), \


### PR DESCRIPTION
When running test as root, there is an additional log done to warn the
user that it is running streamlink as root. This causes some logging
tests to fail.

For these logging test, ensure we run with a mocked user euid when not
testing for the root euid.

I know that running as root is unusual, but it can happen when packaging for distributions.

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
