### PR TITLE
plugins.aloula: update login required message

### DIFF
--- a/src/streamlink/plugins/aloula.py
+++ b/src/streamlink/plugins/aloula.py
@@ -80,7 +80,7 @@ class Aloula(Plugin):
 
         log.trace(f"{vod_data!r}")
         if "cms_error" in vod_data and vod_data["cms_error"] == "auth":
-            log.error("This stream requires a logged-in session cookie to be supplied")
+            log.error("This stream requires a login; specify appropriate Authorization and profile HTTP headers")
             return
         if "cms_error" in vod_data:
             log.error(f"API error: {vod_data['cms_error']} ({vod_data['message']})")


### PR DESCRIPTION
I looked at the full login; it does look to be a bit of a PITA, plus there's the multi profiles within the account thing, so did not seem worthwhile.  This just updates the message to be a bit more precise about what is needed.
