### PR TITLE
cli: fix pluginerror in handle_url if json is True

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -600,7 +600,7 @@ def handle_url():
     except NoPluginError:
         console.exit(f"No plugin can handle URL: {args.url}")
     except PluginError as err:
-        console.exit(err)
+        console.exit(str(err))
 
     if not streams:
         console.exit(f"No playable streams found on this URL: {args.url}")


### PR DESCRIPTION
Fixes #4589 

`console.exit(msg)` requires a `str` parameter, otherwise it'll try to serialize the unknown input type as JSON if `args.json` is True, which can fail:
https://github.com/streamlink/streamlink/blob/2a5b71fa76c538ad0d3ab82492f558514d9b24a0/src/streamlink_cli/console.py#L89-L95

As already said in other threads, the ConsoleOutput usage and handling of console.exit() is pretty bad and needs to be rewritten.

----

