### PR TITLE
chore: update GitHub release message body

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -1,11 +1,15 @@
 {{ changelog }}
 
-## ⚙️ Installation and configuration
+## 📦 Download and Installation
 
-Please see the detailed [installation instructions](https://streamlink.github.io/install.html) and [CLI guide](https://streamlink.github.io/cli.html) on Streamlink's website.
+Please see the [installation instructions](https://streamlink.github.io/install.html) for a list of available install methods and packages on the supported operating systems.
 
 **⚠️ PLEASE NOTE ⚠️**  
-Streamlink's Windows installers have been moved to [streamlink/windows-installer](https://github.com/streamlink/windows-installer/releases).
+Streamlink's Windows installers have been moved to [streamlink/windows-builds](https://github.com/streamlink/windows-builds).
+
+## ⚙️ Configuration and Usage
+
+Please see the [CLI documentation](https://streamlink.github.io/cli.html) for how to configure and use Streamlink.
 
 ## ❤️ Support
 


### PR DESCRIPTION
The release message body still includes the outdated `streamlink/windows-installer` repo name and link.
The download and configuration secions could also be worded better, so let's change it.

We can remove the Windows installers warning again in a couple of releases/months.