### PR TITLE
plugin: fix type of url property

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -231,7 +231,7 @@ class Plugin:
     """Metadata 'category' attribute: name of a game being played, a music genre, etc."""
 
     options = Options()
-    _url: Optional[str] = None
+    _url: str = ""
 
     # deprecated
     can_handle_url: Callable[[str], bool]
@@ -293,7 +293,7 @@ class Plugin:
         self.load_cookies()
 
     @property
-    def url(self) -> Optional[str]:
+    def url(self) -> str:
         """
         The plugin's input URL.
         Setting a new value will automatically update the :attr:`matches`, :attr:`matcher` and :attr:`match` data.


### PR DESCRIPTION
`Plugin.url` will never be `None`, so the type should not be declared as `Optional[str]`. Otherwise, this causes type warnings when parsing the URL via `urllib.parse.urlparse()` for example, because its return values are assumed to be `bytes` due to these type definitions:
```py
@overload
def urlparse(url: str, scheme: str | None = ..., allow_fragments: bool = ...) -> ParseResult: ...
@overload
def urlparse(url: bytes | None, scheme: bytes | None = ..., allow_fragments: bool = ...) -> ParseResultBytes: ...
```