### PR TITLE
http_session: don't disable InsecureRequestWarning

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -3,6 +3,7 @@ import time
 from typing import Any, Callable, List, Pattern, Tuple
 
 import requests.adapters
+# noinspection PyPackageRequirements
 import urllib3
 from requests import Session
 
@@ -13,14 +14,6 @@ from streamlink.utils.parse import parse_json, parse_xml
 
 
 urllib3_version = tuple(map(int, urllib3.__version__.split(".")[:3]))
-
-
-try:
-    # We tell urllib3 to disable warnings about unverified HTTPS requests,
-    # because in some plugins we have to do unverified requests intentionally.
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-except AttributeError:
-    pass
 
 
 class _HTTPResponse(urllib3.response.HTTPResponse):


### PR DESCRIPTION
`InsecureRequestWarning` can be emitted by urllib3 here:
https://github.com/urllib3/urllib3/blob/1.26.9/src/urllib3/connectionpool.py#L1042-L1062

----

Example with HTTPS requests on a temporarily set up TLS certificate that's self-signed:

Without `--http-no-ssl-verify` (`SSLCertVerificationError`):
```
$ streamlink httpstream://https://test.bastimeyer.de/test.mp4 best
[cli][info] Found matching plugin http for URL httpstream://https://test.bastimeyer.de/test.mp4
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Starting player: mpv
[cli][error] Try 1/1: Could not open stream <HTTPStream('https://test.bastimeyer.de/test.mp4')> (Could not open stream: Unable to open URL: https://test.bastimeyer.de/test.mp4 (HTTPSConnectionPool(host='test.bastimeyer.de', port=443): Max retries exceeded with url: /test.mp4 (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:997)')))))
error: Could not open stream <HTTPStream('https://test.bastimeyer.de/test.mp4')>, tried 1 times, exiting
```

With `--http-no-ssl-verify`:
```
$ streamlink httpstream://https://test.bastimeyer.de/test.mp4 best --http-no-ssl-verify
[cli][info] Found matching plugin http for URL httpstream://https://test.bastimeyer.de/test.mp4
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Starting player: mpv
/home/basti/venv/streamlink-310/lib/python3.10/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'test.bastimeyer.de'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```