### PR TITLE
stream.ffmpegmux: remove avconv

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -72,7 +72,7 @@ class MuxedStream(Stream):
 
 
 class FFMPEGMuxer(StreamIO):
-    __commands__ = ["ffmpeg", "avconv"]
+    __commands__ = ["ffmpeg"]
 
     DEFAULT_OUTPUT_FORMAT = "matroska"
     DEFAULT_VIDEO_CODEC = "copy"

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -32,8 +32,7 @@ class TestCommand:
             assert len(mock.call_args_list) == 0
 
     @pytest.mark.parametrize("command,which,expected", [
-        pytest.param(None, {"ffmpeg": None, "avconv": None}, None, id="resolver-negative"),
-        pytest.param(None, {"ffmpeg": None, "avconv": "avconv"}, "avconv", id="resolver-avconv"),
+        pytest.param(None, {"ffmpeg": None}, None, id="resolver-negative"),
         pytest.param(None, {"ffmpeg": "ffmpeg"}, "ffmpeg", id="resolver-posix"),
         pytest.param(None, {"ffmpeg": "ffmpeg.exe"}, "ffmpeg.exe", id="resolver-windows"),
         pytest.param("custom", {"ffmpeg": "ffmpeg"}, None, id="custom-negative"),


### PR DESCRIPTION
The [libav](https://en.wikipedia.org/wiki/Libav) (avconv) fork of FFmpeg has been abandoned since several years with its last release in February 2018. There is no reason to still support it. Everyone who's switched to libav in 2011 has switched back to FFmpeg years ago. The only popular Linux distros which default to libav are outdated Debian releases (Jessie) and forks of it (Ubuntu 14). Debian's Stretch release switched back to FFmpeg in 2017 (announced in 2015).

- https://packages.debian.org/search?suite=stretch&arch=any&mode=exactfilename&searchon=contents&keywords=avconv
- https://packages.debian.org/stretch/libav-tools
- https://lists.debian.org/debian-devel-announce/2015/07/msg00001.html
- https://en.wikipedia.org/wiki/Debian_version_history#Release_table
- https://repology.org/project/libav/versions

However, as #4825 has just shown again, these old FFmpeg versions and abandoned FFmpeg forks don't always work when remuxing streams. Users of Streamlink are supposed to be using up-to-date and maintained dependencies.

Since we're about to release 5.0.0, let's remove the avconv fallback executable name from the list of default FFmpeg executables. If people still want to use their ancient avconv binaries, they can via `--ffmpeg-ffmpeg`, but there's no reason for Streamlink to unnecessarily cause issues and confusion.

Another problem is that Streamlink doesn't log the FFmpeg version that's in use, and errors are also silently ignored. I will take a look at including the version output of FFmpeg in the debug log, but I don't think I want this included in the 5.0.0 release, because this requires a bit more code than just using the available high-level subprocess/asyncio interfaces of the stdlib which read the entire stdout into memory at once. When choosing the wrong executable, this can lead to serious issues. I'm saying this with a potential version validation in mind. But that's a bit off-topic.