### PR TITLE
plugin: remove broken decorator

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -337,24 +337,6 @@ class Plugin:
 
         return stream_types
 
-    @classmethod
-    def broken(cls, issue=None):
-        def func(*args, **kwargs):
-            msg = (
-                "This plugin has been marked as broken. This is likely due to "
-                "changes to the service preventing a working implementation. "
-            )
-
-            if issue:
-                msg += "More info: https://github.com/streamlink/streamlink/issues/{0}".format(issue)
-
-            raise PluginError(msg)
-
-        def decorator(*args, **kwargs):
-            return func
-
-        return decorator
-
     def streams(self, stream_types=None, sorting_excludes=None):
         """
         Attempts to extract available streams.


### PR DESCRIPTION
The `@Plugin.broken` has been unused for a while now and the last time that any plugins were annotated as broken was two years ago. The latest commits with diffs that contained the decorator were either plugin removals or plugin fixes.

```
$ git log --format='%h %cI %s (%an)' -S '@Plugin.broken'
0a3f65a2 2021-03-20T22:49:16+01:00 plugins.btsports: remove plugin (back-to)
2c8f46ba 2020-10-31T18:28:34+01:00 plugins.nbcnews: fix video ID search, add schemas (Ian Cameron)
0aaeb19b 2020-10-31T18:19:40+01:00 plugins.ellobo: plugin removal (Ian Cameron)
f25f2dd1 2020-10-31T18:15:19+01:00 plugins.cnews: fix video ID search, add schema (Ian Cameron)
500c5c4a 2020-10-31T12:45:08+01:00 plugins.kingkong: plugin removal (Ian Cameron)
e2aa85d4 2020-10-31T08:44:44+01:00 plugins.skai: plugin removal (Ian Cameron)
9c8f7708 2020-10-17T22:09:33+02:00 plugins: mark some plugins as broken (#3262) (back-to)
72b2e9cf 2020-10-16T16:18:56-07:00 plugins.dingittv: removed, website is unmaintained (back-to)
0f011ae9 2019-08-09T18:05:44+00:00 plugins.oneplusone: fix site changes (#2425) (Vladimir Stavrinov)
e67c68c6 2019-04-13T05:44:51+00:00 plugins.mediaklikk: update broken plugin (#2401) (Viktor Kálmán)
251a0a94 2019-01-11T19:28:51+01:00 plugins.tvrby: Fixed broken plugin. (back-to)
3364b7cb 2018-09-24T17:17:57+00:00 plugins.ssh101: Fixed plugin (#1916) (Twilight0)
2eb54a3d 2018-08-08T12:33:50+02:00 Removed old or unwanted Streamlink Plugins (back-to)
83e30e15 2018-08-05T17:19:02+02:00 Update and reactivate plugin for dr.dk (Søren Fuglede Jørgensen)
57eea0fb 2018-08-04T16:45:16+02:00 plugins.sportal: Removed old RTMP streams, use HLS (back-to)
755da489 2018-06-28T00:32:28+02:00 plugins.nineanime: no longer supported (beardypig)
17631406 2018-06-08T23:12:38+02:00 plugins: marked or removed broken plugins (back-to)
fd0f3b52 2018-06-01T18:31:47-07:00 plugins.facebook: support for DASH streams (#1727) (beardypig)
0a68c21f 2018-02-22T16:37:59+01:00 [facebook] mark as broken, they use dash now. (back-to)
fb6ac2f5 2016-12-30T15:05:14-08:00 plugins.streamlive: streamlive.to have added some extra protection to their streams which currently prevents us from capturing them (#339) (beardypig)
```

I'm proposing the removal of the decorator, because I don't think that marking plugins as broken and publishing broken code is a good idea. If there are any plugin issues that can't be resolved, then those plugins should be removed and not annotated. The git history is always there should a plugin need to be restored, in case it can get fixed.

Also, plugin issues can always be found on the issue tracker, which is the point of the issue tracker. Maintaining a list of (temporarily) broken plugins in the codebase itself doesn't make sense, both maintenance-wise and release-wise, because most plugin issues get resolved quickly anyway. Annotated plugins would only reach users after a release, and only after users have actually upgraded. That's why almost nobody has cared annotating plugins as broken, because it is useless in almost every case. If one of the maintainers is aware of broken plugins that don't have an appropriate issue thread, then new issues should be opened, so everyone else can see. Which is of course also expected from endusers.

Having some plugins marked as broken while other broken ones are not marked as broken is also bad consistency-wise. There have already been users complaining about that here, because they were confused by the lack of annotations. This means that broken plugins should ideally always be consistently marked as broken, but as explained, this is unfeasible and bad for several reasons.

So let's remove it.