### PR TITLE
docs: protect options, examples and special characters by codeblocks; create more links; apply bold style to a default value

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -26,6 +26,7 @@ _option_line_re = re.compile(r"^(?!\s{2}|Example: )(.+)$", re.MULTILINE)
 _option_re = re.compile(r"(?:^|(?<=\s))(--\w[\w-]*\w)\b")
 _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")
+_cli_metadata_variables_section_cross_link_re = re.compile(r"the \"Metadata variables\" section")
 
 
 def get_parser(module_name, attr):
@@ -86,6 +87,12 @@ class ArgparseDirective(Directive):
 
         # fix escaped chars for percent-formatted argparse help strings
         help = _percent_re.sub("%", help)
+
+        # create cross-link for the "Metadata variables" section
+        help = _cli_metadata_variables_section_cross_link_re.sub(
+            "the \":ref:`Metadata variables <cli/metadata:Variables>`\" section",
+            help
+        )
 
         return indent(help)
 

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -77,7 +77,7 @@ class Schoolism(Plugin):
             help="""
         Play part number PART of the lesson, or assignment feedback video.
 
-        Defaults is 1.
+        Default is 1.
         """
         )
     )

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -580,8 +580,8 @@ def build_parser():
         "-r", "--record",
         metavar="FILENAME",
         help="""
-        Open the stream in the player, while at the same time writing it to FILENAME. If FILENAME is set to ``-`` (dash), then the
-        stream data will be written to stdout, similar to the --stdout argument, while still opening the player.
+        Open the stream in the player, while at the same time writing it to FILENAME. If FILENAME is set to ``-`` (dash), then
+        the stream data will be written to stdout, similar to the --stdout argument, while still opening the player.
 
         Non-existent directories and subdirectories will be created if they do not exist, if filesystem permissions allow.
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -153,7 +153,7 @@ def build_parser():
         help="""
         A URL to attempt to extract streams from.
 
-        Usually, the protocol of http(s) URLs can be omitted ("https://"),
+        Usually, the protocol of http(s) URLs can be omitted (``https://``),
         depending on the implementation of the plugin being used.
 
         Alternatively, the URL can also be specified by using the --url option.
@@ -261,7 +261,7 @@ def build_parser():
 
         User prompts and download progress won't be written to FILE.
 
-        A value of ``-`` will set the file name to an ISO8601-like string
+        A value of ``-`` (dash) will set the file name to an ISO8601-like string
         and will choose the following default log directories.
 
         Windows:
@@ -283,7 +283,7 @@ def build_parser():
         help="""
         Hide all log output.
 
-        Alias for "--loglevel none".
+        Alias for ``--loglevel none``.
         """
     )
     general.add_argument(
@@ -396,14 +396,14 @@ def build_parser():
         any of the player arguments to be logged.
 
         The value can contain formatting variables surrounded by curly braces,
-        {{ and }}. If you need to include a brace character, it can be escaped
-        by doubling, e.g. {{{{ and }}}}.
+        ``{{`` and ``}}``. If you need to include a brace character, it can be escaped
+        by doubling, e.g. ``{{{{`` and ``}}}}``.
 
         Formatting variables available:
 
         {{{PLAYER_ARGS_INPUT_DEFAULT}}}
             This is the input that the player will use. For standard input (stdin),
-            it is ``-``, but it can also be a URL, depending on the options used.
+            it is ``-`` (dash), but it can also be a URL, depending on the options used.
 
         {{{PLAYER_ARGS_INPUT_FALLBACK}}}
             The old fallback variable name with the same functionality.
@@ -521,11 +521,11 @@ def build_parser():
             VLC does support special formatting variables on its own:
             https://wiki.videolan.org/Documentation:Format_String/
 
-            These variables are accessible in the --title option by adding a backslash
+            These variables are accessible in the ``--title`` option by adding a backslash
             in front of the dollar sign which VLC uses as its formatting character.
 
             For example, to put the current date in your VLC window title,
-            the string "\\\\$A" could be inserted inside the --title string.
+            the string ``\\$A`` could be inserted inside the ``--title`` string.
 
         Example:
 
@@ -538,7 +538,7 @@ def build_parser():
         "-o", "--output",
         metavar="FILENAME",
         help="""
-        Write stream data to FILENAME instead of playing it. If FILENAME is set to - (dash), then the stream data will be
+        Write stream data to FILENAME instead of playing it. If FILENAME is set to ``-`` (dash), then the stream data will be
         written to stdout, similar to the --stdout argument.
 
         Non-existent directories and subdirectories will be created if they do not exist, if filesystem permissions allow.
@@ -580,7 +580,7 @@ def build_parser():
         "-r", "--record",
         metavar="FILENAME",
         help="""
-        Open the stream in the player, while at the same time writing it to FILENAME. If FILENAME is set to - (dash), then the
+        Open the stream in the player, while at the same time writing it to FILENAME. If FILENAME is set to ``-`` (dash), then the
         stream data will be written to stdout, similar to the --stdout argument, while still opening the player.
 
         Non-existent directories and subdirectories will be created if they do not exist, if filesystem permissions allow.
@@ -643,7 +643,7 @@ def build_parser():
         help="""
         A URL to attempt to extract streams from.
 
-        Usually, the protocol of http(s) URLs can be omitted (https://),
+        Usually, the protocol of http(s) URLs can be omitted (``https://``),
         depending on the implementation of the plugin being used.
 
         This is an alternative to setting the URL using a positional argument
@@ -720,7 +720,7 @@ def build_parser():
 
         The order will be used to separate streams when there are multiple
         streams with the same name but different stream types. Any stream type
-        not listed will be omitted from the available streams list.  A ``*`` can
+        not listed will be omitted from the available streams list.  An ``*`` (asterisk) can
         be used as a wildcard to match any other type of stream, eg. muxed-stream.
 
         Default is "hls,http,*".
@@ -900,7 +900,7 @@ def build_parser():
         help="""
         A comma-delimited list of segment names that will get filtered out.
 
-        Example: --hls-segment-ignore-names 000,001,002
+        Example: ``--hls-segment-ignore-names 000,001,002``
 
         This will ignore every segment that ends with 000.ts, 001.ts and 002.ts
 
@@ -934,7 +934,7 @@ def build_parser():
         metavar="CODE",
         help="""
         Selects a specific audio source or sources, by language code or name,
-        when multiple audio sources are available. Can be * to download all
+        when multiple audio sources are available. Can be ``*`` (asterisk) to download all
         audio sources.
 
         Examples:
@@ -995,7 +995,7 @@ def build_parser():
         can specify the location of the ffmpeg executable if it is not in your
         PATH.
 
-        Example: "/usr/local/bin/ffmpeg"
+        Example: ``--ffmpeg-ffmpeg /usr/local/bin/ffmpeg``
         """
     )
     transport_ffmpeg.add_argument(
@@ -1022,7 +1022,7 @@ def build_parser():
 
         Default is "matroska".
 
-        Example: "mpegts"
+        Example: ``--ffmpeg-fout mpegts``
         """
     )
     transport_ffmpeg.add_argument(
@@ -1033,7 +1033,7 @@ def build_parser():
 
         Default is "copy".
 
-        Example: "h264"
+        Example: ``--ffmpeg-video-transcode h264``
         """
     )
     transport_ffmpeg.add_argument(
@@ -1044,7 +1044,7 @@ def build_parser():
 
         Default is "copy".
 
-        Example: "aac"
+        Example: ``--ffmpeg-audio-transcode aac``
         """
     )
     transport_ffmpeg.add_argument(
@@ -1070,7 +1070,7 @@ def build_parser():
         help="""
         A HTTP proxy to use for all HTTP and HTTPS requests, including WebSocket connections.
 
-        Example: "http://hostname:port/"
+        Example: ``--http-proxy http://hostname:port/``
         """
     )
     http.add_argument("--https-proxy", help=argparse.SUPPRESS)

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -558,14 +558,14 @@ def build_parser():
         "-f", "--force",
         action="store_true",
         help="""
-        When using -o or -r, always write to file even if it already exists (overwrite).
+        When using --output or --record, always write to file even if it already exists (overwrite).
         """
     )
     output.add_argument(
         "--force-progress",
         action="store_true",
         help="""
-        When using -o or -r,
+        When using --output or --record,
         show the download progress bar even if there is no terminal.
         """
     )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Hello!

cc1036b1e042f290c952adf9fda21240f236ef58 :

> > <p>Defaults is 1.</p>
> 
> > <p>Default is: <strong>1</strong>.</p>

a6280e8a029dd9bd762f837a2524fdba92e270d4 :

> > <p>When using -o or -r, always write to file even if it already exists (overwrite).</p>
> 
> > <p>When using <a class="reference internal" href="#cmdoption-output"><code class="xref std std-option docutils literal notranslate"><span class="pre">--output</span></code></a> or <a class="reference internal" href="#cmdoption-record"><code class="xref std std-option docutils literal notranslate"><span class="pre">--record</span></code></a>, always write to file even if it already exists (overwrite).</p>

> > <p>When using -o or -r, show the download progress bar even if there is no terminal.</p>
> 
> > <p>When using <a class="reference internal" href="#cmdoption-output"><code class="xref std std-option docutils literal notranslate"><span class="pre">--output</span></code></a> or <a class="reference internal" href="#cmdoption-record"><code class="xref std std-option docutils literal notranslate"><span class="pre">--record</span></code></a>, show the download progress bar even if there is no terminal.</p>

76a910d3cc327eaa680c4c78d2d7271784b04d78 :

> > <p>Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.</p>
> 
> > <p>Please see the "<a class="reference internal" href="cli/metadata.html#variables"><span class="std std-ref">Metadata variables</span></a>" section of Streamlink's CLI documentation for all available metadata variables.</p>

1e12d02ba922e936d342d86848b34de5623b95c1 (partial):

> > <p>Usually, the protocol of http(s) URLs can be omitted (<a class="reference external" href="https://">https://</a>), depending on the implementation of the plugin being used.</p>
> 
> > <p>Usually, the protocol of http(s) URLs can be omitted (<code class="docutils literal notranslate"><span class="pre">https://</span></code>), depending on the implementation of the plugin being used.</p>

> > <p>The value can contain formatting variables surrounded by curly braces, { and }. If you need to include a brace character, it can be escaped by doubling, e.g. {{ and }}.</p>
> 
> > <p>The value can contain formatting variables surrounded by curly braces, <code class="docutils literal notranslate"><span class="pre">{</span></code> and <code class="docutils literal notranslate"><span class="pre">}</span></code>. If you need to include a brace character, it can be escaped by doubling, e.g. <code class="docutils literal notranslate"><span class="pre">{{</span></code> and <code class="docutils literal notranslate"><span class="pre">}}</span></code>.</p>

> > <p>For example, to put the current date in your VLC window title, the string "\$A" could be inserted inside the --title string.</p>
> 
> > <p>For example, to put the current date in your VLC window title, the string <code class="docutils literal notranslate"><span class="pre">\$A</span></code> could be inserted inside the <code class="docutils literal notranslate"><span class="pre">--title</span></code> string.</p>

> > <p>Selects a specific audio source or sources, by language code or name, when multiple audio sources are available. Can be * to download all audio sources.</p>
> 
> > <p>Selects a specific audio source or sources, by language code or name, when multiple audio sources are available. Can be <code class="docutils literal notranslate"><span class="pre">*</span></code> (asterisk) to download all audio sources.</p>

Please correct me if I changed the meaning of the docs.
