### PR TITLE
plugins.cbsnews: fix regex, add metadata

### DIFF
--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -1,5 +1,5 @@
 """
-$description 24-hour live streaming world news channel, based in the United States of America.
+$description 24-hour live-streaming world news channel, based in the United States of America.
 $url cbsnews.com
 $type live
 """
@@ -12,32 +12,33 @@ from streamlink.stream.hls import HLSStream
 
 
 @pluginmatcher(re.compile(
-    r"https?://www\.cbsnews\.com/live/"
+    r"https?://(?:www\.)?cbsnews\.com/(?:\w+/)?live/?"
 ))
 class CBSNews(Plugin):
     def _get_streams(self):
-        items = self.session.http.get(self.url, schema=validate.Schema(
-            re.compile(r"CBSNEWS.defaultPayload = (\{.*)"),
+        data = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"CBSNEWS\.defaultPayload\s*=\s*(\{.*?})\s*\n"),
             validate.none_or_all(
                 validate.get(1),
                 validate.parse_json(),
                 {
-                    "items": [
-                        validate.all(
-                            {
-                                "video": validate.url(),
-                                "format": "application/x-mpegURL",
-                            },
-                            validate.get("video"),
-                        ),
-                    ],
+                    "items": [{
+                        "id": str,
+                        "canonicalTitle": str,
+                        "video": validate.url(),
+                        "format": "application/x-mpegURL",
+                    }],
                 },
-                validate.get("items"),
+                validate.get(("items", 0)),
+                validate.union_get("id", "canonicalTitle", "video"),
             ),
         ))
-        if items:
-            for hls_url in items:
-                yield from HLSStream.parse_variant_playlist(self.session, hls_url).items()
+        if not data:
+            return
+
+        self.id, self.title, hls_url = data
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
 
 
 __plugin__ = CBSNews

--- a/tests/plugins/test_cbsnews.py
+++ b/tests/plugins/test_cbsnews.py
@@ -6,9 +6,18 @@ class TestPluginCanHandleUrlCBSNews(PluginCanHandleUrl):
     __plugin__ = CBSNews
 
     should_match = [
-        "https://www.cbsnews.com/live/cbs-sports-hq/",
-        "https://www.cbsnews.com/live/cbsn-local-bay-area/",
+        "https://cbsnews.com/live",
+        "https://cbsnews.com/live/cbs-sports-hq",
+        "https://cbsnews.com/sanfrancisco/live",
+        "https://cbsnews.com/live/",
+        "https://cbsnews.com/live/cbs-sports-hq/",
+        "https://cbsnews.com/sanfrancisco/live/",
         "https://www.cbsnews.com/live/",
+        "https://www.cbsnews.com/live/cbs-sports-hq/",
+        "https://www.cbsnews.com/sanfrancisco/live/",
+        "https://www.cbsnews.com/live/#x",
+        "https://www.cbsnews.com/live/cbs-sports-hq/#x",
+        "https://www.cbsnews.com/sanfrancisco/live/#x",
     ]
 
     should_not_match = [


### PR DESCRIPTION
Resolves #4742 

main news
```
$ streamlink cbsnews.com/live
[cli][info] Found matching plugin cbsnews for URL cbsnews.com/live
Available streams: 180p (worst), 360p_alt, 360p, 540p, 720p_alt, 720p (best)
```

regional news
```
$ streamlink cbsnews.com/losangeles/live
[cli][info] Found matching plugin cbsnews for URL cbsnews.com/losangeles/live
Available streams: 180p (worst), 360p_alt, 360p, 540p, 720p_alt, 720p (best)
```

sports (geo-blocked at HLS segment level, so no checks)
```
$ streamlink cbsnews.com/live/cbs-sports-hq
[cli][info] Found matching plugin cbsnews for URL cbsnews.com/live/cbs-sports-hq
Available streams: 224p (worst), 288p, 360p, 432p, 540p, 720p, 1080p (best)
```