### PR TITLE
cli: implement --player-external-http-continuous

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -482,12 +482,31 @@ def build_parser():
         useful to allow external devices like smartphones or streaming boxes to
         watch streams they wouldn't be able to otherwise.
 
-        Behavior will be similar to the continuous HTTP option, but no player
-        program will be started, and the server will listen on all available
+        The default behavior is similar to the --player-continuous-http option,
+        but no player program will be started, and the server will listen on all available
         connections instead of just in the local (loopback) interface.
+
+        Optionally, the --player-external-http-continuous option allows for disabling
+        the continuous run-mode, so that Streamlink will stop when the stream ends.
 
         The URLs that can be used to access the stream will be printed to the
         console, and the server can be interrupted using CTRL-C.
+        """
+    )
+    player.add_argument(
+        "--player-external-http-continuous",
+        type=boolean,
+        metavar="{yes,true,1,on,no,false,0,off}",
+        default=True,
+        help="""
+        Set the run-mode of --player-external-http to continuous or non-continuous.
+
+        In the continuous run-mode, Streamlink will keep running after the stream has ended
+        and will wait for the next HTTP request being made unless it gets shut down via CTRL-C.
+
+        If set to non-continuous, Streamlink will stop once the stream has ended.
+
+        Default is true.
         """
     )
     player.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -197,6 +197,7 @@ def output_stream_http(
     initial_streams: Dict[str, Stream],
     formatter: Formatter,
     external: bool = False,
+    continuous: bool = True,
     port: int = 0,
 ):
     """Continuously output the stream over HTTP."""
@@ -266,6 +267,9 @@ def output_stream_http(
         if stream_fd and prebuffer:
             log.debug("Writing stream to player")
             read_stream(stream_fd, server, prebuffer, formatter)
+
+        if not continuous:
+            break
 
         server.close(True)
 
@@ -474,8 +478,14 @@ def handle_stream(plugin: Plugin, streams: Dict[str, Stream], stream_name: str) 
                 log.info(f"Opening stream: {stream_name} ({stream_type})")
                 success = output_stream_passthrough(stream, formatter)
             elif args.player_external_http:
-                return output_stream_http(plugin, streams, formatter, external=True,
-                                          port=args.player_external_http_port)
+                return output_stream_http(
+                    plugin,
+                    streams,
+                    formatter,
+                    external=True,
+                    continuous=args.player_external_http_continuous,
+                    port=args.player_external_http_port,
+                )
             elif args.player_continuous_http and not file_output:
                 return output_stream_http(plugin, streams, formatter)
             else:


### PR DESCRIPTION
Resolves #4738 

No tests, because [no tests have ever been written for `output_stream_http()`](https://app.codecov.io/gh/streamlink/streamlink/blob/master/src/streamlink_cli/main.py) or the entire [`streamlink_cli.utils.http_server` module](https://app.codecov.io/gh/streamlink/streamlink/blob/master/src/streamlink_cli/utils/http_server.py).
- https://github.com/streamlink/streamlink/blame/4.3.0/src/streamlink_cli/main.py#L164-L274
- https://github.com/streamlink/streamlink/blame/4.3.0/src/streamlink_cli/utils/http_server.py

----

There are two choices that can be made for implementing the new CLI argument:
1. The current implementation, with `--player-external-http-continuous=bool` requiring a boolean value and affecting the logic of the main argument `--player-external-http`.
   The issue with this is that it's not consistent with the logic of the `--player-http` and `--player-continuous-http` arguments, which are individual arguments. It's also not consistent with the naming scheme (which I just realized), so it probably has to be changed to `--player-external-continuous-http`.
2. Having two individual CLI arguments, `--player-external-http` and `--player-external-http-non-continuous`, similar to `--player-http` and `--player-continuous-http`. As you can see, the default logic of `--player-external-http` already is "continuous", so the second argument name has to be negated, which is not great.

Thoughts?