### PR TITLE
plugins.atresplayer: update input URLs

### DIFF
--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -22,10 +22,12 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?atresplayer\.com/"
 ))
 class AtresPlayer(Plugin):
-    def _get_streams(self):
-        self.url = update_scheme("https://", self.url)
-        path = urlparse(self.url).path
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = update_scheme("https://", f"{self.url.rstrip('/')}/")
 
+    def _get_streams(self):
+        path = urlparse(self.url).path
         api_url = self.session.http.get(self.url, schema=validate.Schema(
             re.compile(r"""window.__PRELOADED_STATE__\s*=\s*({.*?});""", re.DOTALL),
             validate.none_or_all(

--- a/tests/plugins/test_atresplayer.py
+++ b/tests/plugins/test_atresplayer.py
@@ -1,3 +1,7 @@
+from unittest.mock import Mock
+
+import pytest
+
 from streamlink.plugins.atresplayer import AtresPlayer
 from tests.plugins import PluginCanHandleUrl
 
@@ -6,8 +10,20 @@ class TestPluginCanHandleUrlAtresPlayer(PluginCanHandleUrl):
     __plugin__ = AtresPlayer
 
     should_match = [
-        'http://www.atresplayer.com/directos/antena3/',
-        'http://www.atresplayer.com/directos/lasexta/',
-        'https://www.atresplayer.com/directos/antena3/',
-        'https://www.atresplayer.com/flooxer/programas/unas/temporada-1/dario-eme-hache-sindy-takanashi-entrevista_123/',
+        "http://www.atresplayer.com/directos/antena3/",
+        "http://www.atresplayer.com/directos/lasexta/",
+        "https://www.atresplayer.com/directos/antena3/",
+        "https://www.atresplayer.com/flooxer/programas/unas/temporada-1/dario-eme-hache-sindy-takanashi-entrevista_123/",
     ]
+
+
+class TestAtresPlayer:
+    @pytest.mark.parametrize("url,expected", [
+        ("http://www.atresplayer.com/directos/antena3", "https://www.atresplayer.com/directos/antena3/"),
+        ("http://www.atresplayer.com/directos/antena3/", "https://www.atresplayer.com/directos/antena3/"),
+        ("https://www.atresplayer.com/directos/antena3", "https://www.atresplayer.com/directos/antena3/"),
+        ("https://www.atresplayer.com/directos/antena3/", "https://www.atresplayer.com/directos/antena3/"),
+    ])
+    def test_url(self, url, expected):
+        plugin = AtresPlayer(Mock(), url)
+        assert plugin.url == expected


### PR DESCRIPTION
Fixes #4875 

This ensures that the input URL ends with a `/`.
A different and maybe better solution would've been requesting the input URL and reading the `url` attribute from the redirected HTTP response. That would require rewriting the validation schema setup, and it's not worth it.

Site detects my VPN, so I can't validate the actual streams.

```
$ streamlink https://www.atresplayer.com/directos/nova
[cli][info] Found matching plugin atresplayer for URL https://www.atresplayer.com/directos/nova
[plugins.atresplayer][error] Player API error: geoblocked - Content is geoblocked
error: No playable streams found on this URL: https://www.atresplayer.com/directos/nova
```

```
$ streamlink https://www.atresplayer.com/directos/nova
[cli][info] Found matching plugin atresplayer for URL https://www.atresplayer.com/directos/nova
[plugins.atresplayer][error] Player API error: vpn - Using VPN
error: No playable streams found on this URL: https://www.atresplayer.com/directos/nova
```