### PR TITLE
refactor: is_darwin/is_win32 compat exports

### DIFF
--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -1,5 +1,8 @@
 import os
+import sys
 
+
+is_darwin = sys.platform == "darwin"
 is_win32 = os.name == "nt"
 
 # win/nix compatible devnull
@@ -13,4 +16,8 @@ except ImportError:
         return open(os.path.devnull, 'w')
 
 
-__all__ = ["is_win32", "devnull"]
+__all__ = [
+    "is_darwin",
+    "is_win32",
+    "devnull",
+]

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -8,8 +8,10 @@ from pathlib import Path
 
 from streamlink.compat import is_win32
 
-if is_win32:
+try:
     from ctypes import windll, cast, c_ulong, c_void_p, byref  # type: ignore[attr-defined]
+except ImportError:
+    pass
 
 
 log = logging.getLogger(__name__)

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,4 +1,3 @@
-import os
 import sys
 from pathlib import Path
 from typing import BinaryIO, TYPE_CHECKING
@@ -8,9 +7,6 @@ try:
 except ImportError:
     import importlib_metadata  # type: ignore[import]  # noqa: F401
 
-
-is_darwin = sys.platform == "darwin"
-is_win32 = os.name == "nt"
 
 stdout: BinaryIO = sys.stdout.buffer
 
@@ -25,4 +21,8 @@ class DeprecatedPath(_BasePath):
     pass
 
 
-__all__ = ["is_darwin", "is_win32", "stdout", "DeprecatedPath"]
+__all__ = [
+    "importlib_metadata",
+    "stdout",
+    "DeprecatedPath",
+]

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -3,7 +3,9 @@ import tempfile
 from pathlib import Path
 from typing import List
 
-from streamlink_cli.compat import DeprecatedPath, is_darwin, is_win32
+from streamlink.compat import is_darwin, is_win32
+from streamlink_cli.compat import DeprecatedPath
+
 
 PLAYER_ARGS_INPUT_DEFAULT = "playerinput"
 PLAYER_ARGS_INPUT_FALLBACK = "filename"

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -20,12 +20,13 @@ import requests
 import streamlink.logger as logger
 from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __version__ as streamlink_version
 from streamlink.cache import Cache
+from streamlink.compat import is_win32
 from streamlink.exceptions import FatalPluginError
 from streamlink.plugin import Plugin, PluginOptions
 from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink_cli.argparser import ArgumentParser, build_parser
-from streamlink_cli.compat import DeprecatedPath, importlib_metadata, is_win32, stdout
+from streamlink_cli.compat import DeprecatedPath, importlib_metadata, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.output import FileOutput, PlayerOutput

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from time import sleep
 from typing import BinaryIO, Optional
 
-from streamlink_cli.compat import is_win32, stdout
+from streamlink.compat import is_win32
+from streamlink_cli.compat import stdout
 from streamlink_cli.constants import PLAYER_ARGS_INPUT_DEFAULT, PLAYER_ARGS_INPUT_FALLBACK, SUPPORTED_PLAYERS
 from streamlink_cli.utils import Formatter, ignored
 

--- a/src/streamlink_cli/utils/path.py
+++ b/src/streamlink_cli/utils/path.py
@@ -2,7 +2,7 @@ import re
 from pathlib import Path
 from typing import Callable, Optional, Union
 
-from streamlink_cli.compat import is_win32
+from streamlink.compat import is_win32
 
 
 REPLACEMENT = "_"

--- a/src/streamlink_cli/utils/terminal.py
+++ b/src/streamlink_cli/utils/terminal.py
@@ -2,7 +2,7 @@ from shutil import get_terminal_size
 from sys import stderr
 from typing import TextIO
 
-from streamlink_cli.compat import is_win32
+from streamlink.compat import is_win32
 
 
 class TerminalOutput:

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -15,7 +15,7 @@ import tests.resources
 from streamlink.exceptions import PluginError, StreamError
 from streamlink.session import Streamlink
 from streamlink.stream.stream import Stream
-from streamlink_cli.compat import DeprecatedPath, is_win32, stdout
+from streamlink_cli.compat import DeprecatedPath, stdout
 from streamlink_cli.main import (
     Formatter,
     NoPluginError,
@@ -29,6 +29,7 @@ from streamlink_cli.main import (
     setup_config_args
 )
 from streamlink_cli.output import FileOutput, PlayerOutput
+from tests import posix_only, windows_only
 from tests.plugin.testplugin import TestPlugin as _TestPlugin
 
 
@@ -719,7 +720,7 @@ class TestCLIMainLoggingStreams(_TestCLIMainLogging):
 
 
 class TestCLIMainLoggingInfos(_TestCLIMainLogging):
-    @unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
+    @posix_only
     @patch("streamlink_cli.main.log")
     def test_log_root_warning(self, mock_log):
         self.subject(["streamlink"], euid=0)
@@ -859,7 +860,7 @@ class TestCLIMainLoggingLogfile(_TestCLIMainLogging):
         )
 
 
-@unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
+@posix_only
 class TestCLIMainLoggingLogfilePosix(_TestCLIMainLogging):
     @patch("sys.stdout")
     @patch("builtins.open")
@@ -898,7 +899,7 @@ class TestCLIMainLoggingLogfilePosix(_TestCLIMainLogging):
         )
 
 
-@unittest.skipIf(not is_win32, "test only applicable on Windows")
+@windows_only
 class TestCLIMainLoggingLogfileWindows(_TestCLIMainLogging):
     @patch("sys.stdout")
     @patch("builtins.open")

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, Mock, patch
 
 import streamlink_cli.main
 from streamlink import Streamlink
-from streamlink_cli.compat import is_win32
+from tests import posix_only, windows_only
 
 
 class CommandLineTestCase(unittest.TestCase):
@@ -49,7 +49,7 @@ class CommandLineTestCase(unittest.TestCase):
             mock_call.assert_called_with(commandline, stderr=ANY, stdout=ANY)
 
 
-@unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+@posix_only
 class TestCommandLinePOSIX(CommandLineTestCase):
     """
     Commandline tests under POSIX-like operating systems
@@ -87,7 +87,7 @@ class TestCommandLinePOSIX(CommandLineTestCase):
                         ["/usr/bin/player", "-v", "-"])
 
 
-@unittest.skipIf(not is_win32, "test only applicable on Windows")
+@windows_only
 class TestCommandLineWindows(CommandLineTestCase):
     """
     Commandline tests for Windows

--- a/tests/test_cmdline_player_fifo.py
+++ b/tests/test_cmdline_player_fifo.py
@@ -1,11 +1,10 @@
-import unittest
 from unittest.mock import Mock, patch
 
-from streamlink.compat import is_win32
+from tests import posix_only, windows_only
 from tests.test_cmdline import CommandLineTestCase
 
 
-@unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+@posix_only
 @patch("streamlink_cli.main.NamedPipe", Mock(return_value=Mock(path="/tmp/streamlinkpipe")))
 class TestCommandLineWithPlayerFifoPosix(CommandLineTestCase):
     def test_player_fifo_default(self):
@@ -17,7 +16,7 @@ class TestCommandLineWithPlayerFifoPosix(CommandLineTestCase):
         )
 
 
-@unittest.skipIf(not is_win32, "test only applicable on Windows")
+@windows_only
 @patch("streamlink_cli.main.NamedPipe", Mock(return_value=Mock(path="\\\\.\\pipe\\streamlinkpipe")))
 class TestCommandLineWithPlayerFifoWindows(CommandLineTestCase):
     def test_player_fifo_default(self):

--- a/tests/test_cmdline_title.py
+++ b/tests/test_cmdline_title.py
@@ -1,10 +1,8 @@
-import unittest
-
-from streamlink.compat import is_win32
+from tests import posix_only, windows_only
 from tests.test_cmdline import CommandLineTestCase
 
 
-@unittest.skipIf(is_win32, "test only applicable in a POSIX OS")
+@posix_only
 class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
     def test_open_player_with_title_vlc(self):
         self._test_args(["streamlink", "-p", "/usr/bin/vlc",
@@ -28,7 +26,7 @@ class TestCommandLineWithTitlePOSIX(CommandLineTestCase):
                         ["mpv", "--force-media-title=★ ★ ★", "-"])
 
 
-@unittest.skipIf(not is_win32, "test only applicable on Windows")
+@windows_only
 class TestCommandLineWithTitleWindows(CommandLineTestCase):
     def test_open_player_with_title_vlc(self):
         self._test_args(

--- a/tests/utils/test_named_pipe.py
+++ b/tests/utils/test_named_pipe.py
@@ -2,11 +2,13 @@ import threading
 import unittest
 from unittest.mock import Mock, call, patch
 
-from streamlink.compat import is_win32
 from streamlink.utils.named_pipe import NamedPipe, NamedPipeBase, NamedPipePosix, NamedPipeWindows
+from tests import posix_only, windows_only
 
-if is_win32:
+try:
     from ctypes import windll, create_string_buffer, c_ulong, byref  # type: ignore[attr-defined]
+except ImportError:
+    pass
 
 
 GENERIC_READ = 0x80000000
@@ -73,7 +75,7 @@ class TestNamedPipe(unittest.TestCase):
         ])
 
 
-@unittest.skipIf(is_win32, "test only applicable on a POSIX OS")
+@posix_only
 class TestNamedPipePosix(unittest.TestCase):
     def test_export(self):
         self.assertEqual(NamedPipe, NamedPipePosix)
@@ -116,7 +118,7 @@ class TestNamedPipePosix(unittest.TestCase):
         self.assertFalse(reader.is_alive())
 
 
-@unittest.skipIf(not is_win32, "test only applicable on Windows")
+@windows_only
 class TestNamedPipeWindows(unittest.TestCase):
     def test_export(self):
         self.assertEqual(NamedPipe, NamedPipeWindows)


### PR DESCRIPTION
- Move `is_darwin` from `streamlink_cli.compat` to `streamlink.compat`
- Remove `is_win32` from `streamlink_cli.compat`
- Replace last remaining `unittest.skipIf` test decorators with the
  `posix_only`/`windows_only` pytest decorators from the `tests` module
- Remove `is_win32` check when importing from `ctypes` in `named_pipe`

