### PR TITLE
stream.ffmpegmux: expand user in verbose-path

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import threading
 from functools import lru_cache
+from pathlib import Path
 from shutil import which
 from typing import Optional
 
@@ -166,7 +167,7 @@ class FFMPEGMuxer(StreamIO):
         if session.options.get("ffmpeg-verbose"):
             self.errorlog = sys.stderr
         elif session.options.get("ffmpeg-verbose-path"):
-            self.errorlog = open(session.options.get("ffmpeg-verbose-path"), "w")
+            self.errorlog = Path(session.options.get("ffmpeg-verbose-path")).expanduser().open("w")
             self.close_errorlog = True
         else:
             self.errorlog = devnull()

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -323,8 +323,8 @@ class TestOpen:
 
     def test_stderr_path(self, session: Streamlink, popen: Mock):
         session.options.update({"ffmpeg-verbose-path": "foo"})
-        with patch("streamlink.stream.ffmpegmux.open") as mock_open:
-            file: Mock = mock_open("foo", "w")
+        with patch("streamlink.stream.ffmpegmux.Path") as mock_path:
+            file: Mock = mock_path("foo").expanduser().open("w")
             streamio = FFMPEGMuxer(session)
 
             streamio.open()


### PR DESCRIPTION
`--ffmpeg-verbose-path=~/ffmpeg.log` should be properly expanded to the user's home directory. This is currently not the case.