### PR TITLE
docs: enable intersphinx again

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ needs_sphinx = '3.0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
-    # 'sphinx.ext.intersphinx',
+    'sphinx.ext.intersphinx',
     'ext_argparse',
     'ext_github',
     'ext_plugins',
@@ -105,7 +105,7 @@ autodoc_typehints = "description"
 
 intersphinx_mapping = {
     # "python": ("https://docs.python.org/3", None),
-    "requests": ("https://docs.python-requests.org/en/stable/", None),
+    "requests": ("https://requests.readthedocs.io/en/stable/", None),
 }
 
 intersphinx_timeout = 60


### PR DESCRIPTION
Revert of #4543

According to https://github.com/psf/requests/issues/6140#issuecomment-1135071992, requests' readthedocs should not redirect to their own domain anymore, so let's choose readthedocs as intersphinx source for requests. This should be more reliable anyway.