### PR TITLE
stream.ffmpegmux: show warning if unavailable

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -90,12 +90,16 @@ class FFMPEGMuxer(StreamIO):
     @lru_cache(maxsize=128)
     def resolve_command(cls, command: Optional[str] = None) -> Optional[str]:
         if command:
-            return which(command)
-        resolved = None
-        for cmd in cls.__commands__:
-            resolved = which(cmd)
-            if resolved:
-                break
+            resolved = which(command)
+        else:
+            resolved = None
+            for cmd in cls.__commands__:
+                resolved = which(cmd)
+                if resolved:
+                    break
+        if not resolved:
+            log.warning("FFmpeg was not found. See the --ffmpeg-ffmpeg option.")
+            log.warning("Muxing streams is unsupported! Only a subset of the available streams can be returned!")
         return resolved
 
     @staticmethod

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -52,6 +52,23 @@ class TestCommand:
         with patch("streamlink.stream.ffmpegmux.which", return_value=resolved):
             assert FFMPEGMuxer.is_usable(session) is expected
 
+    def test_log(self, session: Streamlink):
+        with patch("streamlink.stream.ffmpegmux.log") as mock_log, \
+             patch("streamlink.stream.ffmpegmux.which", return_value=None):
+            assert not FFMPEGMuxer.is_usable(session)
+            assert mock_log.warning.call_args_list == [
+                call("FFmpeg was not found. See the --ffmpeg-ffmpeg option."),
+                call("Muxing streams is unsupported! Only a subset of the available streams can be returned!"),
+            ]
+            assert not FFMPEGMuxer.is_usable(session)
+            assert len(mock_log.warning.call_args_list) == 2
+
+    def test_no_log(self, session: Streamlink):
+        with patch("streamlink.stream.ffmpegmux.log") as mock_log, \
+             patch("streamlink.stream.ffmpegmux.which", return_value="foo"):
+            assert FFMPEGMuxer.is_usable(session)
+            assert not mock_log.warning.call_args_list
+
 
 class TestOpen:
     FFMPEG_ARGS_DEFAULT_BASE = ["-nostats", "-y"]


### PR DESCRIPTION
There is way too much confusion about FFmpeg and muxed streams.

The problem is that it's not transparent at all which streams are muxed and which are not. This is due to how streams get returned, as a mapping of name->stream dicts or tuples with "alt" deduplications already done by the `Stream` implementations themselves or the `plugin.streams()` method, and only names get shown by the CLI.

The HLS implementation with external audio streams is also not ideal, because it silently falls back to streams without external audio. That needs to be changed, ideally with the implementation of alternative video streams (#3579).

So in order to at least give the user some feedback, let's add warning messages when FFmpeg is not available on the system.
The warning messages get only shown once if multiple checks are done, thanks to the caching added recently.

I decided to add two warning messages and tried to make them as short and precise as possible. Referring to the CLI argument name is not 100% correct, but since the session option does have the same name, it's fine. The empty set is also always a subset, so that should be fine, too.

----

UStreamTV plugin which requires FFmpeg:
```
$ streamlink 'https://www.ustream.tv/nasahdtv'
[cli][info] Found matching plugin ustreamtv for URL https://www.ustream.tv/nasahdtv
Available streams: 252p+a84k (worst), 252p+a95k, 360p+a84k, 360p+a95k, 486p+a84k, 486p+a95k, 720p+a84k, 720p+a95k (best)

$ streamlink --ffmpeg-ffmpeg=/dev/null 'https://www.ustream.tv/nasahdtv'
[cli][info] Found matching plugin ustreamtv for URL https://www.ustream.tv/nasahdtv
[stream.ffmpegmux][warning] FFmpeg was not found. See the --ffmpeg-ffmpeg option.
[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
error: No playable streams found on this URL: https://www.ustream.tv/nasahdtv
```

YouTube plugin with adaptive streams - #4777:
```
$ streamlink 'https://www.youtube.com/watch?v=0Jt8Wu1osgI'
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=0Jt8Wu1osgI
Available streams: audio_mp4a, audio_opus, 144p (worst), 240p, 360p, 480p, 720p, 720p60, 1080p60, 1440p60, 2160p60 (best)

$ streamlink --ffmpeg-ffmpeg=/dev/null 'https://www.youtube.com/watch?v=0Jt8Wu1osgI'
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=0Jt8Wu1osgI
[stream.ffmpegmux][warning] FFmpeg was not found. See the --ffmpeg-ffmpeg option.
[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
Available streams: audio_mp4a, audio_opus, 360p (worst), 720p (best)
```

HLS streams with external audio:
```
$ streamlink 'https://www.france.tv/france-2/direct.html'
[cli][info] Found matching plugin pluzz for URL https://www.france.tv/france-2/direct.html
Available streams: 144p (worst), 216p, 360p, 540p, 720p (best)

$ streamlink --ffmpeg-ffmpeg=/dev/null 'https://www.france.tv/france-2/direct.html'
[cli][info] Found matching plugin pluzz for URL https://www.france.tv/france-2/direct.html
[stream.ffmpegmux][warning] FFmpeg was not found. See the --ffmpeg-ffmpeg option.
[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
Available streams: 144p (worst), 216p, 360p, 540p, 720p (best)
```