### PR TITLE
plugin: fix get_argument()

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -319,7 +319,7 @@ class Plugin:
 
     @classmethod
     def get_argument(cls, key):
-        return cls.arguments.get(key)
+        return cls.arguments and cls.arguments.get(key)
 
     @classmethod
     def stream_weight(cls, stream):


### PR DESCRIPTION
With the addition of the `@pluginargument` decorator in #4747, the initial `Plugin.arguments` value was changed from sharing a common `Arguments()` instance with all plugins that don't define any plugin arguments to `None`:
https://github.com/streamlink/streamlink/pull/4747/files#diff-6c2b818d0eb96fa625a2ff3f5da29b40a1867d6e34a58c730a0972e79c07c99dR197

The `Plugin.get_argument()` method needs to be fixed in regards to this. The method is not used and not tested, so this slipped through.

----

Btw, the [`Plugin.options` attribute is still sharing a common `Options()` instance](https://github.com/streamlink/streamlink/blob/5.0.1/src/streamlink/plugin/plugin.py#L233) (`Plugin.get_option()` and `Plugin.set_option()` are related to this PR here). Individual `Options()` instances get set by the CLI in [`setup_plugin_args`](https://github.com/streamlink/streamlink/blob/5.0.1/src/streamlink_cli/main.py#L779). This is kinda bad and needs to be changed, ideally with a `Plugin.set_options()` classmethod.