### PR TITLE
utils.l10n: switch to locale.getlocale()

### DIFF
--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -118,9 +118,9 @@ class Localization:
 
     def _set_language_code(self, language_code):
         is_system_locale = language_code is None
-        if language_code is None:
+        if is_system_locale:
             try:
-                language_code, _ = locale.getdefaultlocale()
+                language_code, _ = locale.getlocale()
             except ValueError:
                 language_code = None
             if language_code is None or language_code == "C":
@@ -131,13 +131,12 @@ class Localization:
             self.language, self.country = self._parse_locale_code(language_code)
             self._language_code = language_code
         except LookupError:
-            if is_system_locale:
-                # If the system locale returns an invalid code, use the default
-                self.language = self.get_language(DEFAULT_LANGUAGE)
-                self.country = self.get_country(DEFAULT_COUNTRY)
-                self._language_code = DEFAULT_LANGUAGE_CODE
-            else:
+            if not is_system_locale:
                 raise
+            # If the system locale returns an invalid code, use the default
+            self.language = self.get_language(DEFAULT_LANGUAGE)
+            self.country = self.get_country(DEFAULT_COUNTRY)
+            self._language_code = DEFAULT_LANGUAGE_CODE
         log.debug(f"Language code: {self._language_code}")
 
     def equivalent(self, language: Optional[str] = None, country: Optional[str] = None) -> bool:


### PR DESCRIPTION
Replace `locale.getdefaultlocale()` with `locale.getlocale()`, as it's
deprecated since Python 3.11.

Also rewrite and add more tests.

----

- https://bugs.python.org/issue46659
- https://docs.python.org/3.11/library/locale.html#locale.getdefaultlocale
- https://github.com/python/cpython/blame/3.11/Lib/locale.py#L534-L609

----

No changes compared to master:

```bash
# system default
streamlink -l debug hls://file:///dev/null | grep utils.l10n
[utils.l10n][debug] Language code: en_US

# LC_ALL
env LC_ALL=de_DE.UTF-8 streamlink -l debug hls://file:///dev/null | grep utils.l10n
[utils.l10n][debug] Language code: de_DE

# LC_CTYPE
env LC_CTYPE=de_DE.UTF-8 streamlink -l debug hls://file:///dev/null | grep utils.l10n
[utils.l10n][debug] Language code: de_DE

# LANG
env LANG=de_DE.UTF-8 streamlink -l debug hls://file:///dev/null | grep utils.l10n
[utils.l10n][debug] Language code: de_DE

# LANGUAGE (unsupported)
env LANGUAGE=de_DE.UTF-8 streamlink -l debug hls://file:///dev/null | grep utils.l10n
[utils.l10n][debug] Language code: en_US

# --locale param
env LC_ALL=de_DE.UTF-8 streamlink -l debug hls://file:///dev/null --locale fr_FR | grep utils.l10n
[utils.l10n][debug] Language code: fr_FR
```