### PR TITLE
plugins.mitele: fix and refactor plugin

### DIFF
--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -21,83 +21,91 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?mitele\.es/directo/(?P<channel>[\w-]+)"
 ))
 class Mitele(Plugin):
-    caronte_url = "https://caronte.mediaset.es/delivery/channel/mmc/{channel}/mtweb"
-    gbx_url = "https://mab.mediaset.es/1.0.0/get?oid=mtmw&eid=%2Fapi%2Fmtmw%2Fv2%2Fgbx%2Fmtweb%2Flive%2Fmmc%2F{channel}"
+    URL_CARONTE = "https://caronte.mediaset.es/delivery/channel/mmc/{channel}/mtweb"
+    URL_GBX = "https://mab.mediaset.es/1.0.0/get"
 
-    error_schema = validate.Schema({"code": int})
-    caronte_schema = validate.Schema(validate.parse_json(), validate.any(
-        {
-            "cerbero": validate.url(),
-            "bbx": str,
-            "dls": [{
-                "lid": validate.all(int, validate.transform(str)),
-                "format": validate.any("hls", "dash", "smooth"),
-                "stream": validate.url(),
-                validate.optional("assetKey"): str,
-                "drm": bool,
-            }],
-        },
-        error_schema,
-    ))
-    gbx_schema = validate.Schema(
-        validate.parse_json(),
-        {"gbx": str},
-        validate.get("gbx")
-    )
-    cerbero_schema = validate.Schema(
-        validate.parse_json(),
-        validate.any(
-            validate.all(
-                {"tokens": {str: {"cdn": str}}},
-                validate.get("tokens")
-            ),
-            error_schema,
-        )
-    )
-    token_errors = {
-        4038: "User has no privileges"
+    TOKEN_ERRORS = {
+        4038: "User has no privileges",
     }
 
     def _get_streams(self):
         channel = self.match.group("channel")
 
-        pdata = self.session.http.get(self.caronte_url.format(channel=channel),
-                                      acceptable_status=(200, 403, 404),
-                                      schema=self.caronte_schema)
-        gbx = self.session.http.get(self.gbx_url.format(channel=channel),
-                                    schema=self.gbx_schema)
-
+        pdata = self.session.http.get(
+            self.URL_CARONTE.format(channel=channel),
+            acceptable_status=(200, 403, 404),
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    {"code": int},
+                    {
+                        "cerbero": validate.url(),
+                        "bbx": str,
+                        "dls": validate.all(
+                            [{
+                                "drm": bool,
+                                "format": str,
+                                "stream": validate.url(),
+                                "lid": validate.all(int, validate.transform(str)),
+                                validate.optional("assetKey"): str,
+                            }],
+                            validate.filter(lambda obj: obj["format"] == "hls")
+                        ),
+                    },
+                ),
+            ),
+        )
         if "code" in pdata:
-            log.error("error getting pdata: {}".format(pdata["code"]))
+            log.error(f"Error getting pdata: {pdata['code']}")
             return
 
-        tokens = self.session.http.post(pdata["cerbero"],
-                                        acceptable_status=(200, 403, 404),
-                                        json={"bbx": pdata["bbx"], "gbx": gbx},
-                                        headers={"origin": "https://www.mitele.es"},
-                                        schema=self.cerbero_schema)
+        gbx = self.session.http.get(
+            self.URL_GBX,
+            params={
+                "oid": "mtmw",
+                "eid": f"/api/mtmw/v2/gbx/mtweb/live/mmc/{channel}",
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                {"gbx": str},
+                validate.get("gbx"),
+            ),
+        )
 
+        tokens = self.session.http.post(
+            pdata["cerbero"],
+            acceptable_status=(200, 403, 404),
+            json={
+                "bbx": pdata["bbx"],
+                "gbx": gbx,
+            },
+            headers={"origin": "https://www.mitele.es"},
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    {"code": int},
+                    validate.all(
+                        {"tokens": {str: {"cdn": str}}},
+                        validate.get("tokens")
+                    ),
+                ),
+            ),
+        )
         if "code" in tokens:
-            log.error("Could not get stream tokens: {} ({})".format(tokens["code"],
-                                                                    self.token_errors.get(tokens["code"], "unknown error")))
+            tokenerrors = self.TOKEN_ERRORS.get(tokens["code"], "unknown error")
+            log.error(f"Could not get stream tokens: {tokens['code']} ({tokenerrors})")
             return
 
-        list_urls = []
+        urls = set()
         for stream in pdata["dls"]:
             if stream["drm"]:
                 log.warning("Stream may be protected by DRM")
-            else:
-                sformat = stream.get("format")
-                log.debug("Stream: {} ({})".format(stream["stream"], sformat or "n/a"))
-                cdn_token = tokens.get(stream["lid"], {}).get("cdn", "")
-                qsd = parse_qsd(cdn_token)
-                if sformat == "hls":
-                    list_urls.append(update_qsd(stream["stream"], qsd))
+                continue
+            cdn_token = tokens.get(stream["lid"], {}).get("cdn", "")
+            qsd = parse_qsd(cdn_token)
+            urls.add(update_qsd(stream["stream"], qsd, quote_via=lambda string, *_, **__: string))
 
-        if not list_urls:
-            return
-
-        for url in list(set(list_urls)):
+        for url in urls:
             yield from HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items()
 
 


### PR DESCRIPTION
Fixes #4726 

This refactors the plugin (mainly code style and validation schema refinements) and fixes the "Forbidden token format" issue.

The problem was how the query string with the HMAC was applied to the stream URL. Both parts are retrieved from different API calls and instead of concatenating the parts like `{url}?{querystring}`, the query string was parsed and the URL updated with the parsed query string dictionary. While updating the URL, Python automatically quotes/percent-encodes query string values, which broke the token format, hence the added `quote_via=lambda string, *_, **__: string` keyword to `update_qsd()` which simply passes through the value.

- https://github.com/streamlink/streamlink/blame/c1a14d6338a36794cb235e00e79f4faed1614776/src/streamlink/plugins/mitele.py#L93-L95
- https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode

As an additional note, it's probably unnecessary to yield this many streams with duplicate names, but since it's from different CDNs, I don't want to change this. Very much related to https://github.com/streamlink/streamlink/discussions/4758#discussioncomment-3438282

----

Non-Spanish IP address (geo-blocked):
```
$ streamlink 'https://mitele.es/directo/telecinco' best
[cli][info] Found matching plugin mitele for URL https://mitele.es/directo/telecinco
[plugins.mitele][error] Could not get stream tokens: 4038 (User has no privileges)
error: No playable streams found on this URL: https://mitele.es/directo/telecinco
```

Spanish IP address:
```
$ streamlink -l debug 'https://mitele.es/directo/telecinco' best
[cli][debug] OS:         Linux-5.19.2-1-git-x86_64-with-glibc2.36
[cli][debug] Python:     3.10.6
[cli][debug] Streamlink: 4.3.0+9.g3b0c5c36
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.0
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.2
[cli][debug] Arguments:
[cli][debug]  url=https://mitele.es/directo/telecinco
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin mitele for URL https://mitele.es/directo/telecinco
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: none_150k, 360p_620k_alt2 (worst), 360p_620k_alt, 360p_620k, 360p_1100k_alt2, 360p_1100k_alt, 360p_1100k, 576p_1900k_alt2, 576p_1900k_alt, 576p_1900k, 576p_3100k_alt, 576p_3100k, 720p_4200k_alt, 720p_4200k (best)
[cli][info] Opening stream: 720p_4200k (hls)
[cli][info] Starting player: mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 216279944; Last Sequence: 216279947
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 216279945; End Sequence: None
[stream.hls][debug] Adding segment 216279945 to queue
[stream.hls][debug] Adding segment 216279946 to queue
[stream.hls][debug] Adding segment 216279947 to queue
[stream.hls][debug] Segment 216279945 complete
[cli.output][debug] Opening subprocess: mpv --force-media-title=https://mitele.es/directo/telecinco -
[stream.hls][debug] Segment 216279946 complete
[stream.hls][debug] Segment 216279947 complete
[cli][debug] Writing stream to output
```