### PR TITLE
build: add Python 3.11 to package classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
   Topic :: Internet :: WWW/HTTP
   Topic :: Multimedia :: Sound/Audio
   Topic :: Multimedia :: Video


### PR DESCRIPTION
This adds official support for the upcoming Python 3.11 release in October (unless it gets delayed - RC2 already is).

Python 3.11 deprecations in the stdlib have already been fixed:

- #4651
- #4654

and dependency-wise, I haven't noticed any problems apart from `lxml` still only having released pre-built `cp311` wheels for `musllinux_1_1`, `manylinux_2014_x86_64` and `manylinux_2010_i686`, so other platforms will have to build from source with libxml2 and libxslt being installed, but that will get resolved hopefully soon:

- https://pypi.org/project/lxml/4.9.1/#files
- https://bugs.launchpad.net/lxml/+bug/1977998