### PR TITLE
plugin.api.validate: ListSchema, re.Pattern and NoneOrAllSchema

### DIFF
--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -4,6 +4,7 @@ from streamlink.plugin.api.validate._schemas import (  # noqa: I101, F401
     SchemaContainer,
     AllSchema as all,
     AnySchema as any,
+    ListSchema as list,
     TransformSchema as transform,
     OptionalSchema as optional,
     GetItemSchema as get,

--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -4,6 +4,7 @@ from streamlink.plugin.api.validate._schemas import (  # noqa: I101, F401
     SchemaContainer,
     AllSchema as all,
     AnySchema as any,
+    NoneOrAllSchema as none_or_all,
     ListSchema as list,
     TransformSchema as transform,
     OptionalSchema as optional,

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -29,6 +29,13 @@ class AnySchema(_CollectionSchemaContainer):
     """
 
 
+class NoneOrAllSchema(_CollectionSchemaContainer):
+    """
+    Collection of schemas where every schema must be valid. If the initial input is None, all validations will be skipped.
+    The last validation result gets returned.
+    """
+
+
 class ListSchema(_CollectionSchemaContainer):
     """
     Collection of schemas where every indexed schema must be valid, as well as the input type and length.

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -18,12 +18,21 @@ class _CollectionSchemaContainer(SchemaContainer):
 class AllSchema(_CollectionSchemaContainer):
     """
     Collection of schemas where every schema must be valid.
+    The last validation result gets returned.
     """
 
 
 class AnySchema(_CollectionSchemaContainer):
     """
     Collection of schemas where at least one schema must be valid.
+    The first successful validation result gets returned.
+    """
+
+
+class ListSchema(_CollectionSchemaContainer):
+    """
+    Collection of schemas where every indexed schema must be valid, as well as the input type and length.
+    A new list of the validated input gets returned.
     """
 
 

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -10,22 +10,21 @@ class SchemaContainer:
         self.schema = schema
 
 
-class AllSchema(SchemaContainer):
+class _CollectionSchemaContainer(SchemaContainer):
+    def __init__(self, *schemas):
+        super().__init__(schemas)
+
+
+class AllSchema(_CollectionSchemaContainer):
     """
     Collection of schemas where every schema must be valid.
     """
 
-    def __init__(self, *schemas):
-        super().__init__(schemas)
 
-
-class AnySchema(SchemaContainer):
+class AnySchema(_CollectionSchemaContainer):
     """
     Collection of schemas where at least one schema must be valid.
     """
-
-    def __init__(self, *schemas):
-        super().__init__(schemas)
 
 
 class GetItemSchema:

--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -1,7 +1,7 @@
 from collections import abc
 from copy import copy, deepcopy
 from functools import singledispatch
-from re import Match
+from re import Match, Pattern
 
 from lxml.etree import Element, iselement
 
@@ -132,6 +132,24 @@ def _validate_callable(schema: abc.Callable, value):
         )
 
     return value
+
+
+@validate.register
+def _validate_pattern(schema: Pattern, value):
+    if type(value) not in (str, bytes):
+        raise ValidationError(
+            "Type of {value} should be str or bytes, but is {actual}",
+            value=repr(value),
+            actual=type(value).__name__,
+            schema=Pattern,
+        )
+
+    try:
+        result = schema.search(value)
+    except TypeError as err:
+        raise ValidationError(err, schema=Pattern)
+
+    return result
 
 
 @validate.register

--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -13,6 +13,7 @@ from streamlink.plugin.api.validate._schemas import (
     AttrSchema,
     GetItemSchema,
     ListSchema,
+    NoneOrAllSchema,
     OptionalSchema,
     TransformSchema,
     UnionGetSchema,
@@ -170,6 +171,18 @@ def _validate_anyschema(schema: AnySchema, value):
             errors.append(err)
 
     raise ValidationError(*errors, schema=AnySchema)
+
+
+@validate.register
+def _validate_noneorallschema(schema: NoneOrAllSchema, value):
+    if value is not None:
+        try:
+            for schema in schema.schema:
+                value = validate(schema, value)
+        except ValidationError as err:
+            raise ValidationError(err, schema=NoneOrAllSchema)
+
+    return value
 
 
 @validate.register

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -386,6 +386,30 @@ class TestAnySchema:
         """)
 
 
+class TestNoneOrAllSchema:
+    @pytest.mark.parametrize("data,expected", [("foo", "FOO"), ("bar", None)])
+    def test_success(self, data, expected):
+        assert validate.validate(
+            validate.Schema(
+                re.compile(r"foo"),
+                validate.none_or_all(
+                    validate.get(0),
+                    validate.transform(str.upper),
+                ),
+            ),
+            data,
+        ) == expected
+
+    def test_failure(self):
+        with pytest.raises(validate.ValidationError) as cm:
+            validate.validate(validate.none_or_all(str, int), "foo")
+        assert_validationerror(cm.value, """
+            ValidationError(NoneOrAllSchema):
+              ValidationError(type):
+                Type of 'foo' should be int, but is str
+        """)
+
+
 class TestListSchema:
     def test_success(self):
         data = [1, 3.14, "foo"]


### PR DESCRIPTION
This adds new schema validation methods that are useful for commonly used patterns.

### ListSchema

The list instance validation schema (eg. `[int, str]`) only validates a subset of the input, which means it defines any items that can match. This is often not what plugin authors have in mind when trying to validate a list where each indexed item needs to be validated.

The `ListSchema` (via `validate.list(...)`) on the other hand therefore checks for equal length of the input list and then validates each item according to the schema.

### re.Pattern

Instead of having to define the `validate.transform(re.compile(...).search)` validation pattern, a simple `re.compile(...)` is now supported, which will call the `search()` method internally and return either `None` or an instance of `re.Match`. Other methods like `findall()` for example can still be called via `validate.transform()`.

### NoneOrAllSchema

This avoids having to repeatedly define the `validate.any(None, validate.all(...))` validation pattern via the newly added `validate.none_or_all(...)` schema. This is especially useful for `re.Pattern` or `validate.xml_xpath_string(...)` validations.

I am not really happy with the naming of this though. Any better suggestions than `none_or_all`?