### PR TITLE
plugins.tvtoya: rewrite plugin

### DIFF
--- a/src/streamlink/plugins/tvtoya.py
+++ b/src/streamlink/plugins/tvtoya.py
@@ -4,30 +4,42 @@ $url tvtoya.pl
 $type live
 """
 
-import logging
 import re
 
-from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
+from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
-
-log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?tvtoya\.pl/live"
+    r"https?://(?:www\.)?tvtoya\.pl/player/live"
 ))
 class TVToya(Plugin):
-    _playlist_re = re.compile(r'<source src="([^"]+)" type="application/x-mpegURL">')
-
     def _get_streams(self):
-        self.session.set_option('hls-live-edge', 10)
-        res = self.session.http.get(self.url)
-        playlist_m = self._playlist_re.search(res.text)
+        try:
+            hls = self.session.http.get(self.url, schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[@type='application/json'][@id='__NEXT_DATA__']/text()"),
+                str,
+                validate.parse_json(),
+                {
+                    "props": {
+                        "pageProps": {
+                            "type": "live",
+                            "url": validate.all(
+                                str,
+                                validate.transform(lambda url: url.replace("https:////", "https://")),
+                                validate.url(path=validate.endswith(".m3u8")),
+                            )
+                        }
+                    }
+                },
+                validate.get(("props", "pageProps", "url")),
+            ))
+        except PluginError:
+            return
 
-        if playlist_m:
-            return HLSStream.parse_variant_playlist(self.session, playlist_m.group(1))
-        else:
-            log.debug("Could not find stream data")
+        return HLSStream.parse_variant_playlist(self.session, hls)
 
 
 __plugin__ = TVToya

--- a/tests/plugins/test_tvtoya.py
+++ b/tests/plugins/test_tvtoya.py
@@ -6,14 +6,15 @@ class TestPluginCanHandleUrlTVRPlus(PluginCanHandleUrl):
     __plugin__ = TVToya
 
     should_match = [
-        "https://tvtoya.pl/live",
-        "http://tvtoya.pl/live",
+        "http://tvtoya.pl/player/live",
+        "https://tvtoya.pl/player/live",
     ]
 
     should_not_match = [
-        "https://tvtoya.pl",
         "http://tvtoya.pl",
-        "http://tvtoya.pl/other-page",
         "http://tvtoya.pl/",
+        "http://tvtoya.pl/live",
+        "https://tvtoya.pl",
         "https://tvtoya.pl/",
+        "https://tvtoya.pl/live",
     ]


### PR DESCRIPTION
resolves #4565 

I tried adding vods, but VODs with multiple segments/episodes don't have a canonical URL, so yeah, won't be added...

```
$ streamlink -l debug 'tvtoya.pl/player/live'
[cli][debug] OS:         Linux-5.18.1-1-git-x86_64-with-glibc2.35
[cli][debug] Python:     3.10.4
[cli][debug] Streamlink: 4.1.0+1.g81a04e40
[cli][debug] Requests(2.27.1), Socks(1.7.1), Websocket(1.3.2)
[cli][debug] Arguments:
[cli][debug]  url=tvtoya.pl/player/live
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin tvtoya for URL tvtoya.pl/player/live
[utils.l10n][debug] Language code: en_US
Available streams: 272p (worst), 368p, 544p (best)
```