### PR TITLE
docs: update homebrew package link

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -65,7 +65,7 @@ Python pip                           See the `PyPI package and source code`_ sec
                                      `Installing Homebrew packages`_
 ==================================== ===========================================
 
-.. _Homebrew: https://github.com/Homebrew/homebrew-core/blob/master/Formula/streamlink.rb
+.. _Homebrew: https://formulae.brew.sh/formula/streamlink
 .. _Installing Homebrew packages: https://brew.sh
 
 


### PR DESCRIPTION
The docs should link to the package's page on brew.sh, not to the package build instructions in the git repo on github.