### PR TITLE
plugin.api.validate: fix pattern input type

### DIFF
--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -137,7 +137,7 @@ def _validate_callable(schema: abc.Callable, value):
 
 @validate.register
 def _validate_pattern(schema: Pattern, value):
-    if type(value) not in (str, bytes):
+    if not isinstance(value, (str, bytes)):
         raise ValidationError(
             "Type of {value} should be str or bytes, but is {actual}",
             value=repr(value),

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -278,6 +278,16 @@ class TestPattern:
         assert type(result) is re.Match
         assert result.groupdict() == expected
 
+    def test_stringsubclass(self):
+        assert validate.validate(
+            validate.all(
+                validate.xml_xpath_string(".//@bar"),
+                re.compile(r".+"),
+                validate.get(0),
+            ),
+            Element("foo", {"bar": "baz"}),
+        ) == "baz"
+
     def test_failure(self):
         assert validate.validate(re.compile(r"foo"), "bar") is None
 


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/pull/4702#issuecomment-1206106699

`re.Pattern` validations should accept any kind of subclass instances of `str` or `bytes`, like [`xml.etree._ElementUnicodeResult`](https://lxml.de/api/lxml.etree._ElementUnicodeResult-class.html) for example, which is the result of XPath queries when returning an element attribute value, text or tail.