### PR TITLE
plugins.cinergroup: fix showtvcomtr

### DIFF
--- a/src/streamlink/plugins/cinergroup.py
+++ b/src/streamlink/plugins/cinergroup.py
@@ -59,7 +59,7 @@ class CinerGroup(Plugin):
 
     def _get_streams(self):
         root = self.session.http.get(self.url, schema=validate.Schema(validate.parse_html()))
-        schema_getters = self._schema_data_ht, self._schema_videourl
+        schema_getters = self._schema_videourl, self._schema_data_ht
         stream_url = next(filter(lambda res: res, map(lambda get_schema: get_schema().validate(root), schema_getters)), None)
 
         if stream_url:


### PR DESCRIPTION
Showtvcomtr is not opened when self._schema_data_ht is ahead. Showturk is opened.
I had already been trying to fix that issue in previous branch.

![Ekran görüntüsü 2022-09-10 174421](https://user-images.githubusercontent.com/102440553/189488502-35b28c8d-bda0-4850-a98a-8a8dcb5cefbb.png)
