### PR TITLE
cli: refactor setup of session options

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -21,7 +21,7 @@ from streamlink.exceptions import FatalPluginError
 from streamlink.plugin import Plugin, PluginOptions
 from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
-from streamlink_cli.argparser import ArgumentParser, build_parser
+from streamlink_cli.argparser import ArgumentParser, build_parser, setup_session_options
 from streamlink_cli.compat import DeprecatedPath, importlib_metadata, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
@@ -733,42 +733,6 @@ def setup_signals():
     signal.signal(signal.SIGTERM, signal.default_int_handler)
 
 
-def setup_http_session():
-    """Sets the global HTTP settings, such as proxy and headers."""
-    if args.http_proxy:
-        streamlink.set_option("http-proxy", args.http_proxy)
-
-    if args.https_proxy:
-        streamlink.set_option("https-proxy", args.https_proxy)
-
-    if args.http_cookie:
-        streamlink.set_option("http-cookies", dict(args.http_cookie))
-
-    if args.http_header:
-        streamlink.set_option("http-headers", dict(args.http_header))
-
-    if args.http_query_param:
-        streamlink.set_option("http-query-params", dict(args.http_query_param))
-
-    if args.http_ignore_env:
-        streamlink.set_option("http-trust-env", False)
-
-    if args.http_no_ssl_verify:
-        streamlink.set_option("http-ssl-verify", False)
-
-    if args.http_disable_dh:
-        streamlink.set_option("http-disable-dh", True)
-
-    if args.http_ssl_cert:
-        streamlink.set_option("http-ssl-cert", args.http_ssl_cert)
-
-    if args.http_ssl_cert_crt_key:
-        streamlink.set_option("http-ssl-cert", tuple(args.http_ssl_cert_crt_key))
-
-    if args.http_timeout:
-        streamlink.set_option("http-timeout", args.http_timeout)
-
-
 def setup_plugins(extra_plugin_dir=None):
     """Loads any additional plugins."""
     load_plugins(PLUGIN_DIRS, showwarning=False)
@@ -782,84 +746,6 @@ def setup_streamlink():
     global streamlink
 
     streamlink = Streamlink({"user-input-requester": ConsoleUserInputRequester(console)})
-
-
-def setup_options():
-    """Sets Streamlink options."""
-    if args.interface:
-        streamlink.set_option("interface", args.interface)
-    if args.ipv4:
-        streamlink.set_option("ipv4", args.ipv4)
-    if args.ipv6:
-        streamlink.set_option("ipv6", args.ipv6)
-
-    if args.ringbuffer_size:
-        streamlink.set_option("ringbuffer-size", args.ringbuffer_size)
-    if args.mux_subtitles:
-        streamlink.set_option("mux-subtitles", args.mux_subtitles)
-
-    if args.hls_live_edge:
-        streamlink.set_option("hls-live-edge", args.hls_live_edge)
-    if args.hls_segment_stream_data:
-        streamlink.set_option("hls-segment-stream-data", args.hls_segment_stream_data)
-
-    if args.hls_playlist_reload_attempts:
-        streamlink.set_option("hls-playlist-reload-attempts", args.hls_playlist_reload_attempts)
-    if args.hls_playlist_reload_time:
-        streamlink.set_option("hls-playlist-reload-time", args.hls_playlist_reload_time)
-    if args.hls_segment_ignore_names:
-        streamlink.set_option("hls-segment-ignore-names", args.hls_segment_ignore_names)
-    if args.hls_segment_key_uri:
-        streamlink.set_option("hls-segment-key-uri", args.hls_segment_key_uri)
-    if args.hls_audio_select:
-        streamlink.set_option("hls-audio-select", args.hls_audio_select)
-    if args.hls_start_offset:
-        streamlink.set_option("hls-start-offset", args.hls_start_offset)
-    if args.hls_duration:
-        streamlink.set_option("hls-duration", args.hls_duration)
-    if args.hls_live_restart:
-        streamlink.set_option("hls-live-restart", args.hls_live_restart)
-
-    # deprecated
-    if args.hls_segment_attempts:
-        streamlink.set_option("hls-segment-attempts", args.hls_segment_attempts)
-    if args.hls_segment_threads:
-        streamlink.set_option("hls-segment-threads", args.hls_segment_threads)
-    if args.hls_segment_timeout:
-        streamlink.set_option("hls-segment-timeout", args.hls_segment_timeout)
-    if args.hls_timeout:
-        streamlink.set_option("hls-timeout", args.hls_timeout)
-    if args.http_stream_timeout:
-        streamlink.set_option("http-stream-timeout", args.http_stream_timeout)
-
-    # generic stream- arguments take precedence over deprecated stream-type arguments
-    if args.stream_segment_attempts:
-        streamlink.set_option("stream-segment-attempts", args.stream_segment_attempts)
-    if args.stream_segment_threads:
-        streamlink.set_option("stream-segment-threads", args.stream_segment_threads)
-    if args.stream_segment_timeout:
-        streamlink.set_option("stream-segment-timeout", args.stream_segment_timeout)
-    if args.stream_timeout:
-        streamlink.set_option("stream-timeout", args.stream_timeout)
-
-    if args.ffmpeg_ffmpeg:
-        streamlink.set_option("ffmpeg-ffmpeg", args.ffmpeg_ffmpeg)
-    if args.ffmpeg_verbose:
-        streamlink.set_option("ffmpeg-verbose", args.ffmpeg_verbose)
-    if args.ffmpeg_verbose_path:
-        streamlink.set_option("ffmpeg-verbose-path", args.ffmpeg_verbose_path)
-    if args.ffmpeg_fout:
-        streamlink.set_option("ffmpeg-fout", args.ffmpeg_fout)
-    if args.ffmpeg_video_transcode:
-        streamlink.set_option("ffmpeg-video-transcode", args.ffmpeg_video_transcode)
-    if args.ffmpeg_audio_transcode:
-        streamlink.set_option("ffmpeg-audio-transcode", args.ffmpeg_audio_transcode)
-    if args.ffmpeg_copyts:
-        streamlink.set_option("ffmpeg-copyts", args.ffmpeg_copyts)
-    if args.ffmpeg_start_at_zero:
-        streamlink.set_option("ffmpeg-start-at-zero", args.ffmpeg_start_at_zero)
-
-    streamlink.set_option("locale", args.locale)
 
 
 def setup_plugin_args(session: Streamlink, parser: ArgumentParser):
@@ -1047,11 +933,11 @@ def main():
     log_level = args.loglevel if not silent_log else "none"
     logger.root.setLevel(log_level)
 
-    setup_http_session()
-
     log_root_warning()
     log_current_versions()
     log_current_arguments(streamlink, parser)
+
+    setup_session_options(streamlink, args)
 
     setup_signals()
 
@@ -1083,7 +969,6 @@ def main():
             error_code = 130
     elif args.url:
         try:
-            setup_options()
             handle_url()
         except KeyboardInterrupt:
             # Close output

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -1,0 +1,92 @@
+from argparse import ArgumentParser, Namespace
+from typing import Any, List
+from unittest.mock import Mock
+
+import pytest
+
+from streamlink.session import Streamlink
+from streamlink_cli.argparser import build_parser, setup_session_options
+from streamlink_cli.main import main as streamlink_cli_main
+
+
+@pytest.fixture(scope="module")
+def parser():
+    return build_parser()
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("streamlink.session.Streamlink.load_builtin_plugins", lambda _: None)
+    yield Streamlink()
+
+
+@pytest.mark.parametrize("argv,option,expected", [
+    pytest.param(
+        ["--locale", "xx_XX"],
+        "locale",
+        "xx_XX",
+        id="Arg+value without mapper",
+    ),
+    pytest.param(
+        ["--http-query-param", "foo=bar", "--http-query-param", "baz=qux"],
+        "http-query-params",
+        {"foo": "bar", "baz": "qux"},
+        id="Arg+value with dict mapper",
+    ),
+    pytest.param(
+        ["--http-no-ssl-verify"],
+        "http-ssl-verify",
+        False,
+        id="Arg with bool mapper",
+    ),
+    pytest.param(
+        ["--http-ssl-cert-crt-key", "foo.crt", "bar.key"],
+        "http-ssl-cert",
+        ("foo.crt", "bar.key"),
+        id="Arg+value with tuple mapper",
+    ),
+    pytest.param(
+        ["--hls-timeout", "123"],
+        "stream-timeout",
+        123,
+        id="Deprecated argument",
+    ),
+    pytest.param(
+        ["--hls-timeout", "123", "--stream-timeout", "456"],
+        "stream-timeout",
+        456,
+        id="Deprecated argument with override",
+    ),
+])
+def test_setup_session_options(parser: ArgumentParser, session: Streamlink, argv: List, option: str, expected: Any):
+    args = parser.parse_args(argv)
+    setup_session_options(session, args)
+    assert session.get_option(option) == expected
+
+
+def test_cli_main_setup_session_options(monkeypatch: pytest.MonkeyPatch, parser: ArgumentParser, session: Streamlink):
+    class StopTest(Exception):
+        pass
+
+    mock_setup_session_options = Mock()
+
+    monkeypatch.setattr("sys.argv", [])
+    monkeypatch.setattr("streamlink_cli.main.CONFIG_FILES", [])
+    monkeypatch.setattr("streamlink_cli.main.logger", Mock())
+    monkeypatch.setattr("streamlink_cli.main.streamlink", session)
+    monkeypatch.setattr("streamlink_cli.main.build_parser", Mock(return_value=parser))
+    monkeypatch.setattr("streamlink_cli.main.setup_streamlink", Mock())
+    monkeypatch.setattr("streamlink_cli.main.setup_plugins", Mock())
+    monkeypatch.setattr("streamlink_cli.main.log_root_warning", Mock())
+    monkeypatch.setattr("streamlink_cli.main.log_current_versions", Mock())
+    monkeypatch.setattr("streamlink_cli.main.log_current_arguments", Mock())
+    monkeypatch.setattr("streamlink_cli.main.setup_session_options", mock_setup_session_options)
+    monkeypatch.setattr("streamlink_cli.main.setup_signals", Mock(side_effect=StopTest))
+
+    with pytest.raises(StopTest):
+        streamlink_cli_main()
+
+    assert mock_setup_session_options.call_count == 1, \
+        "Has called setup_session_options() before setting up signals and running actual CLI code"
+    assert mock_setup_session_options.call_args_list[0][0][0] is session
+    assert isinstance(mock_setup_session_options.call_args_list[0][0][1], Namespace)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -606,7 +606,6 @@ class _TestCLIMainLogging(unittest.TestCase):
              patch("streamlink_cli.main.CONFIG_FILES", []), \
              patch("streamlink_cli.main.setup_streamlink"), \
              patch("streamlink_cli.main.setup_plugins"), \
-             patch("streamlink_cli.main.setup_http_session"), \
              patch("streamlink.session.Streamlink.load_builtin_plugins"), \
              patch("sys.argv") as mock_argv:
             mock_argv.__getitem__.side_effect = lambda x: argv[x]
@@ -951,15 +950,12 @@ class TestCLIMainPrint(unittest.TestCase):
                  patch("streamlink_cli.main.CONFIG_FILES", []), \
                  patch("streamlink_cli.main.setup_streamlink"), \
                  patch("streamlink_cli.main.setup_plugins"), \
-                 patch("streamlink_cli.main.setup_http_session"), \
-                 patch("streamlink_cli.main.setup_signals"), \
-                 patch("streamlink_cli.main.setup_options") as mock_setup_options:
+                 patch("streamlink_cli.main.setup_signals"):
                 with self.assertRaises(SystemExit) as cm:
                     streamlink_cli.main.main()
                 self.assertEqual(cm.exception.code, 0)
                 mock_resolve_url.assert_not_called()
                 mock_resolve_url_no_redirect.assert_not_called()
-                mock_setup_options.assert_not_called()
 
     @staticmethod
     def get_stdout(mock_stdout):


### PR DESCRIPTION
- Merge `setup_options()` and `setup_http_session()` and always
  initialize all session options:
  It doesn't make sense having this split up into two functions, just
  so that some CLI functions can have a partially configured session
  with just the HTTP options set
- Move merged session setup logic into the `argparser` module
  and replace the dozens of if-statements and `session.set_option()`
  calls with a list of "CLI argument -> session option" mappings
- Add tests and update `streamlink_cli.main` tests respectively