### PR TITLE
plugin.api.validate: rework XML validators

### DIFF
--- a/src/streamlink/plugin/api/validate/_validators.py
+++ b/src/streamlink/plugin/api/validate/_validators.py
@@ -1,7 +1,7 @@
-from typing import Any, Callable
+from typing import Any, Callable, Dict, Optional, Tuple
 from urllib.parse import urlparse
 
-from lxml.etree import iselement
+from lxml.etree import XPathError, iselement
 
 from streamlink.plugin.api.validate._exception import ValidationError
 from streamlink.plugin.api.validate._schemas import AllSchema, AnySchema, TransformSchema
@@ -210,68 +210,123 @@ def validator_map(func: Callable[..., Any]) -> TransformSchema:
 # lxml.etree related validators
 
 
-def validator_xml_find(xpath: str) -> TransformSchema:
+def validator_xml_find(
+    path: str,
+    namespaces: Optional[Dict[str, str]] = None,
+) -> TransformSchema:
     """
-    Find an XML element via xpath (:meth:`Element.find`).
+    Find an XML element (:meth:`Element.find`).
+    This method uses the ElementPath query language, which is a subset of XPath.
     """
 
     def xpath_find(value):
         validate(iselement, value)
-        value = value.find(xpath)
+
+        try:
+            value = value.find(path, namespaces=namespaces)
+        except SyntaxError as err:
+            raise ValidationError(
+                "ElementPath syntax error: {path}",
+                path=repr(path),
+                schema="xml_find",
+                context=err,
+            )
+
         if value is None:
             raise ValidationError(
-                "XPath {xpath} did not return an element",
-                xpath=repr(xpath),
+                "ElementPath query {path} did not return an element",
+                path=repr(path),
                 schema="xml_find",
             )
 
-        return validate(iselement, value)
+        return value
 
     return TransformSchema(xpath_find)
 
 
-def validator_xml_findall(xpath) -> TransformSchema:
+def validator_xml_findall(
+    path: str,
+    namespaces: Optional[Dict[str, str]] = None,
+) -> TransformSchema:
     """
-    Find a list of XML elements via xpath.
+    Find a list of XML elements (:meth:`Element.findall`).
+    This method uses the ElementPath query language, which is a subset of XPath.
     """
 
     def xpath_findall(value):
         validate(iselement, value)
-        return value.findall(xpath)
+        return value.findall(path, namespaces=namespaces)
 
     return TransformSchema(xpath_findall)
 
 
-def validator_xml_findtext(xpath) -> AllSchema:
+def validator_xml_findtext(
+    path: str,
+    namespaces: Optional[Dict[str, str]] = None,
+) -> AllSchema:
     """
-    Find an XML element via xpath and extract its text.
+    Find an XML element (:meth:`Element.find`) and return its text.
+    This method uses the ElementPath query language, which is a subset of XPath.
     """
 
     return AllSchema(
-        validator_xml_find(xpath),
+        validator_xml_find(path, namespaces=namespaces),
         validator_getattr("text"),
     )
 
 
-def validator_xml_xpath(xpath) -> TransformSchema:
+def validator_xml_xpath(
+    xpath: str,
+    namespaces: Optional[Dict[str, str]] = None,
+    extensions: Optional[Dict[Tuple[Optional[str], str], Callable[..., Any]]] = None,
+    smart_strings: bool = True,
+    **variables,
+) -> TransformSchema:
     """
-    Query XML elements via xpath (:meth:`Element.xpath`) and return None if the result is falsy.
+    Query XML elements via XPath (:meth:`Element.xpath`) and return None if the result is falsy.
     """
 
     def transform_xpath(value):
         validate(iselement, value)
-        return value.xpath(xpath) or None
+        try:
+            result = value.xpath(
+                xpath,
+                namespaces=namespaces,
+                extensions=extensions,
+                smart_strings=smart_strings,
+                **variables,
+            )
+        except XPathError as err:
+            raise ValidationError(
+                "XPath evaluation error: {xpath}",
+                xpath=repr(xpath),
+                schema="xml_xpath",
+                context=err,
+            )
+
+        return result or None
 
     return TransformSchema(transform_xpath)
 
 
-def validator_xml_xpath_string(xpath) -> TransformSchema:
+def validator_xml_xpath_string(
+    xpath: str,
+    namespaces: Optional[Dict[str, str]] = None,
+    extensions: Optional[Dict[Tuple[Optional[str], str], Callable[..., Any]]] = None,
+    **variables,
+) -> TransformSchema:
     """
-    Query XML elements via xpath (:meth:`Element.xpath`),
+    Query XML elements via XPath (:meth:`Element.xpath`),
     transform the result into a string and return None if the result is falsy.
     """
 
-    return validator_xml_xpath(f"string({xpath})")
+    return validator_xml_xpath(
+        f"string({xpath})",
+        namespaces=namespaces,
+        extensions=extensions,
+        smart_strings=False,
+        **variables,
+    )
 
 
 # Parse utility related validators

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -44,7 +44,7 @@ class DeutscheWelle(Plugin):
                 # find the video element of the selected channel ID first
                 # node-sets are always ordered by the document order, so these queries can't be merged into one
                 validate.all(
-                    validate.xml_xpath(f".//video[../@data-channel-id='{channel}'][1]"),
+                    validate.xml_xpath(".//video[../@data-channel-id=$channel][1]", channel=channel),
                     # validate.xml_element() can't be used here, because it discards parent nodes of the cloned return value
                     lambda res: res is not None,
                     validate.get(0),

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -146,7 +146,7 @@ class Experience:
     def login_csrf(self):
         return self.session.http.get(self.login_url, schema=validate.Schema(
             validate.parse_html(),
-            validate.xml_xpath_string(f".//input[@name='{self.CSRF_NAME}'][1]/@value")
+            validate.xml_xpath_string(".//input[@name=$name][1]/@value", name=self.CSRF_NAME)
         ))
 
     def login(self, email, password):

--- a/src/streamlink/plugins/mdstrm.py
+++ b/src/streamlink/plugins/mdstrm.py
@@ -35,7 +35,8 @@ class MDStrm(Plugin):
             pattern = fr"{search_string}\s*=\s*'([^']+)';"
         _schema = validate.Schema(
             validate.xml_xpath_string(
-                f".//script[@type='text/javascript'][contains(text(),'{search_string}')]/text()",
+                ".//script[@type='text/javascript'][contains(text(),$search_string)]/text()",
+                search_string=search_string,
             ),
             validate.none_or_all(
                 re.compile(pattern),

--- a/src/streamlink/plugins/useetv.py
+++ b/src/streamlink/plugins/useetv.py
@@ -22,15 +22,15 @@ class UseeTV(Plugin):
 
         for needle, errormsg in (
             (
-                "This service is not available in your Country",
+                "\"This service is not available in your Country\"",
                 "The content is not available in your region",
             ),
             (
-                "Silahkan login Menggunakan akun MyIndihome dan berlangganan minipack",
+                "\"Silahkan login Menggunakan akun MyIndihome dan berlangganan minipack\"",
                 "The content is not available without a subscription",
             ),
         ):
-            if validate.Schema(validate.xml_xpath(f""".//script[contains(text(), '"{needle}"')]""")).validate(root):
+            if validate.Schema(validate.xml_xpath(".//script[contains(text(),$needle)]", needle=needle)).validate(root):
                 log.error(errormsg)
                 return
 


### PR DESCRIPTION
- Add supported `Element.xpath()` keywords to `validate.xml_xpath()`
  - `namespaces` for defining prefix-namespace mappings
  - `extensions` for defining custom XPath functions in Python
  - `smart_strings` for disabling element tree references on any string
     return values that will be kept in memory
  - `**variables` for being able to define custom XPath variables
    instead of having to embed strings in the XPath query itself
- Add `namespaces`, `extensions` and `**variables` keywords to
  `validate.xml_xpath_string()` and always disable `smart_strings`
- Add `namespaces` to `validate.xml_find()`, `validate.xml_findall()`
  and `validate.xml_findtext()`
- Handle XPath evaluation errors via `lxml.etree.XPathError`
  and ElementPath syntax errors via `SyntaxError`
- Update error messages of ElementPath-based validators
- Remove unneeded `iselement` validation at the end of `xml_find()`
- Fix docstrings of both XPath- and ElementPath-based validators
- Add tests for the newly added keywords and XPath evaluation errors

----

The main intention of this PR is adding support for variables in XPath queries, hence the plugin changes included in the second commit. Since that required adding a keyword dict to the XPath validators, I decided to add the missing options to all the XML validators, even if it's probably not that useful, like namespaces, extensions and smart_strings. Having disabled smart_strings on `xml_xpath_string` is a nice optimization though. The changes also fix some docstring issues. See the added tests for clarification of all the changes.