### PR TITLE
plugins.useetv: new plugin

### DIFF
--- a/src/streamlink/plugins/useetv.py
+++ b/src/streamlink/plugins/useetv.py
@@ -1,0 +1,47 @@
+"""
+$description Live TV channels and video on-demand service from UseeTV, owned by Telkom Indonesia.
+$url useetv.com
+$type live, vod
+"""
+
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.dash import DASHStream
+from streamlink.stream.hls import HLSStream
+
+
+@pluginmatcher(re.compile(r"https?://(?:www\.)?useetv\.com/"))
+class UseeTV(Plugin):
+    def find_url(self):
+        url_re = re.compile(r"""['"](https://.*?/(?:[Pp]laylist\.m3u8|manifest\.mpd)[^'"]+)['"]""")
+
+        return self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.any(
+                validate.all(
+                    validate.xml_xpath_string("""
+                        .//script[contains(text(), 'laylist.m3u8') or contains(text(), 'manifest.mpd')][1]/text()
+                    """),
+                    str,
+                    validate.transform(url_re.search),
+                    validate.any(None, validate.all(validate.get(1), validate.url())),
+                ),
+                validate.all(
+                    validate.xml_xpath_string(".//video[@id='video-player']/source/@src"),
+                    validate.any(None, validate.url()),
+                ),
+            ),
+        ))
+
+    def _get_streams(self):
+        url = self.find_url()
+
+        if url and ".m3u8" in url:
+            return HLSStream.parse_variant_playlist(self.session, url)
+        elif url and ".mpd" in url:
+            return DASHStream.parse_manifest(self.session, url)
+
+
+__plugin__ = UseeTV

--- a/tests/plugins/test_useetv.py
+++ b/tests/plugins/test_useetv.py
@@ -1,0 +1,17 @@
+from streamlink.plugins.useetv import UseeTV
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlUseeTV(PluginCanHandleUrl):
+    __plugin__ = UseeTV
+
+    should_match = [
+        "http://useetv.com/any",
+        "http://useetv.com/any/path",
+        "http://www.useetv.com/any",
+        "http://www.useetv.com/any/path",
+        "https://useetv.com/any",
+        "https://useetv.com/any/path",
+        "https://www.useetv.com/any",
+        "https://www.useetv.com/any/path",
+    ]


### PR DESCRIPTION
There are 4 types of content I have found:
* Live TV (/livetv/ URLs)
* TV replay VODs (/tvod/ URLs)
* Premium VODs (/vodpremium/ URLs)
* Event VODs (/ev/ URLs)

There appear to be 3 levels of access:
* Unrestricted
* Country restricted to Indonesia
* Country restricted to Indonesia with subscription (login required)

The main method of access control appears to be based on dynamically rendered HTML pages which either include or do not include the playlist/manifest URL.

Country restricted to Indonesia with subscription has not been tested and is therefore unsupported.  I suspect, however, that with a valid session cookie they may work, as long as they conform to a format supported in `find_url()`.

Live TV:
https://www.useetv.com/livetv/seatoday (unrestricted)
https://www.useetv.com/livetv/jtv (restricted to .id)
https://www.useetv.com/livetv/mtvlive (restricted to .id with sub)

TV replay VODs:
https://www.useetv.com/tvod/seatoday/1652986800/1652988600/meet-the-creators (unrestricted)
https://www.useetv.com/tvod/jtv/1652952600/1652954400/padharan-fit (restricted to .id)
https://www.useetv.com/tvod/mtvlive/1652988600/1652990400/hot-right-now (restricted to .id with sub)

Premium VODs (all seem to be unrestricted if you can get the URL, i.e. not paid for content):
https://www.useetv.com/vodpremium/play/7898
https://www.useetv.com/vodpremium/play/8002
https://www.useetv.com/vodpremium/play/8045

Event VODs (live streaming untested, all tested from gallery):
https://www.useetv.com/ev/CXForumJuni2021 (unrestricted)
https://www.useetv.com/ev/startup-meetup-bufferapp-v-50 (unrestricted)
https://www.useetv.com/ev/webinar-outbreak-challenge-and-opportunities (seems restricted to .id)

closes #4451
