### PR TITLE
plugins.vinhlongtv: rewrite and fix plugin

### DIFF
--- a/tests/plugins/test_vinhlongtv.py
+++ b/tests/plugins/test_vinhlongtv.py
@@ -1,3 +1,7 @@
+from unittest.mock import Mock
+
+from freezegun import freeze_time
+
 from streamlink.plugins.vinhlongtv import VinhLongTV
 from tests.plugins import PluginCanHandleUrl
 
@@ -6,7 +10,17 @@ class TestPluginCanHandleUrlVinhLongTV(PluginCanHandleUrl):
     __plugin__ = VinhLongTV
 
     should_match = [
-        'http://thvli.vn/live/thvl1-hd/aab94d1f-44e1-4992-8633-6d46da08db42',
-        'http://thvli.vn/live/thvl2-hd/bc60bddb-99ac-416e-be26-eb4d0852f5cc',
-        'http://thvli.vn/live/phat-thanh/c87174ba-7aeb-4cb4-af95-d59de715464c',
+        "https://www.thvli.vn/live/thvl1-hd",
+        "https://www.thvli.vn/live/thvl2-hd",
+        "https://www.thvli.vn/live/thvl3-hd",
+        "https://www.thvli.vn/live/thvl4-hd",
     ]
+
+
+@freeze_time("2022-09-25T00:04:45Z")
+def test_headers():
+    # noinspection PyUnresolvedReferences
+    assert VinhLongTV(Mock(), "")._get_headers() == {
+        "X-SFD-Date": "20220925000445",
+        "X-SFD-Key": "3507c190ae8befda3bfa8e2c00af3c7a",
+    }


### PR DESCRIPTION
Closes #4848 

This updates the API URL and adds the required request headers and timezone query string parameter.

As mentioned in #4848, the `timezone` query string parameter on the site is read from
```js
Intl.DateTimeFormat().resolvedOptions().timeZone
```
which means it'll always be in the `$Region/$City` format. The plugin implementation however sets the timezone parameter to the `UTC` string, because it needs the UTC timezone for calculating the MD5 hash in the headers, which depends on the user's local time, and this needs to be calculated based on UTC. Otherwise, we'd need to get the timezone name from the user's local time, and that would require adding `pytz` as a dependency here, because the provided timezone parameter must match. I am not sure though how reliable setting the UTC timezone is, because as said, the site doesn't do this and they could very easily block such requests. Setting the timezone parameter to `Europe/London` doesn't work because of DST.

Either way, the plugin seems to be working now. I am also not sure about VOD content, but this wasn't supported prior to these changes, and I don't care about that one single bit.

Please double-check and test it yourself before merging.

```
$ streamlink https://www.thvli.vn/live/thvl1-hd best
[cli][info] Found matching plugin vinhlongtv for URL https://www.thvli.vn/live/thvl1-hd
[cli][info] Available streams: 480p (worst), 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: mpv
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```