### PR TITLE
plugin.api.validate: refactor ValidationError

### DIFF
--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -1,4 +1,3 @@
-from streamlink.plugin.api.validate._exception import ValidationError  # noqa: F401
 # noinspection PyPep8Naming,PyShadowingBuiltins
 from streamlink.plugin.api.validate._schemas import (  # noqa: I101, F401
     SchemaContainer,

--- a/src/streamlink/plugin/api/validate/_exception.py
+++ b/src/streamlink/plugin/api/validate/_exception.py
@@ -11,11 +11,9 @@ class ValidationError(ValueError):
         self,
         *errors,
         schema: Optional[Union[str, object]] = None,
-        context: Optional[Union[Exception]] = None,
         **errkeywords
     ):
         self.schema = schema
-        self.context = context
         if len(errors) == 1 and type(errors[0]) is str:
             self.errors = (self._truncate(errors[0], **errkeywords), )
         else:
@@ -25,9 +23,7 @@ class ValidationError(ValueError):
         return string if len(string) <= self.MAX_LENGTH else f"<{string[:self.MAX_LENGTH - 5]}...>"
 
     def _truncate(self, template: str, **kwargs):
-        return str(template).format(
-            **{k: self._ellipsis(str(v)) for k, v in kwargs.items()}
-        )
+        return template.format(**{k: self._ellipsis(str(v)) for k, v in kwargs.items()})
 
     def _get_schema_name(self) -> str:
         if not self.schema:
@@ -60,7 +56,7 @@ class ValidationError(ValueError):
                     append(indentation, f"{err.__class__.__name__}{err._get_schema_name()}:")
                     add(level + 1, err)
 
-            context = error.context
+            context = error.__cause__
             if context:
                 if not isinstance(context, cls):
                     append(indentation, "Context:")

--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -32,7 +32,7 @@ class Schema(AllSchema):
         try:
             return validate(self, value)
         except ValidationError as err:
-            raise exception(f"Unable to validate {name}: {err}")
+            raise exception(f"Unable to validate {name}: {err}") from None
 
 
 # ----
@@ -95,11 +95,11 @@ def _validate_dict(schema, value):
                 try:
                     newkey = validate(key, subkey)
                 except ValidationError as err:
-                    raise ValidationError("Unable to validate key", schema=dict, context=err)
+                    raise ValidationError("Unable to validate key", schema=dict) from err
                 try:
                     newvalue = validate(subschema, subvalue)
                 except ValidationError as err:
-                    raise ValidationError("Unable to validate value", schema=dict, context=err)
+                    raise ValidationError("Unable to validate value", schema=dict) from err
                 new[newkey] = newvalue
             break
 
@@ -114,12 +114,7 @@ def _validate_dict(schema, value):
         try:
             new[key] = validate(subschema, value[key])
         except ValidationError as err:
-            raise ValidationError(
-                "Unable to validate value of key {key}",
-                key=repr(key),
-                schema=dict,
-                context=err,
-            )
+            raise ValidationError("Unable to validate value of key {key}", key=repr(key), schema=dict) from err
 
     return new
 
@@ -149,7 +144,7 @@ def _validate_pattern(schema: Pattern, value):
     try:
         result = schema.search(value)
     except TypeError as err:
-        raise ValidationError(err, schema=Pattern)
+        raise ValidationError(err, schema=Pattern) from None
 
     return result
 
@@ -181,7 +176,7 @@ def _validate_noneorallschema(schema: NoneOrAllSchema, value):
             for schema in schema.schema:
                 value = validate(schema, value)
         except ValidationError as err:
-            raise ValidationError(err, schema=NoneOrAllSchema)
+            raise ValidationError(err, schema=NoneOrAllSchema) from None
 
     return value
 
@@ -230,7 +225,7 @@ def _validate_regexschema(schema: RegexSchema, value):
     try:
         result = getattr(schema.pattern, schema.method)(value)
     except TypeError as err:
-        raise ValidationError(err, schema=RegexSchema)
+        raise ValidationError(err, schema=RegexSchema) from None
 
     if result is None:
         raise ValidationError(
@@ -272,7 +267,7 @@ def _validate_getitemschema(schema: GetItemSchema, value):
                 key=repr(key),
                 value=repr(value),
                 schema=GetItemSchema,
-            )
+            ) from None
         return schema.default
     except (TypeError, AttributeError) as err:
         raise ValidationError(
@@ -280,8 +275,7 @@ def _validate_getitemschema(schema: GetItemSchema, value):
             key=repr(key),
             value=repr(value),
             schema=GetItemSchema,
-            context=err,
-        )
+        ) from err
 
 
 @validate.register
@@ -304,8 +298,7 @@ def _validate_attrschema(schema: AttrSchema, value):
                 "Could not validate attribute {key}",
                 key=repr(key),
                 schema=AttrSchema,
-                context=err,
-            )
+            ) from err
 
         setattr(new, key, value)
 
@@ -324,25 +317,25 @@ def _validate_xmlelementschema(schema: XmlElementSchema, value):
         try:
             tag = validate(schema.tag, value.tag)
         except ValidationError as err:
-            raise ValidationError("Unable to validate XML tag", schema=XmlElementSchema, context=err)
+            raise ValidationError("Unable to validate XML tag", schema=XmlElementSchema) from err
 
     if schema.attrib is not None:
         try:
             attrib = validate(schema.attrib, dict(value.attrib))
         except ValidationError as err:
-            raise ValidationError("Unable to validate XML attributes", schema=XmlElementSchema, context=err)
+            raise ValidationError("Unable to validate XML attributes", schema=XmlElementSchema) from err
 
     if schema.text is not None:
         try:
             text = validate(schema.text, value.text)
         except ValidationError as err:
-            raise ValidationError("Unable to validate XML text", schema=XmlElementSchema, context=err)
+            raise ValidationError("Unable to validate XML text", schema=XmlElementSchema) from err
 
     if schema.tail is not None:
         try:
             tail = validate(schema.tail, value.tail)
         except ValidationError as err:
-            raise ValidationError("Unable to validate XML tail", schema=XmlElementSchema, context=err)
+            raise ValidationError("Unable to validate XML tail", schema=XmlElementSchema) from err
 
     new = Element(tag, attrib)
     new.text = text
@@ -365,7 +358,7 @@ def _validate_unionschema(schema: UnionSchema, value):
     try:
         return validate_union(schema.schema, value)
     except ValidationError as err:
-        raise ValidationError("Could not validate union", schema=UnionSchema, context=err)
+        raise ValidationError("Could not validate union", schema=UnionSchema) from err
 
 
 # ----
@@ -398,8 +391,7 @@ def _validate_union_dict(schema, value):
                 "Unable to validate union {key}",
                 key=repr(key),
                 schema=dict,
-                context=err,
-            )
+            ) from err
 
     return new
 

--- a/src/streamlink/plugin/api/validate/_validators.py
+++ b/src/streamlink/plugin/api/validate/_validators.py
@@ -22,7 +22,7 @@ def validator_length(number: int) -> Callable[[str], bool]:
     """
 
     def min_len(value):
-        if not len(value) >= number:
+        if len(value) < number:
             raise ValidationError(
                 "Minimum length is {number}, but value is {value}",
                 number=repr(number),
@@ -129,8 +129,7 @@ def validator_url(**attributes) -> Callable[[str], bool]:
                     "Unable to validate URL attribute {name}",
                     name=repr(name),
                     schema="url",
-                    context=err,
-                )
+                ) from err
 
         return True
 
@@ -229,8 +228,7 @@ def validator_xml_find(
                 "ElementPath syntax error: {path}",
                 path=repr(path),
                 schema="xml_find",
-                context=err,
-            )
+            ) from err
 
         if value is None:
             raise ValidationError(
@@ -301,8 +299,7 @@ def validator_xml_xpath(
                 "XPath evaluation error: {xpath}",
                 xpath=repr(xpath),
                 schema="xml_xpath",
-                context=err,
-            )
+            ) from err
 
         return result or None
 

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -6,6 +6,8 @@ from lxml.etree import Element, tostring as etree_tostring
 
 from streamlink.exceptions import PluginError
 from streamlink.plugin.api import validate
+# noinspection PyProtectedMember
+from streamlink.plugin.api.validate._exception import ValidationError
 
 
 def assert_validationerror(exception, expected):
@@ -64,7 +66,7 @@ class TestEquality:
         assert validate.validate("foo", "foo") == "foo"
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate("foo", "bar")
         assert_validationerror(cm.value, """
             ValidationError(equality):
@@ -87,7 +89,7 @@ class TestType:
         assert validate.validate(A, b) is b
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(int, "1")
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -120,7 +122,7 @@ class TestSequence:
         assert validate.validate([1, 2, 3], []) == []
 
     def test_failure_items(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate([1, 2, 3], [3, 4, 5])
         assert_validationerror(cm.value, """
             ValidationError(AnySchema):
@@ -133,7 +135,7 @@ class TestSequence:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate([1, 2, 3], {1, 2, 3})
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -204,7 +206,7 @@ class TestDict:
         assert validate.validate(schema, value) == expected
 
     def test_failure_key(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate({str: int}, {"foo": 1, 2: 3})
         assert_validationerror(cm.value, """
             ValidationError(dict):
@@ -214,7 +216,7 @@ class TestDict:
         """)
 
     def test_failure_key_value(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate({str: int}, {"foo": "bar"})
         assert_validationerror(cm.value, """
             ValidationError(dict):
@@ -224,7 +226,7 @@ class TestDict:
         """)
 
     def test_failure_notfound(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate({"foo": "bar"}, {"baz": "qux"})
         assert_validationerror(cm.value, """
             ValidationError(dict):
@@ -232,7 +234,7 @@ class TestDict:
         """)
 
     def test_failure_value(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate({"foo": "bar"}, {"foo": 1})
         assert_validationerror(cm.value, """
             ValidationError(dict):
@@ -242,7 +244,7 @@ class TestDict:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate({}, 1)
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -260,7 +262,7 @@ class TestCallable:
         assert validate.validate(self.subject, value) is value
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(self.subject, None)
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -292,7 +294,7 @@ class TestPattern:
         assert validate.validate(re.compile(r"foo"), "bar") is None
 
     def test_failure_type(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(re.compile(r"foo"), b"foo")
         assert_validationerror(cm.value, """
             ValidationError(Pattern):
@@ -300,7 +302,7 @@ class TestPattern:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(re.compile(r"foo"), 123)
         assert_validationerror(cm.value, """
             ValidationError(Pattern):
@@ -352,7 +354,7 @@ class TestAllSchema:
         ]
     )
     def test_failure(self, schema, value, error):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(schema, value)
         assert_validationerror(cm.value, error)
 
@@ -383,7 +385,7 @@ class TestAnySchema:
         assert validate.validate(schema, value) is value
 
     def test_failure(self, schema):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(schema, None)
         assert_validationerror(cm.value, """
             ValidationError(AnySchema):
@@ -411,7 +413,7 @@ class TestNoneOrAllSchema:
         ) == expected
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.none_or_all(str, int), "foo")
         assert_validationerror(cm.value, """
             ValidationError(NoneOrAllSchema):
@@ -443,7 +445,7 @@ class TestListSchema:
 
     def test_failure(self):
         data = [1, 3.14, "foo"]
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.list("foo", int, float), data)
         assert_validationerror(cm.value, """
             ValidationError(ListSchema):
@@ -456,7 +458,7 @@ class TestListSchema:
         """)
 
     def test_failure_type(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.list(), {})
         assert_validationerror(cm.value, """
             ValidationError(ListSchema):
@@ -464,7 +466,7 @@ class TestListSchema:
         """)
 
     def test_failure_length(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.list("foo", "bar", "baz"), ["foo", "bar"])
         assert_validationerror(cm.value, """
             ValidationError(ListSchema):
@@ -489,7 +491,7 @@ class TestRegexSchema:
         assert validate.validate(validate.regex(re.compile(r"\s+"), "split"), "foo bar baz") == ["foo", "bar", "baz"]
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.regex(re.compile(r"foo")), "bar")
         assert_validationerror(cm.value, """
             ValidationError(RegexSchema):
@@ -497,7 +499,7 @@ class TestRegexSchema:
         """)
 
     def test_failure_type(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.regex(re.compile(r"foo")), b"foo")
         assert_validationerror(cm.value, """
             ValidationError(RegexSchema):
@@ -505,7 +507,7 @@ class TestRegexSchema:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.regex(re.compile(r"foo")), 123)
         assert_validationerror(cm.value, """
             ValidationError(RegexSchema):
@@ -535,7 +537,7 @@ class TestTransformSchema:
         assert str(cm.value).endswith("takes 0 positional arguments but 1 was given")
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             # noinspection PyTypeChecker
             validate.validate(
                 validate.transform("not a callable"),
@@ -587,7 +589,7 @@ class TestGetItemSchema:
     @pytest.mark.parametrize("exception", [TypeError, AttributeError])
     def test_getitem_error(self, exception):
         container = self.Container(exception("failure"))
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.get("foo", default="default"), container)
         assert_validationerror(cm.value, """
             ValidationError(GetItemSchema):
@@ -606,7 +608,7 @@ class TestGetItemSchema:
 
     def test_nested_failure(self):
         dictionary = {"foo": {"bar": {"baz": "qux"}}}
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.get(("foo", "qux", "baz"), default="default"), dictionary)
         assert_validationerror(cm.value, """
             ValidationError(GetItemSchema):
@@ -646,7 +648,7 @@ class TestAttrSchema:
         assert newobj.bar is obj.bar
 
     def test_failure_missing(self, obj):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.attr({"missing": int}), obj)
         assert_validationerror(cm.value, """
             ValidationError(AttrSchema):
@@ -654,7 +656,7 @@ class TestAttrSchema:
         """)
 
     def test_failure_subschema(self, obj):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.attr({"foo": str}), obj)
         assert_validationerror(cm.value, """
             ValidationError(AttrSchema):
@@ -777,12 +779,12 @@ class TestXmlElementSchema:
         ]
     )
     def test_failure(self, element, schema, error):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(schema, element)
         assert_validationerror(cm.value, error)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_element(), "not-an-element")
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -825,7 +827,7 @@ class TestUnionSchema:
         assert validate.validate(schema, "value") == {"foo": "value", "bar": "VALUE"}
 
     def test_dict_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.union({"foo": int}), "value")
         assert_validationerror(cm.value, """
             ValidationError(UnionSchema):
@@ -856,7 +858,7 @@ class TestUnionSchema:
         assert result == expected
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.union(None), None)
         assert_validationerror(cm.value, """
             ValidationError(UnionSchema):
@@ -879,7 +881,7 @@ class TestLengthValidator:
         [(3, "foo"), (3, [1, 2, 3])]
     )
     def test_failure(self, minlength, value):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.length(minlength + 1), value)
         assert_validationerror(cm.value, """
             ValidationError(length):
@@ -892,7 +894,7 @@ class TestStartsWithValidator:
         assert validate.validate(validate.startswith("foo"), "foo bar baz")
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.startswith("invalid"), "foo bar baz")
         assert_validationerror(cm.value, """
             ValidationError(startswith):
@@ -900,7 +902,7 @@ class TestStartsWithValidator:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.startswith("invalid"), 1)
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -913,7 +915,7 @@ class TestEndsWithValidator:
         assert validate.validate(validate.endswith("baz"), "foo bar baz")
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.endswith("invalid"), "foo bar baz")
         assert_validationerror(cm.value, """
             ValidationError(endswith):
@@ -921,7 +923,7 @@ class TestEndsWithValidator:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.endswith("invalid"), 1)
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -934,7 +936,7 @@ class TestContainsValidator:
         assert validate.validate(validate.contains("bar"), "foo bar baz")
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.contains("invalid"), "foo bar baz")
         assert_validationerror(cm.value, """
             ValidationError(contains):
@@ -942,7 +944,7 @@ class TestContainsValidator:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.contains("invalid"), 1)
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -972,7 +974,7 @@ class TestUrlValidator:
         assert validate.validate(validate.url(**params), self.url)
 
     def test_failure_valid_url(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.url(), "foo")
         assert_validationerror(cm.value, """
             ValidationError(url):
@@ -980,7 +982,7 @@ class TestUrlValidator:
         """)
 
     def test_failure_url_attribute(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.url(invalid=str), self.url)
         assert_validationerror(cm.value, """
             ValidationError(url):
@@ -988,7 +990,7 @@ class TestUrlValidator:
         """)
 
     def test_failure_subschema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.url(hostname="invalid"), self.url)
         assert_validationerror(cm.value, """
             ValidationError(url):
@@ -998,7 +1000,7 @@ class TestUrlValidator:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.url(), 1)
         assert_validationerror(cm.value, """
             ValidationError(type):
@@ -1036,7 +1038,7 @@ class TestHasAttrValidator:
         assert validate.validate(validate.hasattr("foo"), self.Subject())
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.hasattr("bar"), self.Subject())
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -1080,7 +1082,7 @@ class TestXmlFindValidator:
         assert validate.validate(validate.xml_find("./a:foo", namespaces={"a": "http://a"}), root) is child
 
     def test_failure_no_element(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_find("*"), Element("foo"))
         assert_validationerror(cm.value, """
             ValidationError(xml_find):
@@ -1088,7 +1090,7 @@ class TestXmlFindValidator:
         """)
 
     def test_failure_not_found(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_find("invalid"), Element("foo"))
         assert_validationerror(cm.value, """
             ValidationError(xml_find):
@@ -1096,7 +1098,7 @@ class TestXmlFindValidator:
         """)
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_find("."), "not-an-element")
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -1104,7 +1106,7 @@ class TestXmlFindValidator:
         """)
 
     def test_failure_syntax(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_find("["), Element("foo"))
         assert_validationerror(cm.value, """
             ValidationError(xml_find):
@@ -1136,7 +1138,7 @@ class TestXmlFindallValidator:
         assert validate.validate(validate.xml_findall("./a:*", namespaces={"a": "http://a"}), root) == [root[0], root[2]]
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_findall("*"), "not-an-element")
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -1162,7 +1164,7 @@ class TestXmlFindtextValidator:
         assert validate.validate(validate.xml_findtext("./a:foo", namespaces={"a": "http://a"}), root) == "bar"
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_findtext("."), "not-an-element")
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -1212,7 +1214,7 @@ class TestXmlXpathValidator:
         assert validate.validate(validate.xml_xpath("*[local-name() = $name]/text()", name="foo"), element) == ["FOO"]
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_xpath("."), "not-an-element")
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -1220,7 +1222,7 @@ class TestXmlXpathValidator:
         """)
 
     def test_failure_evaluation(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_xpath("?"), Element("root"))
         assert_validationerror(cm.value, """
             ValidationError(xml_xpath):
@@ -1250,7 +1252,7 @@ class TestXmlXpathStringValidator:
         assert not hasattr(validate.validate(validate.xml_xpath_string("./foo/text()"), element)[0], "getparent")
 
     def test_failure_schema(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.xml_xpath_string("."), "not-an-element")
         assert_validationerror(cm.value, """
             ValidationError(Callable):
@@ -1266,7 +1268,7 @@ class TestParseJsonValidator:
         ) == {"a": ["b", True, False, None, 1, 2.3]}
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.parse_json(), "invalid")
         assert_validationerror(cm.value, """
             ValidationError:
@@ -1282,7 +1284,7 @@ class TestParseHtmlValidator:
         ).tag == "html"
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.parse_html(), None)
         assert_validationerror(cm.value, """
             ValidationError:
@@ -1298,7 +1300,7 @@ class TestParseXmlValidator:
         ).tag == "root"
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.parse_xml(), None)
         assert_validationerror(cm.value, """
             ValidationError:
@@ -1314,7 +1316,7 @@ class TestParseQsdValidator:
         ) == {"foo": "baz", "qux": "quux"}
 
     def test_failure(self):
-        with pytest.raises(validate.ValidationError) as cm:
+        with pytest.raises(ValidationError) as cm:
             validate.validate(validate.parse_qsd(), 123)
         assert_validationerror(cm.value, """
             ValidationError:
@@ -1324,20 +1326,20 @@ class TestParseQsdValidator:
 
 class TestValidationError:
     def test_subclass(self):
-        assert issubclass(validate.ValidationError, ValueError)
+        assert issubclass(ValidationError, ValueError)
 
     def test_empty(self):
-        assert str(validate.ValidationError()) == "ValidationError:"
-        assert str(validate.ValidationError("")) == "ValidationError:"
-        assert str(validate.ValidationError(validate.ValidationError())) == "ValidationError:\n  ValidationError:"
-        assert str(validate.ValidationError(validate.ValidationError(""))) == "ValidationError:\n  ValidationError:"
+        assert str(ValidationError()) == "ValidationError:"
+        assert str(ValidationError("")) == "ValidationError:"
+        assert str(ValidationError(ValidationError())) == "ValidationError:\n  ValidationError:"
+        assert str(ValidationError(ValidationError(""))) == "ValidationError:\n  ValidationError:"
 
     def test_single(self):
-        assert str(validate.ValidationError("foo")) == "ValidationError:\n  foo"
-        assert str(validate.ValidationError(ValueError("bar"))) == "ValidationError:\n  bar"
+        assert str(ValidationError("foo")) == "ValidationError:\n  foo"
+        assert str(ValidationError(ValueError("bar"))) == "ValidationError:\n  bar"
 
     def test_single_nested(self):
-        err = validate.ValidationError(validate.ValidationError("baz"))
+        err = ValidationError(ValidationError("baz"))
         assert_validationerror(err, """
             ValidationError:
               ValidationError:
@@ -1345,11 +1347,11 @@ class TestValidationError:
         """)
 
     def test_multiple_nested(self):
-        err = validate.ValidationError(
+        err = ValidationError(
             "a",
-            validate.ValidationError("b", "c"),
+            ValidationError("b", "c"),
             "d",
-            validate.ValidationError("e"),
+            ValidationError("e"),
             "f",
         )
         assert_validationerror(err, """
@@ -1365,16 +1367,12 @@ class TestValidationError:
         """)
 
     def test_context(self):
-        err = validate.ValidationError(
-            "a",
-            context=validate.ValidationError(
-                "b",
-                context=validate.ValidationError(
-                    "c",
-                )
-            )
-        )
-        assert_validationerror(err, """
+        errA = ValidationError("a")
+        errB = ValidationError("b")
+        errC = ValidationError("c")
+        errA.__cause__ = errB
+        errB.__cause__ = errC
+        assert_validationerror(errA, """
             ValidationError:
               a
               Context:
@@ -1384,22 +1382,18 @@ class TestValidationError:
         """)
 
     def test_multiple_nested_context(self):
-        err = validate.ValidationError(
-            "a",
-            "b",
-            context=validate.ValidationError(
-                validate.ValidationError(
-                    "c",
-                    context=validate.ValidationError("d", "e")
-                ),
-                validate.ValidationError(
-                    "f",
-                    context=validate.ValidationError("g")
-                ),
-                context=validate.ValidationError("h", "i")
-            )
-        )
-        assert_validationerror(err, """
+        errAB = ValidationError("a", "b")
+        errC = ValidationError("c")
+        errDE = ValidationError("d", "e")
+        errF = ValidationError("f")
+        errG = ValidationError("g")
+        errHI = ValidationError("h", "i")
+        errCF = ValidationError(errC, errF)
+        errAB.__cause__ = errCF
+        errC.__cause__ = errDE
+        errF.__cause__ = errG
+        errCF.__cause__ = errHI
+        assert_validationerror(errAB, """
             ValidationError:
               a
               b
@@ -1419,12 +1413,12 @@ class TestValidationError:
         """)
 
     def test_schema(self):
-        err = validate.ValidationError(
-            validate.ValidationError(
+        err = ValidationError(
+            ValidationError(
                 "foo",
                 schema=dict
             ),
-            validate.ValidationError(
+            ValidationError(
                 "bar",
                 schema="something"
             ),
@@ -1439,9 +1433,10 @@ class TestValidationError:
         """)
 
     def test_recursion(self):
-        err1 = validate.ValidationError("foo")
-        err2 = validate.ValidationError("bar", context=err1)
-        err1.context = err2
+        err1 = ValidationError("foo")
+        err2 = ValidationError("bar")
+        err2.__cause__ = err1
+        err1.__cause__ = err2
         assert_validationerror(err1, """
             ValidationError:
               foo
@@ -1452,7 +1447,7 @@ class TestValidationError:
         """)
 
     def test_truncate(self):
-        err = validate.ValidationError(
+        err = ValidationError(
             "foo {foo} bar {bar} baz",
             foo="Some really long error message that exceeds the maximum error message length",
             bar=repr("Some really long error message that exceeds the maximum error message length"),


### PR DESCRIPTION
- Remove `ValidationError` from package's `__init__` module.
  It was never meant to be a public export. Update tests accordingly.
- Remove `context` argument from `ValidationError` and use the
  exception's `__cause__` property instead, and add the "raise from"
  statements to schema validations and validators where a context was
  set previously. Explicitly "raise from None" where a context should
  be suppressed.
- Fix unneeded type cast when printing `ValidationError` template string
- Fix length comparison in `length` validator
