### PR TITLE
Clean up gravyboat donation links

### DIFF
--- a/docs/donate.rst
+++ b/docs/donate.rst
@@ -66,5 +66,4 @@ Gravyboat
    .. container::
 
       - `Github <https://github.com/gravyboat>`__
-      - `Bitcoin <https://www.blockchain.com/btc/address/1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj>`__ :code:`1PpdFh9LkTsjtG2AAcrWqk6RiFrC2iTCxj`
-      - `Flattr <https://flattr.com/@gravyboat>`__
+      - `Github Sponsors <https://github.com/sponsors/gravyboat>`__


### PR DESCRIPTION
Just cleaning up my donation methods since some of them are stale.
