### PR TITLE
stream.ffmpegmux: rewrite tests

### DIFF
--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -309,3 +309,26 @@ class TestOpen:
 
         streamio.close()
         assert not devnull.close.called
+
+    def test_stderr(self, session: Streamlink, popen: Mock):
+        session.options.update({"ffmpeg-verbose": True})
+        with patch("streamlink.stream.ffmpegmux.sys.stderr") as mock_stderr:
+            streamio = FFMPEGMuxer(session)
+
+            streamio.open()
+            assert popen.call_args_list[0][1]["stderr"] is mock_stderr
+
+            streamio.close()
+            assert not mock_stderr.close.called
+
+    def test_stderr_path(self, session: Streamlink, popen: Mock):
+        session.options.update({"ffmpeg-verbose-path": "foo"})
+        with patch("streamlink.stream.ffmpegmux.open") as mock_open:
+            file: Mock = mock_open("foo", "w")
+            streamio = FFMPEGMuxer(session)
+
+            streamio.open()
+            assert popen.call_args_list[0][1]["stderr"] is file
+
+            streamio.close()
+            assert file.close.called


### PR DESCRIPTION
Follow-up of #4660 

This replaces the very repetitive tests of the ffmpegmuxer with parametrized tests, as the setup is exactly the same everywhere. Also some minor adjustments of the tests added in #4660, as the test fixtures could be improved and shared between the newly added tests.

Second commit adds tests for `--ffmpeg-verbose` and `--ffmpeg-verbose-path`. That's mainly just a coverage improvement though.