### PR TITLE
stream: add session typing information

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -107,6 +107,10 @@ class TwitchM3U8Parser(M3U8Parser):
 
 
 class TwitchHLSStreamWorker(HLSStreamWorker):
+    reader: "TwitchHLSStreamReader"
+    writer: "TwitchHLSStreamWriter"
+    stream: "TwitchHLSStream"
+
     def __init__(self, reader, *args, **kwargs):
         self.had_content = False
         super().__init__(reader, *args, **kwargs)
@@ -146,6 +150,9 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
 
 
 class TwitchHLSStreamWriter(HLSStreamWriter):
+    reader: "TwitchHLSStreamReader"
+    stream: "TwitchHLSStream"
+
     def should_filter_sequence(self, sequence: TwitchSequence):  # type: ignore[override]
         return self.stream.disable_ads and sequence.segment.ad
 
@@ -154,7 +161,11 @@ class TwitchHLSStreamReader(HLSStreamReader):
     __worker__ = TwitchHLSStreamWorker
     __writer__ = TwitchHLSStreamWriter
 
-    def __init__(self, stream):
+    worker: "TwitchHLSStreamWorker"
+    writer: "TwitchHLSStreamWriter"
+    stream: "TwitchHLSStream"
+
+    def __init__(self, stream: "TwitchHLSStream"):
         if stream.disable_ads:
             log.info("Will skip ad segments")
         if stream.low_latency:

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -338,8 +338,8 @@ class UStreamTVWsClient(WebsocketClient):
 
 
 class UStreamTVStreamWriter(SegmentedStreamWriter):
-    stream: "UStreamTVStream"
     reader: "UStreamTVStreamReader"
+    stream: "UStreamTVStream"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -394,6 +394,8 @@ class UStreamTVStreamWriter(SegmentedStreamWriter):
 
 
 class UStreamTVStreamWorker(SegmentedStreamWorker):
+    reader: "UStreamTVStreamReader"
+    writer: "UStreamTVStreamWriter"
     stream: "UStreamTVStream"
 
     def __init__(self, *args, **kwargs):
@@ -428,7 +430,10 @@ class UStreamTVStreamWorker(SegmentedStreamWorker):
 class UStreamTVStreamReader(SegmentedStreamReader):
     __worker__ = UStreamTVStreamWorker
     __writer__ = UStreamTVStreamWriter
+
     stream: "UStreamTVStream"
+    worker: "UStreamTVStreamWorker"
+    writer: "UStreamTVStreamWriter"
 
     def open(self):
         self.stream.wsclient.opened.set()

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -21,6 +21,9 @@ log = logging.getLogger(__name__)
 
 
 class DASHStreamWriter(SegmentedStreamWriter):
+    reader: "DASHStreamReader"
+    stream: "DASHStream"
+
     @staticmethod
     def _get_segment_name(segment: Segment) -> str:
         return Path(urlparse(segment.url).path).resolve().name
@@ -70,8 +73,12 @@ class DASHStreamWriter(SegmentedStreamWriter):
 
 
 class DASHStreamWorker(SegmentedStreamWorker):
+    reader: "DASHStreamReader"
+    writer: "DASHStreamWriter"
+    stream: "DASHStream"
+
     def __init__(self, *args, **kwargs):
-        SegmentedStreamWorker.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.mpd = self.stream.mpd
         self.period = self.stream.period
 
@@ -156,8 +163,12 @@ class DASHStreamReader(SegmentedStreamReader):
     __worker__ = DASHStreamWorker
     __writer__ = DASHStreamWriter
 
-    def __init__(self, stream, representation_id, mime_type, *args, **kwargs):
-        SegmentedStreamReader.__init__(self, stream, *args, **kwargs)
+    worker: "DASHStreamWorker"
+    writer: "DASHStreamWriter"
+    stream: "DASHStream"
+
+    def __init__(self, stream: "DASHStream", representation_id, mime_type, *args, **kwargs):
+        super().__init__(stream, *args, **kwargs)
         self.mime_type = mime_type
         self.representation_id = representation_id
         log.debug("Opening DASH reader for: {0} ({1})".format(self.representation_id, self.mime_type))

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -63,6 +63,9 @@ class ByteRangeOffset:
 class HLSStreamWriter(SegmentedStreamWriter):
     WRITE_CHUNK_SIZE = 8192
 
+    reader: "HLSStreamReader"
+    stream: "HLSStream"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         options = self.session.options
@@ -74,7 +77,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
         self.key_uri_override = options.get("hls-segment-key-uri")
         self.stream_data = options.get("hls-segment-stream-data")
 
-        self.ignore_names = False
+        self.ignore_names = None
         ignore_names = {*options.get("hls-segment-ignore-names")}
         if ignore_names:
             segments = "|".join(map(re.escape, ignore_names))
@@ -258,9 +261,12 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
 
 class HLSStreamWorker(SegmentedStreamWorker):
+    reader: "HLSStreamReader"
+    writer: "HLSStreamWriter"
+    stream: "HLSStream"
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stream = self.reader.stream
 
         self.playlist_changed = False
         self.playlist_end: Optional[int] = None
@@ -433,7 +439,11 @@ class HLSStreamReader(SegmentedStreamReader):
     __worker__ = HLSStreamWorker
     __writer__ = HLSStreamWriter
 
-    def __init__(self, stream):
+    worker: "HLSStreamWorker"
+    writer: "HLSStreamWriter"
+    stream: "HLSStream"
+
+    def __init__(self, stream: "HLSStream"):
         self.request_params = dict(stream.args)
         # These params are reserved for internal use
         self.request_params.pop("exception", None)

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -53,7 +53,7 @@ class HTTPStream(Stream):
         The URL to the stream, prepared by :mod:`requests` with parameters read from :attr:`args`.
         """
 
-        return self.session.http.prepare_new_request(**self.args).url
+        return self.session.http.prepare_new_request(**self.args).url  # type: ignore[return-value]
 
     def open(self):
         reqargs = self.session.http.valid_request_args(**self.args)

--- a/src/streamlink/stream/stream.py
+++ b/src/streamlink/stream/stream.py
@@ -2,6 +2,9 @@ import io
 import json
 import logging
 
+from streamlink.session import Streamlink
+
+
 log = logging.getLogger(__name__)
 
 
@@ -17,12 +20,12 @@ class Stream:
     def shortname(cls):
         return cls.__shortname__
 
-    def __init__(self, session):
+    def __init__(self, session: Streamlink):
         """
-        :param streamlink.Streamlink session: Streamlink session instance
+        :param session: Streamlink session instance
         """
 
-        self.session = session
+        self.session: Streamlink = session
 
     def __repr__(self):
         params = [repr(self.shortname())]

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -147,7 +147,7 @@ class HLSStreamReadThread(Thread):
             return self.writer_close()
 
         self.writer_close = self.reader.writer.close
-        self.reader.writer.close = _await_read_then_close
+        self.reader.writer.close = _await_read_then_close  # type: ignore[assignment]
 
     def run(self):
         while not self.reader.buffer.closed:


### PR DESCRIPTION
- Add typing information to `Stream`
- Explicitly set the stream, reader, worker and writer types
- Fix minor typing issues

----

Follow-up of #4802, which was a requirement for being able to add session typing information to the stream classes.

Some typing definitions are redundant, but since some are not, I chose setting all of them explicitly, to make it more consistent.

The stream classes which I didn't touch are either untyped or don't require any changes. And the other changes are minor typing fixes, removals of redundant stuff (duplicate `self.stream = self.reader.stream`) and updates of legacy py2 code (`super()` calls).