### PR TITLE
FFmpeg version logging and validation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,9 @@
 pip>=9
 pytest
+pytest-asyncio
 pytest-cov
 coverage[toml]
+mock ; python_version<"3.8"
 requests-mock
 freezegun>=1.0.0
 flake8

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -81,6 +81,7 @@ class Streamlink:
             "stream-segment-timeout": 10.0,
             "stream-timeout": 60.0,
             "ffmpeg-ffmpeg": None,
+            "ffmpeg-no-validation": False,
             "ffmpeg-fout": None,
             "ffmpeg-video-transcode": None,
             "ffmpeg-audio-transcode": None,
@@ -167,6 +168,9 @@ class Streamlink:
         ffmpeg-ffmpeg            (str) Specify the location of the
                                  ffmpeg executable use by Muxing streams
                                  e.g. ``/usr/local/bin/ffmpeg``
+
+        ffmpeg-no-validation     (bool) Disable FFmpeg validation and version logging.
+                                 default: ``False``
 
         ffmpeg-verbose           (bool) Log stderr from ffmpeg to the
                                  console

--- a/src/streamlink/utils/processoutput.py
+++ b/src/streamlink/utils/processoutput.py
@@ -1,0 +1,71 @@
+import asyncio
+from contextlib import suppress
+from typing import Callable, List, Optional
+
+
+class ProcessOutput:
+    def __init__(self, command: List[str], timeout: Optional[float] = None):
+        self.command = command
+        self.timeout = timeout
+
+    def run(self) -> bool:  # pragma: no cover
+        return asyncio.run(self._run())
+
+    async def _run(self) -> bool:
+        loop = asyncio.get_event_loop()
+        done: asyncio.Future[bool] = loop.create_future()
+        process = await asyncio.create_subprocess_exec(
+            *self.command,
+            stdin=None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        if not process.stdout or not process.stderr:  # pragma: no cover
+            return False
+
+        async def ontimeout():
+            if self.timeout:
+                await asyncio.sleep(self.timeout)
+                done.set_result(False)
+
+        async def onexit():
+            code = await process.wait()
+            done.set_result(self.onexit(code))
+
+        async def onoutput(callback: Callable[[int, str], Optional[bool]], streamreader: asyncio.StreamReader):
+            line: bytes
+            idx = 0
+            async for line in streamreader:
+                try:
+                    result = callback(idx, line.decode().rstrip())
+                except Exception as err:
+                    done.set_exception(err)
+                    break
+                if result is not None:
+                    done.set_result(bool(result))
+                    break
+                idx += 1
+
+        tasks = (
+            loop.create_task(ontimeout()),
+            loop.create_task(onexit()),
+            loop.create_task(onoutput(self.onstdout, process.stdout)),
+            loop.create_task(onoutput(self.onstderr, process.stderr)),
+        )
+
+        try:
+            return await done
+        finally:
+            for task in tasks:
+                task.cancel()
+            with suppress(OSError):
+                process.kill()
+
+    def onexit(self, code: int) -> bool:
+        return code == 0
+
+    def onstdout(self, idx: int, line: str) -> Optional[bool]:  # pragma: no cover
+        pass
+
+    def onstderr(self, idx: int, line: str) -> Optional[bool]:  # pragma: no cover
+        pass

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1044,6 +1044,13 @@ def build_parser():
         """
     )
     transport_ffmpeg.add_argument(
+        "--ffmpeg-no-validation",
+        action="store_true",
+        help="""
+        Disable FFmpeg validation and version logging.
+        """
+    )
+    transport_ffmpeg.add_argument(
         "--ffmpeg-verbose",
         action="store_true",
         help="""
@@ -1263,6 +1270,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("hls_segment_key_uri", "hls-segment-key-uri", None),
     ("hls_audio_select", "hls-audio-select", None),
     ("ffmpeg_ffmpeg", "ffmpeg-ffmpeg", None),
+    ("ffmpeg_no_validation", "ffmpeg-no-validation", None),
     ("ffmpeg_verbose", "ffmpeg-verbose", None),
     ("ffmpeg_verbose_path", "ffmpeg-verbose-path", None),
     ("ffmpeg_fout", "ffmpeg-fout", None),

--- a/tests/utils/test_processoutput.py
+++ b/tests/utils/test_processoutput.py
@@ -1,0 +1,224 @@
+import asyncio
+from collections import deque
+from typing import Iterable, Optional
+
+import freezegun
+import pytest
+import pytest_asyncio
+
+from streamlink.utils.processoutput import ProcessOutput
+
+try:
+    from unittest.mock import AsyncMock, Mock, call, patch  # type: ignore
+except ImportError:
+    # noinspection PyUnresolvedReferences
+    from mock import AsyncMock, Mock, call, patch  # type: ignore
+
+
+class AsyncIterator:
+    def __init__(self, event_loop: asyncio.BaseEventLoop, iterable: Optional[Iterable] = None):
+        self._loop = event_loop
+        self._deque = deque(iterable or ())
+        self._newfuture()
+
+    def append(self, item):
+        self._deque.append(item)
+        self._setfutureresult()
+
+    def extend(self, iterable: Iterable):
+        self._deque.extend(iterable)
+        self._setfutureresult()
+
+    def _newfuture(self):
+        self._future = self._loop.create_future()
+
+    def _setfutureresult(self):
+        if len(self._deque) and not self._future.done():
+            self._future.set_result(True)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        while True:
+            await self._future
+            try:
+                return self._deque.popleft()
+            except IndexError:
+                self._newfuture()
+
+
+class FakeProcessOutput(ProcessOutput):
+    onexit: Mock
+    onstdout: Mock
+    onstderr: Mock
+
+
+@pytest.fixture
+def mock_process(event_loop: asyncio.BaseEventLoop):
+    process = Mock(asyncio.subprocess.Process)
+    process.stdout = AsyncIterator(event_loop)
+    process.stderr = AsyncIterator(event_loop)
+
+    return process
+
+
+@pytest.fixture
+def processoutput(request, mock_process):
+    class MyProcessOutput(FakeProcessOutput):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.onexit = Mock(wraps=self.onexit)
+            self.onstdout = Mock(wraps=self.onstdout)
+            self.onstderr = Mock(wraps=self.onstderr)
+
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_process)) as mock_create_subprocess_exec:
+        yield MyProcessOutput(["foo", "bar"], **getattr(request, "param", {}))
+
+    mock_create_subprocess_exec.assert_awaited_once_with(
+        "foo",
+        "bar",
+        stdin=None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def assert_tasks_cleanup(event_loop: asyncio.BaseEventLoop):
+    yield
+    current_task = asyncio.current_task(event_loop)
+    assert not [task for task in asyncio.all_tasks(event_loop) if task is not current_task]
+    await event_loop.shutdown_asyncgens()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("processoutput", [{"timeout": 1}], indirect=True)
+async def test_ontimeout(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    with freezegun.freeze_time("2000-01-01T00:00:00.000Z") as frozen_time:
+        fut_process_wait = event_loop.create_future()
+        mock_process.wait = Mock(return_value=fut_process_wait)
+
+        async def advance_time():
+            # required for making the run-task await the "done" future
+            await asyncio.sleep(0)
+            frozen_time.tick(2)
+
+        task_run = asyncio.create_task(processoutput._run())
+        task_time = asyncio.create_task(advance_time())
+        await asyncio.wait({task_run, task_time}, return_when=asyncio.FIRST_COMPLETED)
+
+        assert mock_process.wait.called, "Has run the onexit callback and called process.wait()"
+        assert not mock_process.kill.called, "Has not killed the process yet"
+
+        result = await task_run
+
+    assert result is False
+    assert not processoutput.onexit.called
+    assert not processoutput.onstdout.called
+    assert not processoutput.onstderr.called
+    assert fut_process_wait.cancelled()
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("processoutput", [{"timeout": 1}], indirect=True)
+async def test_ontimeout_onexit(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    fut_process_wait = event_loop.create_future()
+    mock_process.wait = Mock(return_value=fut_process_wait)
+
+    with freezegun.freeze_time("2000-01-01T00:00:00.000Z") as frozen_time:
+        async def advance_time():
+            # required for making the run-task await the "done" future
+            await asyncio.sleep(0)
+            frozen_time.tick(0.5)
+
+        task_run = asyncio.create_task(processoutput._run())
+        task_time = asyncio.create_task(advance_time())
+        await asyncio.wait({task_run, task_time}, return_when=asyncio.FIRST_COMPLETED)
+
+        assert mock_process.wait.called, "Has run the onexit callback and called process.wait()"
+        assert not mock_process.kill.called, "Has not killed the process yet"
+
+        # make the process return code 0 while waiting for the timeout
+        fut_process_wait.set_result(0)
+
+        # advance time again (the "done" future will already have a result set and the timeout task be cancelled)
+        frozen_time.tick(1)  # type: ignore[arg-type]  # float/int are supported...
+
+        result = await task_run
+
+    assert result is True
+    assert processoutput.onexit.called
+    assert not processoutput.onstdout.called
+    assert not processoutput.onstderr.called
+    assert fut_process_wait.done()
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code,expected", [(0, True), (1, False)])
+async def test_onexit(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock, code, expected):
+    mock_process.wait = AsyncMock(return_value=code)
+
+    result = await processoutput._run()
+
+    assert result is expected
+    assert processoutput.onexit.called
+    assert not processoutput.onstdout.called
+    assert not processoutput.onstderr.called
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("returnvalue", [True, False])
+async def test_onoutput(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock, returnvalue):
+    mock_process.wait = Mock(return_value=event_loop.create_future())
+    mock_process.stdout.extend([b"foo", b"bar", b"baz"])
+
+    def onstdout(idx: int, line: str):
+        if idx < 3:
+            mock_process.stderr.append(line.upper().encode())
+
+    def onstderr(idx: int, line: str):
+        mock_process.stdout.append(line[::-1].encode())
+        if idx == 1:
+            return returnvalue
+
+    processoutput.onstdout = Mock(wraps=onstdout)
+    processoutput.onstderr = Mock(wraps=onstderr)
+
+    result = await processoutput._run()
+
+    assert result is returnvalue
+    assert not processoutput.onexit.called
+    assert processoutput.onstdout.call_args_list == [
+        call(0, "foo"),
+        call(1, "bar"),
+        call(2, "baz"),
+        call(3, "OOF"),
+        call(4, "RAB"),
+    ]
+    assert processoutput.onstderr.call_args_list == [
+        call(0, "FOO"),
+        call(1, "BAR"),
+    ]
+    assert mock_process.kill.called
+
+
+@pytest.mark.asyncio
+async def test_onoutput_exception(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    mock_process.wait = Mock(return_value=event_loop.create_future())
+    mock_process.stdout.extend([b"foo", b"bar", b"baz"])
+
+    error = ValueError("error")
+    processoutput.onstdout = Mock(side_effect=error)
+
+    with pytest.raises(ValueError) as cm:
+        await processoutput._run()
+
+    assert cm.value is error
+    assert not processoutput.onexit.called
+    assert processoutput.onstdout.call_args_list == [call(0, "foo")]
+    assert processoutput.onstderr.call_args_list == []
+    assert mock_process.kill.called


### PR DESCRIPTION
### Motivation

Recently, warning messages were added to the `FFMPEGMuxer` if muxing streams is unavailable because FFmpeg could not be found on the user's system:
#4781

There are a couple of things which can be further improved though:

1. The FFmpeg version should be logged on the debug logging level, similar to the Streamlink + Python version and the dependencies:
   This will make debugging issues easier, e.g. #4825 
2. The FFmpeg executable should be verified via its version output:
   The user can set arbitrary executables as the `--ffmpeg-ffmpeg` value, and Streamlink will execute it blindly. Not only is this bad, but if a different executable gets set, or if the `ffmpeg` executable on the user's system doesn't work, no error messages will be printed.
3. Muxing certain kinds of streams requires having a certain FFmpeg version in order to work correctly:
   The FFmpeg version should be parsed from the version check output, so that it can be compared against a minimum version. This is currently not implemented, but could be added in the future. Related:
   https://github.com/streamlink/streamlink/issues/4520#issuecomment-1129428877

### Implementation

1. Add a generic `ProcessOutput` utility class which can asynchronously read the subprocess's stdout/stderr streams line-by-line while the process is running, as opposed to waiting for process termination and reading the whole stream data into memory at once via the available high-level stdlib APIs [`subprocess.run(capture_output=True)`](https://docs.python.org/3/library/subprocess.html#subprocess.run) or [`asyncio.create_subprocess_exec().communicate()`](https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.communicate)
2. Read FFmpeg version after resolving the executable path, log the output and validate.
   Also add the `--ffmpeg-no-validation` CLI argument for disabling the validation.

#### Why asyncio?

This makes the implementation and testing way easier compared to running in separate threads and making everything thread-safe. Using asyncio was not possible until last year due to the support for py2. This has changed now, so it should be utilized. Adding it however requires adding two more dev-requirements, namely

- `pytest-asyncio` - already a transitive dependency, so nothing will change here
- `mock` - for backwards compatibility of `unittest.mock` on py37 (AsyncMock). `mock` was already removed in the past (d04767f) after it wasn't required anymore. Just a quick mention, by adding it back, the annoying compatibility of the `Mock.call_args` args/kwargs could also be solved, but that would require changing imports everywhere, and it's probably not worth it.

In regards to the tests, `freezegun` is used for simulating subprocess timeouts, and it might be possible that something will change in future freezegun releases in terms of the asyncio module integration. This will need to be kept in mind and checked, but most likely it'll be harmless.

#### FFmpeg version output

As you can see here (also added as comments to the code)

- https://github.com/FFmpeg/FFmpeg/blame/n5.1.1/fftools/ffmpeg.c#L110
- https://github.com/FFmpeg/FFmpeg/blame/n5.1.1/fftools/opt_common.c#L201
- https://github.com/FFmpeg/FFmpeg/blame/c99b93c5d53d8f4a4f1fafc90f3dfc51467ee02e/fftools/cmdutils.c#L1156
- https://github.com/FFmpeg/FFmpeg/commit/89b503b55f2b2713f1c3cc8981102c1a7b663281

the FFmpeg version string that gets checked is stable. One issue however could be forks which use a different name, but since we've just dropped `avconv` in 5.0.0, I don't think this is going to be a problem. I'm also not aware of any actively used FFmpeg forks, and should there be any, users can disable the validation by setting the CLI argument mentioned above.

Only the first stdout line will be checked during the validation. On success, everything else will be logged (with indentation). I wouldn't mind changing this if you don't agree with this and think that it's too much.

#### Potential issues

Executing FFmpeg introduces a small delay at the beginning while resolving and validating the executable. I don't think this is a problem though, even on weak/limited systems. FFmpeg has to be run anyway when muxing, so loading-wise, I don't see this as an issue. The validation timeout value has been set to a very generous 4 seconds.

On error, the infamous "Unexpected version check" error message (phrased differently) will be shown without any actual error stream outputs. Infamous, because the Twitch GUI also needs to validate Streamlink, and the same logic gets used there, which has caused problems for dozens of users in the past who had broken Streamlink installs or configs. For Streamlink, this shouldn't be an issue though, as it also tells which command it's been running for checking the FFmpeg output, and there are also more error and warning messages.

### Example

```
$ streamlink -l trace --http-proxy socks5h://localhost:1920 https://www.france.tv/france-2/direct.html
[14:46:21.714633][cli][debug] OS:         Linux-5.19.12-1-git-x86_64-with-glibc2.36
[14:46:21.714714][cli][debug] Python:     3.10.7
[14:46:21.714739][cli][debug] Streamlink: 5.0.1+10.gd5793343
[14:46:21.715182][cli][debug] Dependencies:
[14:46:21.715884][cli][debug]  isodate: 0.6.1
[14:46:21.716145][cli][debug]  lxml: 4.9.1
[14:46:21.716578][cli][debug]  pycountry: 22.3.5
[14:46:21.716795][cli][debug]  pycryptodome: 3.14.1
[14:46:21.717094][cli][debug]  PySocks: 1.7.1
[14:46:21.717354][cli][debug]  requests: 2.28.1
[14:46:21.717618][cli][debug]  websocket-client: 1.3.1
[14:46:21.717834][cli][debug]  importlib-metadata: 4.9.0
[14:46:21.717962][cli][debug] Arguments:
[14:46:21.717988][cli][debug]  url=https://www.france.tv/france-2/direct.html
[14:46:21.718014][cli][debug]  --loglevel=trace
[14:46:21.718039][cli][debug]  --player=mpv
[14:46:21.718074][cli][debug]  --http-proxy=socks5h://localhost:1920
[14:46:21.718238][cli][info] Found matching plugin pluzz for URL https://www.france.tv/france-2/direct.html
[14:46:21.935123][plugins.pluzz][debug] Country: FR
[14:46:22.102771][plugins.pluzz][debug] Video ID: 006194ea-117d-4bcf-94a9-153d999c59ae
[14:46:22.522483][utils.l10n][debug] Language code: en_US
[14:46:22.674536][stream.ffmpegmux][trace] Querying FFmpeg version: ['/usr/bin/ffmpeg', '-version']
[14:46:22.695525][stream.ffmpegmux][debug] ffmpeg version n5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
[14:46:22.695601][stream.ffmpegmux][debug]  built with gcc 12.2.0 (GCC)
[14:46:22.695643][stream.ffmpegmux][debug]  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libiec61883 --enable-libjack --enable-libmfx --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-librav1e --enable-librsvg --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-version3 --enable-vulkan
[14:46:22.695688][stream.ffmpegmux][debug]  libavutil      57. 28.100 / 57. 28.100
[14:46:22.695722][stream.ffmpegmux][debug]  libavcodec     59. 37.100 / 59. 37.100
[14:46:22.695755][stream.ffmpegmux][debug]  libavformat    59. 27.100 / 59. 27.100
[14:46:22.695787][stream.ffmpegmux][debug]  libavdevice    59.  7.100 / 59.  7.100
[14:46:22.695819][stream.ffmpegmux][debug]  libavfilter     8. 44.100 /  8. 44.100
[14:46:22.695850][stream.ffmpegmux][debug]  libswscale      6.  7.100 /  6.  7.100
[14:46:22.695882][stream.ffmpegmux][debug]  libswresample   4.  7.100 /  4.  7.100
[14:46:22.695912][stream.ffmpegmux][debug]  libpostproc    56.  6.100 / 56.  6.100
[14:46:22.695955][stream.hls][debug] Using external audio tracks for stream 144p (language=fr, name=Francais)
[14:46:22.696092][stream.hls][debug] Using external audio tracks for stream 216p (language=fr, name=Francais)
[14:46:22.696201][stream.hls][debug] Using external audio tracks for stream 360p (language=fr, name=Francais)
[14:46:22.696300][stream.hls][debug] Using external audio tracks for stream 540p (language=fr, name=Francais)
[14:46:22.696397][stream.hls][debug] Using external audio tracks for stream 720p (language=fr, name=Francais)
[14:46:22.696495][stream.hls][debug] Using external audio tracks for stream 1080p (language=fr, name=Francais)
Available streams: 144p (worst), 216p, 360p, 540p, 720p, 1080p (best)
```

```
$ streamlink -l trace --http-proxy socks5h://localhost:1920 --ffmpeg-ffmpeg /usr/bin/false https://www.france.tv/france-2/direct.html
[14:46:51.375609][cli][debug] OS:         Linux-5.19.12-1-git-x86_64-with-glibc2.36
[14:46:51.375706][cli][debug] Python:     3.10.7
[14:46:51.375736][cli][debug] Streamlink: 5.0.1+10.gd5793343
[14:46:51.376172][cli][debug] Dependencies:
[14:46:51.376845][cli][debug]  isodate: 0.6.1
[14:46:51.377095][cli][debug]  lxml: 4.9.1
[14:46:51.377513][cli][debug]  pycountry: 22.3.5
[14:46:51.377724][cli][debug]  pycryptodome: 3.14.1
[14:46:51.378015][cli][debug]  PySocks: 1.7.1
[14:46:51.378266][cli][debug]  requests: 2.28.1
[14:46:51.378522][cli][debug]  websocket-client: 1.3.1
[14:46:51.378737][cli][debug]  importlib-metadata: 4.9.0
[14:46:51.378869][cli][debug] Arguments:
[14:46:51.378896][cli][debug]  url=https://www.france.tv/france-2/direct.html
[14:46:51.378923][cli][debug]  --loglevel=trace
[14:46:51.378946][cli][debug]  --player=mpv
[14:46:51.378979][cli][debug]  --ffmpeg-ffmpeg=/usr/bin/false
[14:46:51.379001][cli][debug]  --http-proxy=socks5h://localhost:1920
[14:46:51.379167][cli][info] Found matching plugin pluzz for URL https://www.france.tv/france-2/direct.html
[14:46:51.611732][plugins.pluzz][debug] Country: FR
[14:46:51.809546][plugins.pluzz][debug] Video ID: 006194ea-117d-4bcf-94a9-153d999c59ae
[14:46:52.298957][utils.l10n][debug] Language code: en_US
[14:46:52.465542][stream.ffmpegmux][trace] Querying FFmpeg version: ['/usr/bin/false', '-version']
[14:46:52.474301][stream.ffmpegmux][error] Could not validate FFmpeg!
[14:46:52.474372][stream.ffmpegmux][error] Unexpected FFmpeg version output while running ['/usr/bin/false', '-version']
[14:46:52.474417][stream.ffmpegmux][warning] No valid FFmpeg binary was not found. See the --ffmpeg-ffmpeg option.
[14:46:52.474453][stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
Available streams: 144p (worst), 216p, 360p, 540p, 720p, 1080p (best)
```