### PR TITLE
plugins.huya: rewrite and fix plugin

### DIFF
--- a/tests/plugins/test_huya.py
+++ b/tests/plugins/test_huya.py
@@ -6,11 +6,13 @@ class TestPluginCanHandleUrlHuya(PluginCanHandleUrl):
     __plugin__ = Huya
 
     should_match = [
-        'http://www.huya.com/123123123',
-        'http://www.huya.com/name',
-        'https://www.huya.com/123123123',
+        "http://www.huya.com/123123123",
+        "http://www.huya.com/name",
+        "https://www.huya.com/123123123",
+        "https://www.huya.com/name",
     ]
 
     should_not_match = [
-        'http://www.huya.com',
+        "http://www.huya.com",
+        "https://www.huya.com",
     ]


### PR DESCRIPTION
Resolves #4684 

I've once again tried adding HLSStreams instead of having the plugin yield progressive HTTPStreams (see https://github.com/streamlink/streamlink/issues/4609#issuecomment-1159697918), but to no luck. Server response 403 using the same URL logic as the HTTP "FLV" streams.

The issue from the report in #4684 was stream data sometimes not being base64 encoded, so a different regex and validation logic was needed. Because of this, I rewrote and cleaned up the entire plugin in one go, and also added stream metadata.

```
$ streamlink -l debug 'https://www.huya.com/688062'
[cli][debug] OS:         Linux-5.18.14-1-git-x86_64-with-glibc2.35
[cli][debug] Python:     3.10.5
[cli][debug] Streamlink: 4.2.0+26.gad51118e
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.0
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.2
[cli][debug] Arguments:
[cli][debug]  url=https://www.huya.com/688062
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin huya for URL https://www.huya.com/688062
[plugins.huya][debug] QUALITY_WEIGHTS: {'source_ws': 100, 'source_al': 0, 'source_tx': -1, 'source_hw': -1, 'source_bd': -1}
Available streams: source_tx (worst), source_hw, source_bd, source_al, source_ws (best)
```

```
$ streamlink -l debug 'https://www.huya.com/dongerlol'
[cli][debug] OS:         Linux-5.18.14-1-git-x86_64-with-glibc2.35
[cli][debug] Python:     3.10.5
[cli][debug] Streamlink: 4.2.0+26.gad51118e
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.0
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.2
[cli][debug] Arguments:
[cli][debug]  url=https://www.huya.com/dongerlol
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin huya for URL https://www.huya.com/dongerlol
[plugins.huya][debug] QUALITY_WEIGHTS: {'source_al': 0, 'source_tx': -1, 'source_hw': -1, 'source_bd': 100}
Available streams: source_tx (worst), source_hw, source_al, source_bd (best)
```