### PR TITLE
plugins.pandalive: update/fix

### DIFF
--- a/src/streamlink/plugins/pandalive.py
+++ b/src/streamlink/plugins/pandalive.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 ))
 class Pandalive(Plugin):
     def _get_streams(self):
-        re_media_code = re.compile(r"""routePath:\s*(["'])(\\u002F|/)live(\\u002F|/)play(\\u002F|/)(?P<id>\d+)\1""")
+        re_media_code = re.compile(r"""routePath:\s*(["'])(\\u002F|/)live(\\u002F|/)play(\\u002F|/)(?P<id>[^"']+)\1""")
         media_code = self.session.http.get(self.url, schema=validate.Schema(
             validate.transform(re_media_code.search),
             validate.any(None, validate.get("id"))
@@ -34,34 +34,40 @@ class Pandalive(Plugin):
             "https://api.pandalive.co.kr/v1/live/play",
             data={
                 "action": "watch",
-                "userIdx": media_code
+                "userId": media_code
             },
             schema=validate.Schema(
                 validate.parse_json(),
-                {
-                    "media": {
-                        "title": str,
-                        "userId": str,
-                        "userNick": str,
-                        "isPw": bool,
-                        "isLive": bool,
-                        "liveType": str,
+                validate.any(
+                    {
+                        "media": {
+                            "title": str,
+                            "userId": str,
+                            "userNick": str,
+                            "isPw": bool,
+                            "isLive": bool,
+                            "liveType": str,
+                        },
+                        "PlayList": {
+                            validate.optional("hls"): [{
+                                "url": validate.url(),
+                            }],
+                            validate.optional("hls2"): [{
+                                "url": validate.url(),
+                            }],
+                            validate.optional("hls3"): [{
+                                "url": validate.url(),
+                            }],
+                        },
+                        "result": bool,
+                        "message": str,
                     },
-                    "PlayList": {
-                        validate.optional("hls"): [{
-                            "url": validate.url(),
-                        }],
-                        validate.optional("hls2"): [{
-                            "url": validate.url(),
-                        }],
-                        validate.optional("hls3"): [{
-                            "url": validate.url(),
-                        }],
+                    {
+                        "result": bool,
+                        "message": str,
                     },
-                    "result": bool,
-                    "message": str,
-                }
-            )
+                ),
+            ),
         )
 
         if not json["result"]:


### PR DESCRIPTION
Updates pandalive for usernames, rather than numeric IDs.  Fixes validation of streams that are no longer online or not available.

Before:
```
$ streamlink https://www.pandalive.co.kr/live/play/csp1208
[cli][info] Found matching plugin pandalive for URL https://www.pandalive.co.kr/live/play/csp1208
error: No playable streams found on this URL: https://www.pandalive.co.kr/live/play/csp1208
```
After (online):
```
$ streamlink https://www.pandalive.co.kr/live/play/csp1208
[cli][info] Found matching plugin pandalive for URL https://www.pandalive.co.kr/live/play/csp1208
[plugins.pandalive][info] Broadcast type: live
Available streams: 160p (worst), 360p, 480p, 720p (best)
```
After (not online):
```
$ streamlink https://www.pandalive.co.kr/live/play/bar3ie
[cli][info] Found matching plugin pandalive for URL https://www.pandalive.co.kr/live/play/bar3ie
[plugins.pandalive][error] 종료되거나 확인할 수 없는 방송입니다.
다시 시도해 주세요.
error: No playable streams found on this URL: https://www.pandalive.co.kr/live/play/bar3ie
```
