### PR TITLE
plugins: fix regex capture groups

### DIFF
--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -93,9 +93,9 @@ class Albavision(Plugin):
         schema = validate.Schema(
             validate.xml_xpath_string(".//script[contains(text(), 'LIVE_URL')]/text()"),
             validate.none_or_all(
-                re.compile(r"""LIVE_URL\s*=\s*(?P<q>['"])(.+?)(?P=q)"""),
+                re.compile(r"""LIVE_URL\s*=\s*(?P<q>['"])(?P<url>.+?)(?P=q)"""),
                 validate.none_or_all(
-                    validate.get(1),
+                    validate.get("url"),
                     validate.url(),
                 ),
             ),
@@ -108,9 +108,9 @@ class Albavision(Plugin):
         schema = validate.Schema(
             validate.xml_xpath_string(".//script[contains(text(), 'LIVE_URL')]/text()"),
             validate.none_or_all(
-                re.compile(r"""jQuery\.get\s*\((?P<q>['"])(.+?)(?P=q)"""),
+                re.compile(r"""jQuery\.get\s*\((?P<q>['"])(?P<token>.+?)(?P=q)"""),
                 validate.none_or_all(
-                    validate.get(1),
+                    validate.get("token"),
                     validate.url(),
                 ),
             ),
@@ -121,8 +121,8 @@ class Albavision(Plugin):
         schema = validate.Schema(
             validate.xml_xpath_string(".//script[contains(text(), 'LIVE_URL')]/text()"),
             validate.none_or_all(
-                re.compile(r"""Math\.floor\(Date\.now\(\)\s*/\s*3600000\),\s*(?P<q>['"])(.+?)(?P=q)"""),
-                validate.none_or_all(validate.get(1)),
+                re.compile(r"""Math\.floor\(Date\.now\(\)\s*/\s*3600000\),\s*(?P<q>['"])(?P<token>.+?)(?P=q)"""),
+                validate.none_or_all(validate.get("token")),
             ),
         )
         token_req_str = schema.validate(self.page)

--- a/src/streamlink/plugins/hiplayer.py
+++ b/src/streamlink/plugins/hiplayer.py
@@ -38,8 +38,11 @@ class HiPlayer(Plugin):
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(), 'https://hiplayer.hibridcdn.net/l/')]/text()"),
                 validate.none_or_all(
-                    re.compile(r"""(?P<q>['"])(https://hiplayer.hibridcdn.net/l/.+?)(?P=q)"""),
-                    validate.none_or_all(validate.get(1), validate.url()),
+                    re.compile(r"""(?P<q>['"])(?P<url>https://hiplayer.hibridcdn.net/l/.+?)(?P=q)"""),
+                    validate.none_or_all(
+                        validate.get("url"),
+                        validate.url(),
+                    ),
                 ),
             ),
         )

--- a/src/streamlink/plugins/htv.py
+++ b/src/streamlink/plugins/htv.py
@@ -80,8 +80,11 @@ class HTV(Plugin):
                 validate.parse_html(),
                 validate.xml_xpath_string(".//script[contains(text(), 'playlist.m3u8')]/text()"),
                 validate.none_or_all(
-                    re.compile(r"""var\s+iosUrl\s*=\s*(?P<q>")(.+?)(?P=q)"""),
-                    validate.none_or_all(validate.get(1), validate.url()),
+                    re.compile(r"""var\s+iosUrl\s*=\s*(?P<q>")(?P<url>.+?)(?P=q)"""),
+                    validate.none_or_all(
+                        validate.get("url"),
+                        validate.url(),
+                    ),
                 ),
             ),
         )


### PR DESCRIPTION
Fixes #4769 

These changes are based on the diff of #4702, where plugins and their validation schemas were refactored. In some plugins, I modified some regexes and added named capture groups for back-references of quotations, but forgot to change the index of the capture group getter. This change replaces the indexed getter with a named one, to avoid this.

----

```
$ streamlink 'https://rotana.net/live-clip'
[cli][info] Found matching plugin hiplayer for URL https://rotana.net/live-clip
Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)
```

```
$ streamlink 'https://www.cnbcarabia.com/Pages/live'
[cli][info] Found matching plugin hiplayer for URL https://www.cnbcarabia.com/Pages/live
Available streams: 240p (worst), 360p, 480p, 720p (best)
```

```
$ streamlink 'https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTV1'
[cli][info] Found matching plugin hiplayer for URL https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTV1
Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)
```