### PR TITLE
plugins.okru: support mobile page

### DIFF
--- a/tests/plugins/test_okru.py
+++ b/tests/plugins/test_okru.py
@@ -1,5 +1,3 @@
-import pytest
-
 from streamlink.plugins.okru import OKru
 from tests.plugins import PluginCanHandleUrl
 
@@ -15,13 +13,3 @@ class TestPluginCanHandleUrlOKru(PluginCanHandleUrl):
         "https://www.ok.ru/live/12345",
         "https://ok.ru/video/266205792931",
     ]
-
-
-class TestOKru:
-    @pytest.mark.parametrize("url,expected", [
-        ("https://m.ok.ru/live/12345", "https://ok.ru/live/12345"),
-        ("https://mobile.ok.ru/live/12345", "https://ok.ru/live/12345"),
-    ])
-    def test_url_mobile(self, url, expected):
-        plugin = OKru(url)
-        assert plugin.url == expected


### PR DESCRIPTION
Resolves #4682
Reverts #4779

I removed the exception handling of the `PluginError`, because validation error messages are useful now.

----

Mobile HLS
```
$ streamlink 'https://mobile.ok.ru/live/1366902775399'
[cli][info] Found matching plugin okru for URL https://mobile.ok.ru/live/1366902775399
Available streams: 240p (worst), 360p, 480p, 720p (best)
```

Mobile HTTP
```
$ streamlink 'https://mobile.ok.ru/dk?st.cmd=movieLayer&st.groupId=70000000124591&st.discId=4242734320303&st.retLoc=top&st.rtu=%2Fdk%3Fst.cmd%3DuserMovies%26st.page%3D1%26_prevCmd%3DuserMovies%26tkn%3D8051&st.discType=GROUP_MOVIE&st.mvId=4242734320303&_prevCmd=userMovies&tkn=3276#'
[cli][info] Found matching plugin okru for URL https://mobile.ok.ru/dk?st.cmd=movieLayer&st.groupId=70000000124591&st.discId=4242734320303&st.retLoc=top&st.rtu=%2Fdk%3Fst.cmd%3DuserMovies%26st.page%3D1%26_prevCmd%3DuserMovies%26tkn%3D8051&st.discType=GROUP_MOVIE&st.mvId=4242734320303&_prevCmd=userMovies&tkn=3276#
Available streams: vod (worst, best)
```

Main site:
```
$ streamlink 'https://ok.ru/video/266205792931'
[cli][info] Found matching plugin okru for URL https://ok.ru/video/266205792931
Available streams: 144p (worst), 240p, 360p, 480p (best)
```