### PR TITLE
docs: apply bold style to a default value; create more links for cross-references

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -25,6 +25,7 @@ _option_line_re = re.compile(r"^(?!\s{2}|Example: )(.+)$", re.MULTILINE)
 _option_re = re.compile(r"(?:^|(?<=\s))(--\w[\w-]*\w)\b")
 _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")
+_cli_metadata_variables_section_cross_link_re = re.compile(r"the \"Metadata variables\" section")
 
 
 def get_parser(module_name, attr):
@@ -85,6 +86,12 @@ class ArgparseDirective(Directive):
 
         # fix escaped chars for percent-formatted argparse help strings
         help = _percent_re.sub("%", help)
+
+        # create cross-link for the "Metadata variables" section
+        help = _cli_metadata_variables_section_cross_link_re.sub(
+            "the \":ref:`Metadata variables <cli/metadata:Variables>`\" section",
+            help
+        )
 
         return indent(help)
 

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -77,7 +77,7 @@ class Schoolism(Plugin):
             help="""
         Play part number PART of the lesson, or assignment feedback video.
 
-        Defaults is 1.
+        Default is 1.
         """
         )
     )

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -558,14 +558,14 @@ def build_parser():
         "-f", "--force",
         action="store_true",
         help="""
-        When using -o or -r, always write to file even if it already exists (overwrite).
+        When using --output or --record, always write to file even if it already exists (overwrite).
         """
     )
     output.add_argument(
         "--force-progress",
         action="store_true",
         help="""
-        When using -o or -r,
+        When using --output or --record,
         show the download progress bar even if there is no terminal.
         """
     )


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Hi!

e8f01855ddf2c8dca59fa9c2bb253cb2f93471a0 :

> > <p>Defaults is 1.</p>
> 
> > <p>Default is: <strong>1</strong>.</p>

449b0122b29732ff49bf37599bbfd919358c250a :

> > <p>When using -o or -r, always write to file even if it already exists (overwrite).</p>
> 
> > <p>When using <a class="reference internal" href="#cmdoption-output"><code class="xref std std-option docutils literal notranslate"><span class="pre">--output</span></code></a> or <a class="reference internal" href="#cmdoption-record"><code class="xref std std-option docutils literal notranslate"><span class="pre">--record</span></code></a>, always write to file even if it already exists (overwrite).</p>

> > <p>When using -o or -r, show the download progress bar even if there is no terminal.</p>
> 
> > <p>When using <a class="reference internal" href="#cmdoption-output"><code class="xref std std-option docutils literal notranslate"><span class="pre">--output</span></code></a> or <a class="reference internal" href="#cmdoption-record"><code class="xref std std-option docutils literal notranslate"><span class="pre">--record</span></code></a>, show the download progress bar even if there is no terminal.</p>

b2ad48fbca08cd93be2c6a6472872b7e0b412e3b :

> > <p>Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.</p>
> 
> > <p>Please see the "<a class="reference internal" href="cli/metadata.html#variables"><span class="std std-ref">Metadata variables</span></a>" section of Streamlink's CLI documentation for all available metadata variables.</p>

The above commits are cherry-picked from #4618 .