### PR TITLE
FFmpeg validation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,9 @@
 pip>=9
 pytest
+pytest-asyncio
 pytest-cov
 coverage[toml]
+mock ; python_version<"3.8"
 requests-mock
 freezegun>=1.0.0
 flake8

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -81,6 +81,7 @@ class Streamlink:
             "stream-segment-timeout": 10.0,
             "stream-timeout": 60.0,
             "ffmpeg-ffmpeg": None,
+            "ffmpeg-no-validation": False,
             "ffmpeg-fout": None,
             "ffmpeg-video-transcode": None,
             "ffmpeg-audio-transcode": None,
@@ -167,6 +168,9 @@ class Streamlink:
         ffmpeg-ffmpeg            (str) Specify the location of the
                                  ffmpeg executable use by Muxing streams
                                  e.g. ``/usr/local/bin/ffmpeg``
+
+        ffmpeg-no-validation     (bool) Disable FFmpeg validation and version logging.
+                                 default: ``False``
 
         ffmpeg-verbose           (bool) Log stderr from ffmpeg to the
                                  console

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import logging
+import re
 import subprocess
 import sys
 import threading
@@ -12,8 +13,12 @@ from streamlink import StreamError
 from streamlink.compat import devnull
 from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe, NamedPipeBase
+from streamlink.utils.processoutput import ProcessOutput
+
 
 log = logging.getLogger(__name__)
+
+_lock_resolve_command = threading.Lock()
 
 
 class MuxedStream(Stream):
@@ -78,17 +83,24 @@ class FFMPEGMuxer(StreamIO):
     DEFAULT_VIDEO_CODEC = "copy"
     DEFAULT_AUDIO_CODEC = "copy"
 
+    FFMPEG_VERSION: Optional[str] = None
+    FFMPEG_VERSION_TIMEOUT = 4.0
+
     @classmethod
     def is_usable(cls, session):
         return cls.command(session) is not None
 
     @classmethod
     def command(cls, session):
-        return cls.resolve_command(session.options.get("ffmpeg-ffmpeg"))
+        with _lock_resolve_command:
+            return cls.resolve_command(
+                session.options.get("ffmpeg-ffmpeg"),
+                not session.options.get("ffmpeg-no-validation"),
+            )
 
     @classmethod
     @lru_cache(maxsize=128)
-    def resolve_command(cls, command: Optional[str] = None) -> Optional[str]:
+    def resolve_command(cls, command: Optional[str] = None, validate: bool = True) -> Optional[str]:
         if command:
             resolved = which(command)
         else:
@@ -97,9 +109,22 @@ class FFMPEGMuxer(StreamIO):
                 resolved = which(cmd)
                 if resolved:
                     break
+
+        if resolved and validate:
+            log.trace(f"Querying FFmpeg version: {[resolved, '-version']}")  # type: ignore[attr-defined]
+            versionoutput = FFmpegVersionOutput([resolved, "-version"], timeout=cls.FFMPEG_VERSION_TIMEOUT)
+            if not versionoutput.run():
+                log.error("Could not validate FFmpeg. Unexpected FFmpeg version output!")
+                resolved = None
+            else:
+                cls.FFMPEG_VERSION = versionoutput.version
+                for i, line in enumerate(versionoutput.output):
+                    log.debug(f"{' ' if i > 0 else ''}{line}")
+
         if not resolved:
-            log.warning("FFmpeg was not found. See the --ffmpeg-ffmpeg option.")
+            log.warning("No valid FFmpeg binary was not found. See the --ffmpeg-ffmpeg option.")
             log.warning("Muxing streams is unsupported! Only a subset of the available streams can be returned!")
+
         return resolved
 
     @staticmethod
@@ -213,3 +238,31 @@ class FFMPEGMuxer(StreamIO):
             self.errorlog = None
 
         super().close()
+
+
+class FFmpegVersionOutput(ProcessOutput):
+    # The version output format of the fftools hasn't been changed since n0.7.1 (2011-04-23):
+    # https://github.com/FFmpeg/FFmpeg/blame/n5.1.1/fftools/ffmpeg.c#L110
+    # https://github.com/FFmpeg/FFmpeg/blame/n5.1.1/fftools/opt_common.c#L201
+    # https://github.com/FFmpeg/FFmpeg/blame/c99b93c5d53d8f4a4f1fafc90f3dfc51467ee02e/fftools/cmdutils.c#L1156
+    # https://github.com/FFmpeg/FFmpeg/commit/89b503b55f2b2713f1c3cc8981102c1a7b663281
+    _re_version = re.compile(r"ffmpeg version (?P<version>\S+)")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.version = None
+        self.output = []
+
+    def onexit(self, code: int) -> bool:
+        return code == 0 and self.version is not None
+
+    def onstdout(self, idx: int, line: str) -> Optional[bool]:
+        match = self._re_version.match(line)
+        if idx == 0:
+            # abort if the very first line of stdout doesn't match the expected format
+            if not match:
+                return False
+            self.version = match["version"]
+
+        # otherwise, gather the entire stdout
+        self.output.append(line)

--- a/src/streamlink/utils/processoutput.py
+++ b/src/streamlink/utils/processoutput.py
@@ -1,0 +1,71 @@
+import asyncio
+from contextlib import suppress
+from typing import Callable, List, Optional
+
+
+class ProcessOutput:
+    def __init__(self, command: List[str], timeout: Optional[float] = None):
+        self.command = command
+        self.timeout = timeout
+
+    def run(self) -> bool:  # pragma: no cover
+        return asyncio.run(self._run())
+
+    async def _run(self) -> bool:
+        loop = asyncio.get_event_loop()
+        done: asyncio.Future[bool] = loop.create_future()
+        process = await asyncio.create_subprocess_exec(
+            *self.command,
+            stdin=None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        if not process.stdout or not process.stderr:  # pragma: no cover
+            return False
+
+        async def ontimeout():
+            if self.timeout:
+                await asyncio.sleep(self.timeout)
+                done.set_result(False)
+
+        async def onexit():
+            code = await process.wait()
+            done.set_result(self.onexit(code))
+
+        async def onoutput(callback: Callable[[int, str], Optional[bool]], streamreader: asyncio.StreamReader):
+            line: bytes
+            idx = 0
+            async for line in streamreader:
+                try:
+                    result = callback(idx, line.decode().rstrip())
+                except Exception as err:
+                    done.set_exception(err)
+                    break
+                if result is not None:
+                    done.set_result(bool(result))
+                    break
+                idx += 1
+
+        tasks = (
+            loop.create_task(ontimeout()),
+            loop.create_task(onexit()),
+            loop.create_task(onoutput(self.onstdout, process.stdout)),
+            loop.create_task(onoutput(self.onstderr, process.stderr)),
+        )
+
+        try:
+            return await done
+        finally:
+            for task in tasks:
+                task.cancel()
+            with suppress(OSError):
+                process.kill()
+
+    def onexit(self, code: int) -> bool:
+        return code == 0
+
+    def onstdout(self, idx: int, line: str) -> Optional[bool]:  # pragma: no cover
+        pass
+
+    def onstderr(self, idx: int, line: str) -> Optional[bool]:  # pragma: no cover
+        pass

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1044,6 +1044,13 @@ def build_parser():
         """
     )
     transport_ffmpeg.add_argument(
+        "--ffmpeg-no-validation",
+        action="store_true",
+        help="""
+        Disable FFmpeg validation and version logging
+        """
+    )
+    transport_ffmpeg.add_argument(
         "--ffmpeg-verbose",
         action="store_true",
         help="""
@@ -1263,6 +1270,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("hls_segment_key_uri", "hls-segment-key-uri", None),
     ("hls_audio_select", "hls-audio-select", None),
     ("ffmpeg_ffmpeg", "ffmpeg-ffmpeg", None),
+    ("ffmpeg_no_validation", "ffmpeg-no-validation", None),
     ("ffmpeg_verbose", "ffmpeg-verbose", None),
     ("ffmpeg_verbose_path", "ffmpeg-verbose-path", None),
     ("ffmpeg_fout", "ffmpeg-fout", None),

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -18,7 +18,7 @@ def resolve_command_cache_clear():
 @pytest.fixture
 def session():
     with patch("streamlink.session.Streamlink.load_builtin_plugins"):
-        yield Streamlink()
+        yield Streamlink({"ffmpeg-no-validation": True})
 
 
 class TestCommand:
@@ -56,7 +56,7 @@ class TestCommand:
              patch("streamlink.stream.ffmpegmux.which", return_value=None):
             assert not FFMPEGMuxer.is_usable(session)
             assert mock_log.warning.call_args_list == [
-                call("FFmpeg was not found. See the --ffmpeg-ffmpeg option."),
+                call("No valid FFmpeg binary was not found. See the --ffmpeg-ffmpeg option."),
                 call("Muxing streams is unsupported! Only a subset of the available streams can be returned!"),
             ]
             assert not FFMPEGMuxer.is_usable(session)

--- a/tests/utils/test_processoutput.py
+++ b/tests/utils/test_processoutput.py
@@ -1,0 +1,224 @@
+import asyncio
+from collections import deque
+from typing import Iterable, Optional
+
+import freezegun
+import pytest
+import pytest_asyncio
+
+from streamlink.utils.processoutput import ProcessOutput
+
+try:
+    from unittest.mock import AsyncMock, Mock, call, patch  # type: ignore
+except ImportError:
+    # noinspection PyUnresolvedReferences
+    from mock import AsyncMock, Mock, call, patch  # type: ignore
+
+
+class AsyncIterator:
+    def __init__(self, event_loop: asyncio.BaseEventLoop, iterable: Optional[Iterable] = None):
+        self._loop = event_loop
+        self._deque = deque(iterable or ())
+        self._newfuture()
+
+    def append(self, item):
+        self._deque.append(item)
+        self._setfutureresult()
+
+    def extend(self, iterable: Iterable):
+        self._deque.extend(iterable)
+        self._setfutureresult()
+
+    def _newfuture(self):
+        self._future = self._loop.create_future()
+
+    def _setfutureresult(self):
+        if len(self._deque) and not self._future.done():
+            self._future.set_result(True)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        while True:
+            await self._future
+            try:
+                return self._deque.popleft()
+            except IndexError:
+                self._newfuture()
+
+
+class FakeProcessOutput(ProcessOutput):
+    onexit: Mock
+    onstdout: Mock
+    onstderr: Mock
+
+
+@pytest.fixture
+def mock_process(event_loop: asyncio.BaseEventLoop):
+    process = Mock(asyncio.subprocess.Process)
+    process.stdout = AsyncIterator(event_loop)
+    process.stderr = AsyncIterator(event_loop)
+
+    return process
+
+
+@pytest.fixture
+def processoutput(request, mock_process):
+    class MyProcessOutput(FakeProcessOutput):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.onexit = Mock(wraps=self.onexit)
+            self.onstdout = Mock(wraps=self.onstdout)
+            self.onstderr = Mock(wraps=self.onstderr)
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_process)) as mock_create_subprocess_exec:
+        yield MyProcessOutput(["foo", "bar"], **getattr(request, "param", {}))
+
+    mock_create_subprocess_exec.assert_awaited_once_with(
+        "foo",
+        "bar",
+        stdin=None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def assert_tasks_cleanup(event_loop: asyncio.BaseEventLoop):
+    yield
+    current_task = asyncio.current_task(event_loop)
+    assert not [task for task in asyncio.all_tasks(event_loop) if task is not current_task]
+    await event_loop.shutdown_asyncgens()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("processoutput", [{"timeout": 1}], indirect=True)
+async def test_ontimeout(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    with freezegun.freeze_time("2000-01-01T00:00:00.000Z") as frozen_time:
+        fut_process_wait = event_loop.create_future()
+        mock_process.wait = Mock(return_value=fut_process_wait)
+
+        async def advance_time():
+            # required for making the run-task await the "done" future
+            await asyncio.sleep(0)
+            frozen_time.tick(2)
+
+        task_run = asyncio.create_task(processoutput._run())
+        task_time = asyncio.create_task(advance_time())
+        await asyncio.wait({task_run, task_time}, return_when=asyncio.FIRST_COMPLETED)
+
+        assert mock_process.wait.called, "Has run the onexit callback and called process.wait()"
+        assert not mock_process.kill.called, "Has not killed the process yet"
+
+        result = await task_run
+
+    assert result is False
+    assert not processoutput.onexit.called
+    assert not processoutput.onstdout.called
+    assert not processoutput.onstderr.called
+    assert fut_process_wait.cancelled()
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("processoutput", [{"timeout": 1}], indirect=True)
+async def test_ontimeout_onexit(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    fut_process_wait = event_loop.create_future()
+    mock_process.wait = Mock(return_value=fut_process_wait)
+
+    with freezegun.freeze_time("2000-01-01T00:00:00.000Z") as frozen_time:
+        async def advance_time():
+            # required for making the run-task await the "done" future
+            await asyncio.sleep(0)
+            frozen_time.tick(0.5)
+
+        task_run = asyncio.create_task(processoutput._run())
+        task_time = asyncio.create_task(advance_time())
+        await asyncio.wait({task_run, task_time}, return_when=asyncio.FIRST_COMPLETED)
+
+        assert mock_process.wait.called, "Has run the onexit callback and called process.wait()"
+        assert not mock_process.kill.called, "Has not killed the process yet"
+
+        # make the process return code 0 while waiting for the timeout
+        fut_process_wait.set_result(0)
+
+        # advance time again (the "done" future will already have a result set and the timeout task be cancelled)
+        frozen_time.tick(1)  # type: ignore[arg-type]  # float/int are supported...
+
+        result = await task_run
+
+    assert result is True
+    assert processoutput.onexit.called
+    assert not processoutput.onstdout.called
+    assert not processoutput.onstderr.called
+    assert fut_process_wait.done()
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code,expected", [(0, True), (1, False)])
+async def test_onexit(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock, code, expected):
+    mock_process.wait = AsyncMock(return_value=code)
+
+    result = await processoutput._run()
+
+    assert result is expected
+    assert processoutput.onexit.called
+    assert not processoutput.onstdout.called
+    assert not processoutput.onstderr.called
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("returnvalue", [True, False])
+async def test_onoutput(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock, returnvalue):
+    mock_process.wait = Mock(return_value=event_loop.create_future())
+    mock_process.stdout.extend([b"foo", b"bar", b"baz"])
+
+    def onstdout(idx: int, line: str):
+        if idx < 3:
+            mock_process.stderr.append(line.upper().encode())
+
+    def onstderr(idx: int, line: str):
+        mock_process.stdout.append(line[::-1].encode())
+        if idx == 1:
+            return returnvalue
+
+    processoutput.onstdout = Mock(wraps=onstdout)
+    processoutput.onstderr = Mock(wraps=onstderr)
+
+    result = await processoutput._run()
+
+    assert result is returnvalue
+    assert not processoutput.onexit.called
+    assert processoutput.onstdout.call_args_list == [
+        call(0, "foo"),
+        call(1, "bar"),
+        call(2, "baz"),
+        call(3, "OOF"),
+        call(4, "RAB"),
+    ]
+    assert processoutput.onstderr.call_args_list == [
+        call(0, "FOO"),
+        call(1, "BAR"),
+    ]
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+async def test_onoutput_exception(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    mock_process.wait = Mock(return_value=event_loop.create_future())
+    mock_process.stdout.extend([b"foo", b"bar", b"baz"])
+
+    error = ValueError("error")
+    processoutput.onstdout = Mock(side_effect=error)
+
+    with pytest.raises(ValueError) as cm:
+        await processoutput._run()
+
+    assert cm.value is error
+    assert not processoutput.onexit.called
+    assert processoutput.onstdout.call_args_list == [call(0, "foo")]
+    assert processoutput.onstderr.call_args_list == []
+    assert mock_process.kill.called


### PR DESCRIPTION
We've recently added [warning log messages to the `FFMPEGMuxer`'s resolver when FFmpeg could not be found](https://github.com/streamlink/streamlink/pull/4781), so that the user can be informed that muxing is not supported. However, there are still a couple of issues left which I think should be addressed:

1. The chosen/resolved FFmpeg executable does not get validated/verified:
   This is a problem when the user has set an invalid FFmpeg executable, or when it is broken and doesn't work. In case of invalid executables, the output and stream muxing are pretty much undefined, and broken executables lead to empty stream outputs, and unless verbose logging is enabled, no error messages get printed, making the user believe there's an issue with the input stream.
2. The FFmpeg version does not get logged:
   Logging the FFmpeg version makes debugging issues easier. The recent issue which comes to mind is:
   #4825 
3. Certain streams might require a certain FFmpeg version in order to correctly mux streams:
   This PR doesn't add any version checks, but this could be added in the future if it's needed, based on this work.
   https://github.com/streamlink/streamlink/issues/4520#issuecomment-1129428877

Opening the PR as a draft, as it's unfinished work.

----

The first commit implements a generic `ProcessOutput` utility class for **asynchronously** spawning a subprocess and reading its stdout/stderr streams.

This is necessary, because using APIs like [`subprocess.run(capture_output=True)`](https://docs.python.org/3/library/subprocess.html#subprocess.run) or [`asyncio.create_subprocess_exec().communicate()`](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.communicate) read the entire stdout/stderr streams into memory until the process terminates on its own. This is bad when executing unknown binaries. And reading streams of a spawned subprocess in separate threads as well as dealing with timeouts is unnecessarily difficult to implement in regards to making everything thread-safe (especially when writing tests, just see the messy HLS stream tests for example).

Asynchronously iterating output streams and using `asyncio.sleep()` makes this fairly easy and straightforward to implement, but testing stuff unfortunately requires adding two more dev-requirements:

1. [`pytest-asyncio`](https://pypi.org/project/pytest-asyncio/) - already installed as a transitive dependency, so no changes here
2. [`mock`](https://pypi.org/project/mock/) - compatibility backport of the `unittest.mock` stdlib implementation for py37 (`AsyncMock` is missing)
   `mock` was already removed from the dev-requirements in d04767fa5b812a4e971e454226cecb25b4d975ae, and the only gotchas were the [`args`/`kwargs` properties in `Mock.call_args`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.Mock.call_args) which are missing on py37, but that doesn't justify adding compatibility imports everywhere

Another issue I ran into while writing tests was `freezegun`, which currently affects the internals of `asyncio` in its most recent version, and there's an open PR on their repo which will change that. I managed to get the tests working (after lots of issues with `asyncio.sleep()`), but I'm not sure how the next `freezegun` release(s) will affect the tests. We'll see...

----

The second commit adds FFmpeg executable validation and version logging. The validation can be turned off by setting `--ffmpeg-no-validation`.

Still need to update and fix tests.

I've included some links in the code to the FFmpeg version string definitions, which have been stable for 12 years now.