### PR TITLE
plugin.api.validate: add RegexSchema

### DIFF
--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -6,6 +6,7 @@ from streamlink.plugin.api.validate._schemas import (  # noqa: I101, F401
     AnySchema as any,
     NoneOrAllSchema as none_or_all,
     ListSchema as list,
+    RegexSchema as regex,
     TransformSchema as transform,
     OptionalSchema as optional,
     GetItemSchema as get,

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, FrozenSet, List, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, FrozenSet, List, Optional, Pattern, Sequence, Set, Tuple, Type, Union
 
 
 class SchemaContainer:
@@ -61,6 +61,21 @@ class GetItemSchema:
         self.item = item
         self.default = default
         self.strict = strict
+
+
+class RegexSchema:
+    """
+    A regex pattern that must match using the provided method.
+    """
+
+    def __init__(
+        self,
+        pattern: Pattern,
+        # TODO: change type from str to Literal["search", "match", "fullmatch", "findall", "split", "sub", "subn"]
+        method: str = "search",
+    ):
+        self.pattern = pattern
+        self.method = method
 
 
 class TransformSchema:

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -462,6 +462,47 @@ class TestListSchema:
         """)
 
 
+class TestRegexSchema:
+    @pytest.mark.parametrize("pattern,data,expected", [
+        (r"\s(?P<bar>\S+)\s", "foo bar baz", {"bar": "bar"}),
+        (rb"\s(?P<bar>\S+)\s", b"foo bar baz", {"bar": b"bar"}),
+    ])
+    def test_success(self, pattern, data, expected):
+        result = validate.validate(validate.regex(re.compile(pattern)), data)
+        assert type(result) is re.Match
+        assert result.groupdict() == expected
+
+    def test_findall(self):
+        assert validate.validate(validate.regex(re.compile(r"\w+"), "findall"), "foo bar baz") == ["foo", "bar", "baz"]
+
+    def test_split(self):
+        assert validate.validate(validate.regex(re.compile(r"\s+"), "split"), "foo bar baz") == ["foo", "bar", "baz"]
+
+    def test_failure(self):
+        with pytest.raises(validate.ValidationError) as cm:
+            validate.validate(validate.regex(re.compile(r"foo")), "bar")
+        assert_validationerror(cm.value, """
+            ValidationError(RegexSchema):
+              Pattern 'foo' did not match 'bar'
+        """)
+
+    def test_failure_type(self):
+        with pytest.raises(validate.ValidationError) as cm:
+            validate.validate(validate.regex(re.compile(r"foo")), b"foo")
+        assert_validationerror(cm.value, """
+            ValidationError(RegexSchema):
+              cannot use a string pattern on a bytes-like object
+        """)
+
+    def test_failure_schema(self):
+        with pytest.raises(validate.ValidationError) as cm:
+            validate.validate(validate.regex(re.compile(r"foo")), 123)
+        assert_validationerror(cm.value, """
+            ValidationError(RegexSchema):
+              Type of 123 should be str or bytes, but is int
+        """)
+
+
 class TestTransformSchema:
     def test_success(self):
         def callback(string: str, *args, **kwargs):


### PR DESCRIPTION
Follow-up of #4691 / #4708

As mentioned in https://github.com/streamlink/streamlink/pull/4702#issue-1329216134, non-optional regexes currently don't raise useful error messages when a simple `re.Pattern` or `validate.transform(re.Pattern.search)` validation is made. The `RegexSchema` raises a `ValidationError` with a proper error message if the return value is `None`. See the added tests.

`validate.regex` (`RegexSchema`) also takes a second parameter which changes the method that's called on the compiled regex pattern. This is useful for calling `re.Pattern.findall` for example.