### PR TITLE
logger: log deprecation messages as warnings

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -244,7 +244,7 @@ class Plugin:
                 # Take any arguments, but only pass the URL to the custom constructor of the deprecated plugin
                 # noinspection PyArgumentList
                 super().__init__(url)
-                log.info(f"Initialized {self.module} plugin with deprecated constructor")
+                log.warning(f"Initialized {self.module} plugin with deprecated constructor")
 
         # Wrapper class which comes after the deprecated plugin in the MRO
         # noinspection PyAbstractClass

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -233,7 +233,7 @@ class Streamlink:
             self.http.proxies["http"] = update_scheme("https://", value, force=False)
             self.http.proxies["https"] = self.http.proxies["http"]
             if key == "https-proxy":
-                log.info("The https-proxy option has been deprecated in favour of a single http-proxy option")
+                log.warning("The https-proxy option has been deprecated in favor of a single http-proxy option")
 
         elif key == "http-cookies":
             if isinstance(value, dict):
@@ -378,7 +378,7 @@ class Streamlink:
             elif hasattr(plugin, "can_handle_url") and callable(plugin.can_handle_url) and plugin.can_handle_url(url):
                 prio = plugin.priority(url) if hasattr(plugin, "priority") and callable(plugin.priority) else NORMAL_PRIORITY
                 if prio > priority:
-                    log.info(f"Resolved plugin {name} with deprecated can_handle_url API")
+                    log.warning(f"Resolved plugin {name} with deprecated can_handle_url API")
                     candidate = name, plugin
                     priority = prio
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -670,7 +670,7 @@ def load_plugins(dirs: List[Path], showwarning: bool = True):
         if directory.is_dir():
             success = streamlink.load_plugins(str(directory))
             if success and type(directory) is DeprecatedPath:
-                log.info(f"Loaded plugins from deprecated path, see CLI docs for how to migrate: {directory}")
+                log.warning(f"Loaded plugins from deprecated path, see CLI docs for how to migrate: {directory}")
         elif showwarning:
             log.warning(f"Plugin path {directory} does not exist or is not a directory!")
 
@@ -708,7 +708,7 @@ def setup_config_args(parser, ignore_unknown=False):
         # Only load first available default config
         for config_file in filter(lambda path: path.is_file(), CONFIG_FILES):
             if type(config_file) is DeprecatedPath:
-                log.info(f"Loaded config from deprecated path, see CLI docs for how to migrate: {config_file}")
+                log.warning(f"Loaded config from deprecated path, see CLI docs for how to migrate: {config_file}")
             config_files.append(config_file)
             break
 
@@ -721,7 +721,7 @@ def setup_config_args(parser, ignore_unknown=False):
                 if not config_file.is_file():
                     continue
                 if type(config_file) is DeprecatedPath:
-                    log.info(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {config_file}")
+                    log.warning(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {config_file}")
                 config_files.append(config_file)
                 break
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -537,7 +537,7 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
         )
         expected = [self.configdir / "primary"]
         mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        self.assertEqual(mock_log.info.mock_calls, [])
+        assert not mock_log.warning.mock_calls
 
     def test_default_primary(self, mock_log):
         mock_setup_args = self.subject(
@@ -546,7 +546,7 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
         )
         expected = [self.configdir / "primary", self.configdir / "primary.testplugin"]
         mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        self.assertEqual(mock_log.info.mock_calls, [])
+        assert not mock_log.warning.mock_calls
 
     def test_default_secondary_deprecated(self, mock_log):
         mock_setup_args = self.subject(
@@ -555,10 +555,10 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
         )
         expected = [self.configdir / "secondary", self.configdir / "secondary.testplugin"]
         mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        self.assertEqual(mock_log.info.mock_calls, [
+        assert mock_log.warning.mock_calls == [
             call(f"Loaded config from deprecated path, see CLI docs for how to migrate: {expected[0]}"),
-            call(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {expected[1]}")
-        ])
+            call(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {expected[1]}"),
+        ]
 
     def test_custom_with_primary_plugin(self, mock_log):
         mock_setup_args = self.subject(
@@ -567,7 +567,7 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
         )
         expected = [self.configdir / "custom", self.configdir / "primary.testplugin"]
         mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        self.assertEqual(mock_log.info.mock_calls, [])
+        assert not mock_log.warning.mock_calls
 
     def test_custom_with_deprecated_plugin(self, mock_log):
         mock_setup_args = self.subject(
@@ -576,9 +576,9 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
         )
         expected = [self.configdir / "custom", DeprecatedPath(self.configdir / "secondary.testplugin")]
         mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        self.assertEqual(mock_log.info.mock_calls, [
-            call(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {expected[1]}")
-        ])
+        assert mock_log.warning.mock_calls == [
+            call(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {expected[1]}"),
+        ]
 
     def test_custom_multiple(self, mock_log):
         mock_setup_args = self.subject(
@@ -587,7 +587,7 @@ class TestCLIMainSetupConfigArgs(unittest.TestCase):
         )
         expected = [self.configdir / "secondary", self.configdir / "primary", self.configdir / "primary.testplugin"]
         mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        self.assertEqual(mock_log.info.mock_calls, [])
+        assert not mock_log.warning.mock_calls
 
 
 class _TestCLIMainLogging(unittest.TestCase):


### PR DESCRIPTION
Deprecation messages should consistently get logged as warnings, to make them distinguishable from regular log messages, and to make it clear that user interactions are required.

While changing the log message channel, I experimented with switching to the `warnings` module and emitting `DeprecationWarning`s via `warnings.warn()` instead, but that would require capturing warnings in Streamlink's root logger, default warning filters would need to be changed (which I'm not sure how it would affect third party code), and in order to show warnings in a meaningful way for end-users, the resulting `LogRecord`s would need to get changed as well. This is not worth the effort for using the deprecation warnings API of the stdlib.