### PR TITLE
ci: add cpython 3.11-dev test runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,13 +31,13 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-        # include:
-        #   - python: "3.11-dev"
-        #     os: ubuntu-20.04
-        #     continue: true
-        #   - python: "3.11-dev"
-        #     os: windows-latest
-        #     continue: true
+        include:
+          - python: "3.11-dev"
+            os: ubuntu-20.04
+            continue: true
+          - python: "3.11-dev"
+            os: windows-latest
+            continue: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
https://github.com/actions/setup-python#available-versions-of-python

----

3.11 release schedule:
https://peps.python.org/pep-0664/

Release might be delayed though:
https://mail.python.org/archives/list/python-dev@python.org/thread/3JWVCSBPBFWY5ZWSJ7RYB6FS5NIMCEOY/?sort=thread