### PR TITLE
plugins.rtve: fix ZTNR.translate

### DIFF
--- a/tests/plugins/test_rtve.py
+++ b/tests/plugins/test_rtve.py
@@ -8,7 +8,7 @@ class TestPluginCanHandleUrlRtve(PluginCanHandleUrl):
     should_match = [
         "https://www.rtve.es/play/videos/directo/la-1/",
         "https://www.rtve.es/play/videos/directo/canales-lineales/24h/",
-        "https://www.rtve.es/play/videos/rebelion-en-el-reino-salvaje/mata-reyes/5803959/",
+        "https://www.rtve.es/play/videos/informe-semanal/la-semilla-de-la-guerra/6670279/",
     ]
 
     should_not_match = [
@@ -21,7 +21,28 @@ class TestPluginCanHandleUrlRtve(PluginCanHandleUrl):
     ]
 
 
-def test_translate():
+def test_translate_no_content():
+    assert list(ZTNR.translate("")) == []
+
+
+def test_translate_no_streams():
+    # real payload without any tEXt chunks that match the expected format
+    data = \
+        "iVBORw0KGgoAAAANSUhEUgAAAsAAAAGMAQMAAADuk4YmAAAAA1BMVEX///+nxBvIAAAAAXRSTlMA" \
+        "QObYZgAAADlJREFUeF7twDEBAAAAwiD7p7bGDlgYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" \
+        "AAAAAAAAwAGJrAABgPqdWQAAAcp0RVh0ak9lNmRyNkUtV2hmeEE0dERMdS9FOTlCT2d3MF9HMDdG" \
+        "RmxQNy1ZLTdFOFRac0MmbD93VEp5SENvUUlseVY1bjdrYmF2ZkhUUjc4aTBHAEBxY08zdk4yYldE" \
+        "bm09TDVaNGMyVVpNdklVbS5LVUNCUTdZNVpfSUZMVmRMNlN0VE14TmFPLUFGaTF6ai9YenE6PVg9" \
+        "dnJBb3BFU3BBJlpoWFViSER3MCZxbj9AS0d1Si5OSnAudiMwMTYxNDA2MDU2NjcyMDE3MzI4NTcw" \
+        "ODcwMDc3MDI3NjIwNjczMTA0ODEyNDY3MzMwNzgxMDQwMTE4NzQ4MDYwMjIwODgxNTI0ODEzNjQ4" \
+        "MjU0MTEyMzEyNjUxMzc2NTM3MTMzNzgwNTYwNDE0NjI4NDM1NjIzNTA1MTAxNjYwMDExNzE4MDQx" \
+        "MTc3MDMxNTQ2MDEzNDUwMDQ2MTg4MDgwNzMxNDM3MjgwMDQ4NDA3Mzg0MzYxODA0NjU0NDYzMTY1" \
+        "NDIxMzY4ODAzNTQ3MjMyMjYzODUwMzY5MTE3MTMwOTMzMjAwNDg1MDExNTE4MTgxMTgwMTAwNjU0" \
+        "NTg1MzcxNDQ5MDM5MzY2ODMxNTc0MjUyNDVZsdrfAAAAAElFTkSuQmCC"
+    assert list(ZTNR.translate(data)) == []
+
+
+def test_translate_has_streams():
     # real payload with modified end (IEND chunk of size 0), to reduce test size
     data = \
         "iVBORw0KGgoAAAANSUhEUgAAAVQAAAFUCAIAAAD08FPiAAACr3RFWHRXczlVSWdtM2ZPTGY4b2R4" \


### PR DESCRIPTION
Fixes #4838

As mentioned in https://github.com/streamlink/streamlink/issues/4838#issuecomment-1252536683, it's possible (very likely) that the whole embedded and obfuscated stream URL data extraction is useless now. Since I'm not fully sure, I've kept it for now. I've also wrapped the HTTP request which retrieves the obfuscated data into a try-except block, so that if the site removes the endpoint, the plugin will continue working with the generic HLS URL template.

I only tested the URLs listed in the URL matcher tests. The site is also geo-blocked (on the HLS playlist level), so I can't fully test it anyway. The main issue however should be fixed (the old while-loop - see https://github.com/streamlink/streamlink/issues/4838#issuecomment-1252528944).

@jairoxyz I would appreciate it if you could test the PR before this gets merged. Thanks.