### PR TITLE
plugin.api.http_session: suppress type error

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -39,7 +39,7 @@ class _HTTPResponse(urllib3.response.HTTPResponse):
 
 # override all urllib3.response.HTTPResponse references in requests.adapters.HTTPAdapter.send
 urllib3.connectionpool.HTTPConnectionPool.ResponseCls = _HTTPResponse  # type: ignore[attr-defined]
-requests.adapters.HTTPResponse = _HTTPResponse
+requests.adapters.HTTPResponse = _HTTPResponse  # type: ignore[misc]
 
 
 # Never convert percent-encoded characters to uppercase in urllib3>=1.25.4.


### PR DESCRIPTION
This fixes the [new typing error](https://github.com/streamlink/streamlink/runs/7702581070?check_suite_focus=true#step:5:8)
> src/streamlink/plugin/api/http_session.py:42:1: error: Cannot assign to a type  [misc]

which is caused by an upgrade of the `types-requests` package:
https://github.com/python/typeshed/commit/3e88363b34f916ab816c3f7ed5a79c1620f9deee