### PR TITLE
plugins.vkplay: new plugin

### DIFF
--- a/src/streamlink/plugins/vkplay.py
+++ b/src/streamlink/plugins/vkplay.py
@@ -1,0 +1,90 @@
+"""
+$description Russian live-streaming platform owned by VK Company Limited.
+$url vkplay.live
+$type live
+"""
+
+import logging
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(re.compile(r"https?://vkplay.live/(?P<channel>[^/]+)"))
+class VKPlay(Plugin):
+    API_URL = "https://api.vkplay.live/v1/blog/{0}/public_video_stream"
+
+    def _get_streams(self):
+        data = self.session.http.get(
+            self.API_URL.format(self.match.group("channel")),
+            acceptable_status=(200, 400, 404),
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    {
+                        "error": str,
+                        "error_description": str,
+                    },
+                    {
+                        "daNick": str,
+                        "title": str,
+                        validate.optional("category"): validate.all(
+                            {
+                                "title": str
+                            },
+                            validate.get("title"),
+                        ),
+                        "data": validate.none_or_all(
+                            [dict],
+                            validate.get(0),
+                            validate.none_or_all(
+                                {
+                                    "vid": str,
+                                    "playerUrls": validate.all(
+                                        [dict],
+                                        validate.filter(lambda u: u.get("url") and "playback" not in u.get("type")),
+                                        [
+                                            {
+                                                "type": str,
+                                                "url": validate.url(),
+                                            },
+                                        ],
+                                    ),
+                                },
+                            ),
+                        ),
+                    },
+                ),
+            ),
+        )
+
+        log.trace(data)
+
+        error = data.get("error")
+        if error:
+            desc = data.get("error_description")
+            log.error(f"Error: {error!r}, desc: {desc!r}")
+            return
+
+        stream = data.get("data")
+        if not stream:
+            log.error("Stream is currently offline.")
+            return
+
+        self.id = stream.get("vid")
+        self.title = data.get("title")
+        self.author = data.get("daNick")
+        self.category = data.get("category")
+
+        for playlist in stream.get("playerUrls"):
+            url = playlist.get("url")
+            kind = playlist.get("type")
+            if kind.endswith("hls"):
+                return HLSStream.parse_variant_playlist(self.session, url)
+
+
+__plugin__ = VKPlay

--- a/tests/plugins/test_vkplay.py
+++ b/tests/plugins/test_vkplay.py
@@ -1,0 +1,16 @@
+from streamlink.plugins.vkplay import VKPlay
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlVK(PluginCanHandleUrl):
+    __plugin__ = VKPlay
+
+    should_match = [
+        "https://vkplay.live/dmitry_live",
+        "https://vkplay.live/dmitry_live/streams/video_stream?share=stream_link",
+    ]
+
+    should_not_match = [
+        "https://vkplay.live",
+        "https://vkplay.live/",
+    ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
Hi there. This platform have currently beta status, but uses [ok.ru](https://ok.ru) player. I have a question about MPEG(?)-DASH manifest, he looks like: <details><summary>Manifest</summary>
<p>

```
[
  {
    "fragUrlTemplate": "frag-high-%%id%%.dash",
    "jidxUrl": "stream-high.jidx",
    "codecs": "video/mp4; codecs\u003d\"avc1.4D4020,mp4a.40.2\"",
    "headerUrl": "stream-high.hdr",
    "name": "high",
    "video": {
      "width": 1280,
      "height": 720
    },
    "bitrate": 3026621
  },
  {
    "fragUrlTemplate": "frag-medium-%%id%%.dash",
    "jidxUrl": "stream-medium.jidx",
    "codecs": "video/mp4; codecs\u003d\"avc1.4D401F,mp4a.40.2\"",
    "headerUrl": "stream-medium.hdr",
    "name": "medium",
    "video": {
      "width": 852,
      "height": 480
    },
    "bitrate": 1358870
  },
  {
    "fragUrlTemplate": "frag-low-%%id%%.dash",
    "jidxUrl": "stream-low.jidx",
    "codecs": "video/mp4; codecs\u003d\"avc1.4D401F,mp4a.40.2\"",
    "headerUrl": "stream-low.hdr",
    "name": "low",
    "video": {
      "width": 640,
      "height": 360
    },
    "bitrate": 763326
  },
  {
    "fragUrlTemplate": "frag-lowest-%%id%%.dash",
    "jidxUrl": "stream-lowest.jidx",
    "codecs": "video/mp4; codecs\u003d\"avc1.4D401E,mp4a.40.2\"",
    "headerUrl": "stream-lowest.hdr",
    "name": "lowest",
    "video": {
      "width": 428,
      "height": 240
    },
    "bitrate": 364187
  },
  {
    "fragUrlTemplate": "frag-fullhd-%%id%%.dash",
    "jidxUrl": "stream-fullhd.jidx",
    "codecs": "video/mp4; codecs\u003d\"avc1.64002A,mp4a.40.2\"",
    "headerUrl": "stream-fullhd.hdr",
    "name": "fullhd",
    "video": {
      "width": 1920,
      "height": 1080
    },
    "bitrate": 6157049
  }
]
``` 
</p></details>  

<details><summary>.jidx</summary>
<p>

```
{
  "fragIndex": 1511947,
  "start": [
    241844181,
    241845418,
    241846677,
    241847935,
    241849172,
    241850431,
    241851668,
    241852927,
    241854185,
    241855423,
    241856681,
    241857919,
    241859177,
    241860437,
    241861674,
    241862933,
    241864170,
    241865385
  ],
  "dur": [
    1237,
    1259,
    1258,
    1237,
    1259,
    1237,
    1259,
    1258,
    1238,
    1258,
    1238,
    1258,
    1260,
    1237,
    1259,
    1237,
    1215,
    1260
  ],
  "zeroTime": 1662395210328,
  "jitter": 87,
  "shiftDuration": 7200000
}
```  
</p></details>
This type of manifest is used in:

https://github.com/streamlink/streamlink/blob/fff57f041d3f50bb68bb855ed99538f2fae64714/src/streamlink/plugins/okru.py#L127-L128

So, it's impossible use in currently version `Streamlink`, because:
```
error: Unable to parse XML: Start tag expected, '<' not found, line 1, column 1 (<string>, line 1) (b'[\n  {\n    "fragUrlTemplate": "f ...)
```
Is there anything I can do at this time? For example, transform the manifest into an xml.
