### PR TITLE
plugins.useetv: log if no link has been found

### DIFF
--- a/src/streamlink/plugins/useetv.py
+++ b/src/streamlink/plugins/useetv.py
@@ -12,6 +12,7 @@ from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.hls import HLSStream
 
+log = logging.getLogger(__name__)
 
 @pluginmatcher(re.compile(r"https?://(?:www\.)?useetv\.com/"))
 class UseeTV(Plugin):

--- a/src/streamlink/plugins/useetv.py
+++ b/src/streamlink/plugins/useetv.py
@@ -5,6 +5,7 @@ $type live, vod
 """
 
 import re
+import logging
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -42,6 +43,8 @@ class UseeTV(Plugin):
             return HLSStream.parse_variant_playlist(self.session, url)
         elif url and ".mpd" in url:
             return DASHStream.parse_manifest(self.session, url)
+        elif not url:
+            log.error("No streams have been found, you may be subject to geo-restrictions, or this channnel needs a subscription")
 
 
 __plugin__ = UseeTV


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

**Why this PR ?**

This PR has been made to verify if no link has been found. Indeed, USeeTV doesn't provide all his channels worldwide. Some channels are blocked for Indonesian people only, and some others need a subscription to work (see beIN Asia as an example). Some channels like SeaToday would work, but channels like this one : 
![image](https://user-images.githubusercontent.com/30985701/170096616-4d22b9aa-9972-418e-8bc6-1c99be1c1e88.png)
will only show a Geo-restriction message above the player, telling the end-user he has no access to the stream. 

This also reflects inside the player, meaning no link can be scraped.
