### PR TITLE
stream.hls: parse M3U8 from Response obj directly

### DIFF
--- a/src/streamlink/plugins/raiplay.py
+++ b/src/streamlink/plugins/raiplay.py
@@ -16,13 +16,6 @@ from streamlink.stream.hls import HLSStream
 log = logging.getLogger(__name__)
 
 
-class RaiPlayHLSStream(HLSStream):
-    @classmethod
-    def _get_variant_playlist(cls, res):
-        res.encoding = "UTF-8"
-        return super()._get_variant_playlist(res)
-
-
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?raiplay\.it/dirette/(\w+)/?"
 ))
@@ -56,7 +49,7 @@ class RaiPlay(Plugin):
             log.error("Geo-restricted content")
             return
 
-        yield from RaiPlayHLSStream.parse_variant_playlist(self.session, stream_url).items()
+        yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
 
 
 __plugin__ = RaiPlay

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -280,8 +280,8 @@ class HLSStreamWorker(SegmentedStreamWorker):
         elif self.playlist_reload_time_override not in ["segment", "live-edge"]:
             self.playlist_reload_time_override = 0
 
-    def _reload_playlist(self, text, url):
-        return load_hls_playlist(text, url)
+    def _reload_playlist(self, *args, **kwargs):
+        return load_hls_playlist(*args, **kwargs)
 
     def reload_playlist(self):
         if self.closed:  # pragma: no cover
@@ -289,12 +289,15 @@ class HLSStreamWorker(SegmentedStreamWorker):
 
         self.reader.buffer.wait_free()
         log.debug("Reloading playlist")
-        res = self.session.http.get(self.stream.url,
-                                    exception=StreamError,
-                                    retries=self.playlist_reload_retries,
-                                    **self.reader.request_params)
+        res = self.session.http.get(
+            self.stream.url,
+            exception=StreamError,
+            retries=self.playlist_reload_retries,
+            **self.reader.request_params,
+        )
+        res.encoding = "utf-8"
         try:
-            playlist = self._reload_playlist(res.text, res.url)
+            playlist = self._reload_playlist(res)
         except ValueError as err:
             raise StreamError(err)
 
@@ -566,8 +569,8 @@ class HLSStream(HTTPStream):
         return reader
 
     @classmethod
-    def _get_variant_playlist(cls, res):
-        return load_hls_playlist(res.text, base_uri=res.url)
+    def _get_variant_playlist(cls, *args, **kwargs):
+        return load_hls_playlist(*args, **kwargs)
 
     @classmethod
     def parse_variant_playlist(
@@ -604,6 +607,7 @@ class HLSStream(HTTPStream):
 
         # noinspection PyArgumentList
         res = session_.http.get(url, exception=IOError, **request_params)
+        res.encoding = "utf-8"
 
         try:
             parser = cls._get_variant_playlist(res)


### PR DESCRIPTION
- Accept both `str` and `requests.Response` in `M3U8Parser.parse`
- Always set encoding of variant and media HLS playlists to utf-8
  https://datatracker.ietf.org/doc/html/rfc8216#section-9
- Remove old custom utf-8 overrides

----

Passing the HTTP Response object to the parser and iterating its content prevents having to keep a copy of the entire response content in memory. Support for `str` is kept for backwards compatibility and because some tests rely on it and would need to get rewritten.

The content is now also always read as UTF-8, as defined by RFC 8216. This was previously guessed by `chardet`/`charset_normalizer` if no HTTP response headers were set (see #4329) and it required custom overrides if there were issues while figuring out the unknown encodings. All HLS tests have been using implicit utf-8 encoding the entire time. We could add tests for invalid encodings in the future, but I don't think it's important.

----

I have a couple more changes planned for the `HLSStream`+ and `M3U8`+ implementations. But that's not ready yet and unrelated to this PR. Just want to quickly talk about that.

One of the changes is using `typing.Generic` + `typing.TypeVar` for making it easier to subclass HLS streams, the parser and other stuff, without having to suppress invalid type informations or method signatures (see the Twitch plugin for example). Using dataclasses instead of named tuples is also one of the things which will make subclassing/extending HLS logic easier.

Another change is passing the parsed master playlist object to the HLSStreams created by `parse_variant_playlist`, so additional data can be read by the media playlists and their parsers. It currently only adds the master playlist URL to the `{Muxed,}HLSStream` for the `to_manifest_url` method (I also want to change this interface eventually, but that may be a breaking change). I noticed the master playlist issue while rewriting Twitch's low latency stuff two days ago, because there's metadata in the master playlist that should be read by the media playlist. It's also relevant for `EXT-X-SESSION-DATA` and `EXT-X-SESSION-KEY`, which are currently not implemented.