### PR TITLE
plugins.ustreamtv: fix matcher

### DIFF
--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -462,13 +462,15 @@ class UStreamTVStream(Stream):
 
 
 @pluginmatcher(re.compile(r"""
-    https?://(?:(www\.)?ustream\.tv|video\.ibm\.com)
-        (?:
-            (/embed/|/channel/id/)(?P<channel_id>\d+)
-        )?
-        (?:
-            (/embed)?/recorded/(?P<video_id>\d+)
-        )?
+    https?://(?:(?:www\.)?ustream\.tv|video\.ibm\.com)
+    (?:
+        /combined-embed
+        /(?P<combined_channel_id>\d+)
+        (?:/video/(?P<combined_video_id>\d+))?
+        |
+        (?:(?:/embed/|/channel/(?:id/)?)(?P<channel_id>\d+))?
+        (?:(?:/embed)?/recorded/(?P<video_id>\d+))?
+    )
 """, re.VERBOSE))
 @pluginargument(
     "password",
@@ -481,11 +483,11 @@ class UStreamTV(Plugin):
     STREAM_READY_TIMEOUT = 15
 
     def _get_media_app(self):
-        video_id = self.match.group("video_id")
+        video_id = self.match.group("video_id") or self.match.group("combined_video_id")
         if video_id:
             return video_id, "recorded"
 
-        channel_id = self.match.group("channel_id")
+        channel_id = self.match.group("channel_id") or self.match.group("combined_channel_id")
         if not channel_id:
             channel_id = self.session.http.get(
                 self.url,

--- a/tests/plugins/test_ustreamtv.py
+++ b/tests/plugins/test_ustreamtv.py
@@ -9,14 +9,47 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlUStreamTV(PluginCanHandleUrl):
     __plugin__ = UStreamTV
 
-    should_match = [
-        "http://www.ustream.tv/streamlink",
-        "http://www.ustream.tv/channel/id/1234",
-        "http://www.ustream.tv/embed/1234",
-        "http://www.ustream.tv/recorded/6543",
-        "http://www.ustream.tv/embed/recorded/6543",
-        "https://video.ibm.com/channel/H5rQLwmTGrW",
-        "https://video.ibm.com/recorded/124680279",
+    should_match_groups = [
+        (
+            "https://www.ustream.tv/nasahdtv",
+            {},
+        ),
+        (
+            "https://www.ustream.tv/channel/6540154",
+            {"channel_id": "6540154"},
+        ),
+        (
+            "https://www.ustream.tv/channel/id/6540154",
+            {"channel_id": "6540154"},
+        ),
+        (
+            "https://www.ustream.tv/embed/6540154",
+            {"channel_id": "6540154"},
+        ),
+        (
+            "https://www.ustream.tv/recorded/132041157",
+            {"video_id": "132041157"},
+        ),
+        (
+            "https://www.ustream.tv/embed/recorded/132041157",
+            {"video_id": "132041157"},
+        ),
+        (
+            "https://www.ustream.tv/combined-embed/6540154",
+            {"combined_channel_id": "6540154"},
+        ),
+        (
+            "https://www.ustream.tv/combined-embed/6540154/video/132041157",
+            {"combined_channel_id": "6540154", "combined_video_id": "132041157"},
+        ),
+        (
+            "https://video.ibm.com/nasahdtv",
+            {},
+        ),
+        (
+            "https://video.ibm.com/recorded/132041157",
+            {"video_id": "132041157"},
+        ),
     ]
 
 


### PR DESCRIPTION
Fixes #4753

All URLs in the rewritten URL matcher tests are working fine.