### PR TITLE
plugins.huya: Trim whitespace at the beginning of the HTML response

### DIFF
--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -33,6 +33,7 @@ class Huya(Plugin):
 
     def _get_streams(self):
         data = self.session.http.get(self.url, schema=validate.Schema(
+            validate.transform(str.lstrip),
             validate.parse_html(),
             validate.xml_xpath_string(".//script[contains(text(),'var hyPlayerConfig = {')][1]/text()"),
             validate.none_or_all(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

This patch fixes an issue where, at random, some stream (eg. https://huya.com/25886853) would fail with

```
[cli][info] Found matching plugin huya for URL https://huya.com/25886853
error: Unable to validate response text: ValidationError(Callable):
  iselement(None) is not true
```

It appears that the issue is caused by `lxml.etree.HTMLParser`, which in some cases would parse the empty line and whitespaces before `<!DOCTYPE html>` and incorrectly assumes that the page is empty, then returns an empty result, causing subsequent validators to fail

By simply running `lstrip` on the HTML output to get rid of them, lxml parses the content correctly.

```sh
>>> data[0:70]
'\n        <!DOCTYPE html>\n        <html lang="zh-CN">\n            <head'
>>> parser = HTMLParser()
>>> tree = HTML(data, parser)
>>> tree
>>> parser.error_log
<string>:2:1:ERROR:HTML:ERR_DOCUMENT_EMPTY: Document is empty
>>> data = data.lstrip()
>>> data[0:70]
'<!DOCTYPE html>\n        <html lang="zh-CN">\n            <head>\n       '
>>> tree = HTML(data, parser)
>>> tree
<Element html at 0x10467c1c0>
```