### PR TITLE
build: upgrade versioningit to >=2.0.0, <3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ freezegun>=1.0.0
 flake8
 flake8-import-order
 shtab
-versioningit >=1.1.1, <2
+versioningit >=2.0.0, <3
 
 mypy
 lxml-stubs

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=3.0
 furo==2021.09.08
 recommonmark>=0.5.0
-versioningit >=1.1.1, <2
+versioningit >=2.0.0, <3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = [
   "setuptools >=45",
   "wheel",
-  "versioningit >=1.1.1, <2",
+  "versioningit >=2.0.0, <3",
 ]
 
 
@@ -15,9 +15,9 @@ default-version = "0.0.0+unknown"
 method = "git"
 
 [tool.versioningit.format]
-distance = "{version}+{distance}.{vcs}{rev}"
-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
-distance-dirty = "{version}+{distance}.{vcs}{rev}.dirty"
+distance = "{base_version}+{distance}.{vcs}{rev}"
+dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
+distance-dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"
 
 [tool.versioningit.next-version]
 method = "null"


### PR DESCRIPTION
and update deprecated version format strings:
https://github.com/jwodder/versioningit/blob/v2.0.0/CHANGELOG.md

----

Please note that everyone who's installed streamlink in "editable" mode (`pip install -e .`) will need to update versioningit (`pip install -U --upgrade-strategy=eager -r dev-requirements.txt`), as it's not defined as a runtime dependency, only as a build dependency in the isolated build environment where the static version string gets set when building.