### PR TITLE
plugins.linelive: rewrite

### DIFF
--- a/tests/plugins/test_linelive.py
+++ b/tests/plugins/test_linelive.py
@@ -5,11 +5,12 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlLineLive(PluginCanHandleUrl):
     __plugin__ = LineLive
 
-    should_match = [
-        'http://live.line.me/channels/123/broadcast/12345678',
-        'https://live.line.me/channels/123/broadcast/12345678',
+    should_match_groups = [
+        ("https://live.line.me/channels/123/broadcast/456", {"channel": "123", "broadcast": "456"}),
     ]
 
     should_not_match = [
-        'https://live.line.me/channels/123/upcoming/12345678',
+        "https://live.line.me/",
+        "https://live.line.me/channels/123/",
+        "https://live.line.me/channels/123/upcoming/456",
     ]


### PR DESCRIPTION
Simple plugin rewrite and cleanup, similar to the dailymotion plugin cleanup.

Live:
```
$ streamlink https://live.line.me/channels/4912891/broadcast/20864925
[cli][info] Found matching plugin linelive for URL https://live.line.me/channels/4912891/broadcast/20864925
Available streams: 256p (worst), 426p, 640p, 854p, 1280p (best)
```

VOD
```
$ streamlink https://live.line.me/channels/5677886/broadcast/19532126
[cli][info] Found matching plugin linelive for URL https://live.line.me/channels/5677886/broadcast/19532126
Available streams: 640p (worst), 854p, 1280p (best)
```