### PR TITLE
plugins.nicolive: fix email logins

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -260,10 +260,16 @@ class NicoLive(Plugin):
                 self.LOGIN_URL,
                 data={"mail_tel": email, "password": password},
                 params=self.LOGIN_URL_PARAMS,
-                schema=validate.Schema(validate.parse_html()))
+                schema=validate.Schema(validate.parse_html()),
+            )
+
+            if self.session.http.cookies.get("user_session"):
+                log.info("Logged in.")
+                self.save_cookies()
+                return
 
             input_with_value = {}
-            for elem in root.xpath(".//input"):
+            for elem in root.xpath(".//form[@action]//input"):
                 if elem.attrib.get("value"):
                     input_with_value[elem.attrib.get("name")] = elem.attrib.get("value")
                 else:
@@ -283,7 +289,8 @@ class NicoLive(Plugin):
             root = self.session.http.post(
                 urljoin("https://account.nicovideo.jp", root.xpath("string(.//form[@action]/@action)")),
                 data=input_with_value,
-                schema=validate.Schema(validate.parse_html()))
+                schema=validate.Schema(validate.parse_html()),
+            )
             log.debug(f"Cookies: {self.session.http.cookies.get_dict()}")
             if self.session.http.cookies.get("user_session") is None:
                 error = root.xpath("string(//div[@class='formError']/div/text())")


### PR DESCRIPTION
fixes #4539

The `user_session` cookie already gets set in certain regions, so there's no need to check for a confirmation code.

Tested with local German IP and Japanese proxy, using a fresh account.

----

@cddb222 could you please confirm that this is working for you?

Download the plugin file and sideload it
https://streamlink.github.io/cli/plugin-sideloading.html

https://raw.githubusercontent.com/bastimeyer/streamlink/958c42e028160cfdb7f2bedc9cfced414ac63000/src/streamlink/plugins/nicolive.py