### PR TITLE
plugins.tv3cat: rewrite

### DIFF
--- a/src/streamlink/plugins/tv3cat.py
+++ b/src/streamlink/plugins/tv3cat.py
@@ -8,7 +8,7 @@ $region Spain
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
@@ -16,33 +16,54 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?ccma\.cat/tv3/directe/(.+?)/"
+    r"https?://(?:www\.)?ccma\.cat/tv3/directe/(?P<ident>.+?)/"
 ))
 class TV3Cat(Plugin):
-    _stream_info_url = "http://dinamics.ccma.cat/pvideo/media.jsp" \
-                       "?media=video&version=0s&idint={ident}&profile=pc&desplacament=0"
-    _media_schema = validate.Schema({
-        "geo": validate.text,
-        "url": validate.url(scheme=validate.any("http", "https"))
-    })
-    _channel_schema = validate.Schema({
-        "media": validate.any([_media_schema], _media_schema)},
-        validate.get("media"),
-        # If there is only one item, it's not a list ... silly
-        validate.transform(lambda x: x if isinstance(x, list) else [x])
-    )
+    _URL_STREAM_INFO = "https://dinamics.ccma.cat/pvideo/media.jsp"
+
+    _MAP_CHANNELS = {
+        "tv3": "tvi",
+    }
 
     def _get_streams(self):
-        if self.match:
-            ident = self.match.group(1)
-            data_url = self._stream_info_url.format(ident=ident)
-            stream_infos = self.session.http.json(self.session.http.get(data_url), schema=self._channel_schema)
+        ident = self.match.group("ident")
 
-            for stream in stream_infos:
-                try:
-                    return HLSStream.parse_variant_playlist(self.session, stream['url'], name_fmt="{pixels}_{bitrate}")
-                except PluginError:
-                    log.debug("Failed to get streams for: {0}".format(stream['geo']))
+        schema_media = {
+            "geo": str,
+            "url": validate.url(path=validate.endswith(".m3u8")),
+        }
+
+        stream_infos = self.session.http.get(
+            self._URL_STREAM_INFO,
+            params={
+                "media": "video",
+                "versio": "vast",
+                "idint": self._MAP_CHANNELS.get(ident, ident),
+                "profile": "pc",
+                "desplacament": "0",
+                "broadcast": "false",
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "media": validate.any(
+                        [schema_media],
+                        validate.all(
+                            schema_media,
+                            validate.transform(lambda item: [item]),
+                        ),
+                    ),
+                },
+                validate.get("media"),
+            ),
+        )
+
+        for stream in stream_infos:
+            log.info(f"Accessing stream from region {stream['geo']}")
+            try:
+                return HLSStream.parse_variant_playlist(self.session, stream["url"], name_fmt="{pixels}_{bitrate}")
+            except OSError:
+                pass
 
 
 __plugin__ = TV3Cat

--- a/tests/plugins/test_tv3cat.py
+++ b/tests/plugins/test_tv3cat.py
@@ -5,13 +5,9 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlTV3Cat(PluginCanHandleUrl):
     __plugin__ = TV3Cat
 
-    should_match = [
-        'http://ccma.cat/tv3/directe/tv3/',
-        'http://ccma.cat/tv3/directe/324/',
-        'https://ccma.cat/tv3/directe/tv3/',
-        'https://ccma.cat/tv3/directe/324/',
-        'http://www.ccma.cat/tv3/directe/tv3/',
-        'http://www.ccma.cat/tv3/directe/324/',
-        'https://www.ccma.cat/tv3/directe/tv3/',
-        'https://www.ccma.cat/tv3/directe/324/',
+    should_match_groups = [
+        ("https://ccma.cat/tv3/directe/tv3/", {"ident": "tv3"}),
+        ("https://ccma.cat/tv3/directe/324/", {"ident": "324"}),
+        ("https://www.ccma.cat/tv3/directe/tv3/", {"ident": "tv3"}),
+        ("https://www.ccma.cat/tv3/directe/324/", {"ident": "324"}),
     ]


### PR DESCRIPTION
Simple plugin rewrite and cleanup, similar to the dailymotion plugin cleanup.

This also updates the version of the API requests.

Geo-block status could be checked via XPath, but it's not worth it considering that the site's frontend can change at any time.

Not entirely sure how useful the stream fallbacks are, because, as you can see down below, the streams are still blocked even with fallback. It's possible though that this still works in a different region. Btw, the old implementation was trying to catch the wrong exception.

----

Non-geo-blocked streams (TV3 and 324)
```
$ streamlink https://www.ccma.cat/tv3/directe/tv3/ best
[cli][info] Found matching plugin tv3cat for URL https://www.ccma.cat/tv3/directe/tv3/
[plugins.tv3cat][info] Accessing stream from region TOTS
[cli][info] Available streams: 480p_1700k (worst), 720p_2100k, 1080p_4100k (best)
[cli][info] Opening stream: 1080p_4100k (hls)
[cli][info] Starting player: mpv
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

Geo-blocked
```
$ streamlink https://www.ccma.cat/tv3/directe/cs3/ best
[cli][info] Found matching plugin tv3cat for URL https://www.ccma.cat/tv3/directe/cs3/
[plugins.tv3cat][info] Accessing stream from region CATALUNYA
[plugins.tv3cat][info] Accessing stream from region ESPANYA
[plugins.tv3cat][info] Accessing stream from region TOTS
[cli][info] Available streams: 480p_1700k (worst), 720p_2100k, 1080p_4100k (best)
[cli][info] Opening stream: 1080p_4100k (hls)
[cli][info] Starting player: mpv
[stream.hls][error] Failed to fetch segment 277167483: Unable to open URL: https://directes-tv-int.ccma.cat/live-origin/c33-super3-hls/0/br3/220609092109/92390/geo-br3_277167483.ts (403 Client Error: Forbidden for url: https://directes-tv-int.ccma.cat/live-origin/c33-super3-hls/0/br3/220609092109/92390/geo-br3_277167483.ts)
```