### PR TITLE
plugins.huya: update `liveId` to type `str`

### DIFF
--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -54,7 +54,7 @@ class Huya(Plugin):
                 {
                     "data": [{
                         "gameLiveInfo": {
-                            "liveId": int,
+                            "liveId": str,
                             "nick": str,
                             "roomName": str,
                         },


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Fixes the Huya plugin, closes #4762 

It appears that Huya have updated its JSON respose and changed `liveId` from `int` to `str`, which causes Streamlink to throw `ValidationError`

An example of such JSON response
```js
var TT_ROOM_DATA = {
    "type": "NORMAL",
    "state": "ON",
    "isOn": true,
    "isOff": false,
    "isReplay": false,
    "isPayRoom": 0,
    "isSecret": 0,
    "roomPayPassword": "",
    "id": "2246718540",
    "sid": "2246718540",
    "channel": "2246718540",
    "liveChannel": "2246718540",
    "liveId": "7134653690594404016",
    "shortChannel": 0,
    "isBluRay": 1,
    "gameFullName": "QQ飞车",
    "gameHostName": "qqfc",
    "screenType": 1,
    "startTime": 1661166012,
    "totalCount": 94949,
    "cameraOpen": 0,
    "liveCompatibleFlag": 0,
    "bussType": 1,
    "isPlatinum": 1,
    "isAutoBitrate": 0,
    "screenshot": "https://anchorpost.msstatic.com/cdnimage/anchorpost/1048/bf/cabe0c27190175f71f3ba6625d6339_0_1612088308.jpg",
    "previewUrl": "",
    "gameId": 0,
    "liveSourceType": 0,
    "privateHost": "2248015237",
    "profileRoom": 602781,
    "recommendStatus": 0,
    "popular": 0,
    "gid": 9,
    "introduction": "排位3000分段 晚点刷记录走起！",
    "isRedirectHuya": 0,
    "isShowMmsProgramList": 0
};
```

