### PR TITLE
Fix websocket typing, fix twitcasting plugin

### DIFF
--- a/src/streamlink/plugin/api/websocket.py
+++ b/src/streamlink/plugin/api/websocket.py
@@ -14,6 +14,13 @@ log = logging.getLogger(__name__)
 
 
 class WebsocketClient(Thread):
+    OPCODE_CONT: int = ABNF.OPCODE_CONT
+    OPCODE_TEXT: int = ABNF.OPCODE_TEXT
+    OPCODE_BINARY: int = ABNF.OPCODE_BINARY
+    OPCODE_CLOSE: int = ABNF.OPCODE_CLOSE
+    OPCODE_PING: int = ABNF.OPCODE_PING
+    OPCODE_PONG: int = ABNF.OPCODE_PONG
+
     _id: int = 0
 
     ws: WebSocketApp
@@ -157,17 +164,17 @@ class WebsocketClient(Thread):
     def on_close(self, wsapp: WebSocketApp, status: int, message: str) -> None:
         log.debug(f"Closed: {wsapp.url}")  # pragma: no cover
 
-    def on_ping(self, wsapp: WebSocketApp, data: str) -> None:
+    def on_ping(self, wsapp: WebSocketApp, data: bytes) -> None:
         pass  # pragma: no cover
 
-    def on_pong(self, wsapp: WebSocketApp, data: str) -> None:
+    def on_pong(self, wsapp: WebSocketApp, data: bytes) -> None:
         pass  # pragma: no cover
 
     def on_message(self, wsapp: WebSocketApp, data: str) -> None:
         pass  # pragma: no cover
 
-    def on_cont_message(self, wsapp: WebSocketApp, data: str, cont: Any) -> None:
+    def on_cont_message(self, wsapp: WebSocketApp, data: bytes, cont: Any) -> None:
         pass  # pragma: no cover
 
-    def on_data(self, wsapp: WebSocketApp, data: str, data_type: int, cont: Any) -> None:
+    def on_data(self, wsapp: WebSocketApp, data: Union[bytes, str], data_type: int, cont: Any) -> None:
         pass  # pragma: no cover

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -102,7 +102,10 @@ class TwitCastingWsClient(WebsocketClient):
         super().on_close(*args, **kwargs)
         self.buffer.close()
 
-    def on_message(self, wsapp, data: str) -> None:
+    def on_data(self, wsapp, data, data_type, cont):
+        if data_type == self.OPCODE_TEXT:
+            data = bytes(data, "utf-8")
+
         try:
             self.buffer.write(data)
         except Exception as err:

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -2,11 +2,24 @@ import unittest
 from threading import Event
 from unittest.mock import Mock, call, patch
 
+import pytest
 from websocket import ABNF, STATUS_NORMAL  # type: ignore[import]
 
 from streamlink.logger import DEBUG, TRACE
 from streamlink.plugin.api.websocket import WebsocketClient
 from streamlink.session import Streamlink
+
+
+@pytest.mark.parametrize("name,value", [
+    ("OPCODE_CONT", ABNF.OPCODE_CONT),
+    ("OPCODE_TEXT", ABNF.OPCODE_TEXT),
+    ("OPCODE_BINARY", ABNF.OPCODE_BINARY),
+    ("OPCODE_CLOSE", ABNF.OPCODE_CLOSE),
+    ("OPCODE_PING", ABNF.OPCODE_PING),
+    ("OPCODE_PONG", ABNF.OPCODE_PONG),
+])
+def test_opcode_export(name, value):
+    assert getattr(WebsocketClient, name) == value
 
 
 class TestWebsocketClient(unittest.TestCase):


### PR DESCRIPTION
Fixes #4604 

See
https://github.com/websocket-client/websocket-client/blob/v1.3.2/websocket/_app.py#L345-L369

Two commits:
1. Fix typing in WebsocketClient and export opcodes for easier access in subclasses
2. Fix twitcasting plugin and make sure to always write bytes to the stream buffer