### PR TITLE
plugins.huajiao: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/huajiao.py
+++ b/src/streamlink/plugins/huajiao.py
@@ -1,11 +1,10 @@
 """
-$description Chinese live streaming platform for live video game broadcasts and individual live streams.
+$description Chinese live-streaming platform for live video game broadcasts and individual live streams.
 $url huajiao.com
 $type live
 """
 
 import base64
-import json
 import random
 import re
 import time
@@ -13,52 +12,77 @@ import uuid
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.plugin.api.useragents import CHROME as USER_AGENT
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
 
-HUAJIAO_URL = "http://www.huajiao.com/l/{}"
-LAPI_URL = "http://g2.live.360.cn/liveplay?stype=flv&channel={}&bid=huajiao&sn={}&sid={}&_rate=xd&ts={}&r={}" \
-           "&_ostype=flash&_delay=0&_sign=null&_ver=13"
-
-_feed_json_re = re.compile(r'^\s*var\s*feed\s*=\s*(?P<feed>{.*})\s*;', re.MULTILINE)
-
-_feed_json_schema = validate.Schema(
-    validate.all(
-        validate.transform(_feed_json_re.search),
-        validate.any(
-            None,
-            validate.all(
-                validate.get('feed'),
-                validate.transform(json.loads)
-            )
-        )
-    )
-)
-
 
 @pluginmatcher(re.compile(
-    r"https?://(www\.)?huajiao\.com/l/(?P<channel>[^/]+)"
+    r"https?://(?:www\.)?huajiao\.com/l/(?P<channel>[^/]+)"
 ))
 class Huajiao(Plugin):
+    URL_LAPI = "https://g2.live.360.cn/liveplay"
+
     def _get_streams(self):
-        channel = self.match.group("channel")
+        data = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                re.compile(r"var\s*feed\s*=\s*(?P<feed>{.+?})\s*;", re.DOTALL),
+                validate.none_or_all(
+                    validate.get("feed"),
+                    validate.parse_json(),
+                    {
+                        "author": {
+                            "nickname": str,
+                        },
+                        "feed": {
+                            "title": str,
+                            "game": str,
+                            "m3u8": validate.any("", validate.url()),
+                            "sn": str,
+                        },
+                        "relay": {
+                            "channel": str,
+                        },
+                    },
+                    validate.union_get(
+                        ("author", "nickname"),
+                        ("feed", "title"),
+                        ("feed", "game"),
+                        ("feed", "m3u8"),
+                        ("feed", "sn"),
+                        ("relay", "channel"),
+                    ),
+                ),
+            ),
+        )
+        if not data:
+            return
 
-        self.session.http.headers.update({"User-Agent": USER_AGENT})
-        self.session.http.verify = False
+        self.author, self.title, self.category, m3u8, sn, channel_sid = data
 
-        feed_json = self.session.http.get(HUAJIAO_URL.format(channel), schema=_feed_json_schema)
-        if feed_json['feed']['m3u8']:
-            stream = HLSStream(self.session, feed_json['feed']['m3u8'])
-        else:
-            sn = feed_json['feed']['sn']
-            channel_sid = feed_json['relay']['channel']
-            sid = uuid.uuid4().hex.upper()
-            encoded_json = self.session.http.get(LAPI_URL.format(channel_sid, sn, sid, time.time(), random.random())).content
-            decoded_json = base64.decodestring(encoded_json[0:3] + encoded_json[6:]).decode('utf-8')
-            video_data = json.loads(decoded_json)
-            stream = HTTPStream(self.session, video_data['main'])
-        yield "live", stream
+        if m3u8:
+            return HLSStream(self.session, m3u8)
+
+        stream_url = self.session.http.get(
+            self.URL_LAPI,
+            params={
+                "stype": "flv",
+                "channel": channel_sid,
+                "bid": "huajiao",
+                "sn": sn,
+                "sid": uuid.uuid4().hex.upper(),
+                "_rate": "xd",
+                "ts": time.time(),
+                "r": random.random(),
+            },
+            schema=validate.Schema(
+                validate.transform(lambda text: base64.b64decode(text[0:3] + text[6:]).decode("utf-8")),
+                validate.parse_json(),
+                {"main": validate.url()},
+                validate.get("main"),
+            ),
+        )
+        return {"live": HTTPStream(self.session, stream_url)}
 
 
 __plugin__ = Huajiao

--- a/tests/plugins/test_huajiao.py
+++ b/tests/plugins/test_huajiao.py
@@ -6,5 +6,6 @@ class TestPluginCanHandleUrlHuajiao(PluginCanHandleUrl):
     __plugin__ = Huajiao
 
     should_match = [
-        'http://www.huajiao.com/l/123123123',
+        "http://www.huajiao.com/l/123123123",
+        "https://www.huajiao.com/l/123123123",
     ]


### PR DESCRIPTION
Not sure how relevant this plugin actually is. It's been using an old and long-time deprecated base64 decoding API which was removed from the standard library in 3.9, so everyone trying to open streams using those python versions would see an error, and there haven't been any plugin issue reports.

https://docs.python.org/3/whatsnew/3.9.html
> base64.encodestring() and base64.decodestring(), aliases deprecated since Python 3.1, have been removed

----

Apparently, there are also HLS URLs in the "feed" data, but I haven't seen any of those. The website does use HTTP video streams, and so does the plugin when trying to access a stream. I kept it though, just in case. And I also upgraded the plugin to HTTPS and removed the verify=false option on the session.