### PR TITLE
Fix typing issues

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional, Sequence, Union
 
 
 def _normalise_option_name(name):
@@ -55,7 +55,7 @@ class Argument:
         self,
         name: str,
         required: bool = False,
-        requires: Optional[List[str]] = None,
+        requires: Optional[Union[str, Sequence[str]]] = None,
         prompt: Optional[str] = None,
         sensitive: bool = False,
         argument_name: Optional[str] = None,
@@ -80,7 +80,8 @@ class Argument:
         self.options = options
         self._argument_name = argument_name  # override the cli argument name
         self._dest = dest  # override for the plugin option name
-        self.requires = requires and (list(requires) if isinstance(requires, (list, tuple)) else [requires]) or []
+        requires = requires or []
+        self.requires = list(requires) if isinstance(requires, (list, tuple)) else [requires]
         self.prompt = prompt
         self.sensitive = sensitive
         self._default = options.get("default")

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -13,18 +13,19 @@ Copyright 2015 Red Hat, Inc.
    See the License for the specific language governing permissions and
    limitations under the License.
 """
-from io import BytesIO
 
-import sys
-from requests.adapters import BaseAdapter
-from requests.compat import urlparse, unquote, urljoin
-from requests import Response, codes
 import errno
+import io
+import locale
 import os
 import os.path
 import stat
-import locale
-import io
+import sys
+from io import BytesIO
+from urllib.parse import unquote, urljoin, urlparse
+
+from requests import Response, codes
+from requests.adapters import BaseAdapter
 
 from streamlink.compat import is_win32
 

--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -94,6 +94,8 @@ _VALID_REQUEST_ARGS = "method", "url", "headers", "files", "data", "params", "au
 
 
 class HTTPSession(Session):
+    params: Dict
+
     def __init__(self):
         super().__init__()
 

--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -38,7 +38,7 @@ class _HTTPResponse(urllib3.response.HTTPResponse):
 
 
 # override all urllib3.response.HTTPResponse references in requests.adapters.HTTPAdapter.send
-urllib3.connectionpool.HTTPConnectionPool.ResponseCls = _HTTPResponse
+urllib3.connectionpool.HTTPConnectionPool.ResponseCls = _HTTPResponse  # type: ignore[attr-defined]
 requests.adapters.HTTPResponse = _HTTPResponse
 
 
@@ -55,7 +55,7 @@ requests.adapters.HTTPResponse = _HTTPResponse
 # > encodings.
 if urllib3_version >= (1, 25, 4):
     class Urllib3UtilUrlPercentReOverride:
-        _re_percent_encoding: Pattern = urllib3.util.url.PERCENT_RE
+        _re_percent_encoding: Pattern = urllib3.util.url.PERCENT_RE  # type: ignore[attr-defined]
 
         @classmethod
         def _num_percent_encodings(cls, string) -> int:
@@ -77,7 +77,7 @@ if urllib3_version >= (1, 25, 4):
 
             return _List()
 
-    urllib3.util.url.PERCENT_RE = Urllib3UtilUrlPercentReOverride
+    urllib3.util.url.PERCENT_RE = Urllib3UtilUrlPercentReOverride  # type: ignore[attr-defined]
 
 
 def _parse_keyvalue_list(val):

--- a/src/streamlink/plugin/api/validate/_exception.py
+++ b/src/streamlink/plugin/api/validate/_exception.py
@@ -5,19 +5,21 @@ from typing import Optional, Sequence, Union
 class ValidationError(ValueError):
     MAX_LENGTH = 60
 
+    errors: Union[str, Exception, Sequence[Union[str, Exception]]]
+
     def __init__(
         self,
-        *error: Union[str, Exception, Sequence[Union[str, Exception]]],
+        *errors,
         schema: Optional[Union[str, object]] = None,
         context: Optional[Union[Exception]] = None,
         **errkeywords
     ):
         self.schema = schema
         self.context = context
-        if len(error) == 1 and type(error[0]) is str:
-            self.errors = (self._truncate(error[0], **errkeywords), )
+        if len(errors) == 1 and type(errors[0]) is str:
+            self.errors = (self._truncate(errors[0], **errkeywords), )
         else:
-            self.errors = error
+            self.errors = errors
 
     def _ellipsis(self, string: str):
         return string if len(string) <= self.MAX_LENGTH else f"<{string[:self.MAX_LENGTH - 5]}...>"
@@ -32,7 +34,7 @@ class ValidationError(ValueError):
             return ""
         if type(self.schema) is str:
             return f"({self.schema})"
-        return f"({self.schema.__name__})"
+        return f"({self.schema.__name__})"  # type: ignore[attr-defined]
 
     def __str__(self):
         cls = self.__class__

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, FrozenSet, List, Optional, Set, Tuple, Type, Union
+from typing import Any, Callable, FrozenSet, List, Optional, Sequence, Set, Tuple, Type, Union
 
 
 class SchemaContainer:
@@ -108,7 +108,7 @@ class UnionGetSchema:
         *getters,
         seq: Type[Union[List, FrozenSet, Set, Tuple]] = tuple,
     ):
-        self.getters: Tuple[GetItemSchema] = tuple(GetItemSchema(getter) for getter in getters)
+        self.getters: Sequence[GetItemSchema] = tuple(GetItemSchema(getter) for getter in getters)
         self.seq = seq
 
 

--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -121,7 +121,7 @@ def _validate_dict(schema, value):
     return new
 
 
-@validate.register(abc.Callable)
+@validate.register
 def _validate_callable(schema: abc.Callable, value):
     if not schema(value):
         raise ValidationError(
@@ -133,7 +133,7 @@ def _validate_callable(schema: abc.Callable, value):
     return value
 
 
-@validate.register(AllSchema)
+@validate.register
 def _validate_allschema(schema: AllSchema, value):
     for schema in schema.schema:
         value = validate(schema, value)
@@ -141,7 +141,7 @@ def _validate_allschema(schema: AllSchema, value):
     return value
 
 
-@validate.register(AnySchema)
+@validate.register
 def _validate_anyschema(schema: AnySchema, value):
     errors = []
     for subschema in schema.schema:
@@ -153,13 +153,13 @@ def _validate_anyschema(schema: AnySchema, value):
     raise ValidationError(*errors, schema=AnySchema)
 
 
-@validate.register(TransformSchema)
+@validate.register
 def _validate_transformschema(schema: TransformSchema, value):
     validate(abc.Callable, schema.func)
     return schema.func(value, *schema.args, **schema.kwargs)
 
 
-@validate.register(GetItemSchema)
+@validate.register
 def _validate_getitemschema(schema: GetItemSchema, value):
     item = schema.item if type(schema.item) is tuple and not schema.strict else (schema.item,)
     idx = 0
@@ -194,7 +194,7 @@ def _validate_getitemschema(schema: GetItemSchema, value):
         )
 
 
-@validate.register(AttrSchema)
+@validate.register
 def _validate_attrschema(schema: AttrSchema, value):
     new = copy(value)
 
@@ -222,7 +222,7 @@ def _validate_attrschema(schema: AttrSchema, value):
     return new
 
 
-@validate.register(XmlElementSchema)
+@validate.register
 def _validate_xmlelementschema(schema: XmlElementSchema, value):
     validate(iselement, value)
     tag = value.tag
@@ -263,14 +263,14 @@ def _validate_xmlelementschema(schema: XmlElementSchema, value):
     return new
 
 
-@validate.register(UnionGetSchema)
+@validate.register
 def _validate_uniongetschema(schema: UnionGetSchema, value):
     return schema.seq(
         validate(getter, value) for getter in schema.getters
     )
 
 
-@validate.register(UnionSchema)
+@validate.register
 def _validate_unionschema(schema: UnionSchema, value):
     try:
         return validate_union(schema.schema, value)

--- a/src/streamlink/plugin/api/validate/_validators.py
+++ b/src/streamlink/plugin/api/validate/_validators.py
@@ -167,7 +167,7 @@ def validator_hasattr(attr: Any) -> Callable[[Any], bool]:
 # Sequence related validators
 
 
-def validator_filter(func: Callable[[Any], bool]) -> TransformSchema:
+def validator_filter(func: Callable[..., bool]) -> TransformSchema:
     """
     Filter out unwanted items from the input using the specified function.
 
@@ -187,7 +187,7 @@ def validator_filter(func: Callable[[Any], bool]) -> TransformSchema:
     return TransformSchema(filter_values)
 
 
-def validator_map(func: Callable[[Any], Any]) -> TransformSchema:
+def validator_map(func: Callable[..., Any]) -> TransformSchema:
     """
     Transform items from the input using the specified function.
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -136,7 +136,7 @@ def stream_sorting_filter(expr, stream_weight):
 
 
 def parse_params(params: Optional[str] = None) -> Dict[str, Any]:
-    rval = {}
+    rval: Dict[str, Any] = {}
     if not params:
         return rval
 
@@ -190,7 +190,7 @@ class Plugin:
     Plugin base class for retrieving streams and metadata from the URL specified.
     """
 
-    matchers: ClassVar[List[Matcher]] = None
+    matchers: ClassVar[Optional[List[Matcher]]] = None
     """
     The list of plugin matchers (URL pattern + priority).
     Use the :meth:`streamlink.plugin.pluginmatcher` decorator for initializing this list.
@@ -199,10 +199,10 @@ class Plugin:
     matches: Sequence[Optional[Match]]
     """A tuple of :class:`re.Match` results of all defined matchers"""
 
-    matcher: Pattern
+    matcher: Optional[Pattern]
     """A reference to the compiled :class:`re.Pattern` of the first matching matcher"""
 
-    match: Match
+    match: Optional[Match]
     """A reference to the :class:`re.Match` result of the first matching matcher"""
 
     # plugin metadata attributes
@@ -221,8 +221,13 @@ class Plugin:
     options = Options()
     arguments = Arguments()
     session = None
-    _url: str = None
+    _url: Optional[str] = None
     _user_input_requester = None
+
+    # deprecated
+    can_handle_url: Callable[[str], bool]
+    # deprecated
+    priority: Callable[[str], int]
 
     @classmethod
     def bind(cls, session, module, user_input_requester=None):
@@ -238,7 +243,7 @@ class Plugin:
                 raise RuntimeError("user-input-requester must be an instance of UserInputRequester")
 
     @property
-    def url(self) -> str:
+    def url(self) -> Optional[str]:
         """
         The plugin's input URL.
         Setting a new value will automatically update the :attr:`matches`, :attr:`matcher` and :attr:`match` data.

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -1,5 +1,5 @@
 """
-$description Chinese live streaming platform for live video game broadcasts and individual live streams.
+$description Chinese live-streaming platform for live video game broadcasts and individual live streams.
 $url huya.com
 $type live
 """
@@ -8,6 +8,7 @@ import base64
 import logging
 import re
 from html import unescape as html_unescape
+from typing import Any, Dict
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -49,7 +50,7 @@ class Huya(Plugin):
         validate.get(0),
         validate.get('gameStreamInfoList'),
     )
-    QUALITY_WEIGHTS = {}
+    QUALITY_WEIGHTS: Dict[str, Any] = {}
 
     @classmethod
     def stream_weight(cls, key):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -49,7 +49,7 @@ class TwitchSequence(NamedTuple):
 
 
 class TwitchM3U8(M3U8):
-    segments: List[TwitchSegment]
+    segments: List[TwitchSegment]  # type: ignore[assignment]
 
     def __init__(self):
         super().__init__()
@@ -85,7 +85,7 @@ class TwitchM3U8Parser(M3U8Parser):
         if is_ad:
             self.m3u8.dateranges_ads.append(daterange)
 
-    def get_segment(self, uri: str) -> TwitchSegment:
+    def get_segment(self, uri: str) -> TwitchSegment:  # type: ignore[override]
         extinf: ExtInf = self.state.pop("extinf", None) or ExtInf(0, None)
         date = self.state.pop("date", None)
         ad = any(self.m3u8.is_date_in_daterange(date, daterange) for daterange in self.m3u8.dateranges_ads)
@@ -112,13 +112,13 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
     def _reload_playlist(self, *args):
         return load_hls_playlist(*args, parser=TwitchM3U8Parser, m3u8=TwitchM3U8)
 
-    def _playlist_reload_time(self, playlist: TwitchM3U8, sequences: List[TwitchSequence]):
+    def _playlist_reload_time(self, playlist: TwitchM3U8, sequences: List[TwitchSequence]):  # type: ignore[override]
         if self.stream.low_latency and sequences:
             return sequences[-1].segment.duration
 
-        return super()._playlist_reload_time(playlist, sequences)
+        return super()._playlist_reload_time(playlist, sequences)  # type: ignore[arg-type]
 
-    def process_sequences(self, playlist: TwitchM3U8, sequences: List[TwitchSequence]):
+    def process_sequences(self, playlist: TwitchM3U8, sequences: List[TwitchSequence]):  # type: ignore[override]
         # ignore prefetch segments if not LL streaming
         if not self.stream.low_latency:
             sequences = [seq for seq in sequences if not seq.segment.prefetch]
@@ -140,11 +140,11 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
         if self.stream.disable_ads and self.playlist_sequence == -1 and not self.had_content:
             log.info("Waiting for pre-roll ads to finish, be patient")
 
-        return super().process_sequences(playlist, sequences)
+        return super().process_sequences(playlist, sequences)  # type: ignore[arg-type]
 
 
 class TwitchHLSStreamWriter(HLSStreamWriter):
-    def should_filter_sequence(self, sequence: TwitchSequence):
+    def should_filter_sequence(self, sequence: TwitchSequence):  # type: ignore[override]
         return self.stream.disable_ads and sequence.segment.ad
 
 

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -94,7 +94,7 @@ class WWENetwork(Plugin):
 
         return self.auth_token
 
-    @property
+    @property  # type: ignore
     @lru_cache(maxsize=128)
     def item_config(self):
         log.debug("Loading page config")

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 # noinspection PyUnresolvedReferences
-_original_allowed_gai_family = urllib3_util_connection.allowed_gai_family
+_original_allowed_gai_family = urllib3_util_connection.allowed_gai_family  # type: ignore[attr-defined]
 
 
 class PythonDeprecatedWarning(UserWarning):
@@ -222,13 +222,13 @@ class Streamlink:
         elif key == "ipv4" or key == "ipv6":
             self.options.set(key, value)
             if not value:
-                urllib3_util_connection.allowed_gai_family = _original_allowed_gai_family
+                urllib3_util_connection.allowed_gai_family = _original_allowed_gai_family  # type: ignore[attr-defined]
             elif key == "ipv4":
                 self.options.set("ipv6", False)
-                urllib3_util_connection.allowed_gai_family = (lambda: AF_INET)
+                urllib3_util_connection.allowed_gai_family = (lambda: AF_INET)  # type: ignore[attr-defined]
             else:
                 self.options.set("ipv4", False)
-                urllib3_util_connection.allowed_gai_family = (lambda: AF_INET6)
+                urllib3_util_connection.allowed_gai_family = (lambda: AF_INET6)  # type: ignore[attr-defined]
 
         elif key in ("http-proxy", "https-proxy"):
             self.http.proxies["http"] = update_scheme("https://", value, force=False)
@@ -261,11 +261,14 @@ class Streamlink:
             self.http.verify = value
 
         elif key == "http-disable-dh":
-            # noinspection PyUnresolvedReferences
-            default_ciphers = list(item for item in urllib3_util_ssl.DEFAULT_CIPHERS.split(":") if item != "!DH")
+            default_ciphers = list(
+                item
+                for item in urllib3_util_ssl.DEFAULT_CIPHERS.split(":")  # type: ignore[attr-defined]
+                if item != "!DH"
+            )
             if value:
                 default_ciphers.append("!DH")
-            urllib3_util_ssl.DEFAULT_CIPHERS = ":".join(default_ciphers)
+            urllib3_util_ssl.DEFAULT_CIPHERS = ":".join(default_ciphers)  # type: ignore[attr-defined]
 
         elif key == "http-ssl-cert":
             self.http.cert = value
@@ -318,7 +321,7 @@ class Streamlink:
         else:
             return self.options.get(key)
 
-    def set_plugin_option(self, plugin: str, key: str, value: Any):
+    def set_plugin_option(self, plugin: str, key: str, value: Any) -> None:
         """
         Sets plugin specific options used by plugins originating from this session object.
 
@@ -328,10 +331,10 @@ class Streamlink:
         """
 
         if plugin in self.plugins:
-            plugin = self.plugins[plugin]
-            plugin.set_option(key, value)
+            plugincls = self.plugins[plugin]
+            plugincls.set_option(key, value)
 
-    def get_plugin_option(self, plugin: str, key: str):
+    def get_plugin_option(self, plugin: str, key: str) -> Optional[Any]:
         """
         Returns the current value of the plugin specific option.
 
@@ -340,8 +343,8 @@ class Streamlink:
         """
 
         if plugin in self.plugins:
-            plugin = self.plugins[plugin]
-            return plugin.get_option(key)
+            plugincls = self.plugins[plugin]
+            return plugincls.get_option(key)
 
     @lru_cache(maxsize=128)
     def resolve_url(
@@ -386,8 +389,7 @@ class Streamlink:
         if follow_redirect:
             # Attempt to handle a redirect URL
             try:
-                # noinspection PyArgumentList
-                res = self.http.head(url, allow_redirects=True, acceptable_status=[501])
+                res = self.http.head(url, allow_redirects=True, acceptable_status=[501])  # type: ignore[call-arg]
 
                 # Fall back to GET request if server doesn't handle HEAD.
                 if res.status_code == 501:

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -279,12 +279,19 @@ class DASHStream(Stream):
         for k, v in ret:
             dict_value_list[k].append(v)
 
+        def sortby_bandwidth(dash_stream: DASHStream) -> int:
+            if dash_stream.video_representation:
+                return dash_stream.video_representation.bandwidth
+            if dash_stream.audio_representation:
+                return dash_stream.audio_representation.bandwidth
+            return 0  # pragma: no cover
+
         ret_new = {}
         for q in dict_value_list:
             items = dict_value_list[q]
 
             try:
-                items = sorted(items, key=lambda k: k.video_representation.bandwidth, reverse=True)
+                items = sorted(items, key=sortby_bandwidth, reverse=True)
             except AttributeError:
                 pass
 

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -7,24 +7,11 @@ import time
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from itertools import count, repeat
+from typing import Optional
 from urllib.parse import urljoin, urlparse, urlsplit, urlunparse, urlunsplit
 
-from isodate import Duration, parse_datetime, parse_duration
+from isodate import Duration, UTC as utc, parse_datetime, parse_duration
 
-if hasattr(datetime, "timezone"):
-    utc = datetime.timezone.utc
-else:
-    class UTC(datetime.tzinfo):
-        def utcoffset(self, dt):
-            return datetime.timedelta(0)
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def dst(self, dt):
-            return datetime.timedelta(0)
-
-    utc = UTC()
 
 log = logging.getLogger(__name__)
 epoch_start = datetime.datetime(1970, 1, 1, tzinfo=utc)
@@ -134,7 +121,7 @@ class MPDParsingError(Exception):
 
 
 class MPDNode:
-    __tag__ = None
+    __tag__: Optional[str] = None
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         self.node = node

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -15,7 +15,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDe
 
 from streamlink.exceptions import StreamError
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, MuxedStream
-from streamlink.stream.hls_playlist import ByteRange, Key, M3U8, Map, Segment, load as load_hls_playlist
+from streamlink.stream.hls_playlist import ByteRange, Key, M3U8, Map, Media, Segment, load as load_hls_playlist
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.utils.cache import LRUCache
@@ -30,14 +30,14 @@ class Sequence(NamedTuple):
 
 
 class ByteRangeOffset:
-    sequence: Sequence.num = None
-    offset: int = None
+    sequence: Optional[int] = None
+    offset: Optional[int] = None
 
     @staticmethod
-    def _calc_end(start: int, size: ByteRange.range):
+    def _calc_end(start: int, size: int) -> int:
         return start + max(size - 1, 0)
 
-    def cached(self, sequence: Sequence.num, byterange: ByteRange) -> Tuple[int, int]:
+    def cached(self, sequence: int, byterange: ByteRange) -> Tuple[int, int]:
         if byterange.offset is not None:
             bytes_start = byterange.offset
         elif self.offset is not None and self.sequence == sequence - 1:
@@ -68,7 +68,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
         options = self.session.options
 
         self.byterange: ByteRangeOffset = ByteRangeOffset()
-        self.map_cache: LRUCache[Sequence.segment.map.uri, Future] = LRUCache(self.threads)
+        self.map_cache: LRUCache[str, Future] = LRUCache(self.threads)
         self.key_data = None
         self.key_uri = None
         self.key_uri_override = options.get("hls-segment-key-uri")
@@ -78,20 +78,23 @@ class HLSStreamWriter(SegmentedStreamWriter):
         ignore_names = {*options.get("hls-segment-ignore-names")}
         if ignore_names:
             segments = "|".join(map(re.escape, ignore_names))
+            # noinspection RegExpUnnecessaryNonCapturingGroup
             self.ignore_names = re.compile(rf"(?:{segments})\.ts", re.IGNORECASE)
 
     @staticmethod
     def num_to_iv(n: int) -> bytes:
         return struct.pack(">8xq", n)
 
-    def create_decryptor(self, key: Key, num: int) -> AES:
+    def create_decryptor(self, key: Key, num: int):
         if key.method != "AES-128":
             raise StreamError(f"Unable to decrypt cipher {key.method}")
 
         if not self.key_uri_override and not key.uri:
             raise StreamError("Missing URI for decryption key")
 
-        if self.key_uri_override:
+        if not self.key_uri_override:
+            key_uri = key.uri
+        else:
             p = urlparse(key.uri)
             formatter = Formatter({
                 "url": lambda: key.uri,
@@ -101,13 +104,14 @@ class HLSStreamWriter(SegmentedStreamWriter):
                 "query": lambda: p.query,
             })
             key_uri = formatter.format(self.key_uri_override)
-        else:
-            key_uri = key.uri
 
-        if self.key_uri != key_uri:
-            res = self.session.http.get(key_uri, exception=StreamError,
-                                        retries=self.retries,
-                                        **self.reader.request_params)
+        if key_uri and self.key_uri != key_uri:
+            res = self.session.http.get(
+                key_uri,
+                exception=StreamError,
+                retries=self.retries,
+                **self.reader.request_params
+            )
             res.encoding = "binary/octet-stream"
             self.key_data = res.content
             self.key_uri = key_uri
@@ -119,7 +123,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
         return AES.new(self.key_data, AES.MODE_CBC, iv)
 
-    def create_request_params(self, num: Sequence.num, segment: Union[Segment, Map], is_map: bool):
+    def create_request_params(self, num: int, segment: Union[Segment, Map], is_map: bool):
         request_params = dict(self.reader.request_params)
         headers = request_params.pop("headers", {})
 
@@ -140,51 +144,55 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
         if sequence is None:
             self.queue(None, None)
-        else:
-            # always queue the segment's map first if it exists
-            if sequence.segment.map is not None:
-                future = self.map_cache.get(sequence.segment.map.uri)
-                # use cached map request if not a stream discontinuity
-                # don't fetch multiple times when map request of previous segment is still pending
-                if future is None or sequence.segment.discontinuity:
-                    future = self.executor.submit(self.fetch_map, sequence)
-                    self.map_cache.set(sequence.segment.map.uri, future)
-                self.queue(sequence, future, True)
+            return
 
-            # regular segment request
-            future = self.executor.submit(self.fetch, sequence)
-            self.queue(sequence, future, False)
+        # always queue the segment's map first if it exists
+        if sequence.segment.map is not None:
+            cached_map_future = self.map_cache.get(sequence.segment.map.uri)
+            # use cached map request if not a stream discontinuity
+            # don't fetch multiple times when map request of previous segment is still pending
+            if cached_map_future is not None and not sequence.segment.discontinuity:
+                future = cached_map_future
+            else:
+                future = self.executor.submit(self.fetch_map, sequence)
+                self.map_cache.set(sequence.segment.map.uri, future)
+            self.queue(sequence, future, True)
+
+        # regular segment request
+        future = self.executor.submit(self.fetch, sequence)
+        self.queue(sequence, future, False)
 
     def fetch(self, sequence: Sequence) -> Optional[Response]:
         try:
             return self._fetch(
                 sequence.segment.uri,
                 stream=self.stream_data,
-                **self.create_request_params(sequence.num, sequence.segment, False)
+                **self.create_request_params(sequence.num, sequence.segment, False),
             )
         except StreamError as err:
             log.error(f"Failed to fetch segment {sequence.num}: {err}")
 
     def fetch_map(self, sequence: Sequence) -> Optional[Response]:
+        _map: Map = sequence.segment.map  # type: ignore[assignment]  # map is not None
         try:
             return self._fetch(
-                sequence.segment.map.uri,
+                _map.uri,
                 stream=False,
-                **self.create_request_params(sequence.num, sequence.segment.map, True)
+                **self.create_request_params(sequence.num, _map, True),
             )
         except StreamError as err:
             log.error(f"Failed to fetch map for segment {sequence.num}: {err}")
 
     def _fetch(self, url: str, **request_params) -> Optional[Response]:
         if self.closed or not self.retries:  # pragma: no cover
-            return
+            return None
 
         return self.session.http.get(
             url,
             timeout=self.timeout,
             retries=self.retries,
             exception=StreamError,
-            **request_params
+            **request_params,
         )
 
     def should_filter_sequence(self, sequence: Sequence) -> bool:
@@ -255,7 +263,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
         self.stream = self.reader.stream
 
         self.playlist_changed = False
-        self.playlist_end: Optional[Sequence.num] = None
+        self.playlist_end: Optional[int] = None
         self.playlist_sequence: int = -1
         self.playlist_sequences: List[Sequence] = []
         self.playlist_reload_time: float = 6
@@ -346,8 +354,8 @@ class HLSStreamWorker(SegmentedStreamWorker):
         return sequence.num >= self.playlist_sequence
 
     @staticmethod
-    def duration_to_sequence(duration: int, sequences: List[Sequence]) -> int:
-        d = 0
+    def duration_to_sequence(duration: float, sequences: List[Sequence]) -> int:
+        d = 0.0
         default = -1
 
         sequences_order = sequences if duration >= 0 else reversed(sequences)
@@ -594,58 +602,73 @@ class HLSStream(HTTPStream):
         locale = session_.localization
         audio_select = session_.options.get("hls-audio-select") or []
 
+        # noinspection PyArgumentList
         res = session_.http.get(url, exception=IOError, **request_params)
 
         try:
             parser = cls._get_variant_playlist(res)
         except ValueError as err:
-            raise OSError("Failed to parse playlist: {0}".format(err))
+            raise OSError(f"Failed to parse playlist: {err}")
 
-        streams = {}
+        stream_name: Optional[str]
+        stream: Union["HLSStream", "MuxedHLSStream"]
+        streams: Dict[str, Union["HLSStream", "MuxedHLSStream"]] = {}
+
         for playlist in filter(lambda p: not p.is_iframe, parser.playlists):
-            names = dict(name=None, pixels=None, bitrate=None)
+            names: Dict[str, Optional[str]] = dict(name=None, pixels=None, bitrate=None)
             audio_streams = []
-            fallback_audio = []
-            default_audio = []
-            preferred_audio = []
+            fallback_audio: List[Media] = []
+            default_audio: List[Media] = []
+            preferred_audio: List[Media] = []
+
             for media in playlist.media:
                 if media.type == "VIDEO" and media.name:
                     names["name"] = media.name
                 elif media.type == "AUDIO":
                     audio_streams.append(media)
+
             for media in audio_streams:
-                # Media without a uri is not relevant as external audio
+                # Media without a URI is not relevant as external audio
                 if not media.uri:
                     continue
 
                 if not fallback_audio and media.default:
                     fallback_audio = [media]
 
-                # if the media is "audoselect" and it better matches the users preferences, use that
+                # if the media is "autoselect" and it better matches the users preferences, use that
                 # instead of default
                 if not default_audio and (media.autoselect and locale.equivalent(language=media.language)):
                     default_audio = [media]
 
-                # select the first audio stream that matches the users explict language selection
-                if (('*' in audio_select or media.language in audio_select or media.name in audio_select)
-                        or ((not preferred_audio or media.default) and locale.explicit and locale.equivalent(
-                            language=media.language))):
+                # select the first audio stream that matches the user's explict language selection
+                if (
+                    (
+                        "*" in audio_select
+                        or media.language in audio_select
+                        or media.name in audio_select
+                    )
+                    or (
+                        (not preferred_audio or media.default)
+                        and locale.explicit
+                        and locale.equivalent(language=media.language)
+                    )
+                ):
                     preferred_audio.append(media)
 
             # final fallback on the first audio stream listed
-            fallback_audio = fallback_audio or (len(audio_streams) and audio_streams[0].uri and [audio_streams[0]])
+            if not fallback_audio and len(audio_streams) and audio_streams[0].uri:
+                fallback_audio = [audio_streams[0]]
 
-            if playlist.stream_info.resolution:
-                width, height = playlist.stream_info.resolution
-                names["pixels"] = "{0}p".format(height)
+            if playlist.stream_info.resolution and playlist.stream_info.resolution.height:
+                names["pixels"] = f"{playlist.stream_info.resolution.height}p"
 
             if playlist.stream_info.bandwidth:
                 bw = playlist.stream_info.bandwidth
 
                 if bw >= 1000:
-                    names["bitrate"] = "{0}k".format(int(bw / 1000.0))
+                    names["bitrate"] = f"{int(bw / 1000.0)}k"
                 else:
-                    names["bitrate"] = "{0}k".format(bw / 1000.0)
+                    names["bitrate"] = f"{bw / 1000.0}k"
 
             if name_fmt:
                 stream_name = name_fmt.format(**names)
@@ -660,19 +683,20 @@ class HLSStream(HTTPStream):
             if not stream_name:
                 continue
             if name_prefix:
-                stream_name = "{0}{1}".format(name_prefix, stream_name)
+                stream_name = f"{name_prefix}{stream_name}"
 
             if stream_name in streams:  # rename duplicate streams
-                stream_name = "{0}_alt".format(stream_name)
-                num_alts = len(list(filter(lambda n: n.startswith(stream_name), streams.keys())))
+                stream_name = f"{stream_name}_alt"
+                num_alts = len([k for k in streams.keys() if k.startswith(stream_name)])
 
                 # We shouldn't need more than 2 alt streams
                 if num_alts >= 2:
                     continue
                 elif num_alts > 0:
-                    stream_name = "{0}{1}".format(stream_name, num_alts + 1)
+                    stream_name = f"{stream_name}{num_alts + 1}"
 
             if check_streams:
+                # noinspection PyBroadException
                 try:
                     session_.http.get(playlist.uri, **request_params)
                 except KeyboardInterrupt:
@@ -689,22 +713,27 @@ class HLSStream(HTTPStream):
                 ])
                 log.debug(f"Using external audio tracks for stream {stream_name} {external_audio_msg}")
 
-                stream = MuxedHLSStream(session_,
-                                        video=playlist.uri,
-                                        audio=[x.uri for x in external_audio if x.uri],
-                                        url_master=url,
-                                        force_restart=force_restart,
-                                        start_offset=start_offset,
-                                        duration=duration,
-                                        **request_params)
+                stream = MuxedHLSStream(
+                    session_,
+                    video=playlist.uri,
+                    audio=[x.uri for x in external_audio if x.uri],
+                    url_master=url,
+                    force_restart=force_restart,
+                    start_offset=start_offset,
+                    duration=duration,
+                    **request_params
+                )
             else:
-                stream = cls(session_,
-                             playlist.uri,
-                             url_master=url,
-                             force_restart=force_restart,
-                             start_offset=start_offset,
-                             duration=duration,
-                             **request_params)
+                stream = cls(
+                    session_,
+                    playlist.uri,
+                    url_master=url,
+                    force_restart=force_restart,
+                    start_offset=start_offset,
+                    duration=duration,
+                    **request_params
+                )
+
             streams[stream_name] = stream
 
         return streams

--- a/src/streamlink/utils/formatter.py
+++ b/src/streamlink/utils/formatter.py
@@ -11,13 +11,17 @@ def _identity(obj):
 
 
 class Formatter:
-    def __init__(self, mapping: Dict[str, Callable], formatting: Optional[Dict[str, Callable]] = None):
+    def __init__(
+        self,
+        mapping: Dict[str, Callable[[], Any]],
+        formatting: Optional[Dict[str, Callable[[Any, str], Any]]] = None,
+    ):
         super().__init__()
-        self.mapping = mapping
-        self.formatting = formatting or {}
-        self.cache = {}
+        self.mapping: Dict[str, Callable[[], Any]] = mapping
+        self.formatting: Dict[str, Callable[[Any, str], Any]] = formatting or {}
+        self.cache: Dict[str, Any] = {}
 
-    def _get_value(self, field_name: str, format_spec: str, defaults: Dict[str, str]) -> Any:
+    def _get_value(self, field_name: str, format_spec: Optional[str], defaults: Dict[str, str]) -> Any:
         if field_name not in self.mapping:
             return defaults.get(field_name, f"{{{field_name}}}" if not format_spec else f"{{{field_name}:{format_spec}}}")
 

--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -1,5 +1,6 @@
 import locale
 import logging
+from typing import Optional
 
 from pycountry import countries, languages
 
@@ -99,11 +100,15 @@ class Localization:
         self.country = None
         self.language = None
         self.explicit = bool(language_code)
-        self.language_code = language_code
+        self._set_language_code(language_code)
 
     @property
     def language_code(self):
         return self._language_code
+
+    @language_code.setter
+    def language_code(self, language_code):
+        self._set_language_code(language_code)
 
     def _parse_locale_code(self, language_code):
         parts = language_code.split("_", 1)
@@ -111,8 +116,7 @@ class Localization:
             raise LookupError(f"Invalid language code: {language_code}")
         return self.get_language(parts[0]), self.get_country(parts[1])
 
-    @language_code.setter
-    def language_code(self, language_code):
+    def _set_language_code(self, language_code):
         is_system_locale = language_code is None
         if language_code is None:
             try:
@@ -136,16 +140,15 @@ class Localization:
                 raise
         log.debug(f"Language code: {self._language_code}")
 
-    def equivalent(self, language=None, country=None):
-        equivalent = True
+    def equivalent(self, language: Optional[str] = None, country: Optional[str] = None) -> bool:
         try:
-            equivalent = equivalent and (not language or self.language == self.get_language(language))
-            equivalent = equivalent and (not country or self.country == self.get_country(country))
+            return (
+                (not language or self.language == self.get_language(language))
+                and (not country or self.country == self.get_country(country))
+            )
         except LookupError:
-            # if an unknown language/country code is given they cannot equivalent
+            # if an unknown language/country code is given, they cannot be equivalent
             return False
-
-        return equivalent
 
     @classmethod
     def get_country(cls, country):

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from streamlink.compat import is_win32
 
 if is_win32:
-    from ctypes import windll, cast, c_ulong, c_void_p, byref
+    from ctypes import windll, cast, c_ulong, c_void_p, byref  # type: ignore[attr-defined]
 
 
 log = logging.getLogger(__name__)

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, TYPE_CHECKING
 
 
 is_darwin = sys.platform == "darwin"
@@ -10,7 +10,13 @@ is_win32 = os.name == "nt"
 stdout: BinaryIO = sys.stdout.buffer
 
 
-class DeprecatedPath(type(Path())):
+if TYPE_CHECKING:  # pragma: no cover
+    _BasePath = Path
+else:
+    _BasePath = type(Path())
+
+
+class DeprecatedPath(_BasePath):
     pass
 
 

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -1,7 +1,7 @@
 import sys
 from getpass import getpass
 from json import dumps
-from typing import Any, IO, Union
+from typing import Any, Dict, List, Optional, TextIO, Union
 
 from streamlink.plugin.plugin import UserInputRequester
 from streamlink_cli.utils import JSONEncoder
@@ -26,24 +26,25 @@ class ConsoleUserInputRequester(UserInputRequester):
 
 
 class ConsoleOutput:
-    def __init__(self, output: IO, json: bool = False):
+    def __init__(self, output: TextIO, json: bool = False):
         self.json = json
         self.output = output
 
-    def ask(self, prompt: str) -> Union[None, str]:
+    def ask(self, prompt: str) -> Optional[str]:
         if not sys.stdin.isatty():
-            return
+            return None
 
         self.output.write(prompt)
 
+        # noinspection PyBroadException
         try:
             return input().strip()
         except Exception:
-            return
+            return None
 
-    def askpass(self, prompt: str) -> Union[None, str]:
+    def askpass(self, prompt: str) -> Optional[str]:
         if not sys.stdin.isatty():
-            return
+            return None
 
         return getpass(prompt, self.output)
 
@@ -56,6 +57,7 @@ class ConsoleOutput:
         if not self.json:
             return
 
+        out: Union[List, Dict]
         if objs and isinstance(objs[0], list):
             out = []
             for obj in objs:

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -2,6 +2,7 @@ import unittest
 from binascii import hexlify
 from functools import partial
 from threading import Event, Thread
+from typing import ByteString, List
 
 import requests_mock
 
@@ -132,7 +133,7 @@ class HLSStreamReadThread(Thread):
         self.read_once = Event()
         self.read_done = Event()
         self.read_all = False
-        self.data = []
+        self.data: List[ByteString] = []
         self.error = None
 
         self.session = session

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,3 +1,5 @@
+from typing import Dict, List, Sequence, Tuple, Type, Union
+
 from streamlink.plugin import Plugin
 
 
@@ -9,25 +11,25 @@ generic_negative_matches = [
 
 
 class PluginCanHandleUrl:
-    __plugin__ = None
+    __plugin__: Type[Plugin]
 
     # A list of URLs that should match any of the plugin's URL regexes.
     #   ["https://foo", "https://bar"]
-    should_match = []
+    should_match: List[str] = []
 
     # A list of URL+capturegroup tuples, where capturegroup can be a dict (re.Match.groupdict()) or a tuple (re.Match.groups()).
     # URLs defined in this list automatically get appended to the should_match list.
     # Values in capturegroup dictionaries that are None get ignored when comparing and can be omitted in the test fixtures.
     #   [("https://foo", {"foo": "foo"}), ("https://bar", ("bar", None))]
-    should_match_groups = []
+    should_match_groups: List[Union[Tuple[str, Dict], Tuple[str, Sequence]]] = []
 
     # A list of URLs that should not match any of the plugin's URL regexes.
     #   ["https://foo", "https://bar"]
-    should_not_match = []
+    should_not_match: List[str] = []
 
     def test_class_setup(self):
         assert issubclass(self.__plugin__, Plugin), "Test has a __plugin__ that is a subclass of streamlink.plugin.Plugin"
-        assert len(self.should_match + self.should_match_groups) > 0, "Test has at least one positive URL"
+        assert len(self.should_match) + len(self.should_match_groups) > 0, "Test has at least one positive URL"
 
     def test_matchers(self):
         should_match = self.should_match + [url for url, groups in self.should_match_groups]

--- a/tests/stream/test_dash_parser.py
+++ b/tests/stream/test_dash_parser.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 from unittest.mock import Mock
 
 from freezegun import freeze_time
-from freezegun.api import FakeDatetime
+from freezegun.api import FakeDatetime  # type: ignore[attr-defined]
 
 from streamlink.stream.dash_manifest import MPD, MPDParsers, MPDParsingError, Representation, utc
 from tests.resources import xml
@@ -13,8 +13,8 @@ from tests.resources import xml
 
 class TestMPDParsers(unittest.TestCase):
     def test_utc(self):
-        self.assertIn(utc.tzname(None), ("UTC", "UTC+00:00"))  # depends on the implementation
-        self.assertIn(utc.dst(None), (None, datetime.timedelta(0)))  # depends on the implementation
+        self.assertEqual(utc.tzname(None), "UTC")
+        self.assertEqual(utc.dst(None), datetime.timedelta(0))
         self.assertEqual(utc.utcoffset(None), datetime.timedelta(0))
 
     def test_bool_str(self):

--- a/tests/stream/test_stream_json.py
+++ b/tests/stream/test_stream_json.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 # noinspection PyUnresolvedReferences
-from requests.utils import DEFAULT_ACCEPT_ENCODING
+from requests.utils import DEFAULT_ACCEPT_ENCODING  # type: ignore[attr-defined]
 
 from streamlink import Streamlink
 from streamlink.stream.dash import DASHStream

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -37,6 +37,11 @@ class TestWebsocketClient(unittest.TestCase):
             "User-Agent: foo"
         ])
 
+        client = WebsocketClient(self.session, "wss://localhost:0", header={"User-Agent": "bar"})
+        self.assertEqual(client.ws.header, [
+            "User-Agent: bar"
+        ])
+
     def test_args_and_proxy(self):
         self.session.set_option("http-proxy", "https://username:password@hostname:1234")
         client = WebsocketClient(

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -33,8 +33,8 @@ from tests.plugin.testplugin import TestPlugin as _TestPlugin
 
 class FakePlugin(_TestPlugin):
     module = "fake"
-    arguments = []
-    _streams = {}
+    arguments = []  # type: ignore
+    _streams = {}  # type: ignore
 
     def streams(self, *args, **kwargs):
         return self._streams
@@ -237,6 +237,17 @@ class TestCLIMainCheckFileOutput(unittest.TestCase):
 
     @patch("streamlink_cli.main.console")
     @patch("streamlink_cli.main.sys")
+    def test_check_file_output_exists_ask_error(self, mock_sys: Mock, mock_console: Mock):
+        mock_sys.stdin.isatty.return_value = True
+        mock_sys.exit.side_effect = SystemExit
+        mock_console.ask = Mock(return_value=None)
+        path = self.mock_path("foo", is_file=True)
+        with self.assertRaises(SystemExit):
+            check_file_output(path, False)
+        self.assertEqual(mock_console.ask.call_args_list, [call("File foo already exists! Overwrite it? [y/N] ")])
+
+    @patch("streamlink_cli.main.console")
+    @patch("streamlink_cli.main.sys")
     def test_check_file_output_exists_notty(self, mock_sys: Mock, mock_console: Mock):
         mock_sys.stdin.isatty.return_value = False
         mock_sys.exit.side_effect = SystemExit
@@ -265,13 +276,13 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.player_args = ""
 
         output = create_output(formatter)
-        self.assertIsInstance(output, PlayerOutput)
-        self.assertEqual(output.title, "URL")
+        assert type(output) is PlayerOutput
+        assert output.title == "URL"
 
         args.title = "{author} - {title}"
         output = create_output(formatter)
-        self.assertIsInstance(output, PlayerOutput)
-        self.assertEqual(output.title, "foo - bar")
+        assert type(output) is PlayerOutput
+        assert output.title == "foo - bar"
 
     @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.check_file_output")
@@ -286,11 +297,11 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.fs_safe_rules = None
 
         output = create_output(formatter)
-        self.assertEqual(mock_check_file_output.call_args_list, [call(Path("foo"), False)])
-        self.assertIsInstance(output, FileOutput)
-        self.assertEqual(output.filename, Path("foo"))
-        self.assertIsNone(output.fd)
-        self.assertIsNone(output.record)
+        assert mock_check_file_output.call_args_list == [call(Path("foo"), False)]
+        assert type(output) is FileOutput
+        assert output.filename == Path("foo")
+        assert output.fd is None
+        assert output.record is None
 
     @patch("streamlink_cli.main.args")
     def test_create_output_stdout(self, args: Mock):
@@ -301,18 +312,18 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.record_and_pipe = None
 
         output = create_output(formatter)
-        self.assertIsInstance(output, FileOutput)
-        self.assertIsNone(output.filename)
-        self.assertIs(output.fd, stdout)
-        self.assertIsNone(output.record)
+        assert type(output) is FileOutput
+        assert output.filename is None
+        assert output.fd is stdout
+        assert output.record is None
 
         args.output = "-"
         args.stdout = False
         output = create_output(formatter)
-        self.assertIsInstance(output, FileOutput)
-        self.assertIsNone(output.filename)
-        self.assertIs(output.fd, stdout)
-        self.assertIsNone(output.record)
+        assert type(output) is FileOutput
+        assert output.filename is None
+        assert output.fd is stdout
+        assert output.record is None
 
     @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.check_file_output")
@@ -326,14 +337,14 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.fs_safe_rules = None
 
         output = create_output(formatter)
-        self.assertEqual(mock_check_file_output.call_args_list, [call(Path("foo"), False)])
-        self.assertIsInstance(output, FileOutput)
-        self.assertIsNone(output.filename)
-        self.assertIs(output.fd, stdout)
-        self.assertIsInstance(output.record, FileOutput)
-        self.assertEqual(output.record.filename, Path("foo"))
-        self.assertIsNone(output.record.fd)
-        self.assertIsNone(output.record.record)
+        assert mock_check_file_output.call_args_list == [call(Path("foo"), False)]
+        assert type(output) is FileOutput
+        assert output.filename is None
+        assert output.fd is stdout
+        assert type(output.record) is FileOutput
+        assert output.record.filename == Path("foo")
+        assert output.record.fd is None
+        assert output.record.record is None
 
     @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.check_file_output")
@@ -357,21 +368,21 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.player_http = None
 
         output = create_output(formatter)
-        self.assertIsInstance(output, PlayerOutput)
-        self.assertEqual(output.title, "URL")
-        self.assertIsInstance(output.record, FileOutput)
-        self.assertEqual(output.record.filename, Path("foo"))
-        self.assertIsNone(output.record.fd)
-        self.assertIsNone(output.record.record)
+        assert type(output) is PlayerOutput
+        assert output.title == "URL"
+        assert type(output.record) is FileOutput
+        assert output.record.filename == Path("foo")
+        assert output.record.fd is None
+        assert output.record.record is None
 
         args.title = "{author} - {title}"
         output = create_output(formatter)
-        self.assertIsInstance(output, PlayerOutput)
-        self.assertEqual(output.title, "foo - bar")
-        self.assertIsInstance(output.record, FileOutput)
-        self.assertEqual(output.record.filename, Path("foo"))
-        self.assertIsNone(output.record.fd)
-        self.assertIsNone(output.record.record)
+        assert type(output) is PlayerOutput
+        assert output.title == "foo - bar"
+        assert type(output.record) is FileOutput
+        assert output.record.filename == Path("foo")
+        assert output.record.fd is None
+        assert output.record.record is None
 
     @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.DEFAULT_STREAM_METADATA", {"title": "bar"})
@@ -393,12 +404,12 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.player_http = None
 
         output = create_output(formatter)
-        self.assertIsInstance(output, PlayerOutput)
-        self.assertEqual(output.title, "foo - bar")
-        self.assertIsInstance(output.record, FileOutput)
-        self.assertIsNone(output.record.filename)
-        self.assertEqual(output.record.fd, stdout)
-        self.assertIsNone(output.record.record)
+        assert type(output) is PlayerOutput
+        assert output.title == "foo - bar"
+        assert type(output.record) is FileOutput
+        assert output.record.filename is None
+        assert output.record.fd is stdout
+        assert output.record.record is None
 
     @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.console")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,7 +15,7 @@ from streamlink.stream.http import HTTPStream
 
 
 # noinspection PyUnresolvedReferences
-_original_allowed_gai_family = urllib3.util.connection.allowed_gai_family
+_original_allowed_gai_family = urllib3.util.connection.allowed_gai_family  # type: ignore[attr-defined]
 
 
 class EmptyPlugin(Plugin):

--- a/tests/utils/test_l10n.py
+++ b/tests/utils/test_l10n.py
@@ -18,6 +18,7 @@ class TestLocalization(unittest.TestCase):
 
     def test_equivalent(self):
         locale = l10n.Localization("en_CA")
+        self.assertTrue(locale.equivalent())
         self.assertTrue(locale.equivalent(language="eng"))
         self.assertTrue(locale.equivalent(language="en"))
         self.assertTrue(locale.equivalent(language="en", country="CA"))
@@ -37,6 +38,8 @@ class TestLocalization(unittest.TestCase):
         self.assertFalse(locale.equivalent(language="en", country="Canada"))
         self.assertFalse(locale.equivalent(language="en", country="ES"))
         self.assertFalse(locale.equivalent(language="en", country="Spain"))
+        self.assertFalse(locale.equivalent(language="en", country="UNKNOWN"))
+        self.assertFalse(locale.equivalent(language="UNKNOWN", country="Spain"))
 
     @patch("locale.getdefaultlocale")
     def test_default(self, getdefaultlocale):

--- a/tests/utils/test_named_pipe.py
+++ b/tests/utils/test_named_pipe.py
@@ -3,10 +3,10 @@ import unittest
 from unittest.mock import Mock, call, patch
 
 from streamlink.compat import is_win32
-from streamlink.utils.named_pipe import NamedPipe, NamedPipePosix, NamedPipeWindows
+from streamlink.utils.named_pipe import NamedPipe, NamedPipeBase, NamedPipePosix, NamedPipeWindows
 
 if is_win32:
-    from ctypes import windll, create_string_buffer, c_ulong, byref
+    from ctypes import windll, create_string_buffer, c_ulong, byref  # type: ignore[attr-defined]
 
 
 GENERIC_READ = 0x80000000
@@ -14,7 +14,7 @@ OPEN_EXISTING = 3
 
 
 class ReadNamedPipeThread(threading.Thread):
-    def __init__(self, pipe: NamedPipe):
+    def __init__(self, pipe: NamedPipeBase):
         super().__init__(daemon=True)
         self.path = str(pipe.path)
         self.error = None


### PR DESCRIPTION
This will fix lots of typing issues that can be detected using the following mypy config. These commits don't just include simple type annotation changes, but also rearrange and fix a couple of minor things, which is why I didn't create just a single big commit for this.

https://mypy.readthedocs.io/en/stable/index.html

```toml
[tool.mypy]
python_version = 3.7
show_error_codes = true
show_error_context = true
show_column_numbers = true
ignore_missing_imports = true
warn_no_return = false
```

As you can see, there's no commit in this PR for adding mypy to the CI, because it's been a rather unstable experience. mypy has crashed a lot while fixing all these issues and its reports were often flaky and inconsistent, despite clearing and/or disabling its cache. In my test repo, it crashed during its CI run, showing that it's not suitable at the moment.

----

There's also a ton of stuff which doesn't make sense to me. For example, it complains that the custom `log.trace` method doesn't exist (as the base logging class is retrieved dynamically during runtime via `logging.setLoggerClass()` / `logging.getLoggerClass()`), which makes sense for a static type checker, but it only complains about that in the ustream plugin for some reason and nowhere else.

Then there's also the issue with some custom HLSStream and SegmentedStream implementations, which currently requires having a ton of ignore pragmas. Named tuples for example can't be subclassed, and dataclasses (or the [attrs](https://www.attrs.org/en/stable/overview.html) library) would be required as a replacement for that, which requires a bigger rework. I want to do this eventually though.

And py37 is unfortunately a bit limited in terms of the typing module, so certain things can't be used without a stub-module, which I don't want to add.