### PR TITLE
plugins.hiplayer: add alwasat.ly

### DIFF
--- a/src/streamlink/plugins/hiplayer.py
+++ b/src/streamlink/plugins/hiplayer.py
@@ -1,5 +1,6 @@
 """
 $description United Arab Emirates CDN hosting live content for various websites in The Middle East.
+$url alwasat.ly
 $url cnbcarabia.com
 $url media.gov.kw
 $url rotana.net
@@ -21,6 +22,8 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(r"""
     https?://(?:www\.)?
     (
+        alwasat\.ly
+    |
         cnbcarabia\.com
     |
         media\.gov\.kw

--- a/tests/plugins/test_hiplayer.py
+++ b/tests/plugins/test_hiplayer.py
@@ -6,6 +6,8 @@ class TestPluginCanHandleUrlHiPlayer(PluginCanHandleUrl):
     __plugin__ = HiPlayer
 
     should_match = [
+        "https://www.alwasat.ly/any",
+        "https://www.alwasat.ly/any/path",
         "https://www.cnbcarabia.com/any",
         "https://www.cnbcarabia.com/any/path",
         "https://www.media.gov.kw/any",


### PR DESCRIPTION
Testing Evidenc
```
~$ streamlink 'https://alwasat.ly/live' best
[cli][info] Found matching plugin hiplayer for URL https://alwasat.ly/live
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /opt/homebrew/bin/VLC
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
~$ 
```
Testing other urls have not broken

```
~$ streamlink 'https://rotana.net/live-clip/' best
[cli][info] Found matching plugin hiplayer for URL https://rotana.net/live-clip/
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /opt/homebrew/bin/VLC
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
                                                                                                                                                                                                                                   ~$ streamlink 'https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTV1' best
[cli][info] Found matching plugin hiplayer for URL https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTV1
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /opt/homebrew/bin/VLC
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...

~$ streamlink 'https://www.cnbcarabia.com/Pages/live' best               
[cli][info] Found matching plugin hiplayer for URL https://www.cnbcarabia.com/Pages/live
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p (best)
[cli][info] Opening stream: 720p (hls)
[cli][info] Starting player: /opt/homebrew/bin/VLC
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
~$ 
```
