### PR TITLE
stream.hls: cache parsed multivariant playlist

### DIFF
--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -49,7 +49,7 @@ class LTVHLSStream(HLSStream):
         streams = super().parse_variant_playlist(*args, **kwargs)
 
         for stream in streams.values():
-            stream.args["url"] = copy_query_url(stream.args["url"], stream.url_master)
+            stream.args["url"] = copy_query_url(stream.args["url"], stream.multivariant.uri)
 
         return streams
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -51,8 +51,8 @@ class TwitchSequence(NamedTuple):
 class TwitchM3U8(M3U8):
     segments: List[TwitchSegment]  # type: ignore[assignment]
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.dateranges_ads = []
 
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -471,6 +471,7 @@ class MuxedHLSStream(MuxedStream):
         video: str,
         audio: Union[str, List[str]],
         url_master: Optional[str] = None,
+        multivariant: Optional[M3U8] = None,
         force_restart: bool = False,
         ffmpeg_options: Optional[Dict[str, Any]] = None,
         **args
@@ -479,7 +480,8 @@ class MuxedHLSStream(MuxedStream):
         :param streamlink.Streamlink session: Streamlink session instance
         :param video: Video stream URL
         :param audio: Audio stream URL or list of URLs
-        :param url_master: The URL of the HLS playlist's master/variant playlist
+        :param url_master: The URL of the HLS playlist's multivariant playlist (deprecated)
+        :param multivariant: The parsed multivariant playlist
         :param force_restart: Start from the beginning after reaching the playlist's end
         :param ffmpeg_options: Additional keyword arguments passed to :class:`ffmpegmux.FFMPEGMuxer`
         :param args: Additional keyword arguments passed to :class:`HLSStream`
@@ -499,12 +501,15 @@ class MuxedHLSStream(MuxedStream):
 
         super().__init__(session, *substreams, format="mpegts", maps=maps, **ffmpeg_options)
         self.url_master = url_master
+        self.multivariant = multivariant if multivariant and multivariant.is_master else None
 
     def to_manifest_url(self):
-        if self.url_master is None:
+        url = self.multivariant.uri if self.multivariant and self.multivariant.uri else self.url_master
+
+        if url is None:
             return super().to_manifest_url()
 
-        return self.url_master
+        return url
 
 
 class HLSStream(HTTPStream):
@@ -520,6 +525,7 @@ class HLSStream(HTTPStream):
         session_,
         url: str,
         url_master: Optional[str] = None,
+        multivariant: Optional[M3U8] = None,
         force_restart: bool = False,
         start_offset: float = 0,
         duration: Optional[float] = None,
@@ -528,7 +534,8 @@ class HLSStream(HTTPStream):
         """
         :param streamlink.Streamlink session_: Streamlink session instance
         :param url: The URL of the HLS playlist
-        :param url_master: The URL of the HLS playlist's master/variant playlist
+        :param url_master: The URL of the HLS playlist's multivariant playlist (deprecated)
+        :param multivariant: The parsed multivariant playlist
         :param force_restart: Start from the beginning after reaching the playlist's end
         :param start_offset: Number of seconds to be skipped from the beginning
         :param duration: Number of seconds until ending the stream
@@ -537,6 +544,7 @@ class HLSStream(HTTPStream):
 
         super().__init__(session_, url, **args)
         self.url_master = url_master
+        self.multivariant = multivariant if multivariant and multivariant.is_master else None
         self.force_restart = force_restart
         self.start_offset = start_offset
         self.duration = duration
@@ -544,21 +552,24 @@ class HLSStream(HTTPStream):
     def __json__(self):
         json = super().__json__()
 
-        if self.url_master:
+        try:
             json["master"] = self.to_manifest_url()
+        except TypeError:
+            pass
 
-        # Pretty sure HLS is GET only.
         del json["method"]
         del json["body"]
 
         return json
 
     def to_manifest_url(self):
-        if self.url_master is None:
+        url = self.multivariant.uri if self.multivariant and self.multivariant.uri else self.url_master
+
+        if url is None:
             return super().to_manifest_url()
 
         args = self.args.copy()
-        args.update(url=self.url_master)
+        args.update(url=url)
 
         return self.session.http.prepare_new_request(**args).url
 
@@ -610,7 +621,7 @@ class HLSStream(HTTPStream):
         res.encoding = "utf-8"
 
         try:
-            parser = cls._get_variant_playlist(res)
+            multivariant = cls._get_variant_playlist(res)
         except ValueError as err:
             raise OSError(f"Failed to parse playlist: {err}")
 
@@ -618,7 +629,7 @@ class HLSStream(HTTPStream):
         stream: Union["HLSStream", "MuxedHLSStream"]
         streams: Dict[str, Union["HLSStream", "MuxedHLSStream"]] = {}
 
-        for playlist in filter(lambda p: not p.is_iframe, parser.playlists):
+        for playlist in filter(lambda p: not p.is_iframe, multivariant.playlists):
             names: Dict[str, Optional[str]] = dict(name=None, pixels=None, bitrate=None)
             audio_streams = []
             fallback_audio: List[Media] = []
@@ -721,7 +732,7 @@ class HLSStream(HTTPStream):
                     session_,
                     video=playlist.uri,
                     audio=[x.uri for x in external_audio if x.uri],
-                    url_master=url,
+                    multivariant=multivariant,
                     force_restart=force_restart,
                     start_offset=start_offset,
                     duration=duration,
@@ -731,7 +742,7 @@ class HLSStream(HTTPStream):
                 stream = cls(
                     session_,
                     playlist.uri,
-                    url_master=url,
+                    multivariant=multivariant,
                     force_restart=force_restart,
                     start_offset=start_offset,
                     duration=duration,

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -116,7 +116,9 @@ class Segment(NamedTuple):
 
 
 class M3U8:
-    def __init__(self):
+    def __init__(self, uri: Optional[str] = None):
+        self.uri = uri
+
         self.is_endlist: bool = False
         self.is_master: bool = False
 
@@ -160,8 +162,7 @@ class M3U8Parser:
     _res_re = re.compile(r"(\d+)x(\d+)")
 
     def __init__(self, base_uri: Optional[str] = None, m3u8: Type[M3U8] = M3U8):
-        self.base_uri: Optional[str] = base_uri
-        self.m3u8: M3U8 = m3u8()
+        self.m3u8: M3U8 = m3u8(base_uri)
         self.state: Dict[str, Any] = {}
 
         self._add_tag_callbacks()
@@ -566,8 +567,8 @@ class M3U8Parser:
     def uri(self, uri: str) -> str:
         if uri and urlparse(uri).scheme:
             return uri
-        elif self.base_uri and uri:
-            return urljoin(self.base_uri, uri)
+        elif uri and self.m3u8.uri:
+            return urljoin(self.m3u8.uri, uri)
         else:
             return uri
 

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -85,7 +85,7 @@ class TestHLSVariantPlaylist(unittest.TestCase):
 
     def subject(self, playlist, options=None):
         with requests_mock.Mocker() as mock:
-            url = "http://mocked/{0}/master.m3u8".format(self.id())
+            url = f"http://mocked/{self.id()}/master.m3u8"
             content = self.get_master_playlist(playlist)
             mock.get(url, text=content)
 
@@ -95,15 +95,13 @@ class TestHLSVariantPlaylist(unittest.TestCase):
 
     def test_variant_playlist(self):
         streams = self.subject("hls/test_master.m3u8")
-        self.assertEqual(
-            list(streams.keys()),
-            ["720p", "720p_alt", "480p", "360p", "160p", "1080p (source)", "90k"],
-            "Finds all streams in master playlist"
-        )
-        self.assertTrue(
-            all([isinstance(stream, HLSStream) for stream in streams.values()]),
-            "Returns HLSStream instances"
-        )
+        assert list(streams.keys()) == ["720p", "720p_alt", "480p", "360p", "160p", "1080p (source)", "90k"]
+        assert all(isinstance(stream, HLSStream) for stream in streams.values())
+        assert all(stream.multivariant is not None and stream.multivariant.is_master for stream in streams.values())
+
+        base = f"http://mocked/{self.id()}"
+        stream = next(iter(streams.values()))
+        assert repr(stream) == f"<HLSStream ['hls', '{base}/720p.m3u8', '{base}/master.m3u8']>"
 
 
 class EventedHLSReader(HLSStreamReader):


### PR DESCRIPTION
- Move `M3U8Parser.base_uri` to `M3U8.uri`
- Add `multivariant` to `{,Muxed}HLSStream` and deprecate `url_master`:
  - Set `multivariant` in `HLSStream.parse_variant_playlist` instead of
    `url_master`, so that stream instances can keep a reference of
    their parsed multivariant playlist.
    This is required for implementing the `EXT-X-SESSION-{DATA,KEY}`
    HLS tags, or for accessing custom tags in HLS subclasses.
  - Update `to_manifest_url`
    TODO: rename method / refactor interface
- Fix subclasses in various plugins

----

The `url_master` parameter was not removed from `{,Muxed}HLSStream` for backwards compatibility reasons. This can be done later when other HLS method signatures get changed in the future.

Instead of "master", I chose the name "multivariant", because that's how master playlists will be called in future versions of the HLS spec. This avoids one unnecessary parameter name change later on and keeps it consistent with future spec implementations.