### PR TITLE
plugin: add session typing information

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,6 +6,7 @@ requests-mock
 freezegun>=1.0.0
 flake8
 flake8-import-order
+flake8-pyi
 shtab
 versioningit >=2.0.0, <3
 
@@ -14,3 +15,4 @@ lxml-stubs
 types-freezegun
 types-requests
 types-urllib3
+typing_extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ ignore =
   # W503 - line break before binary operator
   # https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator
   W503,
+  # Y037 - Use PEP 604 union types instead of typing.Union
+  Y037,
 extend-exclude =
   build/,
   dist/,

--- a/src/streamlink/plugin/api/http_session.pyi
+++ b/src/streamlink/plugin/api/http_session.pyi
@@ -1,0 +1,345 @@
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, IO, Union
+
+from _typeshed import SupportsItems, SupportsRead
+from requests import PreparedRequest, Response, Session
+from requests.adapters import HTTPAdapter
+from requests.auth import AuthBase
+from requests.cookies import RequestsCookieJar
+from typing_extensions import TypeAlias
+
+from streamlink.plugin.api.validate import Schema
+from streamlink.session import Streamlink
+
+
+# START: borrowed from typeshed / types-requests
+# https://github.com/python/typeshed/blob/b6d28acb2368cdd8c87554e01e22e134061997d6/stubs/requests/requests/sessions.pyi
+
+_Data: TypeAlias = str | bytes | Mapping[str, Any] | Iterable[tuple[str, str | None]] | IO[Any]
+_Auth: TypeAlias = Union[tuple[str, str], AuthBase, Callable[[PreparedRequest], PreparedRequest]]
+_Cert: TypeAlias = Union[str, tuple[str, str]]
+_FileName: TypeAlias = str | None
+_FileContent: TypeAlias = SupportsRead[str | bytes] | str | bytes
+_FileContentType: TypeAlias = str
+_FileCustomHeaders: TypeAlias = Mapping[str, str]
+_FileSpecTuple2: TypeAlias = tuple[_FileName, _FileContent]
+_FileSpecTuple3: TypeAlias = tuple[_FileName, _FileContent, _FileContentType]
+_FileSpecTuple4: TypeAlias = tuple[_FileName, _FileContent, _FileContentType, _FileCustomHeaders]
+_FileSpec: TypeAlias = _FileContent | _FileSpecTuple2 | _FileSpecTuple3 | _FileSpecTuple4
+_Files: TypeAlias = Mapping[str, _FileSpec] | Iterable[tuple[str, _FileSpec]]
+_Hook: TypeAlias = Callable[[Response], Any]
+_HooksInput: TypeAlias = Mapping[str, Iterable[_Hook] | _Hook]
+
+_ParamsMappingKeyType: TypeAlias = str | bytes | float
+_ParamsMappingValueType: TypeAlias = str | bytes | float | Iterable[str | bytes | float] | None
+_Params: TypeAlias = Union[
+    SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType],
+    tuple[_ParamsMappingKeyType, _ParamsMappingValueType],
+    Iterable[tuple[_ParamsMappingKeyType, _ParamsMappingValueType]],
+    str | bytes,
+]
+_TextMapping: TypeAlias = MutableMapping[str, str]
+_HeadersUpdateMapping: TypeAlias = Mapping[str, str | bytes | None]
+_Timeout: TypeAlias = Union[float, tuple[float, float], tuple[float, None]]
+_Verify: TypeAlias = bool | str
+
+# END: borrowed from typeshed / types-requests
+
+
+_AcceptableStatus: TypeAlias = Sequence[int]
+_Exception: TypeAlias = type[Exception]
+
+
+# ----
+
+
+urllib3_version: tuple[int, int, int]
+
+
+class TLSSecLevel1Adapter(HTTPAdapter):
+    ...
+
+
+class HTTPSession(Session):
+    params: dict
+    timeout: float
+
+    @classmethod
+    def determine_json_encoding(cls, sample: bytes) -> str:
+        ...
+
+    @classmethod
+    def json(
+        cls,
+        res: Response,
+        name: str | None = ...,
+        exception: _Exception | None = ...,
+        schema: Schema | None = ...,
+        *args,
+        **kwargs,
+    ) -> Any:
+        ...
+
+    @classmethod
+    def xml(
+        cls,
+        res: Response,
+        ignore_ns: bool | None = ...,
+        invalid_char_entities: bool | None = ...,
+        name: str | None = ...,
+        exception: _Exception | None = ...,
+        schema: Schema | None = ...,
+        *args,
+        **kwargs,
+    ) -> Any:
+        ...
+
+    def resolve_url(self, url: str) -> str:
+        ...
+
+    @staticmethod
+    def valid_request_args(**req_keywords) -> dict[str, Any]:
+        ...
+
+    def prepare_new_request(self, **req_keywords) -> PreparedRequest:
+        ...
+
+    def request(
+        self,
+        method: str | bytes,
+        url: str | bytes,
+        params: _Params | None = ...,
+        data: _Data | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def get(
+        self,
+        url: str | bytes,
+        *,
+        params: _Params | None = ...,
+        data: _Data | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def options(
+        self,
+        url: str | bytes,
+        *,
+        params: _Params | None = ...,
+        data: _Data | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def head(
+        self,
+        url: str | bytes,
+        *,
+        params: _Params | None = ...,
+        data: _Data | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def post(
+        self,
+        url: str | bytes,
+        data: _Data | None = ...,
+        json: Any | None = ...,
+        *,
+        params: _Params | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def put(
+        self,
+        url: str | bytes,
+        data: _Data | None = ...,
+        *,
+        params: _Params | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def patch(
+        self,
+        url: str | bytes,
+        data: _Data | None = ...,
+        *,
+        params: _Params | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...
+
+    def delete(
+        self,
+        url: str | bytes,
+        *,
+        params: _Params | None = ...,
+        data: _Data | None = ...,
+        headers: _HeadersUpdateMapping | None = ...,
+        cookies: RequestsCookieJar | _TextMapping | None = ...,
+        files: _Files | None = ...,
+        auth: _Auth | None = ...,
+        timeout: _Timeout | None = ...,
+        allow_redirects: bool = ...,
+        proxies: _TextMapping | None = ...,
+        hooks: _HooksInput | None = ...,
+        stream: bool | None = ...,
+        verify: _Verify | None = ...,
+        cert: _Cert | None = ...,
+        json: Any | None = ...,
+
+        acceptable_status: _AcceptableStatus | None = ...,
+        exception: _Exception | None = ...,
+        raise_for_status: bool | None = ...,
+        session: Streamlink | None = ...,
+        schema: Schema | None = ...,
+        retries: float | None = ...,
+        retry_backoff: float | None = ...,
+        retry_max_backoff: float | None = ...,
+    ) -> Any:
+        ...

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -6,7 +6,21 @@ import re
 import time
 from functools import partial
 from http.cookiejar import Cookie
-from typing import Any, Callable, ClassVar, Dict, List, Match, NamedTuple, Optional, Pattern, Sequence, Type, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Match,
+    NamedTuple,
+    Optional,
+    Pattern,
+    Sequence,
+    TYPE_CHECKING,
+    Type,
+    Union,
+)
 
 import requests.cookies
 
@@ -14,6 +28,9 @@ from streamlink.cache import Cache
 from streamlink.exceptions import FatalPluginError, NoStreamsError, PluginError
 from streamlink.options import Argument, Arguments, Options
 from streamlink.user_input import UserInputRequester
+
+if TYPE_CHECKING:  # pragma: no cover
+    from streamlink.session import Streamlink
 
 
 log = logging.getLogger(__name__)
@@ -256,7 +273,7 @@ class Plugin:
 
         return cls.__new__(PluginWrapperBack, *args, **kwargs)
 
-    def __init__(self, session, url: str):
+    def __init__(self, session: "Streamlink", url: str):
         """
         :param session: The Streamlink session instance
         :param url: The input URL used for finding and resolving streams
@@ -270,8 +287,8 @@ class Plugin:
             key_prefix=self.module,
         )
 
-        self.session = session
-        self.url = url
+        self.session: "Streamlink" = session
+        self.url: str = url
 
         self.load_cookies()
 


### PR DESCRIPTION
- Add typing information to `Plugin.session`
- Implement `http_session` stub file due to the `HTTPSession` subclass
  of `requests.Session` which adds additional keywords to the
  `request()` method, including all other HTTP-verb methods
- Add `flake8-pyi` and `typing_extensions` to dev-requirements.txt
  (`typing_extensions` is not a runtime dependency)

----

With the removal of the `Plugin.bind()` classmethod in #4768, now that the `Streamlink` session instance gets set on each `Plugin` instance, typing information can finally be added, as the `session` attribute doesn't have to be defined as `None` anymore initially.

Adding typing informations finally allows plugin implementors to see all the stuff that's defined on the `Session`, including the `HTTPSession` via `self.session.http`. However, since Streamlink subclasses requests's `Session` and adds additional keywords to the `request()` method and thus also to all HTTP-verb methods like `get()`, `post()`, etc., this introduces typing issues. The most common problem by far is of course the addition of the `schema` keyword, which also changes the return type of the various methods from `Response` to `Any`.

I originally tried to avoid adding a stub file and directly adding the missing HTTP-verb methods to the `HTTPSession` subclass and adding typing information there, but that got very messy. The repetitive typing information therefore needs to be defined in a stub file. See [PEP561](https://peps.python.org/pep-0561/).

Unfortunately though, it doesn't seem to be possible to import already defined type aliases from the `types-requests` package, so I had to copy all required definitions for the other args+keywords provided by requests.

----

The [`typing_extensions`](https://github.com/python/typing_extensions) dependency had to be added because mypy is [configured for python 3.7](https://github.com/streamlink/streamlink/blob/8a7717f549b3f67fe3d596dbe1e562f17d48a8a8/pyproject.toml#L52-L53), and [`TypeAlias` wasn't part of the `typing` module yet in 3.7](https://docs.python.org/3/library/typing.html#typing.TypeAlias). Otherwise a `error: Module "typing" has no attribute "TypeAlias"` would be raised.

The new `Y037` linting error also has to be ignored because of an apparent mypy bug (`error: Type application has too many types (1 expected)`) when union types like `a | b | c` are defined instead of `Union[a,b,c]`. This is all a bit weird, because the copied type alias defintions are using both styles. Maybe it's because of the re-defintions... The union types syntax in stub files is valid on Python 3.7, btw:
https://typing.readthedocs.io/en/latest/source/stubs.html#syntax

----

Opening this as a draft for now.