### PR TITLE
plugins.btv: fix validation schema

### DIFF
--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -44,14 +44,11 @@ class BTV(Plugin):
                         validate.parse_json(),
                         {
                             "status": "ok",
-                            "config": str,
+                            "info": {
+                                "file": validate.url(path=validate.endswith(".m3u8")),
+                            },
                         },
-                        validate.get("config"),
-                        re.compile(r"src: \"(http.*?)\""),
-                        validate.none_or_all(
-                            validate.get(1),
-                            validate.url(),
-                        ),
+                        validate.get(("info", "file")),
                     ),
                 ),
             ),
@@ -63,7 +60,7 @@ class BTV(Plugin):
             log.error("The content is not available in your region")
             return
 
-        return HLSStream.parse_variant_playlist(self.session, stream_url)
+        return {"live": HLSStream(self.session, stream_url)}
 
 
 __plugin__ = BTV


### PR DESCRIPTION
Fixes #4884 

@TPlamen could you please verify these changes? The site is geo-blocked and I currently don't have local access to a Bulgarian IP address via a VPN/proxy.

Install my branch via pip
https://streamlink.github.io/install.html#pypi-package-and-source-code

or sideload the updated plugin
https://raw.githubusercontent.com/bastimeyer/streamlink/e53ec135d687625c4683d9dce670c4e6f593a3c5/src/streamlink/plugins/btv.py
https://streamlink.github.io/cli/plugin-sideloading.html
