### PR TITLE
docs: temporarily disable intersphinx

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ needs_sphinx = '3.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
-    'sphinx.ext.intersphinx',
+    # 'sphinx.ext.intersphinx',
     'ext_argparse',
     'ext_github',
     'ext_plugins',


### PR DESCRIPTION
The TLS cert of https://python-requests.org/ is currently broken due to a domain suspension. The non-TLS version is broken too.

See
https://github.com/psf/requests/issues/6140

Unless intersphinx gets disabled, docs tests and docs builds will fail, as it can't pull the linked docs data from requests.
Once the issue has been resolved, intersphinx can be re-enabled.