### PR TITLE
plugins.rtve: fix plugin

### DIFF
--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -127,6 +127,7 @@ class ZTNR:
     is_global=True,
 )
 class Rtve(Plugin):
+    URL_M3U8 = "https://ztnr.rtve.es/ztnr/{id}.m3u8"
     URL_VIDEOS = "https://ztnr.rtve.es/ztnr/movil/thumbnail/rtveplayw/videos/{id}.png?q=v2"
     URL_SUBTITLES = "https://www.rtve.es/api/videos/{id}/subtitulos.json"
 
@@ -145,6 +146,8 @@ class Rtve(Plugin):
         if not self.id:
             return
 
+        # check obfuscated stream URLs via self.URL_VIDEOS and ZTNR.translate() first
+        # self.URL_M3U8 appears to be valid for all streams, but doesn't provide any content in same cases
         urls = self.session.http.get(
             self.URL_VIDEOS.format(id=self.id),
             schema=validate.Schema(
@@ -154,12 +157,16 @@ class Rtve(Plugin):
             ),
         )
 
-        url = next((url for _, url in urls if urlparse(url).path.endswith(".m3u8")), None)
-        if not url:
-            url = next((url for _, url in urls if urlparse(url).path.endswith(".mp4")), None)
-            if url:
-                yield "vod", HTTPStream(self.session, url)
-            return
+        # then fall back to self.URL_M3U8
+        if not urls:
+            url = self.URL_M3U8.format(id=self.id)
+        else:
+            url = next((url for _, url in urls if urlparse(url).path.endswith(".m3u8")), None)
+            if not url:
+                url = next((url for _, url in urls if urlparse(url).path.endswith(".mp4")), None)
+                if url:
+                    yield "vod", HTTPStream(self.session, url)
+                return
 
         streams = HLSStream.parse_variant_playlist(self.session, url).items()
 
@@ -173,8 +180,8 @@ class Rtve(Plugin):
                             "items": [{
                                 "lang": str,
                                 "src": validate.url(),
-                            }]
-                        }
+                            }],
+                        },
                     },
                     validate.get(("page", "items")),
                 ),


### PR DESCRIPTION
Fixes #4757

See https://github.com/streamlink/streamlink/issues/4757#issuecomment-1221357795

Some content is geo-blocked, and will result in 403 HTTP requests on HLS segments.

----

Live (via new simple HLS URL requests)
```
$ streamlink https://www.rtve.es/play/videos/directo/la-1/
[cli][info] Found matching plugin rtve for URL https://www.rtve.es/play/videos/directo/la-1/
Available streams: 360p (worst), 576p, 720p (best)

$ streamlink https://www.rtve.es/play/videos/directo/canales-lineales/la-2/
[cli][info] Found matching plugin rtve for URL https://www.rtve.es/play/videos/directo/canales-lineales/la-2/
Available streams: 360p (worst), 576p, 720p, 1080p (best)
```

Documentaries and TV shows  (via old, obfuscated HLS URLs)
```
$ streamlink https://www.rtve.es/play/videos/telediario/eutanasia-pistolero-tarragona-debate-juridico/6676533/
[cli][info] Found matching plugin rtve for URL https://www.rtve.es/play/videos/telediario/eutanasia-pistolero-tarragona-debate-juridico/6676533/
Available streams: 720p (worst, best)

$ streamlink https://www.rtve.es/play/videos/servir-y-proteger/episodio-1280/6675214/
[cli][info] Found matching plugin rtve for URL https://www.rtve.es/play/videos/servir-y-proteger/episodio-1280/6675214/
Available streams: 720p (worst, best)
```

Movies (via old, obfuscated HLS URLs - HTTPStream fallback)
```
$ streamlink https://www.rtve.es/play/videos/somos-cine/de-tu-ventana-a-la-mia/6067670/
[cli][info] Found matching plugin rtve for URL https://www.rtve.es/play/videos/somos-cine/de-tu-ventana-a-la-mia/6067670/
Available streams: vod (worst, best)
```