### PR TITLE
plugins.tvrplus: rewrite plugin

### DIFF
--- a/tests/plugins/test_tvrplus.py
+++ b/tests/plugins/test_tvrplus.py
@@ -6,12 +6,16 @@ class TestPluginCanHandleUrlTVRPlus(PluginCanHandleUrl):
     __plugin__ = TVRPlus
 
     should_match = [
-        "http://tvrplus.ro/live/tvr-1",
-        "http://www.tvrplus.ro/live/tvr-1",
-        "http://www.tvrplus.ro/live/tvr-3",
-        "http://www.tvrplus.ro/live/tvr-international",
+        "https://tvrplus.ro",
+        "https://tvrplus.ro/",
+        "https://tvrplus.ro/live/tvr-1",
+        "https://www.tvrplus.ro",
+        "https://www.tvrplus.ro/",
+        "https://www.tvrplus.ro/live/tvr-1",
+        "https://www.tvrplus.ro/live/tvr-3",
+        "https://www.tvrplus.ro/live/tvr-international",
     ]
 
     should_not_match = [
-        "http://www.tvrplus.ro/",
+        "https://www.tvrplus.ro/emisiuni",
     ]


### PR DESCRIPTION
Just slowly updating some plugins which are still using the deprecated `validate.text` export...

This is one of them, and one of the last simple ones. Others require much more effort and are geo-locked in lots of cases, or they require having an account, which is annoying.

I was thinking about submitting a PR with a simple text substitution for all the `validate.text` definitions in the validation schemas, but that's kinda stupid, because most of those plugin implementations are really old and some are (partially) broken, so applying automated code changes is rather pointless. Maybe I should make a list of old plugins that are in need of a cleanup.