### PR TITLE
docs: tweak CLI argument help texts

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -27,6 +27,7 @@ _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")
 _cli_metadata_variables_section_cross_link_re = re.compile(r"the \"Metadata variables\" section")
 _inline_code_block_re = re.compile(r"(?<!`)`([^`]+?)`")
+_example_inline_code_block_re = re.compile(r"(?<=^Example: )(.+)$", re.MULTILINE)
 
 
 def get_parser(module_name, attr):
@@ -60,6 +61,8 @@ class ArgparseDirective(Directive):
             ),
             help
         )
+
+        help = _example_inline_code_block_re.sub(r":code:`\1`", help)
 
         # Replace option references with links.
         # Do this before indenting blocks and notes.

--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -21,7 +21,7 @@ from sphinx.util.nodes import nested_parse_with_titles
 _block_re = re.compile(r":\n{2}\s{2}")
 _default_re = re.compile(r"Default is (.+)\.\n")
 _note_re = re.compile(r"Note: (.*)(?:\n\n|\n*$)", re.DOTALL)
-_option_line_re = re.compile(r"^(?!\s{2}|Example: )(.+)$", re.MULTILINE)
+_option_line_re = re.compile(r"^(?!\s{2,}%\(prog\)s|\s{2,}--\w[\w-]*\w\b|Example: )(.+)$", re.MULTILINE)
 _option_re = re.compile(r"(?:^|(?<=\s))(--\w[\w-]*\w)\b")
 _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")

--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -26,6 +26,7 @@ _option_re = re.compile(r"(?:^|(?<=\s))(--\w[\w-]*\w)\b")
 _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")
 _cli_metadata_variables_section_cross_link_re = re.compile(r"the \"Metadata variables\" section")
+_inline_code_block_re = re.compile(r"(?<!`)`([^`]+?)`")
 
 
 def get_parser(module_name, attr):
@@ -52,6 +53,13 @@ class ArgparseDirective(Directive):
         # Dedent the help to make sure we are always dealing with
         # non-indented text.
         help = dedent(help)
+
+        help = _inline_code_block_re.sub(
+            lambda m: (
+                ":code:`{0}`".format(m.group(1).replace('\\', '\\\\'))
+            ),
+            help
+        )
 
         # Replace option references with links.
         # Do this before indenting blocks and notes.

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -153,7 +153,11 @@ class NicoLive(Plugin):
             argument_name="niconico-timeshift-offset",
             metavar="[HH:]MM:SS",
             default=None,
-            help="Amount of time to skip from the beginning of a stream. Default is 00:00:00."
+            help="""
+            Amount of time to skip from the beginning of a stream.
+
+            Default is 00:00:00.
+            """
         )
     )
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -504,8 +504,8 @@ class Twitch(Plugin):
             action="store_true",
             help=f"""
             Enables low latency streaming by prefetching HLS segments.
-            Sets --hls-segment-stream-data to true and --hls-live-edge to {LOW_LATENCY_MAX_LIVE_EDGE}, if it is higher.
-            Reducing --hls-live-edge to 1 will result in the lowest latency possible, but will most likely cause buffering.
+            Sets --hls-segment-stream-data to true and --hls-live-edge to `{LOW_LATENCY_MAX_LIVE_EDGE}`, if it is higher.
+            Reducing --hls-live-edge to `1` will result in the lowest latency possible, but will most likely cause buffering.
 
             In order to achieve true low latency streaming during playback, the player's caching/buffering settings will
             need to be adjusted and reduced to a value as low as possible, but still high enough to not cause any buffering.

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -769,13 +769,13 @@ def build_parser():
 
         For example this will exclude streams ranked higher than "480p":
 
-          ">480p"
+          --stream-sorting-excludes ">480p"
 
         Multiple filters can be used by separating each expression with a comma.
 
         For example this will exclude streams from two quality types:
 
-          ">480p,>medium"
+          --stream-sorting-excludes ">480p,>medium"
 
         """
     )
@@ -1018,7 +1018,7 @@ def build_parser():
         can specify the location of the ffmpeg executable if it is not in your
         PATH.
 
-        Example: "/usr/local/bin/ffmpeg"
+        Example: --ffmpeg-ffmpeg "/usr/local/bin/ffmpeg"
         """
     )
     transport_ffmpeg.add_argument(
@@ -1045,7 +1045,7 @@ def build_parser():
 
         Default is "matroska".
 
-        Example: "mpegts"
+        Example: --ffmpeg-fout "mpegts"
         """
     )
     transport_ffmpeg.add_argument(
@@ -1056,7 +1056,7 @@ def build_parser():
 
         Default is "copy".
 
-        Example: "h264"
+        Example: --ffmpeg-video-transcode "h264"
         """
     )
     transport_ffmpeg.add_argument(
@@ -1067,7 +1067,7 @@ def build_parser():
 
         Default is "copy".
 
-        Example: "aac"
+        Example: --ffmpeg-audio-transcode "aac"
         """
     )
     transport_ffmpeg.add_argument(
@@ -1093,7 +1093,7 @@ def build_parser():
         help="""
         A HTTP proxy to use for all HTTP and HTTPS requests, including WebSocket connections.
 
-        Example: "http://hostname:port/"
+        Example: --http-proxy "http://hostname:port/"
         """
     )
     http.add_argument("--https-proxy", help=argparse.SUPPRESS)

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -362,14 +362,14 @@ def build_parser():
         "-4", "--ipv4",
         action="store_true",
         help="""
-        Resolve address names to IPv4 only. This option overrides :option:`-6`.
+        Resolve address names to IPv4 only. This option overrides --ipv6.
         """
     )
     general.add_argument(
         "-6", "--ipv6",
         action="store_true",
         help="""
-        Resolve address names to IPv6 only. This option overrides :option:`-4`.
+        Resolve address names to IPv6 only. This option overrides --ipv4.
         """
     )
 
@@ -1082,7 +1082,7 @@ def build_parser():
         "--ffmpeg-start-at-zero",
         action="store_true",
         help="""
-        Enable the -start_at_zero ffmpeg option when using copyts.
+        Enable the -start_at_zero ffmpeg option when using --ffmpeg-copyts.
         """
     )
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -653,8 +653,8 @@ def build_parser():
 
         These characters are replaced with an underscore for the rules in use:
 
-          POSIX  : \\x00-\\x1F /
-          Windows: \\x00-\\x1F \\x7F " * / : < > ? \\ |
+        - POSIX: \\x00-\\x1F /
+        - Windows: \\x00-\\x1F \\x7F " * / : < > ? \\ |
         """
     )
 
@@ -909,9 +909,9 @@ def build_parser():
         Set a custom HLS playlist reload time value, either in seconds
         or by using one of the following keywords:
 
-            segment: The duration of the last segment in the current playlist
-            live-edge: The sum of segment durations of the live edge value minus one
-            default: The playlist's target duration metadata
+        - segment: The duration of the last segment in the current playlist
+        - live-edge: The sum of segment durations of the live edge value minus one
+        - default: The playlist's target duration metadata
 
         Default is default.
         """

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -284,7 +284,7 @@ def build_parser():
 
         User prompts and download progress won't be written to FILE.
 
-        A value of ``-`` will set the file name to an ISO8601-like string
+        A value of ``-`` (dash) will set the file name to an ISO8601-like string
         and will choose the following default log directories.
 
         Windows:
@@ -426,7 +426,7 @@ def build_parser():
 
         {{{PLAYER_ARGS_INPUT_DEFAULT}}}
             This is the input that the player will use. For standard input (stdin),
-            it is ``-``, but it can also be a URL, depending on the options used.
+            it is ``-`` (dash), but it can also be a URL, depending on the options used.
 
         {{{PLAYER_ARGS_INPUT_FALLBACK}}}
             The old fallback variable name with the same functionality.
@@ -743,7 +743,7 @@ def build_parser():
 
         The order will be used to separate streams when there are multiple
         streams with the same name but different stream types. Any stream type
-        not listed will be omitted from the available streams list.  A ``*`` can
+        not listed will be omitted from the available streams list.  An ``*`` (asterisk) can
         be used as a wildcard to match any other type of stream, eg. muxed-stream.
 
         Default is "hls,http,*".
@@ -957,7 +957,7 @@ def build_parser():
         metavar="CODE",
         help="""
         Selects a specific audio source or sources, by language code or name,
-        when multiple audio sources are available. Can be * to download all
+        when multiple audio sources are available. Can be * (asterisk) to download all
         audio sources.
 
         Examples:

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -176,7 +176,7 @@ def build_parser():
         help="""
         A URL to attempt to extract streams from.
 
-        Usually, the protocol of http(s) URLs can be omitted ("https://"),
+        Usually, the protocol of http(s) URLs can be omitted (`https://`),
         depending on the implementation of the plugin being used.
 
         Alternatively, the URL can also be specified by using the --url option.
@@ -190,7 +190,7 @@ def build_parser():
         help="""
         Stream to play.
 
-        Use ``best`` or ``worst`` for selecting the highest or lowest available
+        Use `best` or `worst` for selecting the highest or lowest available
         quality.
 
         Fallback streams can be specified by using a comma-separated list:
@@ -241,7 +241,7 @@ def build_parser():
         help="""
         Check if Streamlink has a plugin that can handle the specified URL.
 
-        Returns status code 1 for false and 0 for true.
+        Returns status code `1` for false and `0` for true.
 
         Useful for external scripting.
         """
@@ -273,18 +273,18 @@ def build_parser():
         help="""
         Set the log message threshold.
 
-        Valid levels are: none, error, warning, info, debug, trace
+        Valid levels are: `none`, `error`, `warning`, `info`, `debug`, `trace`
         """
     )
     general.add_argument(
         "--logfile",
         metavar="FILE",
         help="""
-        Append log output to FILE instead of writing to stdout/stderr.
+        Append log output to `FILE` instead of writing to stdout/stderr.
 
-        User prompts and download progress won't be written to FILE.
+        User prompts and download progress won't be written to `FILE`.
 
-        A value of ``-`` (dash) will set the file name to an ISO8601-like string
+        A value of `-` (dash) will set the file name to an ISO8601-like string
         and will choose the following default log directories.
 
         Windows:
@@ -306,7 +306,7 @@ def build_parser():
         help="""
         Hide all log output.
 
-        Alias for "--loglevel none".
+        Alias for `--loglevel none`.
         """
     )
     general.add_argument(
@@ -344,8 +344,8 @@ def build_parser():
         The preferred locale setting, for selecting the preferred subtitle and
         audio language.
 
-        The locale is formatted as [language_code]_[country_code], eg. en_US or
-        es_ES.
+        The locale is formatted as `[language_code]_[country_code]`, eg. `en_US` or
+        `es_ES`.
 
         Default is system locale.
         """
@@ -419,14 +419,14 @@ def build_parser():
         any of the player arguments to be logged.
 
         The value can contain formatting variables surrounded by curly braces,
-        {{ and }}. If you need to include a brace character, it can be escaped
-        by doubling, e.g. {{{{ and }}}}.
+        `{{` and `}}`. If you need to include a brace character, it can be escaped
+        by doubling, e.g. `{{{{` and `}}}}`.
 
         Formatting variables available:
 
         {{{PLAYER_ARGS_INPUT_DEFAULT}}}
             This is the input that the player will use. For standard input (stdin),
-            it is ``-`` (dash), but it can also be a URL, depending on the options used.
+            it is `-` (dash), but it can also be a URL, depending on the options used.
 
         {{{PLAYER_ARGS_INPUT_FALLBACK}}}
             The old fallback variable name with the same functionality.
@@ -435,7 +435,7 @@ def build_parser():
 
           %(prog)s -p vlc -a "--play-and-exit {{{PLAYER_ARGS_INPUT_DEFAULT}}}" <url> [stream]
 
-        Note: When neither of the variables are found, ``{{{PLAYER_ARGS_INPUT_DEFAULT}}}``
+        Note: When neither of the variables are found, `{{{PLAYER_ARGS_INPUT_DEFAULT}}}`
         will be appended to the whole parameter value, to ensure that the player
         always receives an input argument.
         """
@@ -497,7 +497,7 @@ def build_parser():
         default=0,
         help="""
         A fixed port to use for the external HTTP server if that mode is
-        enabled. Omit or set to 0 to use a random high ( >1024) port.
+        enabled. Omit or set to `0` to use a random high ( >1024) port.
         """
     )
     player.add_argument(
@@ -548,7 +548,7 @@ def build_parser():
             in front of the dollar sign which VLC uses as its formatting character.
 
             For example, to put the current date in your VLC window title,
-            the string "\\\\$A" could be inserted inside the --title string.
+            the string `\\$A` could be inserted inside the --title string.
 
         Example:
 
@@ -561,7 +561,7 @@ def build_parser():
         "-o", "--output",
         metavar="FILENAME",
         help="""
-        Write stream data to FILENAME instead of playing it. If FILENAME is set to - (dash), then the stream data will be
+        Write stream data to `FILENAME` instead of playing it. If `FILENAME` is set to `-` (dash), then the stream data will be
         written to stdout, similar to the --stdout argument.
 
         Non-existent directories and subdirectories will be created if they do not exist, if filesystem permissions allow.
@@ -603,8 +603,8 @@ def build_parser():
         "-r", "--record",
         metavar="FILENAME",
         help="""
-        Open the stream in the player, while at the same time writing it to FILENAME. If FILENAME is set to - (dash), then the
-        stream data will be written to stdout, similar to the --stdout argument, while still opening the player.
+        Open the stream in the player, while at the same time writing it to `FILENAME`. If `FILENAME` is set to `-` (dash),
+        then the stream data will be written to stdout, similar to the --stdout argument, while still opening the player.
 
         Non-existent directories and subdirectories will be created if they do not exist, if filesystem permissions allow.
 
@@ -623,7 +623,7 @@ def build_parser():
         "-R", "--record-and-pipe",
         metavar="FILENAME",
         help="""
-        Write stream data to stdout, while at the same time writing it to FILENAME.
+        Write stream data to stdout, while at the same time writing it to `FILENAME`.
 
         Non-existent directories and subdirectories will be created if they do not exist, if filesystem permissions allow.
 
@@ -653,8 +653,8 @@ def build_parser():
 
         These characters are replaced with an underscore for the rules in use:
 
-        - POSIX: \\x00-\\x1F /
-        - Windows: \\x00-\\x1F \\x7F " * / : < > ? \\ |
+        - POSIX: `\\x00-\\x1F /`
+        - Windows: `\\x00-\\x1F \\x7F " * / : < > ? \\ |`
         """
     )
 
@@ -666,7 +666,7 @@ def build_parser():
         help="""
         A URL to attempt to extract streams from.
 
-        Usually, the protocol of http(s) URLs can be omitted (https://),
+        Usually, the protocol of http(s) URLs can be omitted (`https://`),
         depending on the implementation of the plugin being used.
 
         This is an alternative to setting the URL using a positional argument
@@ -680,7 +680,7 @@ def build_parser():
         help="""
         Stream to play.
 
-        Use ``best`` or ``worst`` for selecting the highest or lowest available
+        Use `best` or `worst` for selecting the highest or lowest available
         quality.
 
         Fallback streams can be specified by using a comma-separated list:
@@ -704,7 +704,7 @@ def build_parser():
         type=num(float, min=0),
         help="""
         Retry fetching the list of available streams until streams are found
-        while waiting DELAY second(s) between each attempt. If unset, only one
+        while waiting `DELAY` second(s) between each attempt. If unset, only one
         attempt will be made to fetch the list of streams available.
 
         The number of fetch retry attempts can be capped with --retry-max.
@@ -715,8 +715,8 @@ def build_parser():
         metavar="COUNT",
         type=num(int, min=-1),
         help="""
-        When using --retry-streams, stop retrying the fetch after COUNT retry
-        attempt(s). Fetch will retry infinitely if COUNT is zero or unset.
+        When using --retry-streams, stop retrying the fetch after `COUNT` retry
+        attempt(s). Fetch will retry infinitely if `COUNT` is zero or unset.
 
         If --retry-max is set without setting --retry-streams, the delay between
         retries will default to 1 second.
@@ -728,7 +728,7 @@ def build_parser():
         type=num(int, min=0),
         default=1,
         help="""
-        After a successful fetch, try ATTEMPTS time(s) to open the stream until
+        After a successful fetch, try `ATTEMPTS` time(s) to open the stream until
         giving up.
 
         Default is 1.
@@ -743,7 +743,7 @@ def build_parser():
 
         The order will be used to separate streams when there are multiple
         streams with the same name but different stream types. Any stream type
-        not listed will be omitted from the available streams list.  An ``*`` (asterisk) can
+        not listed will be omitted from the available streams list.  An `*` (asterisk) can
         be used as a wildcard to match any other type of stream, eg. muxed-stream.
 
         Default is "hls,http,*".
@@ -754,17 +754,17 @@ def build_parser():
         metavar="STREAMS",
         type=comma_list,
         help="""
-        Fine tune the ``best`` and ``worst`` stream name synonyms by excluding unwanted streams.
+        Fine tune the `best` and `worst` stream name synonyms by excluding unwanted streams.
 
-        If all of the available streams get excluded, ``best`` and ``worst`` will become
-        inaccessible and new special stream synonyms ``best-unfiltered`` and ``worst-unfiltered``
+        If all of the available streams get excluded, `best` and `worst` will become
+        inaccessible and new special stream synonyms `best-unfiltered` and `worst-unfiltered`
         can be used as a fallback selection method.
 
         Uses a filter expression in the format:
 
           [operator]<value>
 
-        Valid operators are ``>``, ``>=``, ``<`` and ``<=``. If no operator is specified then
+        Valid operators are `>`, `>=`, `<` and `<=`. If no operator is specified then
         equality is tested.
 
         For example this will exclude streams ranked higher than "480p":
@@ -824,7 +824,7 @@ def build_parser():
         type=num(int, max=10),
         metavar="THREADS",
         help="""
-        The size of the thread pool used to download segments. Minimum value is 1 and maximum is 10.
+        The size of the thread pool used to download segments. Minimum value is `1` and maximum is `10`.
 
         This applies to all different kinds of segmented stream types, such as DASH, HLS, etc.
 
@@ -957,7 +957,7 @@ def build_parser():
         metavar="CODE",
         help="""
         Selects a specific audio source or sources, by language code or name,
-        when multiple audio sources are available. Can be * (asterisk) to download all
+        when multiple audio sources are available. Can be `*` (asterisk) to download all
         audio sources.
 
         Examples:
@@ -1016,7 +1016,7 @@ def build_parser():
         help="""
         FFMPEG is used to access or mux separate video and audio streams. You
         can specify the location of the ffmpeg executable if it is not in your
-        PATH.
+        `PATH`.
 
         Example: --ffmpeg-ffmpeg "/usr/local/bin/ffmpeg"
         """
@@ -1041,7 +1041,7 @@ def build_parser():
         type=str,
         metavar="OUTFORMAT",
         help="""
-        When muxing streams, set the output format to OUTFORMAT.
+        When muxing streams, set the output format to `OUTFORMAT`.
 
         Default is "matroska".
 
@@ -1052,7 +1052,7 @@ def build_parser():
         "--ffmpeg-video-transcode",
         metavar="CODEC",
         help="""
-        When muxing streams, transcode the video to CODEC.
+        When muxing streams, transcode the video to `CODEC`.
 
         Default is "copy".
 
@@ -1063,7 +1063,7 @@ def build_parser():
         "--ffmpeg-audio-transcode",
         metavar="CODEC",
         help="""
-        When muxing streams, transcode the audio to CODEC.
+        When muxing streams, transcode the audio to `CODEC`.
 
         Default is "copy".
 
@@ -1074,7 +1074,7 @@ def build_parser():
         "--ffmpeg-copyts",
         action="store_true",
         help="""
-        Forces the -copyts ffmpeg option and does not remove
+        Forces the `-copyts` ffmpeg option and does not remove
         the initial start time offset value.
         """
     )
@@ -1082,7 +1082,7 @@ def build_parser():
         "--ffmpeg-start-at-zero",
         action="store_true",
         help="""
-        Enable the -start_at_zero ffmpeg option when using --ffmpeg-copyts.
+        Enable the `-start_at_zero` ffmpeg option when using --ffmpeg-copyts.
         """
     )
 
@@ -1135,7 +1135,7 @@ def build_parser():
         action="store_true",
         help="""
         Ignore HTTP settings set in the environment such as environment
-        variables (HTTP_PROXY, etc) or ~/.netrc authentication.
+        variables (`HTTP_PROXY`, etc) or `~/.netrc` authentication.
         """
     )
     http.add_argument(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Hi! This PR contains the re-implement of 1e12d02ba922e936d342d86848b34de5623b95c1 in #4618 . The comparison are as follows.

## 1. plugins.nicolive: docs: apply bold style to "--timeshift-offset"

Commit: cfe5b418c4add84e38f466167ddea27d8cc1f96c

Original:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-niconico-timeshift-offset">
> <span class="sig-name descname"><span class="pre">--niconico-timeshift-offset</span></span><span class="sig-prename descclassname"> <span class="pre">[HH:]MM:SS</span></span><a class="headerlink" href="#cmdoption-niconico-timeshift-offset" title="Permalink to this definition">#</a></dt>
> <dd><p>Amount of time to skip from the beginning of a stream. Default is 00:00:00.</p>
> </dd></dl>

New:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-niconico-timeshift-offset">
> <span class="sig-name descname"><span class="pre">--niconico-timeshift-offset</span></span><span class="sig-prename descclassname"> <span class="pre">[HH:]MM:SS</span></span><a class="headerlink" href="#cmdoption-niconico-timeshift-offset" title="Permalink to this definition">#</a></dt>
> <dd><p>Amount of time to skip from the beginning of a stream.</p>
> <p>Default is: <strong>00:00:00</strong>.</p>
> </dd></dl>

## 2. docs: use valid or full-length options to create links

Commit: b1c7ac765658004bb19e9538d0475a134e0ae7ee

Original:

```console
$ streamlink --help | grep --before-context=1 -e 'IPv4 only'
  -4, --ipv4
    Resolve address names to IPv4 only. This option overrides :option:`-6`.

```

New:

```console
$ streamlink --help | grep --before-context=1 -e 'IPv4 only'
  -4, --ipv4
    Resolve address names to IPv4 only. This option overrides --ipv6.

```

## 3. docs: use bulleted list to organize content

Commit: 0ae409eecccfd4411325e2ab6187d412ad064cbb

Original:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-hls-playlist-reload-time">
> <span class="sig-name descname"><span class="pre">--hls-playlist-reload-time</span></span><span class="sig-prename descclassname"> <span class="pre">TIME</span></span><a class="headerlink" href="#cmdoption-hls-playlist-reload-time" title="Permalink to this definition">#</a></dt>
> <dd><p>Set a custom HLS playlist reload time value, either in seconds
> or by using one of the following keywords:</p>
> <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">segment</span><span class="p">:</span> <span class="n">The</span> <span class="n">duration</span> <span class="n">of</span> <span class="n">the</span> <span class="n">last</span> <span class="n">segment</span> <span class="ow">in</span> <span class="n">the</span> <span class="n">current</span> <span class="n">playlist</span>
> <span class="n">live</span><span class="o">-</span><span class="n">edge</span><span class="p">:</span> <span class="n">The</span> <span class="nb">sum</span> <span class="n">of</span> <span class="n">segment</span> <span class="n">durations</span> <span class="n">of</span> <span class="n">the</span> <span class="n">live</span> <span class="n">edge</span> <span class="n">value</span> <span class="n">minus</span> <span class="n">one</span>
> <span class="n">default</span><span class="p">:</span> <span class="n">The</span> <span class="n">playlist</span><span class="s1">'s target duration metadata</span>
> </pre></div>
> </div>
> </dd></dl>

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-fs-safe-rules">
> <span class="sig-name descname"><span class="pre">--fs-safe-rules</span></span><span class="sig-prename descclassname"></span><a class="headerlink" href="#cmdoption-fs-safe-rules" title="Permalink to this definition">#</a></dt>
> <dd><p>These characters are replaced with an underscore for the rules in use:</p>
> <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">POSIX</span>  <span class="p">:</span> \<span class="n">x00</span><span class="o">-</span>\<span class="n">x1F</span> <span class="o">/</span>
> <span class="n">Windows</span><span class="p">:</span> \<span class="n">x00</span><span class="o">-</span>\<span class="n">x1F</span> \<span class="n">x7F</span> <span class="s2">" * / : &lt; &gt; ? \ |</span>
> </pre></div>
> </div>
> </dd></dl>

New:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-hls-playlist-reload-time">
> <span class="sig-name descname"><span class="pre">--hls-playlist-reload-time</span></span><span class="sig-prename descclassname"> <span class="pre">TIME</span></span><a class="headerlink" href="#cmdoption-hls-playlist-reload-time" title="Permalink to this definition">#</a></dt>
> <dd><p>Set a custom HLS playlist reload time value, either in seconds
> or by using one of the following keywords:</p>
> <ul class="simple">
> <li><p>segment: The duration of the last segment in the current playlist</p></li>
> <li><p>live-edge: The sum of segment durations of the live edge value minus one</p></li>
> <li><p>default: The playlist's target duration metadata</p></li>
> </ul>
> </dd></dl>

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-fs-safe-rules">
> <span class="sig-name descname"><span class="pre">--fs-safe-rules</span></span><span class="sig-prename descclassname"></span><a class="headerlink" href="#cmdoption-fs-safe-rules" title="Permalink to this definition">#</a></dt>
> <dd><p>These characters are replaced with an underscore for the rules in use:</p>
> <ul class="simple">
> <li><p>POSIX: x00-x1F /</p></li>
> <li><p>Windows: x00-x1F x7F " * / : &lt; &gt; ? |</p></li>
> </ul>
> </dd></dl>

## 4. docs: include the option itself in its example

Commit: 9d7e3e37fe5fd6803437d22f92dc360887b4cc8e

Original:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-stream-sorting-excludes">
> <span class="sig-name descname"><span class="pre">--stream-sorting-excludes</span></span><span class="sig-prename descclassname"> <span class="pre">STREAMS</span></span><a class="headerlink" href="#cmdoption-stream-sorting-excludes" title="Permalink to this definition">#</a></dt>
> <dd><p>For example this will exclude streams from two quality types:</p>
> <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="s2">"&gt;480p,&gt;medium"</span>
> </pre></div>
> </div>
> </dd></dl>

New:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-stream-sorting-excludes">
> <span class="sig-name descname"><span class="pre">--stream-sorting-excludes</span></span><span class="sig-prename descclassname"> <span class="pre">STREAMS</span></span><a class="headerlink" href="#cmdoption-stream-sorting-excludes" title="Permalink to this definition">#</a></dt>
> <dd><p>For example this will exclude streams from two quality types:</p>
> <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="o">--</span><span class="n">stream</span><span class="o">-</span><span class="n">sorting</span><span class="o">-</span><span class="n">excludes</span> <span class="s2">"&gt;480p,&gt;medium"</span>
> </pre></div>
> </div>
> </dd></dl>

## 5. docs: apply option links in indented lines

Commit: 8a0c23f9f2927e94fde1925bbc1ffd4d58725b91

Original:

> <dl>
> <dt>VLC specific information:</dt><dd><p>These variables are accessible in the --title option by adding a backslash
> in front of the dollar sign which VLC uses as its formatting character.</p>
> <p>For example, to put the current date in your VLC window title,
> the string "\$A" could be inserted inside the --title string.</p>
> </dd>
> </dl>

New:

> <dl>
> <dt>VLC specific information:</dt><dd><p>These variables are accessible in the <a class="reference internal" href="#cmdoption-title"><code class="xref std std-option docutils literal notranslate"><span class="pre">--title</span></code></a> option by adding a backslash
> in front of the dollar sign which VLC uses as its formatting character.</p>
> <p>For example, to put the current date in your VLC window title,
> the string "\$A" could be inserted inside the <a class="reference internal" href="#cmdoption-title"><code class="xref std std-option docutils literal notranslate"><span class="pre">--title</span></code></a> string.</p>
> </dd>
> </dl>

## 6. docs: add names for special characters

Commit: 1e6217a54c10e5744bce676bbd80694dc493e76a

Original:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-stream-types">
> <span class="sig-name descname"><span class="pre">--stream-types</span></span><span class="sig-prename descclassname"> <span class="pre">TYPES</span></span><a class="headerlink" href="#cmdoption-stream-types" title="Permalink to this definition">#</a></dt>
> <dt class="sig sig-object std" id="cmdoption-stream-priority">
> <span class="sig-name descname"><span class="pre">--stream-priority</span></span><span class="sig-prename descclassname"> <span class="pre">TYPES</span></span><a class="headerlink" href="#cmdoption-stream-priority" title="Permalink to this definition">#</a></dt>
> <dd><p>A <code class="docutils literal notranslate"><span class="pre">*</span></code> can
> be used as a wildcard to match any other type of stream, eg. muxed-stream.</p>
> </dd></dl>

New:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-stream-types">
> <span class="sig-name descname"><span class="pre">--stream-types</span></span><span class="sig-prename descclassname"> <span class="pre">TYPES</span></span><a class="headerlink" href="#cmdoption-stream-types" title="Permalink to this definition">#</a></dt>
> <dt class="sig sig-object std" id="cmdoption-stream-priority">
> <span class="sig-name descname"><span class="pre">--stream-priority</span></span><span class="sig-prename descclassname"> <span class="pre">TYPES</span></span><a class="headerlink" href="#cmdoption-stream-priority" title="Permalink to this definition">#</a></dt>
> <dd><p>An <code class="docutils literal notranslate"><span class="pre">*</span></code> (asterisk) can
> be used as a wildcard to match any other type of stream, eg. muxed-stream.</p>
> </dd></dl>

## 7. ~~docs: adjust string type to avoid doubling symbols~~

Commit: 72c32f141a8b230700eb597813203bdd41c0edd3 (dropped)

No difference between rendered content.

## 8. docs: use single-backtick inline code block

Commit: 8eda37d4afa3067c0041759b4866a9178f51b7c0 (was 0ac38c860b87c8885ef8c02d260e123399b76298) (was d02c81e8a3c9e4bfaf25dd4304ee8e04b35f831b)

### Group 1: webpage

Original:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-fs-safe-rules">
> <span class="sig-name descname"><span class="pre">--fs-safe-rules</span></span><span class="sig-prename descclassname"></span><a class="headerlink" href="#cmdoption-fs-safe-rules" title="Permalink to this definition">#</a></dt>
> <dd><p>These characters are replaced with an underscore for the rules in use:</p>
> <ul class="simple">
> <li><p>POSIX: x00-x1F /</p></li>
> <li><p>Windows: x00-x1F x7F " * / : &lt; &gt; ? |</p></li>
> </ul>
> </dd></dl>

New:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-fs-safe-rules">
> <span class="sig-name descname"><span class="pre">--fs-safe-rules</span></span><span class="sig-prename descclassname"></span><a class="headerlink" href="#cmdoption-fs-safe-rules" title="Permalink to this definition">#</a></dt>
> <dd><p>These characters are replaced with an underscore for the rules in use:</p>
> <ul class="simple">
> <li><p>POSIX: <code class="code docutils literal notranslate"><span class="pre">\x00-\x1F</span> <span class="pre">/</span></code></p></li>
> <li><p>Windows: <code class="code docutils literal notranslate"><span class="pre">\x00-\x1F</span> <span class="pre">\x7F</span> <span class="pre">"</span> <span class="pre">*</span> <span class="pre">/</span> <span class="pre">:</span> <span class="pre">&lt;</span> <span class="pre">&gt;</span> <span class="pre">?</span> <span class="pre">\</span> <span class="pre">|</span></code></p></li>
> </ul>
> </dd></dl>

### Group 2: man page

Original:

> --locale LOCALE
> 
>   The preferred locale setting, for selecting the preferred subtitle and audio language.
> 
>   The locale is formatted as [language_code]_[country_code], eg. en_US or es_ES.

New:

> --locale LOCALE
> 
>   The preferred locale setting, for selecting the preferred subtitle and audio language.
> 
>   The locale is formatted as **[language_code]_[country_code]**, eg. **en_US** or **es_ES**.

### Group 3: help content

Original:

```console
$ streamlink --help | grep --before-context=4 --after-context=1 -e 'Valid operators are'
    Uses a filter expression in the format:
    
      [operator]<value>
    
    Valid operators are ``>``, ``>=``, ``<`` and ``<=``. If no operator is specified then
    equality is tested.

```

New:

```console
$ streamlink --help | grep --before-context=4 --after-context=1 -e 'Valid operators are'
    Uses a filter expression in the format:
    
      [operator]<value>
    
    Valid operators are `>`, `>=`, `<` and `<=`. If no operator is specified then
    equality is tested.

```

## 9. docs: put inline code to code blocks in examples

Commit: 4ce3cbce79f1fa6dfa3bda429ccd5d6698f06c57 (was 00a9c12c22f08c4ad1172ff9620065f90b963b3e) (was b70aaf1b80d8a6bac26ee0628aa5c58c886bdd98)

Original:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-hls-segment-ignore-names">
> <span class="sig-name descname"><span class="pre">--hls-segment-ignore-names</span></span><span class="sig-prename descclassname"> <span class="pre">NAMES</span></span><a class="headerlink" href="#cmdoption-hls-segment-ignore-names" title="Permalink to this definition">#</a></dt>
> <dd><p>A comma-delimited list of segment names that will get filtered out.</p>
> <p>Example: --hls-segment-ignore-names 000,001,002</p>
> <p>This will ignore every segment that ends with 000.ts, 001.ts and 002.ts</p>
> </dd></dl>

New:

> <dl class="std option">
> <dt class="sig sig-object std" id="cmdoption-hls-segment-ignore-names">
> <span class="sig-name descname"><span class="pre">--hls-segment-ignore-names</span></span><span class="sig-prename descclassname"> <span class="pre">NAMES</span></span><a class="headerlink" href="#cmdoption-hls-segment-ignore-names" title="Permalink to this definition">#</a></dt>
> <dd><p>A comma-delimited list of segment names that will get filtered out.</p>
> <p>Example: <code class="code docutils literal notranslate"><span class="pre">--hls-segment-ignore-names</span> <span class="pre">000,001,002</span></code></p>
> <p>This will ignore every segment that ends with 000.ts, 001.ts and 002.ts</p>
> </dd></dl>
