### PR TITLE
plugins: refactor validation schemas

### DIFF
--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -90,46 +90,40 @@ class Albavision(Plugin):
         return is_token_based_site
 
     def _get_live_url(self):
-        live_url_re = re.compile(r"""LIVE_URL\s*=\s*['"]([^'"]+)['"]""")
         schema = validate.Schema(
             validate.xml_xpath_string(".//script[contains(text(), 'LIVE_URL')]/text()"),
-            validate.any(None, validate.all(
-                validate.transform(live_url_re.search),
-                validate.any(None, validate.all(
+            validate.none_or_all(
+                re.compile(r"""LIVE_URL\s*=\s*(?P<q>['"])(.+?)(?P=q)"""),
+                validate.none_or_all(
                     validate.get(1),
                     validate.url(),
-                )),
-            )),
+                ),
+            ),
         )
         live_url = validate.validate(schema, self.page)
         log.debug(f"live_url={live_url}")
         return live_url
 
     def _get_token_req_url(self):
-        token_req_host_re = re.compile(r"""jQuery\.get\s*\(['"]([^'"]+)['"]""")
         schema = validate.Schema(
             validate.xml_xpath_string(".//script[contains(text(), 'LIVE_URL')]/text()"),
-            validate.any(None, validate.all(
-                validate.transform(token_req_host_re.search),
-                validate.any(None, validate.all(
+            validate.none_or_all(
+                re.compile(r"""jQuery\.get\s*\((?P<q>['"])(.+?)(?P=q)"""),
+                validate.none_or_all(
                     validate.get(1),
                     validate.url(),
-                )),
-            )),
+                ),
+            ),
         )
         token_req_host = validate.validate(schema, self.page)
         log.debug(f"token_req_host={token_req_host}")
 
-        token_req_str_re = re.compile(r"""Math\.floor\(Date\.now\(\)\s*/\s*3600000\),\s*['"]([^'"]+)['"]""")
         schema = validate.Schema(
             validate.xml_xpath_string(".//script[contains(text(), 'LIVE_URL')]/text()"),
-            validate.any(None, validate.all(
-                validate.transform(token_req_str_re.search),
-                validate.any(None, validate.all(
-                    validate.get(1),
-                    str,
-                )),
-            )),
+            validate.none_or_all(
+                re.compile(r"""Math\.floor\(Date\.now\(\)\s*/\s*3600000\),\s*(?P<q>['"])(.+?)(?P=q)"""),
+                validate.none_or_all(validate.get(1)),
+            ),
         )
         token_req_str = validate.validate(schema, self.page)
         log.debug(f"token_req_str={token_req_str}")

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -22,49 +22,47 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?atresplayer\.com/"
 ))
 class AtresPlayer(Plugin):
-    state_re = re.compile(r"""window.__PRELOADED_STATE__\s*=\s*({.*?});""", re.DOTALL)
-    channel_id_schema = validate.Schema(
-        validate.transform(state_re.search),
-        validate.any(
-            None,
-            validate.all(
+    def _get_streams(self):
+        self.url = update_scheme("https://", self.url)
+
+        api_url = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"""window.__PRELOADED_STATE__\s*=\s*({.*?});""", re.DOTALL),
+            validate.none_or_all(
                 validate.get(1),
                 validate.parse_json(),
                 validate.transform(search_dict, key="href"),
-            )
-        )
-    )
-    player_api_schema = validate.Schema(
-        validate.any(
-            None,
-            validate.all(
-                validate.parse_json(),
-                validate.transform(search_dict, key="urlVideo"),
-            )
-        )
-    )
-    stream_schema = validate.Schema(
-        validate.parse_json(),
-        {"sources": [
-            validate.all({
-                "src": validate.url(),
-                validate.optional("type"): validate.text
-            })
-        ]}, validate.get("sources"))
+                [validate.url()],
+                validate.get(0),
+            ),
+        ))
+        if not api_url:
+            return
+        log.debug(f"API URL: {api_url}")
 
-    def __init__(self, url):
-        # must be HTTPS
-        super().__init__(update_scheme("https://", url))
+        player_api_url = self.session.http.get(api_url, schema=validate.Schema(
+            validate.parse_json(),
+            validate.transform(search_dict, key="urlVideo"),
+        ))
 
-    def _get_streams(self):
-        api_urls = self.session.http.get(self.url, schema=self.channel_id_schema)
-        _api_url = list(api_urls)[0]
-        log.debug("API URL: {0}".format(_api_url))
-        player_api_url = self.session.http.get(_api_url, schema=self.player_api_schema)
+        stream_schema = validate.Schema(
+            validate.parse_json(),
+            {
+                "sources": [
+                    validate.all(
+                        {
+                            "src": validate.url(),
+                            validate.optional("type"): str,
+                        },
+                    ),
+                ],
+            },
+            validate.get("sources"),
+        )
+
         for api_url in player_api_url:
-            log.debug("Player API URL: {0}".format(api_url))
-            for source in self.session.http.get(api_url, schema=self.stream_schema):
-                log.debug("Stream source: {0} ({1})".format(source['src'], source.get("type", "n/a")))
+            log.debug(f"Player API URL: {api_url}")
+            for source in self.session.http.get(api_url, schema=stream_schema):
+                log.debug(f"Stream source: {source['src']} ({source.get('type', 'n/a')})")
 
                 if "type" not in source or source["type"] == "application/vnd.apple.mpegurl":
                     streams = HLSStream.parse_variant_playlist(self.session, source["src"])

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -26,8 +26,6 @@ class Bloomberg(Plugin):
     LIVE_API_URL = "https://cdn.gotraffic.net/projector/latest/assets/config/config.min.json?v=1"
     VOD_API_URL = "https://www.bloomberg.com/api/embed?id={0}"
 
-    _re_mp4_bitrate = re.compile(r".*_(?P<bitrate>[0-9]+)\.mp4")
-
     def _get_live_streams(self, data, channel):
         schema_live_ids = validate.Schema(
             {"live": {"channels": {"byChannelId": {
@@ -120,9 +118,9 @@ class Bloomberg(Plugin):
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(),'window.__PRELOADED_STATE__')][1]/text()"),
                 str,
-                validate.transform(re.compile(r"^\s*window\.__PRELOADED_STATE__\s*=\s*({.+})\s*;?\s*$", re.DOTALL).search),
+                validate.regex(re.compile(r"^\s*window\.__PRELOADED_STATE__\s*=\s*({.+})\s*;?\s*$", re.DOTALL)),
                 validate.get(1),
-                validate.parse_json()
+                validate.parse_json(),
             ))
         except PluginError:
             log.error("Could not find JSON data. Invalid URL or bot protection...")

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -1,5 +1,5 @@
 """
-$description Global live streaming and video on-demand hosting platform.
+$description Global live-streaming and video on-demand hosting platform.
 $url players.brightcove.net
 $type live, vod
 """
@@ -41,7 +41,7 @@ class BrightcovePlayer:
             player_url,
             params={"videoId": video_id},
             schema=validate.Schema(
-                validate.transform(re.compile(r"""policyKey\s*:\s*(?P<q>['"])(?P<key>[\w-]+)(?P=q)""").search),
+                re.compile(r"""policyKey\s*:\s*(?P<q>['"])(?P<key>[\w-]+)(?P=q)"""),
                 validate.any(None, validate.get("key"))
             )
         )

--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -15,23 +15,26 @@ from streamlink.stream.hls import HLSStream
     r"https?://www\.cbsnews\.com/live/"
 ))
 class CBSNews(Plugin):
-    _re_default_payload = re.compile(r"CBSNEWS.defaultPayload = (\{.*)")
-
-    _schema_items = validate.Schema(
-        validate.transform(_re_default_payload.search),
-        validate.any(None, validate.all(
-            validate.get(1),
-            validate.parse_json(),
-            {"items": [validate.all({
-                "video": validate.url(),
-                "format": "application/x-mpegURL"
-            }, validate.get("video"))]},
-            validate.get("items")
-        ))
-    )
-
     def _get_streams(self):
-        items = self.session.http.get(self.url, schema=self._schema_items)
+        items = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"CBSNEWS.defaultPayload = (\{.*)"),
+            validate.none_or_all(
+                validate.get(1),
+                validate.parse_json(),
+                {
+                    "items": [
+                        validate.all(
+                            {
+                                "video": validate.url(),
+                                "format": "application/x-mpegURL",
+                            },
+                            validate.get("video"),
+                        ),
+                    ],
+                },
+                validate.get("items"),
+            ),
+        ))
         if items:
             for hls_url in items:
                 yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()

--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -47,8 +47,8 @@ class CDNBG(Plugin):
     @staticmethod
     def _find_url(regex: re.Pattern) -> validate.all:
         return validate.all(
-            validate.transform(regex.search),
-            validate.get("url")
+            validate.regex(regex),
+            validate.get("url"),
         )
 
     def _get_streams(self):

--- a/src/streamlink/plugins/cnews.py
+++ b/src/streamlink/plugins/cnews.py
@@ -11,36 +11,37 @@ from streamlink.plugin.api import validate
 
 
 @pluginmatcher(re.compile(
-    r'https?://(?:www\.)?cnews\.fr'
+    r"https?://(?:www\.)?cnews\.fr"
 ))
 class CNEWS(Plugin):
-    _json_data_re = re.compile(r'jQuery\.extend\(Drupal\.settings, ({.*})\);')
-    _dailymotion_url = 'https://www.dailymotion.com/embed/video/{}'
-
-    _data_schema = validate.Schema(
-        validate.transform(_json_data_re.search),
-        validate.any(None, validate.all(
-            validate.get(1),
-            validate.parse_json(),
-            {
-                validate.optional('dm_player_live_dailymotion'): {
-                    validate.optional('video_id'): str,
-                },
-                validate.optional('dm_player_node_dailymotion'): {
-                    validate.optional('video_id'): str,
-                },
-            },
-        )),
-    )
+    _dailymotion_url = "https://www.dailymotion.com/embed/video/{}"
 
     def _get_streams(self):
-        data = self.session.http.get(self.url, schema=self._data_schema)
-        if 'dm_player_node_dailymotion' in data:
-            return self.session.streams(self._dailymotion_url.format(
-                data['dm_player_node_dailymotion']['video_id']))
-        elif 'dm_player_live_dailymotion' in data:
-            return self.session.streams(self._dailymotion_url.format(
-                data['dm_player_live_dailymotion']['video_id']))
+        data = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"jQuery\.extend\(Drupal\.settings, ({.*})\);"),
+            validate.none_or_all(
+                validate.get(1),
+                validate.parse_json(),
+                {
+                    validate.optional("dm_player_live_dailymotion"): {
+                        validate.optional("video_id"): str,
+                    },
+                    validate.optional("dm_player_node_dailymotion"): {
+                        validate.optional("video_id"): str,
+                    },
+                },
+                validate.union_get("dm_player_live_dailymotion", "dm_player_node_dailymotion")
+            ),
+        ))
+        if not data:
+            return
+
+        live, node = data
+
+        if node:
+            return self.session.streams(self._dailymotion_url.format(node["video_id"]))
+        elif live:
+            return self.session.streams(self._dailymotion_url.format(live["video_id"]))
 
 
 __plugin__ = CNEWS

--- a/src/streamlink/plugins/delfi.py
+++ b/src/streamlink/plugins/delfi.py
@@ -70,10 +70,9 @@ class Delfi(Plugin):
             data = self.session.http.get(src, schema=validate.Schema(
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(),'embedJs.setAttribute(')][1]/text()"),
-                validate.any(None, validate.all(
-                    str,
-                    validate.transform(re.compile(r"embedJs\.setAttribute\('src',\s*'(.+?)'").search),
-                    validate.any(None, validate.all(
+                validate.none_or_all(
+                    re.compile(r"embedJs\.setAttribute\('src',\s*'(.+?)'"),
+                    validate.none_or_all(
                         validate.get(1),
                         validate.transform(lambda url: parse_qsd(urlparse(url).fragment)),
                         {"stream": str},
@@ -83,8 +82,8 @@ class Delfi(Plugin):
                             "hls": str
                         }]},
                         validate.get("versions")
-                    ))
-                ))
+                    ),
+                ),
             ))
         except PluginError:
             log.error("Failed to get streams from iframe")

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -1,5 +1,5 @@
 """
-$description A network of live streaming webcams for tourism and entertainment.
+$description A network of live webcams for tourism and entertainment.
 $url earthcam.com
 $type live, vod
 $notes Only works for the cams hosted on EarthCam
@@ -21,12 +21,10 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?earthcam\.com/"
 ))
 class EarthCam(Plugin):
-    _re_json_base = re.compile(r"""var\s+json_base\s*=\s*(?P<json>{.*?});""", re.DOTALL)
-
     def _get_streams(self):
         data = self.session.http.get(self.url, schema=validate.Schema(
-            validate.transform(self._re_json_base.search),
-            validate.any(None, validate.all(
+            re.compile(r"""var\s+json_base\s*=\s*(?P<json>{.*?});""", re.DOTALL),
+            validate.none_or_all(
                 validate.get("json"),
                 validate.parse_json(),
                 {"cam": {
@@ -39,10 +37,10 @@ class EarthCam(Plugin):
                         "title": str,
                         "liveon": str,
                         "defaulttab": str,
-                    }
+                    },
                 }},
-                validate.get("cam")
-            ))
+                validate.get("cam"),
+            ),
         ))
         if not data:
             return

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -221,7 +221,7 @@ class Filmon(Plugin):
                     log.debug(f"Found cached channel ID: {_id}")
                 else:
                     _id = self.session.http.get(self.url, schema=validate.Schema(
-                        validate.transform(re.compile(r"""channel_id\s*=\s*(?P<q>['"]?)(?P<value>\d+)(?P=q)""").search),
+                        re.compile(r"""channel_id\s*=\s*(?P<q>['"]?)(?P<value>\d+)(?P=q)"""),
                         validate.any(None, validate.get("value")),
                     ))
                     log.debug(f"Found channel ID: {_id}")

--- a/src/streamlink/plugins/hiplayer.py
+++ b/src/streamlink/plugins/hiplayer.py
@@ -30,8 +30,6 @@ log = logging.getLogger(__name__)
 """, re.VERBOSE))
 class HiPlayer(Plugin):
     DAI_URL = "https://pubads.g.doubleclick.net/ssai/event/{0}/streams"
-    js_url_re = re.compile(r"""['"](https://hiplayer.hibridcdn.net/l/[^'"]+)['"]""")
-    base64_data_re = re.compile(r"i\s*=\s*\[(.*)\]\.join")
 
     def _get_streams(self):
         js_url = self.session.http.get(
@@ -39,12 +37,9 @@ class HiPlayer(Plugin):
             schema=validate.Schema(
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(), 'https://hiplayer.hibridcdn.net/l/')]/text()"),
-                validate.any(
-                    None,
-                    validate.all(
-                        validate.transform(self.js_url_re.search),
-                        validate.any(None, validate.all(validate.get(1), validate.url())),
-                    ),
+                validate.none_or_all(
+                    re.compile(r"""(?P<q>['"])(https://hiplayer.hibridcdn.net/l/.+?)(?P=q)"""),
+                    validate.none_or_all(validate.get(1), validate.url()),
                 ),
             ),
         )
@@ -57,23 +52,20 @@ class HiPlayer(Plugin):
         data = self.session.http.get(
             js_url,
             schema=validate.Schema(
-                validate.transform(self.base64_data_re.search),
-                validate.any(
-                    None,
-                    validate.all(
-                        validate.get(1),
-                        validate.transform(lambda s: re.sub(r"['\", ]", "", s)),
-                        validate.transform(lambda s: base64.b64decode(s)),
-                        validate.parse_json(),
-                        validate.any(
-                            None,
-                            {
-                                "daiEnabled": bool,
-                                "daiAssetKey": str,
-                                "daiApiKey": str,
-                                "streamUrl": validate.any(validate.url(), ""),
-                            },
-                        ),
+                re.compile(r"i\s*=\s*\[(.*)]\.join"),
+                validate.none_or_all(
+                    validate.get(1),
+                    validate.transform(lambda s: re.sub(r"['\", ]", "", s)),
+                    validate.transform(lambda s: base64.b64decode(s)),
+                    validate.parse_json(),
+                    validate.any(
+                        None,
+                        {
+                            "daiEnabled": bool,
+                            "daiAssetKey": str,
+                            "daiApiKey": str,
+                            "streamUrl": validate.any(validate.url(), ""),
+                        },
                     ),
                 ),
             ),

--- a/src/streamlink/plugins/htv.py
+++ b/src/streamlink/plugins/htv.py
@@ -20,8 +20,6 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?htv\.com\.vn/truc-tuyen(?:\?channel=(?P<channel>\w+)&?|$)"
 ))
 class HTV(Plugin):
-    hls_url_re = re.compile(r'var\s+iosUrl\s*=\s*"([^"]+)"')
-
     def get_channels(self):
         data = self.session.http.get(self.url, schema=validate.Schema(
             validate.parse_html(),
@@ -81,10 +79,10 @@ class HTV(Plugin):
             schema=validate.Schema(
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(), 'playlist.m3u8')]/text()"),
-                validate.any(None, validate.all(
-                    validate.transform(self.hls_url_re.search),
-                    validate.any(None, validate.all(validate.get(1), validate.url())),
-                )),
+                validate.none_or_all(
+                    re.compile(r"""var\s+iosUrl\s*=\s*(?P<q>")(.+?)(?P=q)"""),
+                    validate.none_or_all(validate.get(1), validate.url()),
+                ),
             ),
         )
 

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -35,10 +35,10 @@ class Huya(Plugin):
         data = self.session.http.get(self.url, schema=validate.Schema(
             validate.parse_html(),
             validate.xml_xpath_string(".//script[contains(text(),'var hyPlayerConfig = {')][1]/text()"),
-            validate.any(None, validate.transform(
-                re.compile(r"""(?P<q>"?)stream(?P=q)\s*:\s*(?:"(?P<base64>.+?)"|(?P<json>\{.+?})\s*}\s*;)""").search,
-            )),
-            validate.any(None, validate.all(
+            validate.none_or_all(
+                re.compile(r"""(?P<q>"?)stream(?P=q)\s*:\s*(?:"(?P<base64>.+?)"|(?P<json>\{.+?})\s*}\s*;)"""),
+            ),
+            validate.none_or_all(
                 validate.any(
                     validate.all(
                         validate.get("base64"),
@@ -85,7 +85,7 @@ class Huya(Plugin):
                     ("gameLiveInfo", "roomName"),
                     "gameStreamInfoList",
                 ),
-            )),
+            ),
         ))
         if not data:
             return

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -44,10 +44,10 @@ class Livestream(Plugin):
                         validate.parse_json(),
                         {"data": [dict]},
                         validate.get(("data", 0)),
-                        validate.any(None, validate.all(
+                        validate.none_or_all(
                             {"id": int},
                             validate.get("id"),
-                        )),
+                        ),
                     ),
                 )
             else:
@@ -56,16 +56,15 @@ class Livestream(Plugin):
                     schema=validate.Schema(
                         validate.parse_html(),
                         validate.xml_xpath_string(".//script[contains(text(), 'window.config = ')][1]/text()"),
-                        validate.any(None, validate.all(
-                            str,
-                            validate.transform(re.compile(r"^window\.config\s*=\s*(\{.+});?\s*$").match),
-                            validate.any(None, validate.all(
+                        validate.none_or_all(
+                            re.compile(r"^window\.config\s*=\s*(\{.+});?\s*$"),
+                            validate.none_or_all(
                                 validate.get(1),
                                 validate.parse_json(),
                                 {"event": {"id": int}},
                                 validate.get(("event", "id")),
-                            ))
-                        )),
+                            ),
+                        ),
                     ),
                 )
             if event is None:

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -58,21 +58,19 @@ class LTVHLSStream(HLSStream):
     r"https://ltv\.lsm\.lv/lv/tiesraide"
 ))
 class LtvLsmLv(Plugin):
-    """
-    Support for Latvian live channels streams on ltv.lsm.lv
-    """
+    API_URL = "https://player.cloudycdn.services/player/ltvlive/channel/{channel_id}/"
 
-    def __init__(self, url: str):
-        super().__init__(url)
-        self._json_data_re = re.compile(r'teliaPlayer\((\{.*?\})\);', re.DOTALL)
+    def _get_streams(self):
+        self.session.http.headers.update({"Referer": self.url})
 
-        self.main_page_schema = validate.Schema(
+        iframe_url = self.session.http.get(self.url, schema=validate.Schema(
             validate.parse_html(),
             validate.xml_xpath_string(".//iframe[contains(@src, 'ltv.lsm.lv/embed')][1]/@src"),
-            validate.url()
-        )
+            validate.url(),
+        ))
+        log.debug(f"Found embed iframe: {iframe_url}")
 
-        self.embed_code_schema = validate.Schema(
+        player_iframe_url = self.session.http.get(iframe_url, schema=validate.Schema(
             validate.parse_html(),
             validate.xml_xpath_string(".//live[1]/@*[name()=':embed-data']"),
             str,
@@ -81,53 +79,43 @@ class LtvLsmLv(Plugin):
             validate.get(("source", "embed_code")),
             validate.parse_html(),
             validate.xml_xpath_string(".//iframe[@src][1]/@src"),
-        )
-
-        self.player_apicall_schema = validate.Schema(
-            validate.transform(self._json_data_re.search),
-            validate.any(
-                None,
-                validate.all(
-                    validate.get(1),
-                    validate.transform(lambda s: s.replace("'", '"')),
-                    validate.transform(lambda s: re.sub(r",\s*\}", "}", s, flags=re.DOTALL)),
-                    validate.parse_json(),
-                    {"channel": str},
-                    validate.get("channel")
-                )
-            )
-        )
-
-        self.sources_schema = validate.Schema(
-            validate.parse_json(),
-            {
-                "source": {
-                    "sources": validate.all(
-                        [{"type": str, "src": validate.url()}],
-                        validate.filter(lambda src: src["type"] == "application/x-mpegURL"),
-                        validate.map(lambda src: src.get("src"))
-                    ),
-                }},
-            validate.get(("source", "sources"))
-        )
-
-    def _get_streams(self):
-        api_url = "https://player.cloudycdn.services/player/ltvlive/channel/{channel_id}/"
-
-        self.session.http.headers.update({"Referer": self.url})
-
-        iframe_url = self.session.http.get(self.url, schema=self.main_page_schema)
-        log.debug(f"Found embed iframe: {iframe_url}")
-        player_iframe_url = self.session.http.get(iframe_url, schema=self.embed_code_schema)
+        ))
         log.debug(f"Found player iframe: {player_iframe_url}")
-        channel_id = self.session.http.get(player_iframe_url, schema=self.player_apicall_schema)
+
+        channel_id = self.session.http.get(player_iframe_url, schema=validate.Schema(
+            re.compile(r"teliaPlayer\((\{.*?})\);", re.DOTALL),
+            validate.none_or_all(
+                validate.get(1),
+                validate.transform(lambda s: s.replace("'", '"')),
+                validate.transform(lambda s: re.sub(r",\s*}", "}", s, flags=re.DOTALL)),
+                validate.parse_json(),
+                {"channel": str},
+                validate.get("channel"),
+            ),
+        ))
         log.debug(f"Found channel ID: {channel_id}")
 
-        stream_sources = self.session.http.post(api_url.format(channel_id=channel_id),
-                                                data=dict(refer="ltv.lsm.lv",
-                                                          playertype="regular",
-                                                          protocol="hls"),
-                                                schema=self.sources_schema)
+        stream_sources = self.session.http.post(
+            self.api_url.format(channel_id=channel_id),
+            data={
+                "refer": "ltv.lsm.lv",
+                "playertype": "regular",
+                "protocol": "hls",
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "source": {
+                        "sources": validate.all(
+                            [{"type": str, "src": validate.url()}],
+                            validate.filter(lambda src: src["type"] == "application/x-mpegURL"),
+                            validate.map(lambda src: src.get("src")),
+                        ),
+                    },
+                },
+                validate.get(("source", "sources")),
+            ),
+        )
         for surl in stream_sources:
             yield from LTVHLSStream.parse_variant_playlist(self.session, surl).items()
 

--- a/src/streamlink/plugins/mdstrm.py
+++ b/src/streamlink/plugins/mdstrm.py
@@ -27,19 +27,21 @@ log = logging.getLogger(__name__)
     r"https://mdstrm\.com/live-stream/\w+"
 ))
 class MDStrm(Plugin):
-    _re_ad = re.compile(r"parent\._dai_session\s*=\s*'([^']+)';")
-
-    def get_script_str(self, root, search_string, custom_pattern=None, custom_schema=None):
+    @staticmethod
+    def get_script_str(root, search_string, custom_pattern=None, custom_schema=None):
         if custom_pattern:
             pattern = custom_pattern
         else:
             pattern = fr"{search_string}\s*=\s*'([^']+)';"
         _schema = validate.Schema(
             validate.xml_xpath_string(
-                f".//script[@type='text/javascript'][contains(text(),'{search_string}')]/text()"),
-            validate.any(None, validate.all(
-                validate.transform(re.compile(pattern).search),
-                validate.any(None, validate.all(validate.get(1), str)))))
+                f".//script[@type='text/javascript'][contains(text(),'{search_string}')]/text()",
+            ),
+            validate.none_or_all(
+                re.compile(pattern),
+                validate.none_or_all(validate.get(1)),
+            ),
+        )
         _string = validate.validate(_schema, root)
         if not _string:
             log.debug(f"Failed to find {search_string}")
@@ -59,17 +61,20 @@ class MDStrm(Plugin):
                 url=self.url,
                 schema=validate.Schema(
                     validate.parse_html(),
-                    validate.xml_xpath_string("normalize-space(.//iframe[contains(@src,'mdstrm.com')]/@src)")))
+                    validate.xml_xpath_string("normalize-space(.//iframe[contains(@src,'mdstrm.com')]/@src)"),
+                ),
+            )
             if not url_iframe:
                 return
 
         url_iframe = update_scheme("https://", url_iframe, force=False)
         log.debug(f"iframe={url_iframe}")
-        root = self.session.http.get(url_iframe,
-                                     schema=validate.Schema(validate.parse_html()))
+        root = self.session.http.get(
+            url_iframe,
+            schema=validate.Schema(validate.parse_html()),
+        )
 
-        schema = validate.Schema(validate.xml_xpath_string(".//div[@id='message']/text()"),
-                                 validate.any(None, str))
+        schema = validate.Schema(validate.xml_xpath_string(".//div[@id='message']/text()"))
         error_msg = validate.validate(schema, root)
         if error_msg:
             log.error(f"{error_msg}")
@@ -83,11 +88,14 @@ class MDStrm(Plugin):
                 "type": str,
                 "without_cookies": bool,
                 "title": str,
-            })
-        options = self.get_script_str(root,
-                                      "window.MDSTRM.OPTIONS",
-                                      r"window\.MDSTRM\.OPTIONS\s*=\s*({.*?});",
-                                      custom_schema=schema_options)
+            },
+        )
+        options = self.get_script_str(
+            root,
+            "window.MDSTRM.OPTIONS",
+            r"window\.MDSTRM\.OPTIONS\s*=\s*({.*?});",
+            custom_schema=schema_options,
+        )
         if not options or not isinstance(options, dict):
             return
 
@@ -110,8 +118,11 @@ class MDStrm(Plugin):
             "without_cookies": "false",
         }
 
-        schema = validate.Schema(validate.xml_xpath_string(
-            "normalize-space(.//iframe[contains(@src,'mdstrm.com')][@id='programmatic']/@src)"))
+        schema = validate.Schema(
+            validate.xml_xpath_string(
+                "normalize-space(.//iframe[contains(@src,'mdstrm.com')][@id='programmatic']/@src)",
+            ),
+        )
         programmatic_url = validate.validate(schema, root)
         if programmatic_url:
             programmatic_url = update_scheme("https://", programmatic_url, force=False)
@@ -122,9 +133,12 @@ class MDStrm(Plugin):
                 schema=validate.Schema(
                     validate.parse_html(),
                     validate.xml_xpath_string(".//script[contains(text(),'parent._dai_session')]/text()"),
-                    validate.any(None, validate.all(
-                        validate.transform(self._re_ad.search),
-                        validate.any(None, validate.all(validate.get(1), str))))))
+                    validate.none_or_all(
+                        re.compile(r"""parent\._dai_session\s*=\s*(?P<q>['"])(?P<dai_session>.+?)(?P=q);"""),
+                        validate.none_or_all(validate.get("dai_session")),
+                    ),
+                ),
+            )
             if ad:
                 params.update({"adInsertionSessionId": ad})
             else:
@@ -133,10 +147,12 @@ class MDStrm(Plugin):
         log.trace(f"{params!r}")
         self.id = options["id"]
         self.title = options["title"]
-        return HLSStream.parse_variant_playlist(self.session,
-                                                options["src"]["hls"],
-                                                headers={"Referer": "https://mdstrm.com/"},
-                                                params=params)
+        return HLSStream.parse_variant_playlist(
+            self.session,
+            options["src"]["hls"],
+            headers={"Referer": "https://mdstrm.com/"},
+            params=params,
+        )
 
 
 __plugin__ = MDStrm

--- a/src/streamlink/plugins/nbcnews.py
+++ b/src/streamlink/plugins/nbcnews.py
@@ -29,13 +29,12 @@ class NBCNews(Plugin):
             schema=validate.Schema(
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[@type='application/ld+json'][1]/text()"),
-                validate.any(None, validate.all(
-                    str,
+                validate.none_or_all(
                     validate.parse_json(),
                     {"embedUrl": validate.url()},
                     validate.get("embedUrl"),
-                    validate.transform(lambda embed_url: embed_url.split("/")[-1])
-                ))
+                    validate.transform(lambda embed_url: embed_url.split("/")[-1]),
+                ),
             ),
         )
         if self.id is None:

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -1,5 +1,5 @@
 """
-$description Chinese, global live streaming platform run by Huya Live.
+$description Chinese, global live-streaming platform run by Huya Live.
 $url nimo.tv
 $type live
 """
@@ -19,21 +19,6 @@ log = logging.getLogger(__name__)
 ))
 class NimoTV(Plugin):
     data_url = 'https://m.nimo.tv/{0}'
-    data_re = re.compile(r'<script>var G_roomBaseInfo = ({.*?});</script>')
-
-    data_schema = validate.Schema(
-        validate.transform(data_re.search),
-        validate.any(None, validate.all(
-            validate.get(1),
-            validate.parse_json(), {
-                'title': str,
-                'nickname': str,
-                'game': str,
-                'liveStreamStatus': int,
-                validate.optional('mStreamPkg'): str,
-            },
-        )),
-    )
 
     video_qualities = {
         250: '240p',
@@ -53,11 +38,25 @@ class NimoTV(Plugin):
         if not username:
             return
 
-        headers = {'User-Agent': useragents.ANDROID}
         data = self.session.http.get(
             self.data_url.format(username),
-            headers=headers,
-            schema=self.data_schema,
+            headers={
+                "User-Agent": useragents.ANDROID,
+            },
+            schema=validate.Schema(
+                re.compile(r"<script>var G_roomBaseInfo = ({.*?});</script>"),
+                validate.none_or_all(
+                    validate.get(1),
+                    validate.parse_json(),
+                    {
+                        "title": str,
+                        "nickname": str,
+                        "game": str,
+                        "liveStreamStatus": int,
+                        validate.optional("mStreamPkg"): str,
+                    },
+                ),
+            ),
         )
 
         if data['liveStreamStatus'] == 0:

--- a/src/streamlink/plugins/pandalive.py
+++ b/src/streamlink/plugins/pandalive.py
@@ -1,5 +1,5 @@
 """
-$description South Korean live streaming platform for individual live streams.
+$description South Korean live-streaming platform for individual live streams.
 $url pandalive.co.kr
 $type live
 """
@@ -19,10 +19,9 @@ log = logging.getLogger(__name__)
 ))
 class Pandalive(Plugin):
     def _get_streams(self):
-        re_media_code = re.compile(r"""routePath:\s*(["'])(\\u002F|/)live(\\u002F|/)play(\\u002F|/)(?P<id>[^"']+)\1""")
         media_code = self.session.http.get(self.url, schema=validate.Schema(
-            validate.transform(re_media_code.search),
-            validate.any(None, validate.get("id"))
+            re.compile(r"""routePath:\s*(?P<q>["'])(\\u002F|/)live(\\u002F|/)play(\\u002F|/)(?P<id>.+?)(?P=q)"""),
+            validate.any(None, validate.get("id")),
         ))
 
         if not media_code:
@@ -34,7 +33,7 @@ class Pandalive(Plugin):
             "https://api.pandalive.co.kr/v1/live/play",
             data={
                 "action": "watch",
-                "userId": media_code
+                "userId": media_code,
             },
             schema=validate.Schema(
                 validate.parse_json(),

--- a/src/streamlink/plugins/radionet.py
+++ b/src/streamlink/plugins/radionet.py
@@ -29,28 +29,21 @@ log = logging.getLogger(__name__)
     r"https?://(\w+)\.radio\.(net|at|de|dk|es|fr|it|pl|pt|se)"
 ))
 class RadioNet(Plugin):
-    _stream_data_re = re.compile(r'\bstation\s*:\s*(\{.+\}),?\s*')
-
-    _stream_schema = validate.Schema(
-        validate.transform(_stream_data_re.search),
-        validate.any(
-            None,
-            validate.all(
+    def _get_streams(self):
+        streams = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"\bstation\s*:\s*(\{.+}),?\s*"),
+            validate.none_or_all(
                 validate.get(1),
                 validate.parse_json(),
                 {
-                    'type': validate.text,
-                    'streams': validate.all([{
-                        'url': validate.url(),
-                        'contentFormat': validate.text,
-                    }])
+                    "type": str,
+                    "streams": [{
+                        "url": validate.url(),
+                        "contentFormat": str,
+                    }],
                 },
-            )
-        )
-    )
-
-    def _get_streams(self):
-        streams = self.session.http.get(self.url, schema=self._stream_schema)
+            ),
+        ))
         if streams is None:
             return
 

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -19,9 +19,6 @@ log = logging.getLogger(__name__)
     r'https?://([\w-]+\.)*reuters\.(com|tv)'
 ))
 class Reuters(Plugin):
-    _re_fusion_global_content = re.compile(r"Fusion\s*\.\s*globalContent\s*=\s*(?P<json>{.+?})\s*;\s*Fusion\s*\.", re.DOTALL)
-    _re_fusion_content_cache = re.compile(r"Fusion\s*\.\s*contentCache\s*=\s*(?P<json>{.+?})\s*;\s*Fusion\s*\.", re.DOTALL)
-
     def _get_data(self):
         root = self.session.http.get(self.url, schema=validate.Schema(
             validate.parse_html()
@@ -58,7 +55,7 @@ class Reuters(Plugin):
             log.debug("Trying to find source via fusion-metadata globalContent")
             schema = validate.Schema(
                 schema_fusion,
-                validate.transform(self._re_fusion_global_content.search),
+                validate.regex(re.compile(r"Fusion\s*\.\s*globalContent\s*=\s*(?P<json>{.+?})\s*;\s*Fusion\s*\.", re.DOTALL)),
                 validate.get("json"),
                 validate.parse_json(),
                 {"result": {"related_content": {"videos": list}}},
@@ -73,7 +70,7 @@ class Reuters(Plugin):
             log.debug("Trying to find source via fusion-metadata contentCache")
             schema = validate.Schema(
                 schema_fusion,
-                validate.transform(self._re_fusion_content_cache.search),
+                validate.regex(re.compile(r"Fusion\s*\.\s*contentCache\s*=\s*(?P<json>{.+?})\s*;\s*Fusion\s*\.", re.DOTALL)),
                 validate.get("json"),
                 validate.parse_json(),
                 {"videohub-by-guid-v1": {str: {"data": {"result": {"videos": list}}}}},

--- a/src/streamlink/plugins/rtpplay.py
+++ b/src/streamlink/plugins/rtpplay.py
@@ -18,50 +18,54 @@ from streamlink.stream.hls import HLSStream
     r"https?://www\.rtp\.pt/play/"
 ))
 class RTPPlay(Plugin):
-    _m3u8_re = re.compile(r"""
-        hls\s*:\s*(?:
-            (["'])(?P<string>[^"']*)\1
-            |
-            decodeURIComponent\s*\((?P<obfuscated>\[.*?])\.join\(
-            |
-            atob\s*\(\s*decodeURIComponent\s*\((?P<obfuscated_b64>\[.*?])\.join\(
-        )
-    """, re.VERBOSE)
-
-    _schema_hls = validate.Schema(
-        validate.transform(lambda text: next(reversed(list(RTPPlay._m3u8_re.finditer(text))), None)),
-        validate.any(
-            None,
-            validate.all(
-                validate.get("string"),
-                str,
-                validate.any(
-                    validate.length(0),
-                    validate.url()
-                )
-            ),
-            validate.all(
-                validate.get("obfuscated"),
-                str,
-                validate.parse_json(),
-                validate.transform(lambda arr: unquote("".join(arr))),
-                validate.url()
-            ),
-            validate.all(
-                validate.get("obfuscated_b64"),
-                str,
-                validate.parse_json(),
-                validate.transform(lambda arr: unquote("".join(arr))),
-                validate.transform(lambda b64: b64decode(b64).decode("utf-8")),
-                validate.url()
-            )
-        )
-    )
-
     def _get_streams(self):
-        self.session.http.headers.update({"User-Agent": useragents.CHROME,
-                                          "Referer": self.url})
-        hls_url = self.session.http.get(self.url, schema=self._schema_hls)
+        self.session.http.headers.update({
+            "User-Agent": useragents.CHROME,
+            "Referer": self.url,
+        })
+
+        re_m3u8 = re.compile(
+            r"""
+                hls\s*:\s*(?:
+                    (?P<q>["'])(?P<string>.*?)(?P=q)
+                    |
+                    decodeURIComponent\s*\((?P<obfuscated>\[.*?])\.join\(
+                    |
+                    atob\s*\(\s*decodeURIComponent\s*\((?P<obfuscated_b64>\[.*?])\.join\(
+                )
+            """,
+            re.VERBOSE,
+        )
+
+        hls_url = self.session.http.get(self.url, schema=validate.Schema(
+            validate.transform(lambda text: next(reversed(list(re_m3u8.finditer(text))), None)),
+            validate.any(
+                None,
+                validate.all(
+                    validate.get("string"),
+                    str,
+                    validate.any(
+                        "",
+                        validate.url(),
+                    ),
+                ),
+                validate.all(
+                    validate.get("obfuscated"),
+                    str,
+                    validate.parse_json(),
+                    validate.transform(lambda arr: unquote("".join(arr))),
+                    validate.url(),
+                ),
+                validate.all(
+                    validate.get("obfuscated_b64"),
+                    str,
+                    validate.parse_json(),
+                    validate.transform(lambda arr: unquote("".join(arr))),
+                    validate.transform(lambda b64: b64decode(b64).decode("utf-8")),
+                    validate.url(),
+                ),
+            ),
+        ))
         if hls_url:
             return HLSStream.parse_variant_playlist(self.session, hls_url)
 

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -132,15 +132,15 @@ class Rtve(Plugin):
 
     def _get_streams(self):
         self.id = self.session.http.get(self.url, schema=validate.Schema(
-            validate.transform(re.compile(r"\bdata-setup='({.+?})'", re.DOTALL).search),
-            validate.any(None, validate.all(
+            re.compile(r"\bdata-setup='({.+?})'", re.DOTALL),
+            validate.none_or_all(
                 validate.get(1),
                 validate.parse_json(),
                 {
                     "idAsset": validate.any(int, validate.all(str, validate.transform(int))),
                 },
-                validate.get("idAsset")
-            )),
+                validate.get("idAsset"),
+            ),
         ))
         if not self.id:
             return

--- a/src/streamlink/plugins/stadium.py
+++ b/src/streamlink/plugins/stadium.py
@@ -19,7 +19,6 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?watchstadium\.com/"
 ))
 class Stadium(Plugin):
-    _policy_key_re = re.compile(r"""options:\s*{.+policyKey:\s*"([^"]+)""", re.DOTALL)
     _API_URL = "https://edge.api.brightcove.com/playback/v1/accounts/{data_account}/videos/{data_video_id}"
     _PLAYER_URL = "https://players.brightcove.net/{data_account}/{data_player}_default/index.min.js"
 
@@ -36,7 +35,7 @@ class Stadium(Plugin):
 
         url = self._PLAYER_URL.format(data_account=data_account, data_player=data_player)
         policy_key = self.session.http.get(url, schema=validate.Schema(
-            validate.transform(self._policy_key_re.search),
+            re.compile(r"""options:\s*{.+policyKey:\s*"([^"]+)""", re.DOTALL),
             validate.any(None, validate.get(1))
         ))
         if not policy_key:

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -200,12 +200,11 @@ class SteamBroadcastPlugin(Plugin):
         return self.session.http.get(url, schema=validate.Schema(
             validate.parse_html(),
             validate.xml_xpath_string(".//div[@id='webui_config']/@data-broadcast"),
-            validate.any(None, validate.all(
-                str,
+            validate.none_or_all(
                 validate.parse_json(),
                 {"steamid": str},
-                validate.get("steamid")
-            ))
+                validate.get("steamid"),
+            ),
         ))
 
     def _get_streams(self):

--- a/src/streamlink/plugins/streamable.py
+++ b/src/streamlink/plugins/streamable.py
@@ -16,30 +16,30 @@ from streamlink.utils.url import update_scheme
     r"https?://(?:www\.)?streamable\.com/(.+)"
 ))
 class Streamable(Plugin):
-    meta_re = re.compile(r'''var\s*videoObject\s*=\s*({.*});''')
-    config_schema = validate.Schema(
-        validate.transform(meta_re.search),
-        validate.any(None,
-                     validate.all(
-                         validate.get(1),
-                         validate.parse_json(),
-                         {
-                             "files": {validate.text: {"url": validate.url(),
-                                                       "width": int,
-                                                       "height": int,
-                                                       "bitrate": int}}
-                         })
-                     )
-    )
-
     def _get_streams(self):
-        data = self.session.http.get(self.url, schema=self.config_schema)
+        data = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"var\s*videoObject\s*=\s*({.*?});"),
+            validate.none_or_all(
+                validate.get(1),
+                validate.parse_json(),
+                {
+                    "files": {
+                        str: {
+                            "url": validate.url(),
+                            "width": int,
+                            "height": int,
+                            "bitrate": int,
+                        },
+                    },
+                },
+            ),
+        ))
 
         for info in data["files"].values():
             stream_url = update_scheme("https://", info["url"])
             # pick the smaller of the two dimensions, for landscape v. portrait videos
             res = min(info["width"], info["height"])
-            yield "{0}p".format(res), HTTPStream(self.session, stream_url)
+            yield f"{res}p", HTTPStream(self.session, stream_url)
 
 
 __plugin__ = Streamable

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -18,17 +18,15 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(re.compile(r"https://mitelefe\.com/vivo"))
 class Telefe(Plugin):
-    _re_content = re.compile(r"=\s*(\{.+\});", re.DOTALL | re.MULTILINE)
-
     def _get_streams(self):
         self.title, hls_url = self.session.http.get(
             self.url,
             schema=validate.Schema(
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(), 'HLS')]/text()"),
-                validate.any(None, validate.all(
-                    validate.transform(self._re_content.search),
-                    validate.any(None, validate.all(
+                validate.none_or_all(
+                    re.compile(r"=\s*(\{.+?});", re.DOTALL | re.MULTILINE),
+                    validate.none_or_all(
                         validate.get(1),
                         validate.parse_json(),
                         {str: {"children": {"top": {"model": {"videos": [{
@@ -36,14 +34,15 @@ class Telefe(Plugin):
                             "sources": validate.all(
                                 [{"url": str, "type": str}],
                                 validate.filter(lambda p: p["type"].lower() == "hls"),
-                                validate.get((0, "url")))
+                                validate.get((0, "url")),
+                            ),
                         }]}}}}},
                         validate.transform(lambda k: next(iter(k.values()))),
                         validate.get(("children", "top", "model", "videos", 0)),
-                        validate.union_get("title", "sources")
-                    ))
-                ))
-            )
+                        validate.union_get("title", "sources"),
+                    ),
+                ),
+            ),
         )
         return HLSStream.parse_variant_playlist(self.session, urljoin(self.url, hls_url))
 

--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -15,17 +15,15 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r'https?://www\.tv8\.com\.tr/canli-yayin'
+    r"https?://www\.tv8\.com\.tr/canli-yayin"
 ))
 class TV8(Plugin):
-    _re_hls = re.compile(r"""file\s*:\s*(["'])(?P<hls_url>https?://.*?\.m3u8.*?)\1""")
-
     title = "TV8"
 
     def _get_streams(self):
         hls_url = self.session.http.get(self.url, schema=validate.Schema(
-            validate.transform(self._re_hls.search),
-            validate.any(None, validate.get("hls_url"))
+            re.compile(r"""file\s*:\s*(?P<q>["'])(?P<hls_url>https?://.*?\.m3u8.*?)(?P=q)"""),
+            validate.any(None, validate.get("hls_url")),
         ))
         if hls_url is not None:
             return HLSStream.parse_variant_playlist(self.session, hls_url)

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -376,13 +376,13 @@ class TwitchAPI:
             vodID=channel_or_vod if not is_live else "",
             playerType="embed"
         )
-        subschema = validate.any(None, validate.all(
+        subschema = validate.none_or_all(
             {
                 "value": str,
-                "signature": str
+                "signature": str,
             },
-            validate.union_get("signature", "value")
-        ))
+            validate.union_get("signature", "value"),
+        )
 
         return self.call(query, schema=validate.Schema(
             {"data": validate.any(

--- a/src/streamlink/plugins/useetv.py
+++ b/src/streamlink/plugins/useetv.py
@@ -41,10 +41,8 @@ class UseeTV(Plugin):
                         .//script[contains(text(), 'laylist.m3u8') or contains(text(), 'manifest.mpd')][1]/text()
                     """),
                     str,
-                    validate.transform(
-                        re.compile(r"""(?P<q>['"])(?P<url>https://.*?/(?:[Pp]laylist\.m3u8|manifest\.mpd).+?)(?P=q)""").search
-                    ),
-                    validate.any(None, validate.all(validate.get("url"), validate.url())),
+                    re.compile(r"""(?P<q>['"])(?P<url>https://.*?/(?:[Pp]laylist\.m3u8|manifest\.mpd).+?)(?P=q)"""),
+                    validate.none_or_all(validate.get("url"), validate.url()),
                 ),
                 validate.all(
                     validate.xml_xpath_string(".//video[@id='video-player']/source/@src"),

--- a/src/streamlink/plugins/vlive.py
+++ b/src/streamlink/plugins/vlive.py
@@ -1,5 +1,5 @@
 """
-$description South Korean live streaming social platform with a focus on celebrities.
+$description South Korean live-streaming social platform with a focus on celebrities.
 $url vlive.tv
 $type live
 $notes Embedded Naver VODs are not supported
@@ -19,38 +19,31 @@ log = logging.getLogger(__name__)
     r"https?://www\.vlive\.tv/(?P<format>video|post)/(?P<id>[\d-]+)"
 ))
 class Vlive(Plugin):
-    _page_info = re.compile(r"window\.__PRELOADED_STATE__\s*=\s*({.*})\s*(?:<|,\s*function)", re.DOTALL)
     _playinfo_url = "https://www.vlive.tv/globalv-web/vam-web/old/v3/live/{0}/playInfo"
-
-    _schema_video = validate.Schema(
-        validate.transform(_page_info.search),
-        validate.any(None, validate.all(
-            validate.get(1),
-            validate.parse_json(),
-            validate.any(
-                validate.all(
-                    {"postDetail": {"post": {"officialVideo": {
-                        "type": str,
-                        "videoSeq": int,
-                        validate.optional("status"): str}}}},
-                    validate.get(("postDetail", "post", "officialVideo"))),
-                validate.all(
-                    {"postDetail": {"error": {"errorCode": str}}},
-                    validate.get(("postDetail", "error")),
-                )
-            )
-        ))
-    )
-
-    _schema_stream = validate.Schema(
-        validate.parse_json(),
-        {"result": {"adaptiveStreamUrl": validate.url()}},
-        validate.get(("result", "adaptiveStreamUrl")),
-    )
 
     def _get_streams(self):
         self.session.http.headers.update({"Referer": self.url})
-        video_json = self.session.http.get(self.url, schema=self._schema_video)
+        video_json = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"window\.__PRELOADED_STATE__\s*=\s*({.*})\s*(?:<|,\s*function)", re.DOTALL),
+            validate.none_or_all(
+                validate.get(1),
+                validate.parse_json(),
+                validate.any(
+                    validate.all(
+                        {"postDetail": {"post": {"officialVideo": {
+                            "type": str,
+                            "videoSeq": int,
+                            validate.optional("status"): str,
+                        }}}},
+                        validate.get(("postDetail", "post", "officialVideo")),
+                    ),
+                    validate.all(
+                        {"postDetail": {"error": {"errorCode": str}}},
+                        validate.get(("postDetail", "error")),
+                    ),
+                ),
+            ),
+        ))
         if video_json is None:
             log.error('Could not parse video page')
             return
@@ -87,7 +80,12 @@ class Vlive(Plugin):
 
         stream_url = self.session.http.get(
             self._playinfo_url.format(video_id),
-            schema=self._schema_stream)
+            schema=validate.Schema(
+                validate.parse_json(),
+                {"result": {"adaptiveStreamUrl": validate.url()}},
+                validate.get(("result", "adaptiveStreamUrl")),
+            ),
+        )
         return HLSStream.parse_variant_playlist(self.session, stream_url).items()
 
 

--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -15,46 +15,47 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r'https?://vtvgo\.vn/xem-truc-tuyen-kenh-'
+    r"https?://vtvgo\.vn/xem-truc-tuyen-kenh-"
 ))
 class VTVgo(Plugin):
-    AJAX_URL = 'https://vtvgo.vn/ajax-get-stream'
-
-    _params_re = re.compile(r'''var\s+(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;''')
-
-    _schema_params = validate.Schema(
-        validate.parse_html(),
-        validate.xml_xpath_string(".//script[contains(text(),'setplayer(')][1]/text()"),
-        validate.any(None, validate.all(
-            str,
-            validate.transform(_params_re.findall),
-            [
-                ("id", int),
-                ("type_id", str),
-                ("time", str),
-                ("token", str)
-            ]
-        ))
-    )
-    _schema_stream_url = validate.Schema(
-        validate.parse_json(),
-        {"stream_url": [validate.url()]},
-        validate.get("stream_url"),
-        validate.get(0)
-    )
+    AJAX_URL = "https://vtvgo.vn/ajax-get-stream"
 
     def _get_streams(self):
         self.session.http.headers.update({
-            'Origin': 'https://vtvgo.vn',
-            'Referer': self.url,
-            'X-Requested-With': 'XMLHttpRequest',
+            "Origin": "https://vtvgo.vn",
+            "Referer": self.url,
+            "X-Requested-With": "XMLHttpRequest",
         })
-        params = self.session.http.get(self.url, schema=self._schema_params)
+
+        params = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath_string(".//script[contains(text(),'setplayer(')][1]/text()"),
+            validate.none_or_all(
+                validate.regex(
+                    re.compile(r"""var\s+(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;"""),
+                    method="findall",
+                ),
+                [
+                    ("id", int),
+                    ("type_id", str),
+                    ("time", str),
+                    ("token", str),
+                ],
+            ),
+        ))
         if not params:
             return
 
         log.trace(f"{params!r}")
-        hls_url = self.session.http.post(self.AJAX_URL, data=dict(params), schema=self._schema_stream_url)
+        hls_url = self.session.http.post(
+            self.AJAX_URL,
+            data=dict(params),
+            schema=validate.Schema(
+                validate.parse_json(),
+                {"stream_url": [validate.url()]},
+                validate.get(("stream_url", 0)),
+            ),
+        )
 
         return HLSStream.parse_variant_playlist(self.session, hls_url)
 

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -45,7 +45,6 @@ log = logging.getLogger(__name__)
 class YouTube(Plugin):
     _re_ytInitialData = re.compile(r"""var\s+ytInitialData\s*=\s*({.*?})\s*;\s*</script>""", re.DOTALL)
     _re_ytInitialPlayerResponse = re.compile(r"""var\s+ytInitialPlayerResponse\s*=\s*({.*?});\s*var\s+\w+\s*=""", re.DOTALL)
-    _re_mime_type = re.compile(r"""^(?P<type>\w+)/(?P<container>\w+); codecs="(?P<codecs>.+)"$""")
 
     _url_canonical = "https://www.youtube.com/watch?v={video_id}"
     _url_channelid_live = "https://www.youtube.com/channel/{channel_id}/live"
@@ -210,7 +209,7 @@ class YouTube(Plugin):
                         "itag": int,
                         "mimeType": validate.all(
                             str,
-                            validate.transform(cls._re_mime_type.search),
+                            validate.regex(re.compile(r"""^(?P<type>\w+)/(?P<container>\w+); codecs="(?P<codecs>.+)"$""")),
                             validate.union_get("type", "codecs"),
                         ),
                         validate.optional("url"): validate.url(scheme="http"),


### PR DESCRIPTION
Follow-up of #4691 

These changes only affect plugins where no major changes were needed for fixing and cleaning them up.

Split into two commits. Please see individual diffs and commit messages:

1. Simple validation schema code refactorings
2. Simple validation schema code refactorings where schemas were defined as class attributes

I haven't checked any of these plugins (yet). This is supposed to be a code refactoring, not a plugin fix. However, since I changed some regexes, it might be worth checking some plugins first though before merging, but should there be any issues, it's most likely due to the plugin code being outdated and not because of my changes. In that case, broken plugins need to be fixed in a new PR.

And as mentioned in #4691, plugins which required more changes to the validation schemas or the remaining implementation will be submitted in separate PRs later. Those for example will include changes from regexes to XPath queries, or other rewrites.

----

Btw, after reviewing the diff of this PR before submitting it, I realized that `validate.all(re.Pattern, re.Match)` is probably not ideal in terms of the error messages that get shown when the regex doesn't match and returns `None` (so that the `re.Match` type doesn't validate). A better solution would be adding a `RegexSchema` where the regex has to match and where better error messages can be shown. However, that can be implemented and changed in the plugins later on.