### PR TITLE
stream.hls: add methods for fetching playlists

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -280,6 +280,18 @@ class HLSStreamWorker(SegmentedStreamWorker):
         elif self.playlist_reload_time_override not in ["segment", "live-edge"]:
             self.playlist_reload_time_override = 0
 
+    def _fetch_playlist(self) -> Response:
+        res = self.session.http.get(
+            self.stream.url,
+            exception=StreamError,
+            retries=self.playlist_reload_retries,
+            **self.reader.request_params,
+        )
+        res.encoding = "utf-8"
+
+        return res
+
+    # TODO: rename to _parse_playlist
     def _reload_playlist(self, *args, **kwargs):
         return load_hls_playlist(*args, **kwargs)
 
@@ -288,14 +300,10 @@ class HLSStreamWorker(SegmentedStreamWorker):
             return
 
         self.reader.buffer.wait_free()
+
         log.debug("Reloading playlist")
-        res = self.session.http.get(
-            self.stream.url,
-            exception=StreamError,
-            retries=self.playlist_reload_retries,
-            **self.reader.request_params,
-        )
-        res.encoding = "utf-8"
+        res = self._fetch_playlist()
+
         try:
             playlist = self._reload_playlist(res)
         except ValueError as err:
@@ -580,6 +588,14 @@ class HLSStream(HTTPStream):
         return reader
 
     @classmethod
+    def _fetch_variant_playlist(cls, session, url: str, **request_params) -> Response:
+        res = session.http.get(url, exception=OSError, **request_params)
+        res.encoding = "utf-8"
+
+        return res
+
+    # TODO: rename to _parse_variant_playlist
+    @classmethod
     def _get_variant_playlist(cls, *args, **kwargs):
         return load_hls_playlist(*args, **kwargs)
 
@@ -616,9 +632,7 @@ class HLSStream(HTTPStream):
         locale = session_.localization
         audio_select = session_.options.get("hls-audio-select") or []
 
-        # noinspection PyArgumentList
-        res = session_.http.get(url, exception=IOError, **request_params)
-        res.encoding = "utf-8"
+        res = cls._fetch_variant_playlist(session_, url, **request_params)
 
         try:
             multivariant = cls._get_variant_playlist(res)


### PR DESCRIPTION
This will make it easier to override HLS playlist fetching behavior.

In the past, we've added `HLSStream._get_variant_playlist` for overriding the parsing of variant playlists and `HLSStreamWorker._reload_playlist` for overriding the parsing of media playlists. Playlist-fetching however could not be customized, so plugins like FilmOn for example subclassed the worker class and [redefined the whole `reload_playlist` method, which is pretty bad](https://github.com/streamlink/streamlink/blob/7cb0ebe96f659f3eeb7b36e58eb545cd2cb9894c/src/streamlink/plugins/filmon.py#L25-L75), because regular HLSStreamWorker changes would also need to be applied there.

I will open a PR with a rewrite of the FilmOn plugin based on the changes of this PR later.

Other plugins with URL-refreshing logic all do that by overriding the HLSStream.url property, and the only plugin which has a custom HLS parser is Twitch, and the worker is overriding the `_reload_playlist` method, so no changes will be required in that regard.

I would've liked to also rename `HLSStream._get_variant_playlist` to `HLSStream._parse_variant_playlist` and `HLSStreamWorker._reload_playlist` to `HLSStreamWorker._parse_playlist`, but that would probably unnecessary break some third party plugins, so let's do it later, even though it's not part of any stable API provided by Streamlink.