### PR TITLE
plugins.useetv: geo+subscription error messages

### DIFF
--- a/src/streamlink/plugins/useetv.py
+++ b/src/streamlink/plugins/useetv.py
@@ -4,6 +4,7 @@ $url useetv.com
 $type live, vod
 """
 
+import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
@@ -11,32 +12,46 @@ from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.hls import HLSStream
 
+log = logging.getLogger(__name__)
+
 
 @pluginmatcher(re.compile(r"https?://(?:www\.)?useetv\.com/"))
 class UseeTV(Plugin):
-    def find_url(self):
-        url_re = re.compile(r"""['"](https://.*?/(?:[Pp]laylist\.m3u8|manifest\.mpd)[^'"]+)['"]""")
+    def _get_streams(self):
+        root = self.session.http.get(self.url, schema=validate.Schema(validate.parse_html()))
 
-        return self.session.http.get(self.url, schema=validate.Schema(
-            validate.parse_html(),
+        for needle, errormsg in (
+            (
+                "This service is not available in your Country",
+                "The content is not available in your region",
+            ),
+            (
+                "Silahkan login Menggunakan akun MyIndihome dan berlangganan minipack",
+                "The content is not available without a subscription",
+            ),
+        ):
+            if validate.Schema(validate.xml_xpath(f""".//script[contains(text(), '"{needle}"')]""")).validate(root):
+                log.error(errormsg)
+                return
+
+        url = validate.Schema(
             validate.any(
                 validate.all(
                     validate.xml_xpath_string("""
                         .//script[contains(text(), 'laylist.m3u8') or contains(text(), 'manifest.mpd')][1]/text()
                     """),
                     str,
-                    validate.transform(url_re.search),
-                    validate.any(None, validate.all(validate.get(1), validate.url())),
+                    validate.transform(
+                        re.compile(r"""(?P<q>['"])(?P<url>https://.*?/(?:[Pp]laylist\.m3u8|manifest\.mpd).+?)(?P=q)""").search
+                    ),
+                    validate.any(None, validate.all(validate.get("url"), validate.url())),
                 ),
                 validate.all(
                     validate.xml_xpath_string(".//video[@id='video-player']/source/@src"),
                     validate.any(None, validate.url()),
                 ),
-            ),
-        ))
-
-    def _get_streams(self):
-        url = self.find_url()
+            )
+        ).validate(root)
 
         if url and ".m3u8" in url:
             return HLSStream.parse_variant_playlist(self.session, url)


### PR DESCRIPTION
closes #4547 

```
$ streamlink --http-proxy 'socks5h://localhost:1920' 'https://www.useetv.com/livetv/dwtv'
[cli][info] Found matching plugin useetv for URL https://www.useetv.com/livetv/dwtv
[plugins.useetv][error] The content is not available in your region
error: No playable streams found on this URL: https://www.useetv.com/livetv/dwtv
```

```
$ streamlink --http-proxy 'socks5h://localhost:1920' 'https://www.useetv.com/livetv/seatoday'
[cli][info] Found matching plugin useetv for URL https://www.useetv.com/livetv/seatoday
Available streams: 270p (worst), 360p, 540p, 720p, 1080p (best)
```