### PR TITLE
docs: update dependencies

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,4 @@
-sphinx>=3.0
-furo==2021.09.08
+sphinx >=4.0.0
+furo ==2022.06.04.1
 recommonmark>=0.5.0
 versioningit >=2.0.0, <3

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,4 @@
 sphinx >=4.0.0
 furo ==2022.06.04.1
-recommonmark>=0.5.0
+myst-parser >=0.18.0
 versioningit >=2.0.0, <3

--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -40,6 +40,35 @@ html {
   font-size: 100% !important;
 }
 
+h1, h2 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  font-weight: 300;
+}
+h3, h4, h5, h6 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-weight: 400;
+}
+h1 {
+  font-size: 2.25rem;
+}
+h2 {
+  font-size: 1.75rem;
+}
+h3 {
+  font-size: 1.25rem;
+}
+h4 {
+  font-size: 1rem;
+}
+h5 {
+  font-size: 0.875rem;
+}
+h6 {
+  font-size: 0.75rem;
+}
+
 code.literal {
   font-size: var(--font-size--small);
 }
@@ -56,14 +85,18 @@ strong.command {
   font: normal var(--font-size--small) var(--font-stack--monospace);
 }
 
-a[href^="http://"],
-a[href^="https://"]:not([href^="https://streamlink.github.io/"]) {
+.highlight .go {
+  font-style: normal;
+}
+
+a[href^="http://"]:not(.muted-link),
+a[href^="https://"]:not(.muted-link):not([href^="https://streamlink.github.io/"]) {
   display: inline-block;
   word-break: break-word;
 }
 
-a[href^="http://"]:not(.no-external-link-icon)::after,
-a[href^="https://"]:not(.no-external-link-icon):not([href^="https://streamlink.github.io/"])::after {
+a[href^="http://"]:not(.no-external-link-icon):not(.muted-link)::after,
+a[href^="https://"]:not(.no-external-link-icon):not(.muted-link):not([href^="https://streamlink.github.io/"])::after {
   content: "\f35d";
   display: inline-block;
   padding-left: .4em;
@@ -133,7 +166,7 @@ a[href^="https://"]:not(.no-external-link-icon):not([href^="https://streamlink.g
 }
 .sidebar-versions-others dd {
   width: 50%;
-  margin: 0;
+  margin: 0 !important;
 }
 .sidebar-versions-others dd:first-of-type {
   padding-right: .5rem;

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ extensions = [
     'ext_github',
     'ext_plugins',
     'ext_releaseref',
-    'recommonmark'
+    'myst_parser',
 ]
 
 autosectionlabel_prefix_document = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,11 @@ html_theme = 'furo'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-html_theme_options = {}
+html_theme_options = {
+    "source_repository": "https://github.com/streamlink/streamlink/",
+    "source_branch": "master",
+    "source_directory": "docs/",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 #html_theme_path = []


### PR DESCRIPTION
This updates the furo theme to the latest version and adds an edit button and scroll-to-top button. Except for some minor details, everything should stay the same, but please check thoroughly before merging.

Noticeable changes

- CLI arguments and API reference are displayed much clearer
- Code highlighting colors are different
- Some tables don't define a colgroup anymore and have thus different sizes

----

This also replaces recommonmark (abandoned project) with myst-parser for parsing markdown (changelog). No differences here.

And sphinx gets set to `>=4.0.0`, which was already a requirement of the previously used version of furo. Sphinx 5.0.0 does not have any interesting changes, and both furo and myst-parser require at least 4.0.0. We've been using the latest version the whole time, so this is only relevant for packagers who package offline documentation.

----

- https://www.sphinx-doc.org/en/master/changes.html
- https://github.com/pradyunsg/furo/blob/2022.06.04.1/docs/changelog.md
- https://github.com/readthedocs/recommonmark#recommonmark
- https://myst-parser.readthedocs.io/en/latest/intro.html