### PR TITLE
ci: fix git fetch in netlify build config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 # https://docs.netlify.com/configure-builds/file-based-configuration/#build-settings
 [build]
   command = """\
-    git fetch --tags \
+    git fetch --tags https://github.com/streamlink/streamlink.git \
       && pip install -U pip setuptools \
       && pip install -e . \
       && pip install -U -r docs-requirements.txt \


### PR DESCRIPTION
Trying to fix the incorrect version number on netlify preview builds.

~~Don't merge yet. I need to see the git remotes first. According to support forum threads, they have some weird caching and build setup in regards to git repos, and apparently no remotes at all are defined.~~

If that's the case (will see after the initial push in the build logs), I will fetch explicitly from the GH repo.