### PR TITLE
cli: remove custom `ignored` contextmanager

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -6,7 +6,7 @@ import platform
 import re
 import signal
 import sys
-from contextlib import closing
+from contextlib import closing, suppress
 from functools import partial
 from gettext import gettext
 from itertools import chain
@@ -26,7 +26,7 @@ from streamlink_cli.compat import DeprecatedPath, importlib_metadata, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.output import FileOutput, PlayerOutput
-from streamlink_cli.utils import Formatter, HTTPServer, datetime, ignored
+from streamlink_cli.utils import Formatter, HTTPServer, datetime
 from streamlink_cli.utils.progress import Progress
 from streamlink_cli.utils.versioncheck import check_version
 
@@ -711,7 +711,7 @@ def setup_config_args(parser, ignore_unknown=False):
 
     if streamlink and args.url:
         # Only load first available plugin config
-        with ignored(NoPluginError):
+        with suppress(NoPluginError):
             pluginname, pluginclass, resolved_url = streamlink.resolve_url(args.url)
             for config_file in CONFIG_FILES:
                 config_file = config_file.with_name(f"{config_file.name}.{pluginname}")

--- a/src/streamlink_cli/output.py
+++ b/src/streamlink_cli/output.py
@@ -4,6 +4,7 @@ import re
 import shlex
 import subprocess
 import sys
+from contextlib import suppress
 from pathlib import Path
 from time import sleep
 from typing import BinaryIO, Optional
@@ -11,7 +12,7 @@ from typing import BinaryIO, Optional
 from streamlink.compat import is_win32
 from streamlink_cli.compat import stdout
 from streamlink_cli.constants import PLAYER_ARGS_INPUT_DEFAULT, PLAYER_ARGS_INPUT_FALLBACK, SUPPORTED_PLAYERS
-from streamlink_cli.utils import Formatter, ignored
+from streamlink_cli.utils import Formatter
 
 if is_win32:
     import msvcrt
@@ -263,7 +264,7 @@ class PlayerOutput(Output):
             self.record.close()
 
         if self.kill:
-            with ignored(Exception):
+            with suppress(Exception):
                 self.player.terminate()
                 if not is_win32:
                     t, timeout = 0.0, self.PLAYER_TERMINATE_TIMEOUT

--- a/src/streamlink_cli/utils/__init__.py
+++ b/src/streamlink_cli/utils/__init__.py
@@ -1,5 +1,4 @@
 import json
-from contextlib import contextmanager
 from datetime import datetime as _datetime
 
 from streamlink_cli.utils.formatter import Formatter
@@ -9,7 +8,7 @@ from streamlink_cli.utils.player import find_default_player
 __all__ = [
     "Formatter", "HTTPServer", "JSONEncoder",
     "datetime",
-    "find_default_player", "ignored",
+    "find_default_player",
 ]
 
 
@@ -21,14 +20,6 @@ class JSONEncoder(json.JSONEncoder):
             return obj.decode("utf8", "ignore")
         else:
             return json.JSONEncoder.default(self, obj)
-
-
-@contextmanager
-def ignored(*exceptions):
-    try:
-        yield
-    except exceptions:
-        pass
 
 
 # noinspection PyPep8Naming


### PR DESCRIPTION
and replace it with `contextlib.suppress`

----

Available since Python 3.4
https://docs.python.org/3/library/contextlib.html#contextlib.suppress