### PR TITLE
cli: refactor nested argparse argument groups

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -131,21 +131,22 @@ class ArgparseDirective(Directive):
                 yield f"    **Supported plugins:** {', '.join(action.plugins)}"
                 yield ""
 
-    def generate_parser_rst(self, parser, depth=0):
+    def generate_parser_rst(self, parser, parent=None, depth=0):
         if depth >= len(self._headlines):
             return
-        for group in parser._action_groups:
+        for group in parser.NESTED_ARGUMENT_GROUPS[parent]:
+            is_parent = group in parser.NESTED_ARGUMENT_GROUPS
             # Exclude empty groups
-            if not group._group_actions and not group._action_groups:
+            if not group._group_actions and not is_parent:
                 continue
             title = group.title
             yield ""
             yield title
             yield self._headlines[depth] * len(title)
             yield from self.generate_group_rst(group)
-            if group._action_groups:
+            if is_parent:
                 yield ""
-                yield from self.generate_parser_rst(group, depth + 1)
+                yield from self.generate_parser_rst(parser, group, depth + 1)
 
     def run(self):
         module = self.options.get("module")

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -24,7 +24,7 @@ from streamlink.exceptions import FatalPluginError
 from streamlink.plugin import Plugin, PluginOptions
 from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
-from streamlink_cli.argparser import build_parser
+from streamlink_cli.argparser import ArgumentParser, build_parser
 from streamlink_cli.compat import DeprecatedPath, importlib_metadata, is_win32, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
@@ -855,13 +855,13 @@ def setup_options():
     streamlink.set_option("locale", args.locale)
 
 
-def setup_plugin_args(session, parser):
+def setup_plugin_args(session: Streamlink, parser: ArgumentParser):
     """Sets Streamlink plugin options."""
 
     plugin_args = parser.add_argument_group("Plugin options")
     for pname, plugin in session.plugins.items():
         defaults = {}
-        group = plugin_args.add_argument_group(pname.capitalize())
+        group = parser.add_argument_group(pname.capitalize(), parent=plugin_args)
 
         for parg in plugin.arguments:
             if not parg.is_global:

--- a/tests/plugins/test_funimationnow.py
+++ b/tests/plugins/test_funimationnow.py
@@ -22,7 +22,8 @@ class TestPluginFunimationNow(unittest.TestCase):
         from streamlink_cli.main import setup_plugin_args
         session = Streamlink()
         parser = MagicMock()
-        group = parser.add_argument_group("Plugin Options").add_argument_group("FunimationNow")
+        plugins = parser.add_argument_group("Plugin Options")
+        group = parser.add_argument_group("FunimationNow", parent=plugins)
 
         session.plugins = {
             'funimationnow': FunimationNow

--- a/tests/plugins/test_ustreamtv.py
+++ b/tests/plugins/test_ustreamtv.py
@@ -25,7 +25,8 @@ class TestPluginUStreamTV(unittest.TestCase):
         from streamlink_cli.main import setup_plugin_args
         session = Streamlink()
         parser = MagicMock()
-        group = parser.add_argument_group("Plugin Options").add_argument_group("UStreamTV")
+        plugins = parser.add_argument_group("Plugin Options")
+        group = parser.add_argument_group("UStreamTV", parent=plugins)
 
         session.plugins = {
             'ustreamtv': UStreamTV


### PR DESCRIPTION
- Use a custom mapping of parent->child argument group relations
  instead of calling `group.add_argument_group()` for creating
  a tree structure of argument groups (deprecated in Python 3.11)
- Override `parser.add_argument_group()` and add the `parent` keyword
  argument to nested group defintions
- Update custom `--help` format output
- Update the argparser Sphinx extension
- Fix tests

----

Resolves #4648 

Help text stays the same, and so do the docs (see the preview build).

```sh
$ diff \
    <(~/venv/streamlink-310/bin/streamlink --help) \
    <(~/venv/streamlink-311/bin/streamlink --help)
$ echo $?
0
```