### PR TITLE
plugins.vidio: fix referer HTTP header

### DIFF
--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -59,7 +59,7 @@ class Vidio(Plugin):
             return DASHStream.parse_manifest(
                 self.session,
                 dash_url,
-                headers={"Referer": self.url},
+                headers={"Referer": "https://www.vidio.com/"},
             )
 
         if not hls_url:
@@ -72,7 +72,7 @@ class Vidio(Plugin):
         return HLSStream.parse_variant_playlist(
             self.session,
             hls_url,
-            headers={"Referer": self.url},
+            headers={"Referer": "https://www.vidio.com/"},
         )
 
 


### PR DESCRIPTION
The `referer` header needs to be an exact match, otherwise it'll return HTTP status 403 on DASH stream manifest requests.
https://github.com/streamlink/streamlink/issues/4640#issuecomment-1182772500