### PR TITLE
plugin: remove `Plugin.bind()`, change `Plugin.__init__()` and `Session.resolve_url()`

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,33 @@
 Deprecations
 ============
 
+streamlink 5.0.0
+----------------
+
+Deprecation of Plugin.__init__(self, url)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+With the removal of the ``Plugin.bind()`` class method which was used for setting up the
+:py:class:`Streamlink <streamlink.session.Streamlink>` session instance and module name in each plugin class,
+the :py:class:`Plugin <streamlink.plugin.Plugin>` constructor's signature was changed and it now requires
+the ``session`` and ``url`` arguments. Implementors of custom plugins should define variable positional arguments and keyword
+arguments when subclassing and adding a custom constructor (``*args, **kwargs``), and the ``url`` should be accessed via
+``self.url`` after calling the constructor of the super class.
+
+Compatibility wrappers were added for old custom plugin implementations, and a deprecation message will be shown until
+the compatibility wrappers will get removed in a future release.
+
+
+Session.resolve_url() return type changes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Due to the changes of the :py:class:`Plugin <streamlink.plugin.Plugin>` class mentioned above, the return value of
+:py:meth:`Streamlink.resolve_url <streamlink.Streamlink.resolve_url>` and
+:py:meth:`Streamlink.resolve_url_no_redirect <streamlink.Streamlink.resolve_url_no_redirect>` had to be changed
+from ``tuple[type[Plugin], str]`` to ``tuple[str, type[Plugin], str]``, and both methods now return the resolved plugin name
+as the first item, in addition to the plugin class and resolved URL.
+
+
 streamlink 4.2.0
 ----------------
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -1,4 +1,5 @@
 import ast
+import inspect
 import logging
 import operator
 import re
@@ -164,6 +165,16 @@ class Matcher(NamedTuple):
     priority: int
 
 
+# Add front- and back-wrappers to the deprecated plugin's method resolution order (see Plugin.__new__)
+class PluginWrapperMeta(type):
+    def mro(cls):
+        # cls.__base__ is the PluginWrapperFront which is based on the deprecated plugin class
+        mro = list(cls.__base__.__mro__)
+        # cls is the PluginWrapperBack and needs to be inserted after the deprecated plugin class
+        mro.insert(2, cls)
+        return mro
+
+
 class Plugin:
     """
     Plugin base class for retrieving streams and metadata from the URL specified.
@@ -209,6 +220,41 @@ class Plugin:
     can_handle_url: Callable[[str], bool]
     # deprecated
     priority: Callable[[str], int]
+
+    # Handle deprecated plugin constructors which only take the url argument
+    def __new__(cls, *args, **kwargs):
+        # Ignore plugins without custom constructors or wrappers
+        if cls.__init__ is Plugin.__init__ or hasattr(cls, "_IS_DEPRECATED_PLUGIN_WRAPPER"):
+            return super().__new__(cls)
+
+        # Ignore custom constructors which have a formal "session" parameter or a variable positional parameter
+        sig = inspect.signature(cls.__init__).parameters
+        if "session" in sig or any(param.kind == inspect.Parameter.VAR_POSITIONAL for param in sig.values()):
+            return super().__new__(cls)
+
+        # Wrapper class which overrides the very first constructor in the MRO
+        # noinspection PyAbstractClass
+        class PluginWrapperFront(cls):
+            _IS_DEPRECATED_PLUGIN_WRAPPER = True
+
+            # The __module__ value needs to be copied
+            __module__ = cls.__module__
+
+            def __init__(self, session, url):
+                # Take any arguments, but only pass the URL to the custom constructor of the deprecated plugin
+                # noinspection PyArgumentList
+                super().__init__(url)
+                log.info(f"Initialized {self.module} plugin with deprecated constructor")
+
+        # Wrapper class which comes after the deprecated plugin in the MRO
+        # noinspection PyAbstractClass
+        class PluginWrapperBack(PluginWrapperFront, metaclass=PluginWrapperMeta):
+            def __init__(self, *_, **__):
+                # Take any arguments from the super() call of the constructor of the deprecated plugin,
+                # but pass the right args and keywords to the Plugin constructor
+                super().__init__(*args, **kwargs)
+
+        return cls.__new__(PluginWrapperBack, *args, **kwargs)
 
     def __init__(self, session, url: str):
         """

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -160,8 +160,8 @@ class AbemaTV(Plugin):
 
     _SLOT_SCHEMA = validate.Schema({"slot": {"flags": {validate.optional("timeshiftFree"): bool}}})
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.session.http.headers.update({'User-Agent': useragents.CHROME})
 
     def _generate_applicationkeysecret(self, deviceid):

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -82,8 +82,8 @@ class AfreecaTV(Plugin):
         }
     )
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._authed = (
             self.session.http.cookies.get("PdboxBbs")
             and self.session.http.cookies.get("PdboxSaveTicket")

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -69,8 +69,8 @@ log = logging.getLogger(__name__)
     (?:/|\#)?$
 """, re.VERBOSE))
 class Albavision(Plugin):
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._page = None
 
     @property

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -84,8 +84,8 @@ class BBCiPlayer(Plugin):
         validate.filter(lambda x: x["kind"] == "video")
     )
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.url = urlunparse(urlparse(self.url)._replace(scheme="https"))
 
     @classmethod

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -172,8 +172,8 @@ class Filmon(Plugin):
 
     TIME_CHANNEL = 60 * 60 * 24 * 365
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         parsed = urlparse(self.url)
         if parsed.path.startswith("/channel/"):
             self.url = urlunparse(parsed._replace(path=parsed.path.replace("/channel/", "/tv/")))

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -71,8 +71,8 @@ class OPENRECtv(Plugin):
         validate.optional("data"): object
     })
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.video_id = None
 
     def login(self, email, password):

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -80,8 +80,8 @@ class Pixiv(Plugin):
     login_url_get = "https://accounts.pixiv.net/login"
     login_url_post = "https://accounts.pixiv.net/api/login"
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._authed = (self.session.http.cookies.get("PHPSESSID")
                         and self.session.http.cookies.get("device_token"))
         self.session.http.headers.update({"Referer": self.url})

--- a/src/streamlink/plugins/ruv.py
+++ b/src/streamlink/plugins/ruv.py
@@ -43,8 +43,8 @@ _multi_re = re.compile(r"""(?P<base_url>http://[0-9a-zA-Z\-\.]*/
     /?
 """, re.VERBOSE))
 class Ruv(Plugin):
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
         self.live = self.matches[0] is not None
         if self.live:

--- a/src/streamlink/plugins/tvrby.py
+++ b/src/streamlink/plugins/tvrby.py
@@ -33,11 +33,11 @@ class TVRBy(Plugin):
         ),
     )
 
-    def __init__(self, url):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         # ensure the URL ends with a /
-        if not url.endswith("/"):
-            url += "/"
-        super().__init__(url)
+        if not self.url.endswith("/"):
+            self.url += "/"
 
     def _get_streams(self):
         res = self.session.http.get(self.url)

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -45,8 +45,8 @@ class TwitCasting(Plugin):
         }
     })
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.channel = self.match.group("channel")
 
     def _get_streams(self):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -528,10 +528,10 @@ class Twitch(Plugin):
             return sys.maxsize, stream
         return super().stream_weight(stream)
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         match = self.match.groupdict()
-        parsed = urlparse(url)
+        parsed = urlparse(self.url)
         self.params = parse_qsd(parsed.query)
         self.subdomain = match.get("subdomain")
         self.video_id = None

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -48,8 +48,8 @@ class USTVNow(Plugin):
     _token_url = _api_url + "get/token"
     _signin_url = "https://www.ustvnow.com/signin"
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._encryption_config = {}
         self._token = None
 

--- a/src/streamlink/plugins/wwenetwork.py
+++ b/src/streamlink/plugins/wwenetwork.py
@@ -46,8 +46,8 @@ class WWENetwork(Plugin):
 
     customer_id = 16
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.session.http.headers.update({"User-Agent": useragents.CHROME})
         self.auth_token = None
 

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -74,9 +74,9 @@ class YouTube(Plugin):
         258: 258,
     }
 
-    def __init__(self, url):
-        super().__init__(url)
-        parsed = urlparse(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        parsed = urlparse(self.url)
 
         # translate input URLs to be able to find embedded data and to avoid unnecessary HTTP redirects
         if parsed.netloc == "gaming.youtube.com":

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -41,8 +41,8 @@ class YuppTV(Plugin):
     _m3u8_re = re.compile(r'''['"](http.+\.m3u8.*?)['"]''')
     _cookie_expiry = 3600 * 24 * 365
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self._authed = (self.session.http.cookies.get("BoxId")
                         and self.session.http.cookies.get("YuppflixToken"))
 

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -99,8 +99,8 @@ class Zattoo(Plugin):
     TIME_CONTROL = 60 * 60 * 2
     TIME_SESSION = 60 * 60 * 24 * 30
 
-    def __init__(self, url):
-        super().__init__(url)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.domain = self.match.group('base_url')
         self._session_attributes = Cache(
             filename='plugin-cache.json',

--- a/tests/plugin/override/testplugin.py
+++ b/tests/plugin/override/testplugin.py
@@ -2,10 +2,7 @@ from tests.plugin.testplugin import __plugin__ as TestPlugin
 
 
 class TestPluginOverride(TestPlugin):
-    @classmethod
-    def bind(cls, *args, **kwargs):
-        super().bind(*args, **kwargs)
-        cls.module = "testplugin"
+    pass
 
 
 __plugin__ = TestPluginOverride

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -28,8 +28,6 @@ class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
     ("http://example.com/bar", NO_PRIORITY),
 ])
 def test_priority(url, priority):
-    session = Mock()
-    MPEGDASH.bind(session, "tests.plugins.test_dash")
     assert next((matcher.priority for matcher in MPEGDASH.matchers if matcher.pattern.match(url)), NO_PRIORITY) == priority
 
 
@@ -44,8 +42,7 @@ def test_priority(url, priority):
 @patch("streamlink.stream.DASHStream.parse_manifest")
 def test_get_streams(parse_manifest, url, expected):
     session = Mock()
-    MPEGDASH.bind(session, "tests.plugins.test_dash")
-    p = MPEGDASH(url)
+    p = MPEGDASH(session, url)
     p.streams()
     parse_manifest.assert_called_with(session, expected)
 

--- a/tests/plugins/test_rtpplay.py
+++ b/tests/plugins/test_rtpplay.py
@@ -57,8 +57,7 @@ class TestRTPPlay(unittest.TestCase):
             mock.get("https://valid", text=self.playlist)
             mock.get("https://invalid", exc=AssertionError)
             session = Streamlink()
-            RTPPlay.bind(session, "tests.plugins.test_rtpplay")
-            plugin = RTPPlay(url)
+            plugin = RTPPlay(session, url)
             return plugin._get_streams()
 
     def test_empty(self):

--- a/tests/plugins/test_tvrby.py
+++ b/tests/plugins/test_tvrby.py
@@ -1,4 +1,6 @@
-import unittest
+from unittest.mock import Mock
+
+import pytest
 
 from streamlink.plugins.tvrby import TVRBy
 from tests.plugins import PluginCanHandleUrl
@@ -15,17 +17,16 @@ class TestPluginCanHandleUrlTVRBy(PluginCanHandleUrl):
     ]
 
 
-class TestPluginTVRBy(unittest.TestCase):
-    def test_url_fix(self):
-        self.assertTrue(
+class TestPluginTVRBy:
+    @pytest.mark.parametrize("url,expected", [
+        (
             "http://www.tvr.by/televidenie/belarus-1/",
-            TVRBy("http://www.tvr.by/televidenie/belarus-1/").url)
-        self.assertTrue(
             "http://www.tvr.by/televidenie/belarus-1/",
-            TVRBy("http://www.tvr.by/televidenie/belarus-1").url)
-        self.assertTrue(
-            "http://www.tvr.by/televidenie/belarus-24/",
-            TVRBy("http://www.tvr.by/televidenie/belarus-24/").url)
-        self.assertTrue(
-            "http://www.tvr.by/televidenie/belarus-24/",
-            TVRBy("http://www.tvr.by/televidenie/belarus-24").url)
+        ),
+        (
+            "http://www.tvr.by/televidenie/belarus-1",
+            "http://www.tvr.by/televidenie/belarus-1/",
+        ),
+    ])
+    def test_url_fix(self, url, expected):
+        assert TVRBy(Mock(), url).url == expected

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -98,8 +98,7 @@ class _TwitchHLSStream(TwitchHLSStream):
 
 def test_stream_weight():
     session = Streamlink()
-    Twitch.bind(session, "tests.plugins.test_twitch")
-    plugin = Twitch("http://twitch.tv/foo")
+    plugin = Twitch(session, "http://twitch.tv/foo")
 
     with text("hls/test_master_twitch_vod.m3u8") as fh:
         playlist = fh.read()
@@ -359,8 +358,7 @@ class TestTwitchMetadata(unittest.TestCase):
     @staticmethod
     def subject(url):
         session = Streamlink()
-        Twitch.bind(session, "tests.plugins.test_twitch")
-        plugin = Twitch(url)
+        plugin = Twitch(session, url)
         return plugin.get_id(), plugin.get_author(), plugin.get_category(), plugin.get_title()
 
     def mock_request_channel(self, data=True):
@@ -563,8 +561,7 @@ class TestTwitchHosting(unittest.TestCase):
                 ])
 
             session = Streamlink()
-            Twitch.bind(session, "tests.plugins.test_twitch")
-            plugin = Twitch("https://twitch.tv/{0}".format(channel))
+            plugin = Twitch(session, f"https://twitch.tv/{channel}")
             plugin.options.set("disable-hosting", disable)
 
             res = plugin._switch_to_hosted_channel()
@@ -657,8 +654,7 @@ class TestTwitchReruns(unittest.TestCase):
         with patch("streamlink.plugins.twitch.TwitchAPI.stream_metadata") as mock:
             mock.return_value = None if params.pop("offline", False) else {"type": params.pop("stream_type", "live")}
             session = Streamlink()
-            Twitch.bind(session, "tests.plugins.test_twitch")
-            plugin = Twitch("https://www.twitch.tv/foo")
+            plugin = Twitch(session, "https://www.twitch.tv/foo")
             plugin.options.set("disable-reruns", params.pop("disable", True))
 
             return plugin._check_for_rerun()

--- a/tests/plugins/test_vk.py
+++ b/tests/plugins/test_vk.py
@@ -61,8 +61,7 @@ class TestPluginCanHandleUrlVK(PluginCanHandleUrl):
 ])
 def test_url_redirect(url, newurl, raises, requests_mock):
     session = Streamlink()
-    VK.bind(session, "tests.plugins.test_vk")
-    plugin = VK(url)
+    plugin = VK(session, url)
     requests_mock.register_uri(rm.ANY, rm.ANY, exc=rm.exceptions.InvalidRequest)
     requests_mock.get(url, text=f"""<!DOCTYPE html><html><head><meta property="og:url" content="{newurl}"/></head></html>""")
     try:

--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -68,5 +68,4 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
     ("http://www.youtube.com/watch?v=0123456789A", "https://www.youtube.com/watch?v=0123456789A"),
 ])
 def test_translate_url(url, expected):
-    YouTube.bind(Mock(), "tests.plugins.test_youtube")
-    assert YouTube(url).url == expected
+    assert YouTube(Mock(), url).url == expected

--- a/tests/test_cli_main_formatter.py
+++ b/tests/test_cli_main_formatter.py
@@ -10,15 +10,16 @@ from streamlink_cli.utils import datetime
 @pytest.fixture(scope="module")
 def plugin():
     class FakePlugin(Plugin):
+        __module__ = "FAKE"
+
         def _get_streams(self):  # pragma: no cover
             pass
 
-    plugin = FakePlugin("https://foo/bar")
+    plugin = FakePlugin(Mock(), "https://foo/bar")
     plugin.id = "ID"
     plugin.author = "AUTHOR"
     plugin.category = "CATEGORY"
     plugin.title = "TITLE"
-    plugin.bind(Mock(), "FAKE")
 
     return plugin
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -156,8 +156,6 @@ class TestSetupOptions:
         @pluginargument("bar-bar", default=456)
         @pluginargument("baz-baz", default=789, help=argparse.SUPPRESS)
         class FakePlugin(Plugin):
-            module = "plugin"
-
             def _get_streams(self):  # pragma: no cover
                 pass
 
@@ -178,7 +176,7 @@ class TestSetupOptions:
             assert FakePlugin.options.get("bar_bar") == 456, "Sets the plugin-argument's default value"
             assert FakePlugin.options.get("baz_baz") == 789, "Sets the suppressed plugin-argument's default value"
 
-            setup_plugin_options(session, FakePlugin)
+            setup_plugin_options(session, "plugin", FakePlugin)
             assert FakePlugin.options.get("foo_foo") == 321, "Sets the provided global-argument value"
             assert FakePlugin.options.get("bar_bar") == 654, "Sets the provided plugin-argument value"
             assert FakePlugin.options.get("baz_baz") == 789, "Doesn't set values of suppressed plugin-arguments"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,6 +1,7 @@
 import pkgutil
 import re
 import tokenize
+from inspect import Parameter, signature
 from pathlib import Path
 
 import pytest
@@ -66,6 +67,19 @@ class TestPlugins:
         classname = plugin.__plugin__.__name__
         assert classname == classname[0].upper() + classname[1:], "__plugin__ class name starts with uppercase letter"
         assert "_" not in classname, "__plugin__ class name does not contain underscores"
+
+    def test_constructor(self, plugin):
+        assert (
+            plugin.__plugin__.__init__ is Plugin.__init__
+            or tuple(
+                (param.name, param.kind)
+                for param in signature(plugin.__plugin__.__init__).parameters.values()
+            ) == (
+                ("self", Parameter.POSITIONAL_OR_KEYWORD),
+                ("args", Parameter.VAR_POSITIONAL),
+                ("kwargs", Parameter.VAR_KEYWORD),
+            )
+        )
 
     def test_matchers(self, plugin):
         pluginclass = plugin.__plugin__

--- a/tests/test_plugins_input.py
+++ b/tests/test_plugins_input.py
@@ -21,9 +21,7 @@ class TestPluginUserInput:
 
     @pytest.fixture
     def testplugin(self, session: Streamlink):
-        testplugin = _TestPlugin("http://example.com/stream")
-        testplugin.bind(session, "testplugin")
-        return testplugin
+        return _TestPlugin(session, "http://example.com/stream")
 
     @pytest.fixture
     def console_input(self, request, session: Streamlink):


### PR DESCRIPTION
Resolves #4744 
Fixes #4358

This introduces breaking changes to the `Plugin.__init__()` method, as well as `Session.resolve_url()` and `Session.resolve_url_no_redirect()`.

**See the commit messages of each individual commit for proper descriptions and explanations.**

Current `master`:
```py
>>> import streamlink
>>> import gc
>>> streamlink.__version__
'4.3.0+18.g60e87243'
>>> s = streamlink.Streamlink()
>>> del s
>>> gc.collect()
0
>>> [obj for obj in gc.get_objects() if isinstance(obj, streamlink.Streamlink)]
[<streamlink.session.Streamlink object at 0x7f59380a36d0>]
```

Removal of `Plugin.bind()`:
```py
>>> import streamlink
>>> import gc
>>> streamlink.__version__
'4.3.0+21.gf34a33cc'
>>> s = streamlink.Streamlink()
>>> del s
>>> gc.collect()
3835
>>> [obj for obj in gc.get_objects() if isinstance(obj, streamlink.Streamlink)]
[]
```

----

I've decided to add compatibility wrappers for old-style `Plugin` constructors, so that breaking changes for custom plugin implementations can be avoided for a short while and deprecation messages be shown.

~~I still need to update the docs (which I just remembered while writing this). But even then,~~ I want to keep this PR open for a bit, so I can think about all this and check if something's wrong or missing.