### PR TITLE
plugins.qq: rewrite and fix plugin

### DIFF
--- a/tests/plugins/test_qq.py
+++ b/tests/plugins/test_qq.py
@@ -5,26 +5,8 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlQQ(PluginCanHandleUrl):
     __plugin__ = QQ
 
-    should_match = [
-        "http://live.qq.com/10003715",
-        "http://live.qq.com/10007266",
-        "http://live.qq.com/10039165",
-        "http://m.live.qq.com/10003715",
-        "http://m.live.qq.com/10007266",
-        "http://m.live.qq.com/10039165"
-    ]
-
     should_match_groups = [
-        ("http://live.qq.com/10003715", {
-            "room_id": "10003715"
-        }),
-        ("http://m.live.qq.com/10039165", {
-            "room_id": "10039165"
-        }),
-    ]
-
-    should_not_match = [
-        "http://live.qq.com/",
-        "http://qq.com/",
-        "http://www.qq.com/"
+        ("https://live.qq.com/", {}),
+        ("https://live.qq.com/123456789", {"room_id": "123456789"}),
+        ("https://m.live.qq.com/123456789", {"room_id": "123456789"}),
     ]


### PR DESCRIPTION
Quick plugin cleanup and improvement, with support for optional room IDs

**master**
```
$ streamlink https://live.qq.com/
error: No plugin can handle URL: https://live.qq.com/

$ streamlink https://live.qq.com/10164211
[cli][info] Found matching plugin qq for URL https://live.qq.com/10164211
Available streams: live (worst, best)

$ streamlink https://live.qq.com/10164211 -j | jq .metadata
{
  "id": null,
  "author": null,
  "category": null,
  "title": null
}
```

**PR**
```
$ streamlink https://live.qq.com/
[cli][info] Found matching plugin qq for URL https://live.qq.com/
Available streams: live (worst, best)

$ streamlink https://live.qq.com/ -j | jq .metadata
{
  "id": "10003870",
  "author": "蓝猫篮球lan解读",
  "category": "棒球/橄榄球/冰球",
  "title": "公羊vs49人【蓝猫】"
}

$ streamlink https://live.qq.com/10164211
[cli][info] Found matching plugin qq for URL https://live.qq.com/10164211
Available streams: live (worst, best)

$ streamlink https://live.qq.com/0
[cli][info] Found matching plugin qq for URL https://live.qq.com/0
[plugins.qq][error] 房间未找到
error: No playable streams found on this URL: https://live.qq.com/0
```