### PR TITLE
plugin: pluginargument decorator

### DIFF
--- a/docs/ext_plugins.py
+++ b/docs/ext_plugins.py
@@ -77,7 +77,6 @@ class PluginArguments(ast.NodeVisitor, IDatalistItem):
         super().__init__()
         self.pluginname = pluginname
         self.arguments = []
-        self.found = False
         self.visit(pluginast)
 
     def generate(self) -> Iterator[str]:
@@ -107,21 +106,29 @@ class PluginArguments(ast.NodeVisitor, IDatalistItem):
 
         get_string = get_bool
 
-    # loosely find all PluginArgument() calls inside the args list of the first PluginArguments() call
-    # and assume that no plugin is defining arguments incorrectly
-    def visit_Call(self, node: ast.Call) -> None:
-        if getattr(node.func, "id", None) != "PluginArguments" or self.found:
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        for base in node.bases:
+            if not isinstance(base, ast.Name):
+                continue
+            if base.id == "Plugin":
+                break
+        else:
             return
-        self.found = True
-        for arg in node.args:
-            if type(arg) is not ast.Call or getattr(arg.func, "id", None) != "PluginArgument":
+
+        for decorator in node.decorator_list:
+            if (
+                not isinstance(decorator, ast.Call)
+                or not isinstance(decorator.func, ast.Name)
+                or decorator.func.id != "pluginargument"
+                or (len(decorator.args) == 0 and len(decorator.keywords) == 0)
+            ):
                 continue
 
-            if any(self.get_bool(arg.keywords, lambda kw: kw.arg == "is_global", lambda kw: kw.value)):
+            if any(self.get_bool(decorator.keywords, lambda kw: kw.arg == "is_global", lambda kw: kw.value)):
                 continue
 
             custom_name: Optional[str] = next(
-                self.get_string(arg.keywords, lambda kw: kw.arg == "argument_name", lambda kw: kw.value),
+                self.get_string(decorator.keywords, lambda kw: kw.arg == "argument_name", lambda kw: kw.value),
                 None
             )
             if custom_name:
@@ -129,11 +136,11 @@ class PluginArguments(ast.NodeVisitor, IDatalistItem):
                 continue
 
             name: Optional[str] = next(
-                self.get_string(arg.keywords, lambda kw: kw.arg == "name", lambda kw: kw.value),
-                None
+                self.get_string(decorator.keywords, lambda kw: kw.arg == "name", lambda kw: kw.value),
+                None,
             ) or next(
-                self.get_string(arg.args[:1], lambda a: True, lambda a: a),
-                None
+                self.get_string(decorator.args[:1], lambda a: True, lambda a: a),
+                None,
             )
             if name:
                 self.arguments.append(f"{self.pluginname}-{name}")

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence, Union
+from typing import Iterator, Optional, Sequence, Union
 
 
 def _normalise_option_name(name):
@@ -135,12 +135,18 @@ class Arguments:
     """
 
     def __init__(self, *args):
-        self.arguments = dict((arg.name, arg) for arg in args)
+        # keep the initial arguments of the constructor in reverse order (see __iter__())
+        self.arguments = {arg.name: arg for arg in reversed(args)}
 
-    def __iter__(self):
-        return iter(self.arguments.values())
+    def __iter__(self) -> Iterator[Argument]:
+        # iterate in reverse order due to add() being called by multiple pluginargument decorators in reverse order
+        # TODO: Python 3.7 removal: remove list()
+        return reversed(list(self.arguments.values()))
 
-    def get(self, name):
+    def add(self, argument: Argument) -> None:
+        self.arguments[argument.name] = argument
+
+    def get(self, name: str) -> Optional[Argument]:
         return self.arguments.get(name)
 
     def requires(self, name):

--- a/src/streamlink/plugin/__init__.py
+++ b/src/streamlink/plugin/__init__.py
@@ -1,9 +1,17 @@
 from streamlink.exceptions import PluginError
 from streamlink.options import Argument as PluginArgument, Arguments as PluginArguments, Options as PluginOptions
-from streamlink.plugin.plugin import HIGH_PRIORITY, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, Plugin, pluginmatcher
+from streamlink.plugin.plugin import (
+    HIGH_PRIORITY,
+    LOW_PRIORITY,
+    NORMAL_PRIORITY,
+    NO_PRIORITY,
+    Plugin,
+    pluginargument,
+    pluginmatcher,
+)
 
 __all__ = [
     "HIGH_PRIORITY", "NORMAL_PRIORITY", "LOW_PRIORITY", "NO_PRIORITY",
     "Plugin", "PluginArguments", "PluginArgument", "PluginError", "PluginOptions",
-    "pluginmatcher",
+    "pluginmatcher", "pluginargument",
 ]

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -4,13 +4,13 @@ import operator
 import re
 import time
 from functools import partial
-from typing import Any, Callable, ClassVar, Dict, List, Match, NamedTuple, Optional, Pattern, Sequence, Type
+from typing import Any, Callable, ClassVar, Dict, List, Match, NamedTuple, Optional, Pattern, Sequence, Type, Union
 
 import requests.cookies
 
 from streamlink.cache import Cache
 from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
-from streamlink.options import Arguments, Options
+from streamlink.options import Argument, Arguments, Options
 from streamlink.user_input import UserInputRequester
 
 
@@ -571,8 +571,44 @@ def pluginmatcher(pattern: Pattern, priority: int = NORMAL_PRIORITY) -> Callable
     return decorator
 
 
+def pluginargument(
+    name: str,
+    required: bool = False,
+    requires: Optional[Union[str, Sequence[str]]] = None,
+    prompt: Optional[str] = None,
+    sensitive: bool = False,
+    argument_name: Optional[str] = None,
+    dest: Optional[str] = None,
+    is_global: bool = False,
+    **options,
+):
+    arg = Argument(
+        name,
+        required=required,
+        requires=requires,
+        prompt=prompt,
+        sensitive=sensitive,
+        argument_name=argument_name,
+        dest=dest,
+        is_global=is_global,
+        **options,
+    )
+
+    def decorator(cls: Type[Plugin]) -> Type[Plugin]:
+        if not issubclass(cls, Plugin):
+            raise TypeError(f"{repr(cls)} is not a Plugin")
+        if cls.arguments is None:
+            cls.arguments = Arguments()
+        cls.arguments.add(arg)
+
+        return cls
+
+    return decorator
+
+
 __all__ = [
     "HIGH_PRIORITY", "NORMAL_PRIORITY", "LOW_PRIORITY", "NO_PRIORITY",
     "Plugin",
     "Matcher", "pluginmatcher",
+    "pluginargument",
 ]

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -194,7 +194,7 @@ class Plugin:
     logger = None
     module = "unknown"
     options = Options()
-    arguments = Arguments()
+    arguments: Optional[Arguments] = None
     session = None
     _url: Optional[str] = None
 

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -7,7 +7,7 @@ $type live
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWriter
 
@@ -30,6 +30,24 @@ class AfreecaHLSStream(HLSStream):
 @pluginmatcher(re.compile(
     r"https?://play\.afreecatv\.com/(?P<username>\w+)(?:/(?P<bno>:\d+))?"
 ))
+@pluginargument(
+    "username",
+    sensitive=True,
+    requires=["password"],
+    metavar="USERNAME",
+    help="The username used to register with afreecatv.com.",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="A afreecatv.com account password to use with --afreeca-username.",
+)
+@pluginargument(
+    "purge-credentials",
+    action="store_true",
+    help="Purge cached AfreecaTV credentials to initiate a new session and reauthenticate.",
+)
 class AfreecaTV(Plugin):
     _re_bno = re.compile(r"var nBroadNo = (?P<bno>\d+);")
 
@@ -62,29 +80,6 @@ class AfreecaTV(Plugin):
             ),
             "stream_status": str,
         }
-    )
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            sensitive=True,
-            requires=["password"],
-            metavar="USERNAME",
-            help="The username used to register with afreecatv.com."
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="A afreecatv.com account password to use with --afreeca-username."
-        ),
-        PluginArgument(
-            "purge-credentials",
-            action="store_true",
-            help="""
-        Purge cached AfreecaTV credentials to initiate a new session
-        and reauthenticate.
-        """),
     )
 
     def __init__(self, url):

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from hashlib import sha1
 from urllib.parse import urlparse, urlunparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.hls import HLSStream
@@ -29,6 +29,24 @@ log = logging.getLogger(__name__)
         live/(?P<channel_name>\w+)
     )
 """, re.VERBOSE))
+@pluginargument(
+    "username",
+    requires=["password"],
+    metavar="USERNAME",
+    help="The username used to register with bbc.co.uk.",
+)
+@pluginargument(
+    "password",
+    prompt="Enter bbc.co.uk account password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="A bbc.co.uk account password to use with --bbciplayer-username.",
+)
+@pluginargument(
+    "hd",
+    action="store_true",
+    help="Prefer HD streams over local SD streams, some live programmes may not be broadcast in HD.",
+)
 class BBCiPlayer(Plugin):
     """
     Allows streaming of live channels from bbc.co.uk/iplayer/live/* and of iPlayer programmes from
@@ -64,29 +82,6 @@ class BBCiPlayer(Plugin):
         ]},
         validate.get("media"),
         validate.filter(lambda x: x["kind"] == "video")
-    )
-    arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            requires=["password"],
-            metavar="USERNAME",
-            help="The username used to register with bbc.co.uk."
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="A bbc.co.uk account password to use with --bbciplayer-username.",
-            prompt="Enter bbc.co.uk account password"
-        ),
-        PluginArgument(
-            "hd",
-            action="store_true",
-            help="""
-            Prefer HD streams over local SD streams, some live programmes may
-            not be broadcast in HD.
-            """
-        ),
     )
 
     def __init__(self, url):

--- a/src/streamlink/plugins/clubbingtv.py
+++ b/src/streamlink/plugins/clubbingtv.py
@@ -8,7 +8,7 @@ $account Login required
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
@@ -17,6 +17,18 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(www\.)?clubbingtv\.com/"
 ))
+@pluginargument(
+    "username",
+    required=True,
+    requires=["password"],
+    help="The username used to register with Clubbing TV.",
+)
+@pluginargument(
+    "password",
+    required=True,
+    sensitive=True,
+    help="A Clubbing TV account password to use with --clubbingtv-username.",
+)
 class ClubbingTV(Plugin):
     _login_url = "https://www.clubbingtv.com/user/login"
 
@@ -25,21 +37,6 @@ class ClubbingTV(Plugin):
         re.DOTALL,
     )
     _vod_re = re.compile(r'<iframe src="(?P<stream_url>.+?)"')
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            required=True,
-            requires=["password"],
-            help="The username used to register with Clubbing TV.",
-        ),
-        PluginArgument(
-            "password",
-            required=True,
-            sensitive=True,
-            help="A Clubbing TV account password to use with --clubbingtv-username.",
-        ),
-    )
 
     def login(self):
         username = self.get_option("username")

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -9,7 +9,7 @@ import logging
 import re
 from uuid import uuid4
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
@@ -244,52 +244,45 @@ class CrunchyrollAPI:
         /watch/(?P<beta_id>\w+)/[\w-]+
     )
 """, re.VERBOSE))
+@pluginargument(
+    "username",
+    requires=["password"],
+    metavar="USERNAME",
+    help="A Crunchyroll username to allow access to restricted streams.",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    nargs="?",
+    const=None,
+    default=None,
+    help="""
+        A Crunchyroll password for use with --crunchyroll-username.
+
+        If left blank you will be prompted.
+    """,
+)
+@pluginargument(
+    "purge-credentials",
+    action="store_true",
+    help="Purge cached Crunchyroll credentials to initiate a new session and reauthenticate.",
+)
+@pluginargument(
+    "session-id",
+    sensitive=True,
+    metavar="SESSION_ID",
+    help="""
+        Set a specific session ID for crunchyroll, can be used to bypass
+        region restrictions. If using an authenticated session ID, it is
+        recommended that the authentication parameters be omitted as the
+        session ID is account specific.
+
+        Note: The session ID will be overwritten if authentication is used
+        and the session ID does not match the account.
+    """,
+)
 class Crunchyroll(Plugin):
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            metavar="USERNAME",
-            requires=["password"],
-            help="A Crunchyroll username to allow access to restricted streams."
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            nargs="?",
-            const=None,
-            default=None,
-            help="""
-            A Crunchyroll password for use with --crunchyroll-username.
-
-            If left blank you will be prompted.
-            """
-        ),
-        PluginArgument(
-            "purge-credentials",
-            action="store_true",
-            help="""
-            Purge cached Crunchyroll credentials to initiate a new session
-            and reauthenticate.
-            """
-        ),
-        PluginArgument(
-            "session-id",
-            sensitive=True,
-            metavar="SESSION_ID",
-            help="""
-            Set a specific session ID for crunchyroll, can be used to bypass
-            region restrictions. If using an authenticated session ID, it is
-            recommended that the authentication parameters be omitted as the
-            session ID is account specific.
-
-            Note: The session ID will be overwritten if authentication is used
-            and the session ID does not match the account.
-            """
-        )
-    )
-
     @classmethod
     def stream_weight(cls, key):
         weight = STREAM_WEIGHTS.get(key)

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -10,7 +10,7 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream.ffmpegmux import MuxedStream
 from streamlink.stream.hls import HLSStream
@@ -163,34 +163,34 @@ class Experience:
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?funimation(\.com|now\.uk)"
 ))
+@pluginargument(
+    "email",
+    argument_name="funimation-email",
+    requires=["password"],
+    help="Email address for your Funimation account.",
+)
+@pluginargument(
+    "password",
+    argument_name="funimation-password",
+    sensitive=True,
+    help="Password for your Funimation account.",
+)
+@pluginargument(
+    "language",
+    argument_name="funimation-language",
+    choices=["en", "ja", "english", "japanese"],
+    default="english",
+    help="""
+        The audio language to use for the stream; japanese or english.
+
+        Default is "english".
+    """,
+)
+@pluginargument(
+    "mux-subtitles",
+    is_global=True,
+)
 class FunimationNow(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            argument_name="funimation-email",
-            requires=["password"],
-            help="Email address for your Funimation account."
-        ),
-        PluginArgument(
-            "password",
-            argument_name="funimation-password",
-            sensitive=True,
-            help="Password for your Funimation account."
-        ),
-        PluginArgument(
-            "language",
-            argument_name="funimation-language",
-            choices=["en", "ja", "english", "japanese"],
-            default="english",
-            help="""
-            The audio language to use for the stream; japanese or english.
-
-            Default is "english".
-            """
-        ),
-        PluginArgument("mux-subtitles", is_global=True)
-    )
-
     experience_id_re = re.compile(r"/player/(\d+)")
     mp4_quality = "480p"
 

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -1,5 +1,5 @@
 """
-$description Japanese live streaming and video hosting social platform.
+$description Japanese live-streaming and video hosting social platform.
 $url live.nicovideo.jp
 $type live, vod
 $account Required by some streams
@@ -12,7 +12,7 @@ from threading import Event
 from urllib.parse import urljoin
 
 from streamlink.exceptions import FatalPluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.websocket import WebsocketClient
 from streamlink.stream.hls import HLSStream, HLSStreamReader
@@ -117,50 +117,50 @@ class NicoLiveHLSStream(HLSStream):
 @pluginmatcher(re.compile(
     r"https?://(?P<domain>live\d*\.nicovideo\.jp)/watch/(lv|co)\d+"
 ))
+@pluginargument(
+    "email",
+    sensitive=True,
+    argument_name="niconico-email",
+    metavar="EMAIL",
+    help="The email or phone number associated with your Niconico account",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    argument_name="niconico-password",
+    metavar="PASSWORD",
+    help="The password of your Niconico account",
+)
+@pluginargument(
+    "user-session",
+    sensitive=True,
+    argument_name="niconico-user-session",
+    metavar="VALUE",
+    help="""
+        Value of the user-session token.
+
+        Can be used as an alternative to providing a password.
+    """,
+)
+@pluginargument(
+    "purge-credentials",
+    argument_name="niconico-purge-credentials",
+    action="store_true",
+    help="Purge cached Niconico credentials to initiate a new session and reauthenticate.",
+)
+@pluginargument(
+    "timeshift-offset",
+    type=hours_minutes_seconds,
+    argument_name="niconico-timeshift-offset",
+    metavar="[HH:]MM:SS",
+    default=None,
+    help="""
+        Amount of time to skip from the beginning of a stream.
+
+        Default is 00:00:00.
+    """,
+)
 class NicoLive(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            argument_name="niconico-email",
-            sensitive=True,
-            metavar="EMAIL",
-            help="The email or phone number associated with your Niconico account"
-        ),
-        PluginArgument(
-            "password",
-            argument_name="niconico-password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="The password of your Niconico account"
-        ),
-        PluginArgument(
-            "user-session",
-            argument_name="niconico-user-session",
-            sensitive=True,
-            metavar="VALUE",
-            help="Value of the user-session token \n(can be used in "
-                 "case you do not want to put your password here)"
-        ),
-        PluginArgument(
-            "purge-credentials",
-            argument_name="niconico-purge-credentials",
-            action="store_true",
-            help="Purge cached Niconico credentials to initiate a new session and reauthenticate."
-        ),
-        PluginArgument(
-            "timeshift-offset",
-            type=hours_minutes_seconds,
-            argument_name="niconico-timeshift-offset",
-            metavar="[HH:]MM:SS",
-            default=None,
-            help="""
-            Amount of time to skip from the beginning of a stream.
-
-            Default is 00:00:00.
-            """
-        )
-    )
-
     STREAM_READY_TIMEOUT = 6
     LOGIN_URL = "https://account.nicovideo.jp/login/redirector"
     LOGIN_URL_PARAMS = {

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -1,5 +1,5 @@
 """
-$description Japanese live streaming and video hosting social platform.
+$description Japanese live-streaming and video hosting social platform.
 $url openrec.tv
 $type live, vod
 """
@@ -7,7 +7,7 @@ $type live, vod
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
@@ -17,6 +17,18 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?openrec\.tv/(?:live|movie)/(?P<id>[^/]+)"
 ))
+@pluginargument(
+    "email",
+    requires=["password"],
+    metavar="EMAIL",
+    help="The email associated with your openrectv account, required to access any openrectv stream.",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="An openrectv account password to use with --openrectv-email.",
+)
 class OPENRECtv(Plugin):
     _stores_re = re.compile(r"window.stores\s*=\s*({.*?});", re.DOTALL | re.MULTILINE)
     _config_re = re.compile(r"window.sharedConfig\s*=\s*({.*?});", re.DOTALL | re.MULTILINE)
@@ -58,24 +70,6 @@ class OPENRECtv(Plugin):
         "status": int,
         validate.optional("data"): object
     })
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            requires=["password"],
-            metavar="EMAIL",
-            help="""
-            The email associated with your openrectv account,
-            required to access any openrectv stream.
-            """),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="""
-            An openrectv account password to use with --openrectv-email.
-            """)
-    )
 
     def __init__(self, url):
         super().__init__(url)

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -1,5 +1,5 @@
 """
-$description Global live streaming platform for the creative community.
+$description Global live-streaming platform for the creative community.
 $url sketch.pixiv.net
 $type live
 """
@@ -8,7 +8,7 @@ import logging
 import re
 
 from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
@@ -18,6 +18,29 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://sketch\.pixiv\.net/@?(?P<user>[^/]+)"
 ))
+@pluginargument(
+    "sessionid",
+    requires=["devicetoken"],
+    sensitive=True,
+    metavar="SESSIONID",
+    help="The pixiv.net sessionid that's used in pixiv's PHPSESSID cookie.",
+)
+@pluginargument(
+    "devicetoken",
+    sensitive=True,
+    metavar="DEVICETOKEN",
+    help="The pixiv.net device token that's used in pixiv's device_token cookie.",
+)
+@pluginargument(
+    "purge-credentials",
+    action="store_true",
+    help="Purge cached Pixiv credentials to initiate a new session and reauthenticate.",
+)
+@pluginargument(
+    "performer",
+    metavar="USER",
+    help="Select a co-host stream instead of the owner stream.",
+)
 class Pixiv(Plugin):
     _post_key_re = re.compile(
         r"""name=["']post_key["']\svalue=["'](?P<data>[^"']+)["']""")
@@ -56,41 +79,6 @@ class Pixiv(Plugin):
     api_lives = "https://sketch.pixiv.net/api/lives.json"
     login_url_get = "https://accounts.pixiv.net/login"
     login_url_post = "https://accounts.pixiv.net/api/login"
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "sessionid",
-            requires=["devicetoken"],
-            sensitive=True,
-            metavar="SESSIONID",
-            help="""
-        The pixiv.net sessionid that's used in pixivs PHPSESSID cookie.
-        can be used instead of the username/password login process.
-        """
-        ),
-        PluginArgument(
-            "devicetoken",
-            sensitive=True,
-            metavar="DEVICETOKEN",
-            help="""
-        The pixiv.net device token that's used in pixivs device_token cookie.
-        can be used instead of the username/password login process.
-        """
-        ),
-        PluginArgument(
-            "purge-credentials",
-            action="store_true",
-            help="""
-        Purge cached Pixiv credentials to initiate a new session
-        and reauthenticate.
-        """),
-        PluginArgument(
-            "performer",
-            metavar="USER",
-            help="""
-        Select a co-host stream instead of the owner stream.
-        """)
-    )
 
     def __init__(self, url):
         super().__init__(url)

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -12,7 +12,7 @@ from io import BytesIO
 from typing import Iterator, Sequence, Tuple
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.ffmpegmux import MuxedStream
 from streamlink.stream.hls import HLSStream
@@ -122,11 +122,11 @@ class ZTNR:
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?rtve\.es/play/videos/.+"
 ))
+@pluginargument(
+    "mux-subtitles",
+    is_global=True,
+)
 class Rtve(Plugin):
-    arguments = PluginArguments(
-        PluginArgument("mux-subtitles", is_global=True),
-    )
-
     URL_VIDEOS = "https://ztnr.rtve.es/ztnr/movil/thumbnail/rtveplayw/videos/{id}.png?q=v2"
     URL_SUBTITLES = "https://www.rtve.es/api/videos/{id}/subtitulos.json"
 

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -9,7 +9,7 @@ import logging
 import random
 import re
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
@@ -19,6 +19,19 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r'https?://play\.sbs\.co\.kr/onair/pc/index\.html'
 ))
+@pluginargument(
+    "id",
+    metavar="CHANNELID",
+    type=str.upper,
+    help="""
+        Channel ID to play.
+
+        Example:
+
+            %(prog)s http://play.sbs.co.kr/onair/pc/index.html best --sbscokr-id S01
+
+    """,
+)
 class SBScokr(Plugin):
     api_channel = 'http://apis.sbs.co.kr/play-api/1.0/onair/channel/{0}'
     api_channels = 'http://static.apis.sbs.co.kr/play-api/1.0/onair/channels'
@@ -51,22 +64,6 @@ class SBScokr(Plugin):
             }
         },
         validate.get('onair'),
-    )
-
-    arguments = PluginArguments(
-        PluginArgument(
-            'id',
-            metavar='CHANNELID',
-            type=str.upper,
-            help='''
-            Channel ID to play.
-
-            Example:
-
-                %(prog)s http://play.sbs.co.kr/onair/pc/index.html best --sbscokr-id S01
-
-            '''
-        )
     )
 
     def _get_streams(self):

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -9,7 +9,7 @@ import logging
 import re
 from functools import partial
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
@@ -20,6 +20,30 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?schoolism\.com/(viewAssignment|watchLesson)\.php"
 ))
+@pluginargument(
+    "email",
+    required=True,
+    requires=["password"],
+    metavar="EMAIL",
+    help="The email associated with your Schoolism account, required to access any Schoolism stream.",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="A Schoolism account password to use with --schoolism-email.",
+)
+@pluginargument(
+    "part",
+    metavar="PART",
+    type=int,
+    default=1,
+    help="""
+        Play part number PART of the lesson, or assignment feedback video.
+
+        Default is 1.
+    """,
+)
 class Schoolism(Plugin):
     login_url = "https://www.schoolism.com/index.php"
     key_time_url = "https://www.schoolism.com/video-html/key-time.php"
@@ -49,36 +73,6 @@ class Schoolism(Plugin):
                     )
                 }]
             )
-        )
-    )
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            required=True,
-            requires=["password"],
-            metavar="EMAIL",
-            help="""
-        The email associated with your Schoolism account,
-        required to access any Schoolism stream.
-        """
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="A Schoolism account password to use with --schoolism-email."
-        ),
-        PluginArgument(
-            "part",
-            type=int,
-            default=1,
-            metavar="PART",
-            help="""
-        Play part number PART of the lesson, or assignment feedback video.
-
-        Default is 1.
-        """
         )
     )
 

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -15,7 +15,7 @@ from Crypto.Cipher import PKCS1_v1_5
 from Crypto.PublicKey import RSA
 
 from streamlink.exceptions import FatalPluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 
@@ -32,30 +32,24 @@ class SteamLoginFailed(Exception):
 @pluginmatcher(re.compile(
     r"https?://steam\.tv/(\w+)"
 ))
+@pluginargument(
+    "email",
+    requires=["password"],
+    metavar="EMAIL",
+    help="A Steam account email address to access friends/private streams",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="A Steam account password to use with --steam-email.",
+)
 class SteamBroadcastPlugin(Plugin):
     _watch_broadcast_url = "https://steamcommunity.com/broadcast/watch/{steamid}"
     _get_broadcast_url = "https://steamcommunity.com/broadcast/getbroadcastmpd/"
     _get_rsa_key_url = "https://steamcommunity.com/login/getrsakey/"
     _dologin_url = "https://steamcommunity.com/login/dologin/"
     _captcha_url = "https://steamcommunity.com/public/captcha.php?gid={}"
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            metavar="EMAIL",
-            requires=["password"],
-            help="""
-            A Steam account email address to access friends/private streams
-            """
-        ),
-        PluginArgument(
-            "password",
-            metavar="PASSWORD",
-            sensitive=True,
-            help="""
-            A Steam account password to use with --steam-email.
-            """
-        ))
 
     @property
     def donotcache(self):

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -15,7 +15,7 @@ import re
 import time
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 from streamlink.utils.crypto import decrypt_openssl
@@ -40,19 +40,13 @@ log = logging.getLogger(__name__)
         telecuracao\.com
     )
 """, re.VERBOSE))
+@pluginargument(
+    "url",
+    metavar="URL",
+    type=str,
+    help="Source URL where the iframe is located, only required for direct URLs of ott.streann.com",
+)
 class Streann(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "url",
-            type=str,
-            metavar="URL",
-            help="""
-            Source URL where the iframe is located,
-            only required for direct URLs of `ott.streann.com`
-            """
-        )
-    )
-
     base_url = "https://ott.streann.com"
     get_time_url = base_url + "/web/services/public/get-server-time"
     token_url = base_url + "/loadbalancer/services/web-players/{playerId}/token/{type}/{dataId}/{deviceId}"

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -9,7 +9,7 @@ import logging
 import re
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -21,6 +21,10 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r'https?://(?:www\.)?svtplay\.se(/(kanaler/)?.*)'
 ))
+@pluginargument(
+    "mux-subtitles",
+    is_global=True,
+)
 class SVTPlay(Plugin):
     api_url = 'https://api.svt.se/videoplayer-api/video/{0}'
 
@@ -42,10 +46,6 @@ class SVTPlay(Plugin):
             'format': validate.text,
         }],
     })
-
-    arguments = PluginArguments(
-        PluginArgument("mux-subtitles", is_global=True)
-    )
 
     def _set_metadata(self, data, category):
         if 'programTitle' in data:

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -9,7 +9,7 @@ import logging
 import re
 
 from streamlink.buffers import RingBuffer
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.plugin.api.websocket import WebsocketClient
 from streamlink.stream.stream import Stream, StreamIO
@@ -22,15 +22,13 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://twitcasting\.tv/(?P<channel>[^/]+)"
 ))
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="Password for private Twitcasting streams.",
+)
 class TwitCasting(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="Password for private Twitcasting streams."
-        )
-    )
     _STREAM_INFO_URL = "https://twitcasting.tv/streamserver.php?target={channel}&mode=client"
     _STREAM_REAL_URL = "{proto}://{host}/ws.app/stream/{movie_id}/fmp4/bd/1/1500?mode={mode}"
 

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -15,7 +15,7 @@ from typing import List, NamedTuple, Optional
 from urllib.parse import urlparse
 
 from streamlink.exceptions import NoStreamsError, PluginError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker, HLSStreamWriter
 from streamlink.stream.hls_playlist import ByteRange, ExtInf, Key, M3U8, M3U8Parser, Map, load as load_hls_playlist
@@ -475,60 +475,53 @@ class TwitchAPI:
         )?
     )
 """, re.VERBOSE))
+@pluginargument(
+    "disable-ads",
+    action="store_true",
+    help="""
+        Skip embedded advertisement segments at the beginning or during a stream.
+        Will cause these segments to be missing from the output.
+    """,
+)
+@pluginargument(
+    "disable-hosting",
+    action="store_true",
+    help="Do not open the stream if the target channel is hosting another channel.",
+)
+@pluginargument(
+    "disable-reruns",
+    action="store_true",
+    help="Do not open the stream if the target channel is currently broadcasting a rerun.",
+)
+@pluginargument(
+    "low-latency",
+    action="store_true",
+    help=f"""
+        Enables low latency streaming by prefetching HLS segments.
+        Sets --hls-segment-stream-data to true and --hls-live-edge to `{LOW_LATENCY_MAX_LIVE_EDGE}`, if it is higher.
+        Reducing --hls-live-edge to `1` will result in the lowest latency possible, but will most likely cause buffering.
+
+        In order to achieve true low latency streaming during playback, the player's caching/buffering settings will
+        need to be adjusted and reduced to a value as low as possible, but still high enough to not cause any buffering.
+        This depends on the stream's bitrate and the quality of the connection to Twitch's servers. Please refer to the
+        player's own documentation for the required configuration. Player parameters can be set via --player-args.
+
+        Note: Low latency streams have to be enabled by the broadcasters on Twitch themselves.
+        Regular streams can cause buffering issues with this option enabled due to the reduced --hls-live-edge value.
+    """,
+)
+@pluginargument(
+    "api-header",
+    metavar="KEY=VALUE",
+    type=keyvalue,
+    action="append",
+    help="""
+        A header to add to each Twitch API HTTP request.
+
+        Can be repeated to add multiple headers.
+    """,
+)
 class Twitch(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "disable-hosting",
-            action="store_true",
-            help="""
-            Do not open the stream if the target channel is hosting another channel.
-            """
-        ),
-        PluginArgument(
-            "disable-ads",
-            action="store_true",
-            help="""
-            Skip embedded advertisement segments at the beginning or during a stream.
-            Will cause these segments to be missing from the stream.
-            """
-        ),
-        PluginArgument(
-            "disable-reruns",
-            action="store_true",
-            help="""
-            Do not open the stream if the target channel is currently broadcasting a rerun.
-            """
-        ),
-        PluginArgument(
-            "low-latency",
-            action="store_true",
-            help=f"""
-            Enables low latency streaming by prefetching HLS segments.
-            Sets --hls-segment-stream-data to true and --hls-live-edge to `{LOW_LATENCY_MAX_LIVE_EDGE}`, if it is higher.
-            Reducing --hls-live-edge to `1` will result in the lowest latency possible, but will most likely cause buffering.
-
-            In order to achieve true low latency streaming during playback, the player's caching/buffering settings will
-            need to be adjusted and reduced to a value as low as possible, but still high enough to not cause any buffering.
-            This depends on the stream's bitrate and the quality of the connection to Twitch's servers. Please refer to the
-            player's own documentation for the required configuration. Player parameters can be set via --player-args.
-
-            Note: Low latency streams have to be enabled by the broadcasters on Twitch themselves.
-            Regular streams can cause buffering issues with this option enabled due to the reduced --hls-live-edge value.
-            """
-        ),
-        PluginArgument(
-            "api-header",
-            metavar="KEY=VALUE",
-            type=keyvalue,
-            action="append",
-            help="""
-            A header to add to each Twitch API HTTP request.
-
-            Can be repeated to add multiple headers.
-            """
-        )
-    )
-
     @classmethod
     def stream_weight(cls, stream):
         if stream == "source":

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -17,7 +17,7 @@ from urllib.parse import urljoin, urlunparse
 from requests import Response
 
 from streamlink.exceptions import PluginError, StreamError
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.websocket import WebsocketClient
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -470,17 +470,14 @@ class UStreamTVStream(Stream):
             (/embed)?/recorded/(?P<video_id>\d+)
         )?
 """, re.VERBOSE))
+@pluginargument(
+    "password",
+    sensitive=True,
+    argument_name="ustream-password",
+    metavar="PASSWORD",
+    help="A password to access password protected UStream.tv channels.",
+)
 class UStreamTV(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "password",
-            argument_name="ustream-password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="A password to access password protected UStream.tv channels."
-        )
-    )
-
     STREAM_READY_TIMEOUT = 15
 
     def _get_media_app(self):

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -16,7 +16,7 @@ from Crypto.Cipher import AES
 from Crypto.Hash import SHA256
 from Crypto.Util.Padding import pad, unpad
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.stream.hls import HLSStream
 
 log = logging.getLogger(__name__)
@@ -25,6 +25,20 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?ustvnow\.com/live/(?P<scode>\w+)/-(?P<id>\d+)"
 ))
+@pluginargument(
+    "username",
+    required=True,
+    requires=["password"],
+    metavar="USERNAME",
+    help="Your USTV Now account username",
+)
+@pluginargument(
+    "password",
+    required=True,
+    sensitive=True,
+    metavar="PASSWORD",
+    help="Your USTV Now account password",
+)
 class USTVNow(Plugin):
     _main_js_re = re.compile(r"""src=['"](main\..*\.js)['"]""")
     _enc_key_re = re.compile(r'(?P<key>AES_(?:Key|IV))\s*:\s*"(?P<value>[^"]+)"')
@@ -33,23 +47,6 @@ class USTVNow(Plugin):
     _api_url = "https://teleupapi.revlet.net/service/api/v1/"
     _token_url = _api_url + "get/token"
     _signin_url = "https://www.ustvnow.com/signin"
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "username",
-            metavar="USERNAME",
-            required=True,
-            help="Your USTV Now account username"
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            required=True,
-            help="Your USTV Now account password",
-            prompt="Enter USTV Now account password"
-        )
-    )
 
     def __init__(self, url):
         super().__init__(url)

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -1,5 +1,5 @@
 """
-$description Global live streaming and video hosting social platform.
+$description Global live-streaming and video hosting social platform.
 $url vimeo.com
 $type live, vod
 $notes Password protected streams are not supported
@@ -10,7 +10,7 @@ import re
 from html import unescape as html_unescape
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -23,6 +23,10 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(player\.vimeo\.com/video/\d+|(www\.)?vimeo\.com/.+)"
 ))
+@pluginargument(
+    "mux-subtitles",
+    is_global=True,
+)
 class Vimeo(Plugin):
     _config_url_re = re.compile(r'(?:"config_url"|\bdata-config-url)\s*[:=]\s*(".+?")')
     _config_re = re.compile(r"var\s+config\s*=\s*({.+?})\s*;")
@@ -58,10 +62,6 @@ class Vimeo(Plugin):
     _player_schema = validate.Schema(
         validate.transform(_config_re.search),
         validate.any(None, validate.Schema(validate.get(1), _config_schema)),
-    )
-
-    arguments = PluginArguments(
-        PluginArgument("mux-subtitles", is_global=True)
     )
 
     def _get_streams(self):

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -11,7 +11,7 @@ import re
 from functools import lru_cache
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream.hls import HLSStream
 from streamlink.utils.times import seconds_to_hhmmss
@@ -22,6 +22,20 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://watch\.wwe\.com/(channel)?"
 ))
+@pluginargument(
+    "email",
+    required=True,
+    requires=["password"],
+    metavar="EMAIL",
+    help="The email associated with your WWE Network account, required to access any WWE Network stream.",
+)
+@pluginargument(
+    "password",
+    required=True,
+    sensitive=True,
+    metavar="PASSWORD",
+    help="A WWE Network account password to use with --wwenetwork-email.",
+)
 class WWENetwork(Plugin):
     site_config_re = re.compile(r'''">window.__data = (\{.*?\})</script>''')
     stream_url = "https://dce-frontoffice.imggaming.com/api/v2/stream/{id}"
@@ -31,26 +45,6 @@ class WWENetwork(Plugin):
     API_KEY = "cca51ea0-7837-40df-a055-75eb6347b2e7"
 
     customer_id = 16
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            required=True,
-            metavar="EMAIL",
-            requires=["password"],
-            help="""
-        The email associated with your WWE Network account,
-        required to access any WWE Network stream.
-        """
-        ),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="""
-        A WWE Network account password to use with --wwenetwork-email.
-        """
-        )
-    )
 
     def __init__(self, url):
         super().__init__(url)

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -9,7 +9,7 @@ import logging
 import re
 import time
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream.hls import HLSStream
 
@@ -19,36 +19,27 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r'https?://(?:www\.)?yupptv\.com'
 ))
+@pluginargument(
+    "boxid",
+    requires=["yuppflixtoken"],
+    sensitive=True,
+    metavar="BOXID",
+    help="The yupptv.com boxid that's used in the BoxId cookie.",
+)
+@pluginargument(
+    "yuppflixtoken",
+    sensitive=True,
+    metavar="YUPPFLIXTOKEN",
+    help="The yupptv.com yuppflixtoken that's used in the YuppflixToken cookie.",
+)
+@pluginargument(
+    "purge-credentials",
+    action="store_true",
+    help="Purge cached YuppTV credentials to initiate a new session and reauthenticate.",
+)
 class YuppTV(Plugin):
     _m3u8_re = re.compile(r'''['"](http.+\.m3u8.*?)['"]''')
     _cookie_expiry = 3600 * 24 * 365
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "boxid",
-            requires=["yuppflixtoken"],
-            sensitive=True,
-            metavar="BOXID",
-            help="""
-        The yupptv.com boxid that's used in the BoxId cookie.
-        Can be used instead of the username/password login process.
-        """),
-        PluginArgument(
-            "yuppflixtoken",
-            sensitive=True,
-            metavar="YUPPFLIXTOKEN",
-            help="""
-        The yupptv.com yuppflixtoken that's used in the YuppflixToken cookie.
-        Can be used instead of the username/password login process.
-        """),
-        PluginArgument(
-            "purge-credentials",
-            action="store_true",
-            help="""
-        Purge cached YuppTV credentials to initiate a new session
-        and reauthenticate.
-        """),
-    )
 
     def __init__(self, url):
         super().__init__(url)

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -22,13 +22,15 @@ import re
 import uuid
 
 from streamlink.cache import Cache
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.hls import HLSStream
 from streamlink.utils.args import comma_list_filter
 
 log = logging.getLogger(__name__)
+
+STREAMS_ZATTOO = ["dash", "hls7"]
 
 
 @pluginmatcher(re.compile(r'''
@@ -63,50 +65,39 @@ log = logging.getLogger(__name__)
         ondemand(?:\?video=|/watch/)(?P<vod_id>[^-]+)
     )
 ''', re.VERBOSE))
-class Zattoo(Plugin):
-    STREAMS_ZATTOO = ['dash', 'hls7']
+@pluginargument(
+    "email",
+    requires=["password"],
+    metavar="EMAIL",
+    help="The email associated with your zattoo account, required to access any zattoo stream.",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+    help="A zattoo account password to use with --zattoo-email.",
+)
+@pluginargument(
+    "purge-credentials",
+    action="store_true",
+    help="Purge cached zattoo credentials to initiate a new session and reauthenticate.",
+)
+@pluginargument(
+    "stream-types",
+    metavar="TYPES",
+    type=comma_list_filter(STREAMS_ZATTOO),
+    default=["dash"],
+    help=f"""
+        A comma-delimited list of stream types which should be used.
 
+        The following types are allowed: {','.join(STREAMS_ZATTOO)}
+
+        Default is "dash".
+    """,
+)
+class Zattoo(Plugin):
     TIME_CONTROL = 60 * 60 * 2
     TIME_SESSION = 60 * 60 * 24 * 30
-
-    arguments = PluginArguments(
-        PluginArgument(
-            "email",
-            requires=["password"],
-            metavar="EMAIL",
-            help="""
-            The email associated with your zattoo account,
-            required to access any zattoo stream.
-            """),
-        PluginArgument(
-            "password",
-            sensitive=True,
-            metavar="PASSWORD",
-            help="""
-            A zattoo account password to use with --zattoo-email.
-            """),
-        PluginArgument(
-            "purge-credentials",
-            action="store_true",
-            help="""
-            Purge cached zattoo credentials to initiate a new session
-            and reauthenticate.
-            """),
-        PluginArgument(
-            'stream-types',
-            metavar='TYPES',
-            type=comma_list_filter(STREAMS_ZATTOO),
-            default=['dash'],
-            help='''
-            A comma-delimited list of stream types which should be used,
-            the following types are allowed:
-
-            - {0}
-
-            Default is "dash".
-            '''.format('\n            - '.join(STREAMS_ZATTOO))
-        )
-    )
 
     def __init__(self, url):
         super().__init__(url)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -862,7 +862,7 @@ def setup_plugin_args(session: Streamlink, parser: ArgumentParser):
         defaults = {}
         group = parser.add_argument_group(pname.capitalize(), parent=plugin_args)
 
-        for parg in plugin.arguments:
+        for parg in plugin.arguments or []:
             if not parg.is_global:
                 group.add_argument(parg.argument_name(pname), **parg.options)
                 defaults[parg.dest] = parg.default
@@ -884,6 +884,9 @@ def setup_plugin_args(session: Streamlink, parser: ArgumentParser):
 
 def setup_plugin_options(session: Streamlink, plugin: Type[Plugin]):
     """Sets Streamlink plugin options."""
+    if plugin.arguments is None:
+        return
+
     pname = plugin.module
     required = {}
 
@@ -957,14 +960,14 @@ def log_current_versions():
         log.debug(f" {name}: {version}")
 
 
-def log_current_arguments(session, parser):
+def log_current_arguments(session: Streamlink, parser: argparse.ArgumentParser):
     global args
     if not logger.root.isEnabledFor(logging.DEBUG):
         return
 
     sensitive = set()
     for pname, plugin in session.plugins.items():
-        for parg in plugin.arguments:
+        for parg in plugin.arguments or []:
             if parg.sensitive:
                 sensitive.add(parg.argument_name(pname))
 

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 from streamlink import NoStreamsError
 from streamlink.options import Options
-from streamlink.plugin import PluginArgument, PluginArguments, pluginmatcher
+from streamlink.plugin import pluginargument, pluginmatcher
 from streamlink.plugins import Plugin
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
@@ -20,19 +20,16 @@ class TestStream(Stream):
 @pluginmatcher(re.compile(
     r"https?://test\.se"
 ))
+@pluginargument(
+    "bool",
+    action="store_true",
+)
+@pluginargument(
+    "password",
+    sensitive=True,
+    metavar="PASSWORD",
+)
 class TestPlugin(Plugin):
-    arguments = PluginArguments(
-        PluginArgument(
-            "bool",
-            action="store_true"
-        ),
-        PluginArgument(
-            "password",
-            metavar="PASSWORD",
-            sensitive=True
-        )
-    )
-
     options = Options({
         "a_option": "default"
     })

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -35,7 +35,6 @@ from tests.plugin.testplugin import TestPlugin as _TestPlugin
 
 class FakePlugin(_TestPlugin):
     module = "fake"
-    arguments = []  # type: ignore
     _streams = {}  # type: ignore
 
     def streams(self, *args, **kwargs):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -79,7 +79,7 @@ class TestPlugins:
         assert callable(pluginclass._get_streams), "Implements _get_streams()"
 
     def test_has_valid_global_args(self, global_arg_dests, plugin):
-        assert all(parg.dest in global_arg_dests for parg in plugin.__plugin__.arguments if parg.is_global), \
+        assert all(parg.dest in global_arg_dests for parg in plugin.__plugin__.arguments or [] if parg.is_global), \
             "All plugin arguments with is_global=True are valid global arguments"
 
 


### PR DESCRIPTION
This PR changes the plugin argument definitions from

```py
from streamlink.plugin import Plugin, PluginArgument, PluginArguments

@pluginmatcher(...)
class Foo(Plugin):
    arguments = PluginArguments(
        PluginArgument(...),
        PluginArgument(...),
        PluginArgument(...),
    )
```

to

```py
from streamlink.plugin import Plugin, pluginargument, pluginmatcher

@pluginmatcher(...)
@pluginargument(...)
@pluginargument(...)
@pluginargument(...)
class Foo(Plugin):
    ...
```

As mentioned in https://github.com/streamlink/streamlink/issues/4741#issue-1340972848, having plugin arguments definied in a similar declarative way as the URL matchers makes it much more consistent and easier to read. The previous definitions were all rather messy.

This also simplifies the parsing of each plugin module's AST via the plugins extension of the docs and the planned URL-cache pre-build step (#4741).

These changes are fully backwards compatible and custom plugins don't need to change anything. I didn't add tests for the old definition style though, but that's not important.

The docs and man page should stay the same, except for the changes of the help texts and some argument rearrangements.

I also fixed some of the help texts, but didn't do a very careful job here. There's still lots of room for improvement. Since this requires testing plugins in some cases, I couldn't be bothered, so I only fixed the obvious stuff.

As usual, review the commits separately.