### PR TITLE
stream.dash: remove time.sleep() calls

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -4,11 +4,13 @@ import itertools
 import logging
 import os.path
 from collections import defaultdict
+from contextlib import contextmanager
+from time import time
 from typing import Dict, Optional
 from urllib.parse import urlparse, urlunparse
 
 from streamlink import PluginError, StreamError
-from streamlink.stream.dash_manifest import MPD, Representation, freeze_timeline, sleep_until, sleeper, utc
+from streamlink.stream.dash_manifest import MPD, Representation, freeze_timeline, sleep_until, utc
 from streamlink.stream.ffmpegmux import FFMPEGMuxer
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.stream.stream import Stream
@@ -67,6 +69,17 @@ class DASHStreamWorker(SegmentedStreamWorker):
         self.mpd = self.stream.mpd
         self.period = self.stream.period
 
+    @contextmanager
+    def sleeper(self, duration):
+        """
+        Do something and then wait for a given duration minus the time it took doing something
+        """
+        s = time()
+        yield
+        time_to_sleep = duration - (time() - s)
+        if time_to_sleep > 0:
+            self.wait(time_to_sleep)
+
     @staticmethod
     def get_representation(mpd, representation_id, mime_type):
         for aset in mpd.periods[0].adaptationSets:
@@ -80,28 +93,35 @@ class DASHStreamWorker(SegmentedStreamWorker):
         while not self.closed:
             # find the representation by ID
             representation = self.get_representation(self.mpd, self.reader.representation_id, self.reader.mime_type)
-            refresh_wait = max(self.mpd.minimumUpdatePeriod.total_seconds(),
-                               self.mpd.periods[0].duration.total_seconds()) or 5
 
             if self.mpd.type == "static":
                 refresh_wait = 5
+            else:
+                refresh_wait = max(
+                    self.mpd.minimumUpdatePeriod.total_seconds(),
+                    self.mpd.periods[0].duration.total_seconds(),
+                ) or 5
 
-            with sleeper(refresh_wait * back_off_factor):
-                if representation:
-                    for segment in representation.segments(init=init):
-                        if self.closed:
-                            break
-                        yield segment
-                        # log.debug(f"Adding segment {segment.url} to queue")
+            with self.sleeper(refresh_wait * back_off_factor):
+                if not representation:
+                    continue
 
-                    if self.mpd.type == "dynamic":
-                        if not self.reload():
-                            back_off_factor = max(back_off_factor * 1.3, 10.0)
-                        else:
-                            back_off_factor = 1
-                    else:
-                        return
-                    init = False
+                for segment in representation.segments(init=init):
+                    if self.closed:
+                        break
+                    yield segment
+
+                # close worker if type is not dynamic (all segments were put into writer queue)
+                if self.mpd.type != "dynamic":
+                    self.close()
+                    return
+
+                if not self.reload():
+                    back_off_factor = max(back_off_factor * 1.3, 10.0)
+                else:
+                    back_off_factor = 1
+
+                init = False
 
     def reload(self):
         if self.closed:

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 import math
 import re
-import time
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from itertools import count, repeat
@@ -43,13 +42,6 @@ def freeze_timeline(mpd):
     timelines = copy.copy(mpd.timelines)
     yield
     mpd.timelines = timelines
-
-
-def sleep_until(walltime):
-    c = datetime.datetime.now(tz=utc)
-    time_to_wait = (walltime - c).total_seconds()
-    if time_to_wait > 0:
-        time.sleep(time_to_wait)
 
 
 class MPDParsers:

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -45,15 +45,6 @@ def freeze_timeline(mpd):
     mpd.timelines = timelines
 
 
-@contextmanager
-def sleeper(duration):
-    s = time.time()
-    yield
-    time_to_sleep = duration - (time.time() - s)
-    if time_to_sleep > 0:
-        time.sleep(time_to_sleep)
-
-
 def sleep_until(walltime):
     c = datetime.datetime.now(tz=utc)
     time_to_wait = (walltime - c).total_seconds()

--- a/tests/stream/test_dash.py
+++ b/tests/stream/test_dash.py
@@ -1,5 +1,8 @@
 import unittest
+from typing import List
 from unittest.mock import ANY, MagicMock, Mock, call, patch
+
+import pytest
 
 from streamlink import PluginError
 from streamlink.stream.dash import DASHStream, DASHStreamWorker
@@ -300,124 +303,141 @@ class TestDASHStream(unittest.TestCase):
         self.assertEqual(streams["1080p_alt2"].video_representation.bandwidth, 32.0)
 
 
-class TestDASHStreamWorker(unittest.TestCase):
-    @patch("streamlink.stream.dash_manifest.time.sleep")
-    @patch('streamlink.stream.dash.MPD')
-    def test_dynamic_reload(self, mpdClass, sleep):
-        reader = MagicMock()
-        worker = DASHStreamWorker(reader)
-        reader.representation_id = 1
-        reader.mime_type = "video/mp4"
+class TestDASHStreamWorker:
+    @pytest.fixture
+    def mock_time(self, monkeypatch: pytest.MonkeyPatch) -> Mock:
+        mock = Mock(return_value=1)
+        monkeypatch.setattr("streamlink.stream.dash_manifest.time.time", mock)
+        return mock
 
-        representation = Mock(id=1, mimeType="video/mp4", height=720)
-        segments = [Mock(url="init_segment"), Mock(url="first_segment"), Mock(url="second_segment")]
-        representation.segments.return_value = [segments[0]]
-        mpdClass.return_value = worker.mpd = Mock(dynamic=True,
-                                                  publishTime=1,
-                                                  periods=[
-                                                      Mock(adaptationSets=[
-                                                          Mock(contentProtection=None,
-                                                               representations=[
-                                                                   representation
-                                                               ])
-                                                      ])
-                                                  ])
-        worker.mpd.type = "dynamic"
-        worker.mpd.minimumUpdatePeriod.total_seconds.return_value = 0
-        worker.mpd.periods[0].duration.total_seconds.return_value = 0
+    @pytest.fixture(autouse=True)
+    def mock_sleep(self, monkeypatch: pytest.MonkeyPatch) -> Mock:
+        mock = Mock(return_value=True)
+        monkeypatch.setattr("streamlink.stream.dash_manifest.time.sleep", mock)
+        return mock
+
+    @pytest.fixture
+    def representation(self) -> Mock:
+        return Mock(id=1, mimeType="video/mp4", height=720)
+
+    @pytest.fixture
+    def segments(self) -> List[Mock]:
+        return [
+            Mock(url="init_segment"),
+            Mock(url="first_segment"),
+            Mock(url="second_segment"),
+        ]
+
+    @pytest.fixture
+    def mpd(self, representation) -> Mock:
+        return Mock(
+            publishTime=1,
+            minimumUpdatePeriod=Mock(total_seconds=Mock(return_value=0)),
+            periods=[
+                Mock(
+                    duration=Mock(total_seconds=Mock(return_value=0)),
+                    adaptationSets=[
+                        Mock(
+                            contentProtection=None,
+                            representations=[representation],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    @pytest.fixture
+    def worker(self, mpd):
+        reader = MagicMock(representation_id=1, mime_type="video/mp4")
+        worker = DASHStreamWorker(reader)
+        worker.mpd = mpd
+        return worker
+
+    def test_dynamic_reload(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        worker: DASHStreamWorker,
+        representation: Mock,
+        segments: List[Mock],
+        mpd: Mock,
+    ):
+        mpd.dynamic = True
+        mpd.type = "dynamic"
+        monkeypatch.setattr("streamlink.stream.dash.MPD", lambda *args, **kwargs: mpd)
 
         segment_iter = worker.iter_segments()
 
         representation.segments.return_value = segments[:1]
-        self.assertEqual(next(segment_iter), segments[0])
-        representation.segments.assert_called_with(init=True)
+        assert next(segment_iter) is segments[0]
+        assert representation.segments.call_args_list == [call(init=True)]
 
+        representation.segments.reset_mock()
         representation.segments.return_value = segments[1:]
-        self.assertSequenceEqual([next(segment_iter), next(segment_iter)], segments[1:])
-        representation.segments.assert_called_with(init=False)
+        assert [next(segment_iter), next(segment_iter)] == segments[1:]
+        assert representation.segments.call_args_list == [call(), call(init=False)]
 
-    @patch("streamlink.stream.dash_manifest.time.sleep")
-    def test_static(self, sleep):
-        reader = MagicMock()
-        worker = DASHStreamWorker(reader)
-        reader.representation_id = 1
-        reader.mime_type = "video/mp4"
-
-        representation = Mock(id=1, mimeType="video/mp4", height=720)
-        segments = [Mock(url="init_segment"), Mock(url="first_segment"), Mock(url="second_segment")]
-        representation.segments.return_value = [segments[0]]
-        worker.mpd = Mock(dynamic=False,
-                          publishTime=1,
-                          periods=[
-                              Mock(adaptationSets=[
-                                  Mock(contentProtection=None,
-                                       representations=[
-                                           representation
-                                       ])
-                              ])
-                          ])
-        worker.mpd.type = "static"
-        worker.mpd.minimumUpdatePeriod.total_seconds.return_value = 0
-        worker.mpd.periods[0].duration.total_seconds.return_value = 0
+    def test_static(
+        self,
+        worker: DASHStreamWorker,
+        representation: Mock,
+        segments: List[Mock],
+        mpd: Mock,
+    ):
+        mpd.dynamic = False
+        mpd.type = "static"
 
         representation.segments.return_value = segments
-        self.assertSequenceEqual(list(worker.iter_segments()), segments)
-        representation.segments.assert_called_with(init=True)
+        assert list(worker.iter_segments()) == segments
+        assert representation.segments.call_args_list == [call(init=True)]
 
-    @patch("streamlink.stream.dash_manifest.time.time")
-    @patch("streamlink.stream.dash_manifest.time.sleep")
-    def test_static_refresh_wait(self, sleep, time):
+    @pytest.mark.parametrize("duration", [
+        0,
+        204.32,
+    ])
+    def test_static_refresh_wait(
+        self,
+        duration: float,
+        mock_sleep,
+        mock_time: Mock,
+        worker: DASHStreamWorker,
+        representation: Mock,
+        segments: List[Mock],
+        mpd: Mock,
+    ):
         """
             Verify the fix for https://github.com/streamlink/streamlink/issues/2873
         """
-        time.return_value = 1
-        reader = MagicMock()
-        worker = DASHStreamWorker(reader)
-        reader.representation_id = 1
-        reader.mime_type = "video/mp4"
+        mpd.dynamic = False
+        mpd.type = "static"
+        mpd.periods[0].duration.total_seconds.return_value = duration
 
-        representation = Mock(id=1, mimeType="video/mp4", height=720)
-        segments = [Mock(url="init_segment"), Mock(url="first_segment"), Mock(url="second_segment")]
-        representation.segments.return_value = [segments[0]]
-        worker.mpd = Mock(dynamic=False,
-                          publishTime=1,
-                          periods=[
-                              Mock(adaptationSets=[
-                                  Mock(contentProtection=None,
-                                       representations=[
-                                           representation
-                                       ])
-                              ])
-                          ])
-        worker.mpd.type = "static"
-        for duration in (0, 204.32):
-            worker.mpd.minimumUpdatePeriod.total_seconds.return_value = 0
-            worker.mpd.periods[0].duration.total_seconds.return_value = duration
+        representation.segments.return_value = segments
+        assert list(worker.iter_segments()) == segments
+        assert representation.segments.call_args_list == [call(init=True)]
+        assert mock_sleep.call_args_list == [call(5)]
 
-            representation.segments.return_value = segments
-            self.assertSequenceEqual(list(worker.iter_segments()), segments)
-            representation.segments.assert_called_with(init=True)
-            sleep.assert_called_with(5)
-
-    @patch("streamlink.stream.dash_manifest.time.sleep")
-    def test_duplicate_rep_id(self, sleep):
+    def test_duplicate_rep_id(self):
         representation_vid = Mock(id=1, mimeType="video/mp4", height=720)
-        representation_aud = Mock(id=1, mimeType="audio/aac", lang='en')
+        representation_aud = Mock(id=1, mimeType="audio/aac", lang="en")
 
-        mpd = Mock(dynamic=False,
-                   publishTime=1,
-                   periods=[
-                       Mock(adaptationSets=[
-                           Mock(contentProtection=None,
-                                representations=[
-                                    representation_vid
-                                ]),
-                           Mock(contentProtection=None,
-                                representations=[
-                                    representation_aud
-                                ])
-                       ])
-                   ])
+        mpd = Mock(
+            dynamic=False,
+            publishTime=1,
+            periods=[
+                Mock(
+                    adaptationSets=[
+                        Mock(
+                            contentProtection=None,
+                            representations=[representation_vid],
+                        ),
+                        Mock(
+                            contentProtection=None,
+                            representations=[representation_aud],
+                        ),
+                    ],
+                ),
+            ],
+        )
 
-        self.assertEqual(representation_vid, DASHStreamWorker.get_representation(mpd, 1, "video/mp4"))
-        self.assertEqual(representation_aud, DASHStreamWorker.get_representation(mpd, 1, "audio/aac"))
+        assert DASHStreamWorker.get_representation(mpd, 1, "video/mp4") is representation_vid
+        assert DASHStreamWorker.get_representation(mpd, 1, "audio/aac") is representation_aud


### PR DESCRIPTION
Resolves #4311

This replaces the `time.sleep()` calls made by the `DASHStreamWorker` thread and threads of the `DASHStreamWriter` thread pool with `threading.Event.wait()` calls, so that the execution of those threads can be stopped immediately when the stream gets closed.

----

1. Refactor `SegmentedStream{Worker,Writer}` and add a common `wait()` method via the `AwaitableMixin`.
   Not sure if this is a fitting name. Any better suggestions?
2. Refactor `DASHStreamWorker` tests. Not strictly necessary, but one test needed to be parametrized, because it was testing two things without resetting its state. Parametrizing while also patching via unittest.mock doesn't work via decorators, so the whole test needed to be rewritten either way.
3. Remove `time.sleep()` from `DASHStreamWorker.iter_segments()` and make thread stop immediately when calling `close()` or after putting segments into the writer's queue if the manifest type is "static".
4. Remove `time.sleep()` from `DASHStreamWriter.fetch()` and make threads of the thread pool stop immediately when calling `close()`.

----

### Notes

- Even though the worker tests were refactored, they weren't necessarily improved. There's still some stuff that needs to be tested here, ideally via proper integration tests, similar to the HLS tests.
- The writer.fetch changes don't have any tests.
- #4634:
  Any additional closing delay needs to be fixed in the `FFMPEGMuxer` (see #3137).
  For example, `FFMPEGMuxer.close()` calls `close()` on the various substreams sequentially, which means that if the streams wait until all of their threads have terminated (see #4517), this introduces an additional delay.
- Being able to abort HTTP requests would also be good.

DASH live streams for testing can be found on https://steamcommunity.com/?subsection=broadcasts