### PR TITLE
plugin: remove user_input_requester from bind()

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -76,7 +76,7 @@ class Streamlink:
             "ffmpeg-start-at-zero": False,
             "mux-subtitles": False,
             "locale": None,
-            "user-input-requester": None
+            "user-input-requester": None,
         })
         if options:
             self.options.update(options)
@@ -200,9 +200,8 @@ class Streamlink:
                                  default: ``system locale``.
 
         user-input-requester     (UserInputRequester) instance of UserInputRequester
-                                 to collect input from the user at runtime. Must be
-                                 set before the plugins are loaded.
-                                 default: ``UserInputRequester``.
+                                 to collect input from the user at runtime.
+                                 default: ``None``.
         ======================== =========================================
         """
 
@@ -446,7 +445,6 @@ class Streamlink:
         """
 
         success = False
-        user_input_requester = self.get_option("user-input-requester")
         for loader, name, ispkg in pkgutil.iter_modules([path]):
             # set the full plugin module name
             module_name = f"streamlink.plugins.{name}"
@@ -460,7 +458,7 @@ class Streamlink:
                 continue
             success = True
             plugin = mod.__plugin__
-            plugin.bind(self, name, user_input_requester)
+            plugin.bind(self, name)
             if plugin.module in self.plugins:
                 log.debug(f"Plugin {plugin.module} is being overridden by {mod.__file__}")
             self.plugins[plugin.module] = plugin

--- a/src/streamlink/user_input.py
+++ b/src/streamlink/user_input.py
@@ -1,0 +1,30 @@
+import abc
+
+
+class UserInputRequester(abc.ABC):
+    """
+    Base Class / Interface for requesting user input
+
+    e.g. from the console
+    """
+    @abc.abstractmethod
+    def ask(self, prompt: str) -> str:
+        """
+        Ask the user for a text input, the input is not sensitive
+        and can be echoed to the user
+
+        :param prompt: message to display when asking for the input
+        :return: the value of the user input
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def ask_password(self, prompt: str) -> str:
+        """
+        Ask the user for a text input, the input _is_ sensitive
+        and should be masked as the user gives the input
+
+        :param prompt: message to display when asking for the input
+        :return: the value of the user input
+        """
+        raise NotImplementedError

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -3,7 +3,7 @@ from getpass import getpass
 from json import dumps
 from typing import Any, Dict, List, Optional, TextIO, Union
 
-from streamlink.plugin.plugin import UserInputRequester
+from streamlink.user_input import UserInputRequester
 from streamlink_cli.utils import JSONEncoder
 
 


### PR DESCRIPTION
- Remove `user_input_requester` from `Plugin.bind()`, don't set it in
  `Session.load_plugins()` and remove `Plugin._user_input_requester`
- Make `Plugin.input_ask{,_password}` read input requester from session
- Move `UserInputRequester` to the new `streamlink.user_input` module,
  turn it into an abstract base class, and update imports
- Fix docstring of `Session.set_option()`
- Rewrite tests

----

In preparation for #4744 
