### PR TITLE
plugins.ard_mediathek: fix plugin

### DIFF
--- a/tests/plugins/test_ard_mediathek.py
+++ b/tests/plugins/test_ard_mediathek.py
@@ -5,12 +5,35 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlARDMediathek(PluginCanHandleUrl):
     __plugin__ = ARDMediathek
 
-    should_match = [
-        'http://mediathek.daserste.de/live',
-        'http://www.ardmediathek.de/tv/Sportschau/'
-    ]
-
-    should_not_match = [
-        'https://daserste.de/live/index.html',
-        'https://www.daserste.de/live/index.html',
+    should_match_groups = [
+        (
+            "https://www.ardmediathek.de/live/"
+            + "Y3JpZDovL2Rhc2Vyc3RlLmRlL2xpdmUvY2xpcC9hYmNhMDdhMy0zNDc2LTQ4NTEtYjE2Mi1mZGU4ZjY0NmQ0YzQ",
+            {"id_live": "Y3JpZDovL2Rhc2Vyc3RlLmRlL2xpdmUvY2xpcC9hYmNhMDdhMy0zNDc2LTQ4NTEtYjE2Mi1mZGU4ZjY0NmQ0YzQ"},
+        ),
+        (
+            "https://www.ardmediathek.de/live/"
+            + "Y3JpZDovL2Rhc2Vyc3RlLmRlL2xpdmUvY2xpcC9hYmNhMDdhMy0zNDc2LTQ4NTEtYjE2Mi1mZGU4ZjY0NmQ0YzQ?toolbarType=default",
+            {"id_live": "Y3JpZDovL2Rhc2Vyc3RlLmRlL2xpdmUvY2xpcC9hYmNhMDdhMy0zNDc2LTQ4NTEtYjE2Mi1mZGU4ZjY0NmQ0YzQ"},
+        ),
+        (
+            "https://www.ardmediathek.de/live/tagesschau24/"
+            + "Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2Vzc2NoYXUvbGl2ZXN0cmVhbQ",
+            {"id_live": "Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2Vzc2NoYXUvbGl2ZXN0cmVhbQ"},
+        ),
+        (
+            "https://www.ardmediathek.de/video/"
+            + "Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2Vzc2NoYXUvOWE4NGIzODgtZDEzNS00ZWU0LWI4ODEtZDYyNTQzYjg3ZmJlLzE",
+            {"id_video": "Y3JpZDovL2Rhc2Vyc3RlLmRlL3RhZ2Vzc2NoYXUvOWE4NGIzODgtZDEzNS00ZWU0LWI4ODEtZDYyNTQzYjg3ZmJlLzE"},
+        ),
+        (
+            "https://www.ardmediathek.de/video/arte/blackfish-der-killerwal/arte/"
+            + "Y3JpZDovL2FydGUudHYvdmlkZW9zLzA1MDMyNy0wMDAtQQ",
+            {"id_video": "Y3JpZDovL2FydGUudHYvdmlkZW9zLzA1MDMyNy0wMDAtQQ"},
+        ),
+        (
+            "https://www.ardmediathek.de/video/expeditionen-ins-tierreich/die-revolte-der-schimpansen/ndr/"
+            + "Y3JpZDovL25kci5kZS9jY2E3M2MzZS00ZTljLTRhOWItODE3MC05MjhjM2MwNWEyMDM?toolbarType=default",
+            {"id_video": "Y3JpZDovL25kci5kZS9jY2E3M2MzZS00ZTljLTRhOWItODE3MC05MjhjM2MwNWEyMDM"},
+        ),
     ]


### PR DESCRIPTION
Fixes #4687 

This doesn't fully fix the plugin, because some HLS streams (most live TV streams and some VODs) are using external [packed audio](https://www.rfc-editor.org/rfc/rfc8216.html#section-3.4) streams, which Streamlink currently does not support. Raw ADTS segments with ID3 metadata will be concatenated by Streamlink's HLS implementation and the data gets piped into FFmpeg, which it does not understand, so there's no output stream when trying to mux the video and audio streams. This is however not related to the plugin, and a separate issue needs to be opened for that.