### PR TITLE
stream.ffmpegmux: close sub-streams concurrently

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -1,3 +1,4 @@
+import concurrent.futures
 import logging
 import subprocess
 import sys
@@ -183,10 +184,13 @@ class FFMPEGMuxer(StreamIO):
             self.process.stdout.close()
 
             # close the streams
+            futures = []
+            executor = concurrent.futures.ThreadPoolExecutor()
             for stream in self.streams:
                 if hasattr(stream, "close") and callable(stream.close):
-                    stream.close()
+                    futures.append(executor.submit(stream.close))
 
+            concurrent.futures.wait(futures, return_when=concurrent.futures.ALL_COMPLETED)
             log.debug("Closed all the substreams")
 
         if self.close_errorlog:


### PR DESCRIPTION
Resolves #3137

The `FFMPEGMuxer` was closing its substreams sequentially, which is bad when closing a substream takes a bit of time. This is especially the case now that the [`SegmentedStreamReader` waits for its worker and writer threads to terminate](https://github.com/streamlink/streamlink/blame/ad8cf544236a420808111efeec6122d8a41467e5/src/streamlink/stream/segmented.py#L232-L235).

DASH streams need #4630 to be merged in order to close without any unnecessary additional delay.

One issue still remains though, and that is that HTTP requests don't get cancelled when a segmented stream gets closed, so if a segmented stream (eg. one of the substreams of a muxed stream) still has ongoing HTTP requests, then these need to finish first because the [`SegmentedStreamWriter` waits for all of its thread-pool threads to terminate first](https://github.com/streamlink/streamlink/blame/ad8cf544236a420808111efeec6122d8a41467e5/src/streamlink/stream/segmented.py#L133). The `wait=True` parameter is set there intentionally, for being able to run tests deterministically. This wasn't the case until two years ago when I changed it in 3b5a2cb, because the original implementation was done only with Streamlink's CLI in mind, where it doesn't matter much that streams get closed ungracefully.