### PR TITLE
Code cleanup

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -26,10 +26,7 @@ class Options:
 
     @classmethod
     def _normalise_dict(cls, src):
-        dest = {}
-        for key, value in src.items():
-            dest[_normalise_option_name(key)] = value
-        return dest
+        return {_normalise_option_name(key): value for key, value in src.items()}
 
     def set(self, key, value):
         self.options[_normalise_option_name(key)] = value

--- a/src/streamlink/packages/requests_file.py
+++ b/src/streamlink/packages/requests_file.py
@@ -40,14 +40,14 @@ class FileAdapter(BaseAdapter):
 
         # Check that the method makes sense. Only support GET
         if request.method not in ("GET", "HEAD"):
-            raise ValueError("Invalid request method %s" % request.method)
+            raise ValueError(f"Invalid request method {request.method}")
 
         # Parse the URL
         url_parts = urlparse(request.url)
 
         # Make the Windows URLs slightly nicer
         if is_win32 and url_parts.netloc.endswith(":"):
-            url_parts = url_parts._replace(path="/" + url_parts.netloc + url_parts.path, netloc='')
+            url_parts = url_parts._replace(path=f"/{url_parts.netloc}{url_parts.path}", netloc="")
 
         # Reject URLs with a hostname component
         if url_parts.netloc and url_parts.netloc not in ("localhost", ".", "..", "-"):
@@ -58,7 +58,7 @@ class FileAdapter(BaseAdapter):
             pwd = os.path.abspath(url_parts.netloc).replace(os.sep, "/") + "/"
             if is_win32:
                 # prefix the path with a / in Windows
-                pwd = "/" + pwd
+                pwd = f"/{pwd}"
             url_parts = url_parts._replace(path=urljoin(pwd, url_parts.path.lstrip("/")))
 
         resp = Response()
@@ -94,7 +94,7 @@ class FileAdapter(BaseAdapter):
                 if path_parts and (path_parts[0].endswith('|') or path_parts[0].endswith(':')):
                     path_drive = path_parts.pop(0)
                     if path_drive.endswith('|'):
-                        path_drive = path_drive[:-1] + ':'
+                        path_drive = f"{path_drive[:-1]}:"
 
                     while path_parts and not path_parts[0]:
                         path_parts.pop(0)

--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -33,7 +33,7 @@ class _HTTPResponse(urllib3.response.HTTPResponse):
         #
         # Fix this by overriding urllib3.response.HTTPResponse's constructor and always setting enforce_content_length to True,
         # as there is no way to make requests set this parameter on its own.
-        kwargs.update({"enforce_content_length": True})
+        kwargs["enforce_content_length"] = True
         super().__init__(*args, **kwargs)
 
 

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -105,9 +105,7 @@ class AbemaTVLicenseAdapter(BaseAdapter):
         enckey = h.digest()
 
         aes = AES.new(enckey, AES.MODE_ECB)
-        rawvideokey = aes.decrypt(encvideokey)
-
-        return rawvideokey
+        return aes.decrypt(encvideokey)
 
     def send(self, request, stream=False, timeout=None, verify=True, cert=None,
              proxies=None):

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -89,8 +89,8 @@ class AbemaTVLicenseAdapter(BaseAdapter):
         cid = jsonres['cid']
         k = jsonres['k']
 
-        res = sum([self.STRTABLE.find(k[i]) * (58 ** (len(k) - 1 - i))
-                  for i in range(len(k))])
+        res = sum(self.STRTABLE.find(k[i]) * (58 ** (len(k) - 1 - i)) for i in range(len(k)))
+
         encvideokey = struct.pack('>QQ', res >> 64, res & 0xffffffffffffffff)
 
         # HKEY:

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -163,11 +163,10 @@ class AfreecaTV(Plugin):
         res = self.session.http.post("https://login.afreecatv.com/app/LoginAction.php", data=data)
         data = self.session.http.json(res)
         log.trace(f"{data!r}")
-        if data["RESULT"] == self.CHANNEL_RESULT_OK:
-            self.save_cookies()
-            return True
-        else:
+        if data["RESULT"] != self.CHANNEL_RESULT_OK:
             return False
+        self.save_cookies()
+        return True
 
     def _get_streams(self):
         login_username = self.get_option("username")

--- a/src/streamlink/plugins/albavision.py
+++ b/src/streamlink/plugins/albavision.py
@@ -137,6 +137,9 @@ class Albavision(Plugin):
             return update_qsd(token_req_host, {"rsk": token_req_token})
 
     def _get_token(self):
+        if not self._is_token_based_site():
+            return
+
         token_req_url = self._get_token_req_url()
         if not token_req_url:
             return
@@ -183,13 +186,11 @@ class Albavision(Plugin):
             log.info("This stream may be off-air or not available in your country")
             return
 
-        if self._is_token_based_site():
-            token = self._get_token()
-            if not token:
-                return
-            return HLSStream.parse_variant_playlist(self.session, update_qsd(live_url, {"iut": token}))
-        else:
-            return HLSStream.parse_variant_playlist(self.session, live_url)
+        token = self._get_token()
+        if token:
+            live_url = update_qsd(live_url, {"iut": token})
+
+        return HLSStream.parse_variant_playlist(self.session, live_url)
 
 
 __plugin__ = Albavision

--- a/src/streamlink/plugins/app17.py
+++ b/src/streamlink/plugins/app17.py
@@ -52,12 +52,10 @@ class App17(Plugin):
         s = HLSStream.parse_variant_playlist(self.session, hls_url)
         if not s:
             yield "live", HLSStream(self.session, hls_url)
+        elif len(s) == 1:
+            yield "live", next(iter(s.values()))
         else:
-            if len(s) == 1:
-                for _n, _s in s.items():
-                    yield "live", _s
-            else:
-                yield from s.items()
+            yield from s.items()
 
 
 __plugin__ = App17

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -107,8 +107,7 @@ class BBCiPlayer(Plugin):
         # Use pre-fetched page if available
         res = res or self.session.http.get(url)
         m = self.mediator_re.search(res.text)
-        vpid = m and parse_json(m.group(1), schema=self.mediator_schema)
-        return vpid
+        return m and parse_json(m.group(1), schema=self.mediator_schema)
 
     def find_tvip(self, url, master=False):
         log.debug("Looking for {0} tvip on {1}".format("master" if master else "", url))

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -338,7 +338,7 @@ class Crunchyroll(Plugin):
         info = info["stream_data"]
 
         # The adaptive quality stream sometimes a subset of all the other streams listed, ultra is no included
-        has_adaptive = any([s["quality"] == "adaptive" for s in info["streams"]])
+        has_adaptive = any(s["quality"] == "adaptive" for s in info["streams"])
         if has_adaptive:
             log.debug("Loading streams from adaptive playlist")
             for stream in filter(lambda x: x["quality"] == "adaptive", info["streams"]):

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -33,7 +33,7 @@ def parse_timestamp(ts):
     return (
         datetime.datetime.strptime(ts[:-7], "%Y-%m-%dT%H:%M:%S")
         + datetime.timedelta(hours=int(ts[-5:-3]), minutes=int(ts[-2:]))
-        * int(ts[-6:-5] + "1")
+        * int(f"{ts[-6:-5]}1")
     )
 
 

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -92,8 +92,7 @@ class DailyMotion(Plugin):
 
         data = self.session.http.json(res, schema=_live_id_schema)
         if data["total"] > 0:
-            media_id = data["list"][0]["id"]
-            return media_id
+            return data["list"][0]["id"]
         return False
 
     def _get_streams(self):

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -134,8 +134,7 @@ class Facebook(Plugin):
             data=urlencode(data).encode("ascii")
         )
 
-        for s in self._parse_streams(res):
-            yield s
+        yield from self._parse_streams(res)
 
 
 __plugin__ = Facebook

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -41,13 +41,12 @@ class Facebook(Plugin):
         ).validate(res.text)
         if not stream_url:
             log.debug("No meta og:video:url")
-        else:
-            if ".mpd" in stream_url:
-                yield from DASHStream.parse_manifest(self.session, stream_url).items()
-                return
-            elif ".mp4" in stream_url:
-                yield "vod", HTTPStream(self.session, stream_url)
-                return
+        elif ".mpd" in stream_url:
+            yield from DASHStream.parse_manifest(self.session, stream_url).items()
+            return
+        elif ".mp4" in stream_url:
+            yield "vod", HTTPStream(self.session, stream_url)
+            return
 
         for match in self._src_re.finditer(res.text):
             stream_url = match.group("url")

--- a/src/streamlink/plugins/gulli.py
+++ b/src/streamlink/plugins/gulli.py
@@ -77,10 +77,7 @@ class Gulli(Plugin):
                     yield from HLSStream.parse_variant_playlist(self.session, video_url).items()
                 elif '.mp4' in video_url:
                     match = self._mp4_bitrate_re.match(video_url)
-                    if match is not None:
-                        bitrate = '%sk' % match.group('bitrate')
-                    else:
-                        bitrate = 'vod'
+                    bitrate = "vod" if match is None else f"{match.group('bitrate')}k"
                     yield bitrate, HTTPStream(self.session, video_url)
             except OSError as err:
                 if '403 Client Error' in str(err):

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -24,7 +24,7 @@ class HLSPlugin(Plugin):
 
         streams = HLSStream.parse_variant_playlist(self.session, url, **params)
 
-        return streams if streams else {"live": HLSStream(self.session, url, **params)}
+        return streams or {"live": HLSStream(self.session, url, **params)}
 
 
 __plugin__ = HLSPlugin

--- a/src/streamlink/plugins/htv.py
+++ b/src/streamlink/plugins/htv.py
@@ -29,7 +29,7 @@ class HTV(Plugin):
             ],
         ))
 
-        return {k: v for k, v in data}
+        return dict(data)
 
     def _get_streams(self):
         channels = self.get_channels()

--- a/src/streamlink/plugins/mdstrm.py
+++ b/src/streamlink/plugins/mdstrm.py
@@ -141,7 +141,7 @@ class MDStrm(Plugin):
                 ),
             )
             if ad:
-                params.update({"adInsertionSessionId": ad})
+                params["adInsertionSessionId"] = ad
             else:
                 log.debug("Failed to find 'parent._dai_session'")
 

--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -201,9 +201,10 @@ class Mildom(Plugin):
                 log.debug("User doesn't appear to be live")
                 return
 
-            qualities = []
-            for quality_info in data["ext"]["cmode_params"]:
-                qualities.append((quality_info["name"], "_" + quality_info["cmode"] if quality_info["cmode"] != "raw" else ""))
+            qualities = [
+                (quality_info["name"], f"_{quality_info['cmode']}" if quality_info["cmode"] != "raw" else "")
+                for quality_info in data["ext"]["cmode_params"]
+            ]
 
             server = api.get_server()
             token = api.get_token()

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -114,9 +114,10 @@ class Mjunoon(Plugin):
         return unpad(cipher.decrypt(binascii.unhexlify(encrypted_data)), 16, 'pkcs7')
 
     def get_stream(self, slug, js_data):
-        token_data = {}
-        token_data['token'] = self.cache.get('token')
-        token_data['token_type'] = self.cache.get('token_type')
+        token_data = {
+            "token": self.cache.get("token"),
+            "token_type": self.cache.get("token_type"),
+        }
 
         if token_data['token'] and token_data['token_type']:
             log.debug('Using cached token')

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -90,11 +90,11 @@ class NimoTV(Plugin):
         log.debug(f'URL={url}')
         for k, v in self.video_qualities.items():
             _params = params.copy()
-            _params.update({'ratio': k})
+            _params["ratio"] = k
             if v == '1080p':
-                _params.update({'needwm': 0})
+                _params["needwm"] = 0
             elif v in ('720p', '480p', '360p'):
-                _params.update({'sphd': 1})
+                _params["sphd"] = 1
 
             log.trace(f'{v} params={_params!r}')
             # some qualities might not exist, but it will select a different lower quality

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -100,7 +100,7 @@ class OnePlusOneAPI:
             return
 
         log.debug(f"url_ovva={url_ovva}")
-        url_hls = self.session.http.get(
+        return self.session.http.get(
             url=url_ovva,
             schema=validate.Schema(
                 validate.transform(lambda x: x.split("=")),
@@ -108,7 +108,6 @@ class OnePlusOneAPI:
                 validate.get(1),
             ),
         )
-        return url_hls
 
 
 @pluginmatcher(re.compile(

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -56,7 +56,7 @@ class OnePlusOneHLS(HLSStream):
 
             self._url = parsed._replace(
                 netloc=self._first_netloc,
-                path="/".join([p for p in path_parts])
+                path="/".join(list(path_parts))
             ).geturl()
         return self._url
 

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -131,11 +131,7 @@ class Pixiv(Plugin):
         performers = streamer_data.get("performers")
         log.trace("{0!r}".format(streamer_data))
         if performers:
-            co_hosts = []
-            # create a list of all available performers
-            for p in performers:
-                co_hosts += [(p["user"]["unique_name"], p["user"]["name"])]
-
+            co_hosts = [(p["user"]["unique_name"], p["user"]["name"]) for p in performers]
             log.info("Available hosts: {0}".format(", ".join(
                 ["{0} ({1})".format(k, v) for k, v in co_hosts])))
 

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -124,7 +124,7 @@ class Pixiv(Plugin):
 
         if self._authed:
             log.debug("Attempting to authenticate using cached cookies")
-        elif not self._authed and login_session_id and login_device_token:
+        elif login_session_id and login_device_token:
             self._login_using_session_id_and_device_token(login_session_id, login_device_token)
 
         streamer_data = self.get_streamer_data()
@@ -137,8 +137,7 @@ class Pixiv(Plugin):
 
             # control if the host from --pixiv-performer is valid,
             # if not let the User select a different host
-            if (self.get_option("performer")
-                    and not self.get_option("performer") in [v[0] for v in co_hosts]):
+            if self.get_option("performer") and self.get_option("performer") not in [v[0] for v in co_hosts]:
 
                 # print the owner as 0
                 log.info("0 - {0} ({1})".format(

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -83,7 +83,7 @@ class SBScokr(Plugin):
         if not user_channel_id:
             log.error('No channel selected, use --sbscokr-id CHANNELID')
             return
-        elif user_channel_id and user_channel_id not in channels.keys():
+        elif user_channel_id not in channels.keys():
             log.error('Channel ID "{0}" is not available.'.format(user_channel_id))
             return
 
@@ -99,14 +99,17 @@ class SBScokr(Plugin):
                                     params=params)
         res = self.session.http.json(res, schema=self._channel_schema)
 
+        streams = []
         for media in res['source']['mediasourcelist']:
             if media['mediaurl']:
-                yield from HLSStream.parse_variant_playlist(self.session, media['mediaurl']).items()
-        else:
-            if res['info']['onair_yn'] != 'Y':
-                log.error('This channel is currently unavailable')
-            elif res['info']['overseas_yn'] != 'Y':
-                log.error(res['info']['overseas_text'])
+                streams.extend(HLSStream.parse_variant_playlist(self.session, media["mediaurl"]).items())
+        if streams:
+            return streams
+
+        if res["info"]["onair_yn"] != "Y":
+            log.error("This channel is currently unavailable")
+        elif res["info"]["overseas_yn"] != "Y":
+            log.error(res["info"]["overseas_text"])
 
 
 __plugin__ = SBScokr

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -72,10 +72,11 @@ class SBScokr(Plugin):
         res = self.session.http.get(self.api_channels)
         res = self.session.http.json(res, schema=self._channels_schema)
 
-        channels = {}
-        for channel in sorted(res, key=lambda x: x['channelid']):
-            if channel.get('type') in ('TV', 'Radio'):
-                channels[channel['channelid']] = channel['channelname']
+        channels = {
+            channel["channelid"]: channel["channelname"]
+            for channel in sorted(res, key=lambda x: x["channelid"])
+            if channel.get("type") in ("TV", "Radio")
+        }
 
         log.info('Available IDs: {0}'.format(', '.join(
             '{0} ({1})'.format(key, value) for key, value in channels.items())))

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -46,8 +46,8 @@ class TVP(Plugin):
         for url in m:
             log.debug('URL={0}'.format(url))
             if url.endswith('.m3u8'):
-                for s in HLSStream.parse_variant_playlist(self.session, url, name_fmt='{pixels}_{bitrate}').items():
-                    streams.append(s)
+                streams.extend(HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items())
+
             elif url.endswith('.mp4'):
                 streams.append(('vod', HTTPStream(self.session, url)))
 

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -33,8 +33,7 @@ class TVP(Plugin):
 
         video_id = m.group('video_id')
         log.debug('Found video id: {0}'.format(video_id))
-        p_url = self.player_url.format(video_id)
-        return p_url
+        return self.player_url.format(video_id)
 
     def _get_streams(self):
         embed_url = self.get_embed_url()

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -221,7 +221,7 @@ class TwitchAPI:
         self.headers = {
             "Client-ID": "kimne78kx3ncx6brgo4mv6wki5h1ko",
         }
-        self.headers.update(**{k: v for k, v in session.get_plugin_option("twitch", "api-header") or []})
+        self.headers.update(**dict(session.get_plugin_option("twitch", "api-header") or []))
 
     def call(self, data, schema=None):
         res = self.session.http.post(

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -111,8 +111,7 @@ class Vimeo(Plugin):
             for quality, stream in streams:
                 yield quality, MuxedStream(self.session, stream, subtitles=substreams)
         else:
-            for stream in streams:
-                yield stream
+            yield from streams
 
 
 __plugin__ = Vimeo

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -45,7 +45,7 @@ class VK(Plugin):
         self.session.http.get("https://vk.com/", hooks={"response": on_response})
 
     def _has_video_id(self):
-        return any(m for m in self.matches[:-1])
+        return any(self.matches[:-1])
 
     def follow_vk_redirect(self):
         if self._has_video_id():

--- a/src/streamlink/plugins/yupptv.py
+++ b/src/streamlink/plugins/yupptv.py
@@ -85,7 +85,7 @@ class YuppTV(Plugin):
 
         if self._authed:
             log.debug("Attempting to authenticate using cached cookies")
-        elif not self._authed and login_box_id and login_yuppflix_token:
+        elif login_box_id and login_yuppflix_token:
             self._login_using_box_id_and_yuppflix_token(
                 login_box_id,
                 login_yuppflix_token,

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -298,11 +298,7 @@ class Zattoo(Plugin):
             )
         )
 
-        c_list = []
-        for d in data:
-            for c in d['channels']:
-                c_list.append(c)
-
+        c_list = [channel for channel_group in data for channel in channel_group["channels"]]
         cid = None
         zattoo_list = []
         for c in c_list:

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -260,11 +260,12 @@ class Streamlink:
             self.http.verify = value
 
         elif key == "http-disable-dh":
-            default_ciphers = list(
+            default_ciphers = [
                 item
                 for item in urllib3_util_ssl.DEFAULT_CIPHERS.split(":")  # type: ignore[attr-defined]
                 if item != "!DH"
-            )
+            ]
+
             if value:
                 default_ciphers.append("!DH")
             urllib3_util_ssl.DEFAULT_CIPHERS = ":".join(default_ciphers)  # type: ignore[attr-defined]

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -583,8 +583,7 @@ class Representation(MPDNode):
                     yield segment
         elif segmentLists:
             for segmentList in segmentLists:
-                for segment in segmentList.segments:
-                    yield segment
+                yield from segmentList.segments
         else:
             yield Segment(self.base_url, 0, True, True)
 

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -75,11 +75,11 @@ class MPDParsers:
 
     @staticmethod
     def frame_rate(frame_rate):
-        if "/" in frame_rate:
-            a, b = frame_rate.split("/")
-            return float(a) / float(b)
-        else:
+        if "/" not in frame_rate:
             return float(frame_rate)
+
+        a, b = frame_rate.split("/")
+        return float(a) / float(b)
 
     @staticmethod
     def timedelta(timescale=1):

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -185,8 +185,7 @@ class FFMPEGMuxer(StreamIO):
         return self
 
     def read(self, size=-1):
-        data = self.process.stdout.read(size)
-        return data
+        return self.process.stdout.read(size)
 
     def close(self):
         if self.closed:

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -198,11 +198,12 @@ class FFMPEGMuxer(StreamIO):
             self.process.stdout.close()
 
             # close the streams
-            futures = []
             executor = concurrent.futures.ThreadPoolExecutor()
-            for stream in self.streams:
-                if hasattr(stream, "close") and callable(stream.close):
-                    futures.append(executor.submit(stream.close))
+            futures = [
+                executor.submit(stream.close)
+                for stream in self.streams
+                if hasattr(stream, "close") and callable(stream.close)
+            ]
 
             concurrent.futures.wait(futures, return_when=concurrent.futures.ALL_COMPLETED)
             log.debug("Closed all the substreams")

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -328,13 +328,13 @@ class HLSStreamWorker(SegmentedStreamWorker):
         if self.playlist_reload_time_override == "segment" and sequences:
             return sequences[-1].segment.duration
         if self.playlist_reload_time_override == "live-edge" and sequences:
-            return sum([s.segment.duration for s in sequences[-max(1, self.live_edge - 1):]])
+            return sum(s.segment.duration for s in sequences[-max(1, self.live_edge - 1):])
         if type(self.playlist_reload_time_override) is float and self.playlist_reload_time_override > 0:
             return self.playlist_reload_time_override
         if playlist.target_duration:
             return playlist.target_duration
         if sequences:
-            return sum([s.segment.duration for s in sequences[-max(1, self.live_edge - 1):]])
+            return sum(s.segment.duration for s in sequences[-max(1, self.live_edge - 1):])
 
         return self.playlist_reload_time
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -502,8 +502,7 @@ class MuxedHLSStream(MuxedStream):
                 tracks.extend(audio)
             else:
                 tracks.append(audio)
-        for i in range(1, len(tracks)):
-            maps.append("{0}:a".format(i))
+        maps.extend(f"{i}:a" for i in range(1, len(tracks)))
         substreams = map(lambda url: HLSStream(session, url, force_restart=force_restart, **args), tracks)
         ffmpeg_options = ffmpeg_options or {}
 

--- a/src/streamlink/utils/url.py
+++ b/src/streamlink/utils/url.py
@@ -38,13 +38,13 @@ def update_scheme(current: str, target: str, force: bool = True) -> str:
         # py>=3.9: urlparse("127.0.0.1:1234") == ParseResult(scheme='127.0.0.1', netloc='', path='1234', ...)
         # py<3.9 : urlparse("127.0.0.1:1234") == ParseResult(scheme='', netloc='', path='127.0.0.1:1234', ...)
         not _re_uri_implicit_scheme.search(target) and not target.startswith("//")
-        # target URLs without scheme and netloc: ("http://", "foo.bar/foo") -> "http://foo.bar/foo"
+        # target URLs without scheme and without netloc: ("http://", "foo.bar/foo") -> "http://foo.bar/foo"
         or not target_p.scheme and not target_p.netloc
     ):
         return f"{urlparse(current).scheme}://{urlunparse(target_p)}"
 
     # target URLs without scheme but with netloc: ("http://", "//foo.bar/foo") -> "http://foo.bar/foo"
-    if not target_p.scheme and target_p.netloc:
+    if not target_p.scheme:
         return f"{urlparse(current).scheme}:{urlunparse(target_p)}"
 
     # target URLs with scheme

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -62,8 +62,7 @@ class ConsoleOutput:
             out = []
             for obj in objs:
                 if isinstance(obj, list):
-                    for item in obj:
-                        out.append(item)
+                    out.extend(obj)
                 else:
                     if hasattr(obj, "__json__") and callable(obj.__json__):
                         obj = obj.__json__()

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -698,9 +698,12 @@ def setup_config_args(parser, ignore_unknown=False):
 
     if args.config:
         # We want the config specified last to get highest priority
-        for config_file in map(lambda path: Path(path).expanduser(), reversed(args.config)):
-            if config_file.is_file():
-                config_files.append(config_file)
+        config_files.extend(
+            config_file
+            for config_file in map(lambda path: Path(path).expanduser(), reversed(args.config))
+            if config_file.is_file()
+        )
+
     else:
         # Only load first available default config
         for config_file in filter(lambda path: path.is_file(), CONFIG_FILES):

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -279,7 +279,7 @@ class TestMixinStreamHLS(unittest.TestCase):
     def subject(self, playlists, options=None, streamoptions=None, threadoptions=None, start=True, *args, **kwargs):
         # filter out tags and duplicate segments between playlist responses while keeping index order
         segments_all = [item for playlist in playlists for item in playlist.items if isinstance(item, Segment)]
-        segments = dict((segment.num, segment) for segment in segments_all)
+        segments = {segment.num: segment for segment in segments_all}
 
         self.mock("GET", self.url(playlists[0]), [{"text": pl.build(self.id())} for pl in playlists])
         for segment in segments.values():

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -181,7 +181,8 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments, cond=lambda s: s.num >= 4),
             "Filters out preroll ad segments"
         )
-        self.assertTrue(all([self.called(s) for s in segments.values()]), "Downloads all segments")
+        self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
+
         self.assertEqual(mock_log.info.mock_calls, [
             call("Will skip ad segments"),
             call("Waiting for pre-roll ads to finish, be patient")
@@ -202,7 +203,8 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments, cond=lambda s: s.num != 2 and s.num != 3),
             "Filters out mid-stream ad segments"
         )
-        self.assertTrue(all([self.called(s) for s in segments.values()]), "Downloads all segments")
+        self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
+
         self.assertEqual(mock_log.info.mock_calls, [
             call("Will skip ad segments")
         ])
@@ -221,7 +223,8 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments),
             "Doesn't filter out segments"
         )
-        self.assertTrue(all([self.called(s) for s in segments.values()]), "Downloads all segments")
+        self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
+
         self.assertEqual(mock_log.info.mock_calls, [], "Doesn't log anything")
 
     @patch("streamlink.plugins.twitch.log")
@@ -240,8 +243,10 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments, cond=lambda s: s.num >= 4),
             "Skips first four segments due to reduced live-edge"
         )
-        self.assertFalse(any([self.called(s) for s in segments.values() if s.num < 4]), "Doesn't download old segments")
-        self.assertTrue(all([self.called(s) for s in segments.values() if s.num >= 4]), "Downloads all remaining segments")
+        self.assertFalse(any(self.called(s) for s in segments.values() if s.num < 4), "Doesn't download old segments")
+
+        self.assertTrue(all(self.called(s) for s in segments.values() if s.num >= 4), "Downloads all remaining segments")
+
         self.assertEqual(mock_log.info.mock_calls, [
             call("Low latency streaming (HLS live edge: 2)")
         ])
@@ -262,8 +267,10 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments, cond=lambda s: s.num < 8),
             "Ignores prefetch segments"
         )
-        self.assertTrue(all([self.called(s) for s in segments.values() if s.num <= 7]), "Ignores prefetch segments")
-        self.assertFalse(any([self.called(s) for s in segments.values() if s.num > 7]), "Ignores prefetch segments")
+        self.assertTrue(all(self.called(s) for s in segments.values() if s.num <= 7), "Ignores prefetch segments")
+
+        self.assertFalse(any(self.called(s) for s in segments.values() if s.num > 7), "Ignores prefetch segments")
+
         self.assertEqual(mock_log.info.mock_calls, [], "Doesn't log anything")
 
     @patch("streamlink.plugins.twitch.log")
@@ -297,8 +304,10 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments, cond=lambda s: s.num > 1),
             "Skips first two segments due to reduced live-edge"
         )
-        self.assertFalse(any([self.called(s) for s in segments.values() if s.num < 2]), "Skips first two preroll segments")
-        self.assertTrue(all([self.called(s) for s in segments.values() if s.num >= 2]), "Downloads all remaining segments")
+        self.assertFalse(any(self.called(s) for s in segments.values() if s.num < 2), "Skips first two preroll segments")
+
+        self.assertTrue(all(self.called(s) for s in segments.values() if s.num >= 2), "Downloads all remaining segments")
+
         self.assertEqual(mock_log.info.mock_calls, [
             call("Low latency streaming (HLS live edge: 2)")
         ])

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -351,7 +351,7 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
 
     def test_hls_encrypted_aes128_key_uri_override(self):
         aesKey, aesIv, key = self.gen_key(uri="http://real-mocked/{namespace}/encryption.key?foo=bar")
-        aesKeyInvalid = bytes([ord(aesKey[i:i + 1]) ^ 0xFF for i in range(16)])
+        aesKeyInvalid = bytes(ord(aesKey[i:i + 1]) ^ 0xFF for i in range(16))
         _, __, key_invalid = self.gen_key(aesKeyInvalid, aesIv, uri="http://mocked/{namespace}/encryption.key?foo=bar")
 
         # noinspection PyTypeChecker

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -589,9 +589,7 @@ class TestHlsExtAudio(unittest.TestCase):
         if audio_select:
             streamlink.set_option("hls-audio-select", audio_select)
 
-        master_stream = HLSStream.parse_variant_playlist(streamlink, playlist)
-
-        return master_stream
+        return HLSStream.parse_variant_playlist(streamlink, playlist)
 
     def test_hls_ext_audio_not_selected(self):
         master_url = "http://mocked/path/master.m3u8"

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -48,13 +48,13 @@ class TagKey(Tag):
     def __init__(self, method="NONE", uri=None, iv=None, keyformat=None, keyformatversions=None):
         attrs = {"METHOD": method}
         if uri is not False:  # pragma: no branch
-            attrs.update({"URI": lambda tag, namespace: tag.val_quoted_string(tag.url(namespace))})
+            attrs["URI"] = lambda tag, namespace: tag.val_quoted_string(tag.url(namespace))
         if iv is not None:  # pragma: no branch
-            attrs.update({"IV": self.val_hex(iv)})
+            attrs["IV"] = self.val_hex(iv)
         if keyformat is not None:  # pragma: no branch
-            attrs.update({"KEYFORMAT": self.val_quoted_string(keyformat)})
+            attrs["KEYFORMAT"] = self.val_quoted_string(keyformat)
         if keyformatversions is not None:  # pragma: no branch
-            attrs.update({"KEYFORMATVERSIONS": self.val_quoted_string(keyformatversions)})
+            attrs["KEYFORMATVERSIONS"] = self.val_quoted_string(keyformatversions)
         super().__init__("EXT-X-KEY", attrs)
         self.uri = uri
 

--- a/tests/stream/test_hls_filtered.py
+++ b/tests/stream/test_hls_filtered.py
@@ -85,7 +85,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
             self.content(segments, cond=lambda s: s.num % 4 > 1),
             "Correctly filters out segments"
         )
-        self.assertTrue(all([self.called(s) for s in segments.values()]), "Downloads all segments")
+        self.assertTrue(all(self.called(s) for s in segments.values()), "Downloads all segments")
 
     @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_sequence", new=filter_sequence)
     def test_filtered_timeout(self):

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -102,7 +102,7 @@ class TestHLSPlaylist(unittest.TestCase):
         self.assertEqual(playlist.target_duration, 120)
 
         self.assertEqual(
-            [daterange for daterange in playlist.dateranges],
+            list(playlist.dateranges),
             [
                 DateRange(id="start-invalid",
                           start_date=None,
@@ -137,7 +137,7 @@ class TestHLSPlaylist(unittest.TestCase):
             ]
         )
         self.assertEqual(
-            [segment for segment in playlist.segments],
+            list(playlist.segments),
             [
                 Segment(uri="http://test.se/segment0-15.ts", duration=15.0, title="live", date=start_date,
                         key=None, discontinuity=False, byterange=None, map=None),

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -271,7 +271,7 @@ class TestCookies:
         return r
 
     def _cookies_to_list(self, cookies):
-        return list(self._cookie_to_dict(cookie) for cookie in cookies)
+        return [self._cookie_to_dict(cookie) for cookie in cookies]
 
     @pytest.mark.parametrize(
         "plugincache",


### PR DESCRIPTION
Code cleanup done via [sourcery.ai](https://sourcery.ai/).

The changes are split into multiple logical commits, depending on which [sourcery rules](https://docs.sourcery.ai/refactorings/) were used. And depending on the resulting code, I also refactored a little bit of logic of some plugins. These plugin changes are untested but should be working fine unless the plugins were already broken in the first place.

I didn't include all the changes suggested by sourcery though, because there's stuff which I think is either completely unnecessary, which is misleading, or which is simply wrong. And there's tons of stuff which would just bloat up the diff for no good reason.

I also ignored some reasonable suggestions, eg. in the dash_manifest module, because [some lines](https://github.com/streamlink/streamlink/blame/1c731644b4daf6fea599fcf4da13118eaada812d/src/streamlink/stream/dash_manifest.py#L577-L583) looked like they were written like this intentionally, with future modifications in mind.

Please see the individual commits and commit messages.

----

Sourcery could be added to the CI, but I don't think it would be a good idea, because it's a proprietary code analysis tool, and linting should always be possible locally without any proprietary tools that have different feature levels and which require licenses. For this one-time cleanup, it's good enough though and helped finding code smells.

Once most bad code **styles** have been fixed, other linters like "black" could be added, which then only check the diff of PRs, so that the code base can be improved gradually over time, but that's a completely different topic.