### PR TITLE
plugins.atpchallenger: new plugin

### DIFF
--- a/src/streamlink/plugins/atpchallenger.py
+++ b/src/streamlink/plugins/atpchallenger.py
@@ -1,0 +1,63 @@
+"""
+$description Professional tennis tournaments.
+$url www.atptour.com/en/atp-challenger-tour/challenger-tv
+$type live, vod
+"""
+
+import logging
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.)?atptour.com/en/atp-challenger-tour/challenger-tv"
+))
+class AtpChallengerTour(Plugin):
+    _re_window_config = re.compile(r""".*window.config\s*=\s*(?P<json>{.*?});""", re.DOTALL)
+
+    def _get_streams(self):
+        iframe_url = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath_string("normalize-space(.//iframe[contains(@src,'livestream.com')]/@src)")
+        ))
+        if not iframe_url:
+            return None
+
+        stream_data = self.session.http.get(iframe_url, schema=validate.Schema(
+            validate.transform(self._re_window_config.search),
+            validate.any(None, validate.all(
+                validate.get("json"),
+                validate.parse_json(),
+                {
+                    "event": {
+                        "full_name": str,
+                        "feed": {
+                            "data": list
+                        }
+                    }
+                },
+                validate.get("event")
+            ))
+        ))
+        if not stream_data:
+            return None
+        if len(stream_data['feed']['data']) < 1:
+            return None
+        if 'data' not in stream_data['feed']['data'][0]:
+            return None
+        if 'secure_m3u8_url' not in stream_data['feed']['data'][0]['data']:
+            return None
+        self.title = stream_data['full_name'].replace(" ", "")
+        self.category = "atp-challenger"
+        self.author = "ATP"
+        stream_url = stream_data['feed']['data'][0]['data']['secure_m3u8_url']
+
+        yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
+
+
+__plugin__ = AtpChallengerTour

--- a/src/streamlink/plugins/atpchallenger.py
+++ b/src/streamlink/plugins/atpchallenger.py
@@ -9,7 +9,6 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
 

--- a/src/streamlink/plugins/atpchallenger.py
+++ b/src/streamlink/plugins/atpchallenger.py
@@ -4,13 +4,10 @@ $url atptour.com/en/atp-challenger-tour/challenger-tv
 $type live, vod
 """
 
-import logging
 import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-
-log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/atpchallenger.py
+++ b/src/streamlink/plugins/atpchallenger.py
@@ -1,6 +1,6 @@
 """
-$description Professional tennis tournaments.
-$url www.atptour.com/en/atp-challenger-tour/challenger-tv
+$description Tennis tournaments organized by the Association of Tennis Professionals.
+$url atptour.com/en/atp-challenger-tour/challenger-tv
 $type live, vod
 """
 
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?atptour.com/en/atp-challenger-tour/challenger-tv"
+    r"https?://(?:www\.)?atptour\.com/(?:en|es)/atp-challenger-tour/challenger-tv"
 ))
 class AtpChallengerTour(Plugin):
     _re_window_config = re.compile(r""".*window.config\s*=\s*(?P<json>{.*?});""", re.DOTALL)

--- a/src/streamlink/plugins/atpchallenger.py
+++ b/src/streamlink/plugins/atpchallenger.py
@@ -18,46 +18,14 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?atptour\.com/(?:en|es)/atp-challenger-tour/challenger-tv"
 ))
 class AtpChallengerTour(Plugin):
-    _re_window_config = re.compile(r""".*window.config\s*=\s*(?P<json>{.*?});""", re.DOTALL)
-
     def _get_streams(self):
         iframe_url = self.session.http.get(self.url, schema=validate.Schema(
             validate.parse_html(),
-            validate.xml_xpath_string("normalize-space(.//iframe[contains(@src,'livestream.com')]/@src)")
+            validate.xml_xpath_string(".//iframe[starts-with(@id,'vimeoPlayer_')][@src][1]/@src"),
+            validate.any(None, validate.url()),
         ))
-        if not iframe_url:
-            return None
-
-        stream_data = self.session.http.get(iframe_url, schema=validate.Schema(
-            validate.transform(self._re_window_config.search),
-            validate.any(None, validate.all(
-                validate.get("json"),
-                validate.parse_json(),
-                {
-                    "event": {
-                        "full_name": str,
-                        "feed": {
-                            "data": list
-                        }
-                    }
-                },
-                validate.get("event")
-            ))
-        ))
-        if not stream_data:
-            return None
-        if len(stream_data['feed']['data']) < 1:
-            return None
-        if 'data' not in stream_data['feed']['data'][0]:
-            return None
-        if 'secure_m3u8_url' not in stream_data['feed']['data'][0]['data']:
-            return None
-        self.title = stream_data['full_name'].replace(" ", "")
-        self.category = "atp-challenger"
-        self.author = "ATP"
-        stream_url = stream_data['feed']['data'][0]['data']['secure_m3u8_url']
-
-        yield from HLSStream.parse_variant_playlist(self.session, stream_url).items()
+        if iframe_url:
+            return self.session.streams(iframe_url)
 
 
 __plugin__ = AtpChallengerTour

--- a/tests/plugins/test_atpchallenger.py
+++ b/tests/plugins/test_atpchallenger.py
@@ -1,0 +1,11 @@
+from streamlink.plugins.atpchallenger import AtpChallengerTour
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlAtpChallenger(PluginCanHandleUrl):
+    __plugin__ = AtpChallengerTour
+
+    should_match = [
+        'https://www.atptour.com/en/atp-challenger-tour/challenger-tv/challenger-tv-search-results/2022-2785-ms005-zug-alexander-ritschard-vs-dominic-stricker/2022/2785/all',
+        'https://www.atptour.com/en/atp-challenger-tour/challenger-tv'
+    ]

--- a/tests/plugins/test_atpchallenger.py
+++ b/tests/plugins/test_atpchallenger.py
@@ -6,6 +6,7 @@ class TestPluginCanHandleUrlAtpChallenger(PluginCanHandleUrl):
     __plugin__ = AtpChallengerTour
 
     should_match = [
-        'https://www.atptour.com/en/atp-challenger-tour/challenger-tv/challenger-tv-search-results/2022-2785-ms005-zug-alexander-ritschard-vs-dominic-stricker/2022/2785/all',
+        'https://www.atptour.com/en/atp-challenger-tour/challenger-tv/challenger-tv-search-results/'
+        + '2022-2785-ms005-zug-alexander-ritschard-vs-dominic-stricker/2022/2785/all',
         'https://www.atptour.com/en/atp-challenger-tour/challenger-tv'
     ]

--- a/tests/plugins/test_atpchallenger.py
+++ b/tests/plugins/test_atpchallenger.py
@@ -6,7 +6,8 @@ class TestPluginCanHandleUrlAtpChallenger(PluginCanHandleUrl):
     __plugin__ = AtpChallengerTour
 
     should_match = [
-        'https://www.atptour.com/en/atp-challenger-tour/challenger-tv/challenger-tv-search-results/'
-        + '2022-2785-ms005-zug-alexander-ritschard-vs-dominic-stricker/2022/2785/all',
-        'https://www.atptour.com/en/atp-challenger-tour/challenger-tv'
+        "https://www.atptour.com/en/atp-challenger-tour/challenger-tv",
+        "https://www.atptour.com/es/atp-challenger-tour/challenger-tv",
+        "https://www.atptour.com/en/atp-challenger-tour/challenger-tv/challenger-tv-search-results/"
+        + "2022-2785-ms005-zug-alexander-ritschard-vs-dominic-stricker/2022/2785/all",
     ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->


Hi team,

This change implements one of the plugin I proposed in this issue: https://github.com/streamlink/streamlink/issues/4693. This plugin enables streamlink to scrap livestream from https://www.atptour.com/en/atp-challenger-tour/challenger-tv. 

For testing, I locally run the tests described here: https://streamlink.github.io/latest/developing.html#validating-changes
Thanks,
Yu