### PR TITLE
stream.hls_playlist: refactor M3U8Parser

### DIFF
--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -4,8 +4,29 @@ from datetime import datetime, timedelta
 # noinspection PyPackageRequirements
 from isodate import tzinfo
 
-from streamlink.stream.hls_playlist import DateRange, Media, Resolution, Segment, StreamInfo, load
+from streamlink.stream.hls_playlist import DateRange, M3U8Parser, Media, Resolution, Segment, StreamInfo, load
 from tests.resources import text
+
+
+def test_parse_tag_callback_cache():
+    class M3U8ParserSubclass(M3U8Parser):
+        def parse_tag_foo_bar(self):  # pragma: no cover
+            pass
+
+    parent = M3U8Parser()
+    assert hasattr(parent, "_TAGS")
+    assert "EXT-X-VERSION" in parent._TAGS
+
+    childA = M3U8ParserSubclass()
+    assert hasattr(childA, "_TAGS")
+    assert "FOO-BAR" in childA._TAGS
+
+    childB = M3U8ParserSubclass()
+    assert hasattr(childB, "_TAGS")
+    assert "FOO-BAR" in childB._TAGS
+
+    assert parent._TAGS is not childA._TAGS
+    assert childA._TAGS is childB._TAGS
 
 
 class TestHLSPlaylist(unittest.TestCase):


### PR DESCRIPTION
- Generate a mapping of tags->callbacks on parser init once
  and cache mapping as class attribute (avoid parent class lookups)
- Performance: look up tags in cached mapping in `parse_line()`
- Re-order `parse_tag_...` methods by definition order of RFC 8216
- Add docstring to each `parse_tag_...` method with link to RFC 8216
- Add typing annotations to each `parse_tag_...` method
- Fix minor typing issues in regards to optional URIs in Key and Media
  and update parse methods accordingly
- Pass keywords to various named tuples instead of positional args

----

This improves the performance of the `M3U8Parser`, as it doesn't have to generate a string with the name of supported tag methods for each tag anymore, and it can simply look up tags in a pre-generated mapping of tags->callbacks that get only built once after the first instantiation of the class. This is fully compatible with `M3U8Parser` subclasses which override or add tag methods, and nothing has to be changed by those subclasses (tag method names stay the same). Subclasses have their own cache.

One thing to note is that the parser doesn't call `tag.lower()` anymore in `parse_line()`, which means that if for some reason an HLS playlist includes lowercase tag names or anything that doesn't match the exact case of the tag names, those invalid tags won't be recognized anymore, because [tags are case sensitive](https://datatracker.ietf.org/doc/html/rfc8216#section-4.1).

These changes will introduce a merge conflict with #4538.