### PR TITLE
plugins.picarto: Fix streams and VODs

### DIFF
--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -34,7 +34,8 @@ class Picarto(Plugin):
 
     def get_live(self, username):
         channel, multistreams, loadbalancer = self.session.http.get(
-            self.API_URL_LIVE.format(username=username), schema=validate.Schema(
+            self.API_URL_LIVE.format(username=username),
+            schema=validate.Schema(
                 validate.parse_json(),
                 {
                     "channel": validate.any(None, {

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -104,7 +104,7 @@ class Picarto(Plugin):
             validate.parse_json(),
             {"data": {
                 "video": validate.any(None, {
-                    "id": str,
+                    "id": int,
                     "title": str,
                     "file_name": str,
                     "video_recording_image_url": str,

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -33,29 +33,31 @@ class Picarto(Plugin):
     HLS_URL = "https://{netloc}/stream/hls/{file_name}/index.m3u8"
 
     def get_live(self, username):
-        channel, multistreams, loadbalancer = self.session.http.get(self.API_URL_LIVE.format(username=username), schema=validate.Schema(
-            validate.parse_json(),
-            {
-                "channel": validate.any(None, {
-                    "stream_name": str,
-                    "title": str,
-                    "online": bool,
-                    "private": bool,
-                    "categories": [{"label": str}],
-                }),
-                "getMultiStreams": validate.any(None, {
-                    "multistream": bool,
-                    "streams": [{
-                        "name": str,
+        channel, multistreams, loadbalancer = self.session.http.get(
+            self.API_URL_LIVE.format(username=username), schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "channel": validate.any(None, {
+                        "stream_name": str,
+                        "title": str,
                         "online": bool,
-                    }],
-                }),
-                "getLoadBalancerUrl": validate.any(None, {
-                    "url": validate.any(None, validate.transform(lambda url: urlparse(url).netloc))
-                })
-            },
-            validate.union_get("channel", "getMultiStreams", "getLoadBalancerUrl"),
-        ))
+                        "private": bool,
+                        "categories": [{"label": str}],
+                    }),
+                    "getMultiStreams": validate.any(None, {
+                        "multistream": bool,
+                        "streams": [{
+                            "name": str,
+                            "online": bool,
+                        }],
+                    }),
+                    "getLoadBalancerUrl": validate.any(None, {
+                        "url": validate.any(None, validate.transform(lambda url: urlparse(url).netloc))
+                    })
+                },
+                validate.union_get("channel", "getMultiStreams", "getLoadBalancerUrl"),
+            )
+        )
         if not channel or not multistreams or not loadbalancer:
             log.debug("Missing channel or streaming data")
             return


### PR DESCRIPTION
For streams it looks like the page no longer includes the player JS used to read the stream server URL when loading the page without JS enabled. However it is included in the already existing call to the private API.

For VODs it seems to just complain about the type of the video ID.

Tested with some random streams.

Resolves #4727.

Before:
```
# Stream
streamlink https://picarto.tv/Noxcuro best
[cli][info] Found matching plugin picarto for URL https://picarto.tv/Noxcuro
[plugins.picarto][error] Could not find server netloc
error: No playable streams found on this URL: https://picarto.tv/Noxcuro

#VOD
streamlink https://picarto.tv/sate/videos/681901
[cli][info] Found matching plugin picarto for URL https://picarto.tv/sate/videos/681901
error: Unable to validate response text: ValidationError(dict):
  Unable to validate value of key 'data'
  Context(dict):
    Unable to validate value of key 'video'
    Context(AnySchema):
      ValidationError(equality):
        <{'id': 681901, 'title': 'tropical depression stream', '...> does not equal None
      ValidationError(dict):
        Unable to validate value of key 'id'
        Context(type):
          Type of 681901 should be str, but is int
```

After:
```
#Stream
streamlink https://picarto.tv/Noxcuro
[cli][info] Found matching plugin picarto for URL https://picarto.tv/Noxcuro
Available streams: 478p (worst), 720p (best)

#VOD
streamlink https://picarto.tv/sate/videos/681901
[cli][info] Found matching plugin picarto for URL https://picarto.tv/sate/videos/681901
Available streams: 1080p (worst, best)
```