### PR TITLE
docs: remove dead packages and add package availability notes

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -180,6 +180,7 @@ openSUSE                             Simon Puchert <simonpuchert at alice.de>
 Solus                                Joey Riches <josephriches at gmail.com>
 Void                                 Michal Vasilek <michal at vasilek.cz>
 Windows binaries                     Sebastian Meyer <mail at bastimeyer.de>
+Linux AppImages                      Sebastian Meyer <mail at bastimeyer.de>
 ==================================== ===========================================
 
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -140,9 +140,6 @@ Python pip                           See the `PyPI package and source code`_ sec
                                         sudo xbps-install streamlink
 ==================================== ===========================================
 
-Please see the `PyPI package and source code`_ or `AppImages`_ sections down below
-if a package is not available for your distro or platform, or if it's out of date.
-
 .. _Arch Linux: https://www.archlinux.org/packages/community/any/streamlink/
 .. _Arch Linux (aur, git): https://aur.archlinux.org/packages/streamlink-git/
 .. _Debian (sid, testing): https://packages.debian.org/unstable/streamlink
@@ -182,6 +179,24 @@ Void                                 Michal Vasilek <michal at vasilek.cz>
 Windows binaries                     Sebastian Meyer <mail at bastimeyer.de>
 Linux AppImages                      Sebastian Meyer <mail at bastimeyer.de>
 ==================================== ===========================================
+
+
+Package availability
+--------------------
+
+Packaging is not done by the Streamlink maintainers themselves except for
+the `PyPI package <PyPI package and source code_>`_,
+the `Windows installers + portable builds <Windows binaries_>`_,
+and the `Linux AppImages <AppImages_>`_.
+
+If a packaged release of Streamlink is not available for your operating system / distro or your system's architecture,
+or if it's out of date or broken, then please contact the respective package maintainers or package-repository maintainers
+of your operating system / distro, as it's up to them to add, update, or fix those packages.
+
+Users of glibc-based Linux distros can find up-to-date Streamlink releases via the available `AppImages`_.
+
+Please open an issue or pull request on GitHub if an **available**, **maintained** and **up-to-date** package is missing
+from the install docs.
 
 
 PyPI package and source code

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -135,12 +135,6 @@ Python pip                           See the `PyPI package and source code`_ sec
 
                                         sudo eopkg install streamlink
 
-`Ubuntu`_                            .. code-block:: bash
-
-                                        sudo add-apt-repository ppa:nilarimogard/webupd8
-                                        sudo apt update
-                                        sudo apt install streamlink
-
 `Void`_                              .. code-block:: bash
 
                                         sudo xbps-install streamlink
@@ -159,7 +153,6 @@ if a package is not available for your distro or platform, or if it's out of dat
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
 .. _openSUSE: https://build.opensuse.org/package/show/multimedia:apps/streamlink
 .. _Solus: https://dev.getsol.us/source/streamlink/
-.. _Ubuntu: https://launchpad.net/~nilarimogard/+archive/ubuntu/webupd8/+packages?field.name_filter=streamlink&field.status_filter=published&field.series_filter=
 .. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
 
 .. _Installing AUR packages: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages
@@ -185,7 +178,6 @@ NetBSD                               Maya Rashish <maya at netbsd.org>
 NixOS                                Tuomas Tynkkynen <tuomas.tynkkynen at iki.fi>
 openSUSE                             Simon Puchert <simonpuchert at alice.de>
 Solus                                Joey Riches <josephriches at gmail.com>
-Ubuntu                               Alin Andrei <andrew at webupd8.org>
 Void                                 Michal Vasilek <michal at vasilek.cz>
 Windows binaries                     Sebastian Meyer <mail at bastimeyer.de>
 ==================================== ===========================================

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -127,10 +127,6 @@ Python pip                           See the `PyPI package and source code`_ sec
 
                                      `NixOS channel`_
 
-`OpenBSD`_                           .. code-block:: bash
-
-                                        doas pkg_add streamlink
-
 `openSUSE`_                          .. code-block:: bash
 
                                         sudo zypper install streamlink
@@ -161,7 +157,6 @@ if a package is not available for your distro or platform, or if it's out of dat
 .. _Gentoo Linux: https://packages.gentoo.org/package/net-misc/streamlink
 .. _NetBSD (pkgsrc): https://pkgsrc.se/multimedia/streamlink
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
-.. _OpenBSD: https://openports.se/multimedia/streamlink
 .. _openSUSE: https://build.opensuse.org/package/show/multimedia:apps/streamlink
 .. _Solus: https://dev.getsol.us/source/streamlink/
 .. _Ubuntu: https://launchpad.net/~nilarimogard/+archive/ubuntu/webupd8/+packages?field.name_filter=streamlink&field.status_filter=published&field.series_filter=
@@ -188,7 +183,6 @@ Fedora                               Mohamed El Morabity <melmorabity at fedorap
 Gentoo                               soredake <fdsfgs at krutt.org>
 NetBSD                               Maya Rashish <maya at netbsd.org>
 NixOS                                Tuomas Tynkkynen <tuomas.tynkkynen at iki.fi>
-OpenBSD                              Brian Callahan <bcallah at openbsd.org>
 openSUSE                             Simon Puchert <simonpuchert at alice.de>
 Solus                                Joey Riches <josephriches at gmail.com>
 Ubuntu                               Alin Andrei <andrew at webupd8.org>


### PR DESCRIPTION
Closes #4670 

Since nobody has had anything to comment about my suggested removal of dead packages from the install docs, I'm just going to submit a PR.

Please see the rendered docs fist. I've tried to be as precise and short as possible in the added notes. I don't mind rewriting/improving it though.

The removals are done in separate commits, in case we want to revert this later on, should the package maintainers start maintaining the packages again.