### PR TITLE
plugins.sbscokr: rewrite and fix plugin

### DIFF
--- a/tests/plugins/test_sbscokr.py
+++ b/tests/plugins/test_sbscokr.py
@@ -5,7 +5,11 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlSBScokr(PluginCanHandleUrl):
     __plugin__ = SBScokr
 
-    should_match = [
-        'https://play.sbs.co.kr/onair/pc/index.html',
-        'http://play.sbs.co.kr/onair/pc/index.html',
+    should_match_groups = [
+        # regular channels
+        ("https://www.sbs.co.kr/live/S01", {"channel": "S01"}),
+        ("https://www.sbs.co.kr/live/S01?div=live_list", {"channel": "S01"}),
+        # "virtual" channels
+        ("https://www.sbs.co.kr/live/S21", {"channel": "S21"}),
+        ("https://www.sbs.co.kr/live/S21?div=live_list", {"channel": "S21"}),
     ]


### PR DESCRIPTION
I noticed the `--sbscokr-id` plugin argument while cleaning up some plugins, and apparently it's not needed anymore as the individual streams are accessible from a canonical URL now.

This PR therefore suppresses the plugin argument. The old implementation also didn't support "virtual" channels which are retrieved from a different API endpoint. Geo-restriction seems to depend on the content that's currently being shown.

**master**
```
$ streamlink https://play.sbs.co.kr/onair/pc/index.html --sbscokr-id S01
[cli][info] Found matching plugin sbscokr for URL https://play.sbs.co.kr/onair/pc/index.html
[plugins.sbscokr][info] Available IDs: S01 (SBS), S02 (SBS Sports), S03 (SBS Plus), S04 (SBS funE), S05 (SBS Golf), S06 (SBS BIZ), S07 (POWER FM), S08 (LOVE FM), S09 (SBS M), S10 (Kizmom), S17 (POWER FM), S18 (LOVE FM), S19 (GorealraM), S20 (K POP)
[plugins.sbscokr][error] We’re sorry, it’s permitted to see this content in South Korea only.
error: No playable streams found on this URL: https://play.sbs.co.kr/onair/pc/index.html

$ streamlink https://play.sbs.co.kr/onair/pc/index.html --sbscokr-id S21
[cli][info] Found matching plugin sbscokr for URL https://play.sbs.co.kr/onair/pc/index.html
[plugins.sbscokr][info] Available IDs: S01 (SBS), S02 (SBS Sports), S03 (SBS Plus), S04 (SBS funE), S05 (SBS Golf), S06 (SBS BIZ), S07 (POWER FM), S08 (LOVE FM), S09 (SBS M), S10 (Kizmom), S17 (POWER FM), S18 (LOVE FM), S19 (GorealraM), S20 (K POP)
[plugins.sbscokr][error] Channel ID "S21" is not available.
error: No playable streams found on this URL: https://play.sbs.co.kr/onair/pc/index.html
```

**PR**
```
$ streamlink https://www.sbs.co.kr/live/S01
[cli][info] Found matching plugin sbscokr for URL https://www.sbs.co.kr/live/S01
[plugins.sbscokr][error] Geo-restricted content: We’re sorry, it’s permitted to see this content in South Korea only.
error: No playable streams found on this URL: https://www.sbs.co.kr/live/S01

$ streamlink https://www.sbs.co.kr/live/S21
[cli][info] Found matching plugin sbscokr for URL https://www.sbs.co.kr/live/S21
Available streams: 720p (worst, best)

$ streamlink https://www.sbs.co.kr/live/foo
[cli][info] Found matching plugin sbscokr for URL https://www.sbs.co.kr/live/foo
error: No playable streams found on this URL: https://www.sbs.co.kr/live/foo
```