### PR TITLE
plugins.goltelevision: add missing HTTP headers

### DIFF
--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -17,12 +17,16 @@ from streamlink.stream.hls import HLSStream
 ))
 class GOLTelevision(Plugin):
     def _get_streams(self):
+        self.session.http.headers.update({
+            "Origin": "https://goltelevision.com",
+            "Referer": "https://goltelevision.com/",
+        })
         url = self.session.http.get(
             "https://play.goltelevision.com/api/stream/live",
             schema=validate.Schema(
                 validate.parse_json(),
                 {"manifest": validate.url()},
-                validate.get("manifest")
+                validate.get("manifest"),
             )
         )
         return HLSStream.parse_variant_playlist(self.session, url)


### PR DESCRIPTION
Fixes #4872 

Tested with Spanish VPN. Geo-blocking happens on the media-playlist level, so it's not worth adding a check for that.

```
$ streamlink -l debug goltelevision.com/en-directo best
[cli][debug] OS:         Linux-5.17.0-rc6-1-git-01586-g15f9cd4334c8-x86_64-with-glibc2.36
[cli][debug] Python:     3.10.7
[cli][debug] Streamlink: 5.0.1+16.gf13f431b
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.1
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.2
[cli][debug] Arguments:
[cli][debug]  url=goltelevision.com/en-directo
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin goltelevision for URL goltelevision.com/en-directo
[utils.l10n][debug] Language code: en_US
[stream.ffmpegmux][debug] ffmpeg version n5.1.2 Copyright (c) 2000-2022 the FFmpeg developers
[stream.ffmpegmux][debug]  built with gcc 12.2.0 (GCC)
[stream.ffmpegmux][debug]  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libiec61883 --enable-libjack --enable-libmfx --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libpulse --enable-librav1e --enable-librsvg --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-version3 --enable-vulkan
[stream.ffmpegmux][debug]  libavutil      57. 28.100 / 57. 28.100
[stream.ffmpegmux][debug]  libavcodec     59. 37.100 / 59. 37.100
[stream.ffmpegmux][debug]  libavformat    59. 27.100 / 59. 27.100
[stream.ffmpegmux][debug]  libavdevice    59.  7.100 / 59.  7.100
[stream.ffmpegmux][debug]  libavfilter     8. 44.100 /  8. 44.100
[stream.ffmpegmux][debug]  libswscale      6.  7.100 /  6.  7.100
[stream.ffmpegmux][debug]  libswresample   4.  7.100 /  4.  7.100
[stream.ffmpegmux][debug]  libpostproc    56.  6.100 / 56.  6.100
[stream.hls][debug] Using external audio tracks for stream 720p (language=spa, name=Spanish)
[stream.hls][debug] Using external audio tracks for stream 576p (language=spa, name=Spanish)
[stream.hls][debug] Using external audio tracks for stream 480p (language=spa, name=Spanish)
[stream.hls][debug] Using external audio tracks for stream 360p (language=spa, name=Spanish)
[cli][info] Available streams: 360p (worst), 480p, 576p, 720p (best)
[cli][info] Opening stream: 720p (hls-multi)
[cli][info] Starting player: mpv
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[utils.named_pipe][info] Creating pipe streamlinkpipe-376109-1-3695
[utils.named_pipe][info] Creating pipe streamlinkpipe-376109-2-2720
[stream.ffmpegmux][debug] ffmpeg command: /usr/bin/ffmpeg -nostats -y -i /tmp/streamlinkpipe-376109-1-3695 -i /tmp/streamlinkpipe-376109-2-2720 -c:v copy -c:a copy -map 0:v? -map 0:a? -map 1:a -f mpegts pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-376109-1-3695
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-376109-2-2720
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 341957; Last Sequence: 341966
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 341964; End Sequence: None
[stream.hls][debug] Adding segment 341964 to queue
[stream.hls][debug] Adding segment 341965 to queue
[stream.hls][debug] Adding segment 341966 to queue
[stream.hls][debug] First Sequence: 341958; Last Sequence: 341967
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 341965; End Sequence: None
[stream.hls][debug] Adding segment 341965 to queue
[stream.hls][debug] Adding segment 341966 to queue
[stream.hls][debug] Adding segment 341967 to queue
[stream.hls][debug] Segment 341965 complete
[stream.hls][debug] Segment 341966 complete
[stream.hls][debug] Segment 341967 complete
[stream.hls][debug] Segment 341964 complete
[cli.output][debug] Opening subprocess: mpv --force-media-title=goltelevision.com/en-directo -
[stream.hls][debug] Segment 341965 complete
[stream.hls][debug] Segment 341966 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 341967 to queue
[stream.hls][debug] Adding segment 341968 to queue
[stream.hls][debug] Segment 341968 complete
[stream.hls][debug] Segment 341967 complete
[cli][info] Player closed
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][error] Pipe copy aborted: /tmp/streamlinkpipe-376109-2-2720
[stream.ffmpegmux][error] Pipe copy aborted: /tmp/streamlinkpipe-376109-1-3695
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-376109-2-2720
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-376109-1-3695
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```