### PR TITLE
ci: fix push filter ignoring tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches-ignore:
       - 'automated/**'
+    tags:
+      - '**'
   pull_request: {}
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
#4639 

The *should* resolve pushed tags being ignored by GH actions.

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-filters-to-target-specific-branches-or-tags-for-push-events
> If you define only tags/tags-ignore or only branches/branches-ignore, the workflow won't run for events affecting the undefined Git ref. If you define neither tags/tags-ignore or branches/branches-ignore, the workflow will run for events affecting either branches or tags.

----

I have deleted the `4.2.0` tag pushed by @gravyboat as well as mine. Once this is merged, I will re-tag. No need for a 4.2.1 release.