### PR TITLE
cli: list all dependencies in debug output

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ package_dir =
   =src
 packages = find:
 install_requires =
+  importlib-metadata ; python_version<"3.8"
   isodate
   lxml >=4.6.4,<5.0
   pycountry

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -3,6 +3,11 @@ import sys
 from pathlib import Path
 from typing import BinaryIO, TYPE_CHECKING
 
+try:
+    import importlib.metadata as importlib_metadata  # type: ignore[import]  # noqa: F401
+except ImportError:
+    import importlib_metadata  # type: ignore[import]  # noqa: F401
+
 
 is_darwin = sys.platform == "darwin"
 is_win32 = os.name == "nt"

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -574,18 +574,18 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
 
 
 class _TestCLIMainLogging(unittest.TestCase):
+    # stop test execution at the setup_signals() call, as we're not interested in what comes afterwards
+    class StopTest(Exception):
+        pass
+
     @classmethod
     def subject(cls, argv, **kwargs):
         session = Streamlink()
         session.load_plugins(os.path.join(os.path.dirname(__file__), "plugin"))
 
-        # stop test execution at the setup_signals() call, as we're not interested in what comes afterwards
-        class StopTest(Exception):
-            pass
-
         with patch("streamlink_cli.main.os.geteuid", create=True, new=Mock(return_value=kwargs.get("euid", 1000))), \
              patch("streamlink_cli.main.streamlink", session), \
-             patch("streamlink_cli.main.setup_signals", side_effect=StopTest), \
+             patch("streamlink_cli.main.setup_signals", side_effect=cls.StopTest), \
              patch("streamlink_cli.main.CONFIG_FILES", []), \
              patch("streamlink_cli.main.setup_streamlink"), \
              patch("streamlink_cli.main.setup_plugins"), \
@@ -595,7 +595,7 @@ class _TestCLIMainLogging(unittest.TestCase):
             mock_argv.__getitem__.side_effect = lambda x: argv[x]
             try:
                 streamlink_cli.main.main()
-            except StopTest:
+            except cls.StopTest:
                 pass
 
     def tearDown(self):
@@ -712,55 +712,71 @@ class TestCLIMainLoggingInfos(_TestCLIMainLogging):
 
     @patch("streamlink_cli.main.log")
     @patch("streamlink_cli.main.streamlink_version", "streamlink")
-    @patch("streamlink_cli.main.requests.__version__", "requests")
-    @patch("streamlink_cli.main.socks_version", "socks")
-    @patch("streamlink_cli.main.websocket_version", "websocket")
+    @patch("streamlink_cli.main.importlib_metadata")
+    @patch("streamlink_cli.main.log_current_arguments", Mock(side_effect=_TestCLIMainLogging.StopTest))
     @patch("platform.python_version", Mock(return_value="python"))
-    def test_log_current_versions(self, mock_log):
+    def test_log_current_versions(self, mock_importlib_metadata: Mock, mock_log: Mock):
+        class FakePackageNotFoundError(Exception):
+            pass
+
+        def version(dist):
+            if dist == "foo":
+                return "1.2.3"
+            if dist == "bar-baz":
+                return "2.0.0"
+            raise FakePackageNotFoundError()
+
+        mock_importlib_metadata.PackageNotFoundError = FakePackageNotFoundError
+        mock_importlib_metadata.requires.return_value = ["foo>1", "bar-baz==2", "qux~=3"]
+        mock_importlib_metadata.version.side_effect = version
+
         self.subject(["streamlink", "--loglevel", "info"])
         self.assertEqual(mock_log.debug.mock_calls, [], "Doesn't log anything if not debug logging")
 
         with patch("sys.platform", "linux"), \
              patch("platform.platform", Mock(return_value="linux")):
             self.subject(["streamlink", "--loglevel", "debug"])
-            self.assertEqual(
-                mock_log.debug.mock_calls[:4],
-                [
-                    call("OS:         linux"),
-                    call("Python:     python"),
-                    call("Streamlink: streamlink"),
-                    call("Requests(requests), Socks(socks), Websocket(websocket)")
-                ]
-            )
+            assert mock_importlib_metadata.requires.mock_calls == [call("streamlink")]
+            assert mock_log.debug.mock_calls == [
+                call("OS:         linux"),
+                call("Python:     python"),
+                call("Streamlink: streamlink"),
+                call("Dependencies:"),
+                call(" foo: 1.2.3"),
+                call(" bar-baz: 2.0.0"),
+            ]
+            mock_importlib_metadata.requires.reset_mock()
             mock_log.debug.reset_mock()
 
         with patch("sys.platform", "darwin"), \
              patch("platform.mac_ver", Mock(return_value=["0.0.0"])):
             self.subject(["streamlink", "--loglevel", "debug"])
-            self.assertEqual(
-                mock_log.debug.mock_calls[:4],
-                [
-                    call("OS:         macOS 0.0.0"),
-                    call("Python:     python"),
-                    call("Streamlink: streamlink"),
-                    call("Requests(requests), Socks(socks), Websocket(websocket)")
-                ]
-            )
+            assert mock_importlib_metadata.requires.mock_calls == [call("streamlink")]
+            assert mock_log.debug.mock_calls == [
+                call("OS:         macOS 0.0.0"),
+                call("Python:     python"),
+                call("Streamlink: streamlink"),
+                call("Dependencies:"),
+                call(" foo: 1.2.3"),
+                call(" bar-baz: 2.0.0"),
+            ]
+            mock_importlib_metadata.requires.reset_mock()
             mock_log.debug.reset_mock()
 
         with patch("sys.platform", "win32"), \
              patch("platform.system", Mock(return_value="Windows")), \
              patch("platform.release", Mock(return_value="0.0.0")):
             self.subject(["streamlink", "--loglevel", "debug"])
-            self.assertEqual(
-                mock_log.debug.mock_calls[:4],
-                [
-                    call("OS:         Windows 0.0.0"),
-                    call("Python:     python"),
-                    call("Streamlink: streamlink"),
-                    call("Requests(requests), Socks(socks), Websocket(websocket)")
-                ]
-            )
+            assert mock_importlib_metadata.requires.mock_calls == [call("streamlink")]
+            assert mock_log.debug.mock_calls == [
+                call("OS:         Windows 0.0.0"),
+                call("Python:     python"),
+                call("Streamlink: streamlink"),
+                call("Dependencies:"),
+                call(" foo: 1.2.3"),
+                call(" bar-baz: 2.0.0"),
+            ]
+            mock_importlib_metadata.requires.reset_mock()
             mock_log.debug.reset_mock()
 
     @patch("streamlink_cli.main.log")


### PR DESCRIPTION
- Require importlib-metadata as fallback on Python < 3.8
- Add importlib_metadata to streamlink_cli.compat
- List all dependencies in `log_current_versions`
- Update tests

----

All of Streamlink's dependencies should be listed in the debug output. This is especially useful for figuring out issues like #4562.

```
$ streamlink -l debug
[cli][debug] OS:         Linux-5.18.1-1-git-x86_64-with-glibc2.35
[cli][debug] Python:     3.10.4
[cli][debug] Streamlink: 4.1.0+7.g0b539fd1
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.0
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.27.1
[cli][debug]  websocket-client: 1.3.2
[cli][debug] Arguments:
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io
```

----

Since `importlib.metadata` is only available on py38 and above, the `importlib-metadata` fallback requirement needs to be added for py37.
https://github.com/python/importlib_metadata#compatibility
https://pypi.org/project/importlib-metadata/

The version restriction of `<4.3` is intentional because of `flake8`, which sets the same requirement:
https://github.com/PyCQA/flake8/blob/4.0.1/setup.cfg#L45
This unfortunately causes a conflict with sphinx, which requires `>=4.4` for py37-py39:
https://github.com/sphinx-doc/sphinx/blob/v4.5.0/setup.py#L32

Since we don't build docs and thus don't install docs requirements on py37, we don't need to care about sphinx's dependency version conflict. But since we obviously run tests and lint code on py37, the version requirement of flake8 needs to be set to avoid introducing version conflicts when installing streamlink first and then streamlink's dev-requirements, because pip won't downgrade in this case.

This means that the version conflict does only affect packagers of streamlink who publish the latest versions for py37. This is already unlikely, and then it can simply be patched out if needed.

It probably doesn't matter anyway and the version conflict can probably be ignored... Flake8 is running fine with the latest importlib-metadata version. **So should I remove the version restriction again?**

```
$ pip install -U importlib-metadata
...
flake8 4.0.1 requires importlib-metadata<4.3; python_version < "3.8", but you have importlib-metadata 4.11.4 which is incompatible.
Successfully installed importlib-metadata-4.11.4
$ flake8
0
```