### PR TITLE
stream.hls: turn url_master into property

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,17 @@
 Deprecations
 ============
 
+streamlink 4.2.0
+----------------
+
+Deprecation of url_master in HLSStream
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``url_master`` parameter and attribute of the :py:class:`streamlink.stream.HLSStream`
+and :py:class:`streamlink.stream.MuxedHLSStream` classes have been deprecated in favor of the ``multivariant`` parameter
+and attribute. ``multivariant`` is an :py:class:`M3U8` reference of the parsed HLS multivariant playlist.
+
+
 streamlink 4.0.0
 ----------------
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -508,8 +508,13 @@ class MuxedHLSStream(MuxedStream):
         ffmpeg_options = ffmpeg_options or {}
 
         super().__init__(session, *substreams, format="mpegts", maps=maps, **ffmpeg_options)
-        self.url_master = url_master
+        self._url_master = url_master
         self.multivariant = multivariant if multivariant and multivariant.is_master else None
+
+    @property
+    def url_master(self):
+        """Deprecated"""
+        return self.multivariant.uri if self.multivariant and self.multivariant.uri else self._url_master
 
     def to_manifest_url(self):
         url = self.multivariant.uri if self.multivariant and self.multivariant.uri else self.url_master
@@ -551,7 +556,7 @@ class HLSStream(HTTPStream):
         """
 
         super().__init__(session_, url, **args)
-        self.url_master = url_master
+        self._url_master = url_master
         self.multivariant = multivariant if multivariant and multivariant.is_master else None
         self.force_restart = force_restart
         self.start_offset = start_offset
@@ -569,6 +574,11 @@ class HLSStream(HTTPStream):
         del json["body"]
 
         return json
+
+    @property
+    def url_master(self):
+        """Deprecated"""
+        return self.multivariant.uri if self.multivariant and self.multivariant.uri else self._url_master
 
     def to_manifest_url(self):
         url = self.multivariant.uri if self.multivariant and self.multivariant.uri else self.url_master

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -103,6 +103,18 @@ class TestHLSVariantPlaylist(unittest.TestCase):
         stream = next(iter(streams.values()))
         assert repr(stream) == f"<HLSStream ['hls', '{base}/720p.m3u8', '{base}/master.m3u8']>"
 
+        assert stream.multivariant is not None
+        assert stream.multivariant.uri == f"{base}/master.m3u8"
+        assert stream.url_master == f"{base}/master.m3u8"
+
+    def test_url_master(self):
+        session = Streamlink()
+        stream = HLSStream(session, "http://mocked/foo", url_master="http://mocked/master.m3u8")
+
+        assert stream.multivariant is None
+        assert stream.url == "http://mocked/foo"
+        assert stream.url_master == "http://mocked/master.m3u8"
+
 
 class EventedHLSReader(HLSStreamReader):
     __writer__ = EventedHLSStreamWriter


### PR DESCRIPTION
with backwards compatibility for the deprecated url_master parameter,
and read the value from the parsed multivariant playlist instead, if it
exists.

See 7cb0ebe96f65

----

Backwards compatibility for #4568, when custom user plugins or users of Streamlink's Python API are accessing an HLSStream's master playlist URL.

Tests for MuxedHLSStream were not added, because I didn't want it to be repetitive and I didn't want to rewrite the test class because of that.