### PR TITLE
ci: install custom lxml wheel on cp311 win-amd64

### DIFF
--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -8,4 +8,9 @@ python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
 # https://github.com/streamlink/streamlink/issues/4021
 python -m pip install brotli
+# Temporary custom lxml wheel for cp311 on Windows: https://github.com/streamlink/streamlink/pull/4806#issue-1364468477
+[[ "$(uname)" != "Linux" ]] \
+  && [[ "$(python -V)" =~ "Python 3.11."* ]] \
+  && python -m pip install https://github.com/streamlink/temp-wheel-for-lxml-cp311-win-amd64/releases/download/lxml-4.9.1-1/lxml-4.9.1-cp311-cp311-win_amd64.whl \
+  || true
 python -m pip install -e .


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/pull/4806#issue-1364468477
That will make the tests on Windows with Python 3.11 pass... As soon as lxml has published official wheels, we can remove it again.

The wheel is not intended for any end users, just for the CI.

Its build config can be found here:
https://github.com/streamlink/temp-wheel-for-lxml-cp311-win-amd64/blob/lxml-4.9.1-1/.github/workflows/main.yml