### PR TITLE
plugins.bsyoshimoto: new plugin

### DIFF
--- a/src/streamlink/plugins/bsyoshimoto.py
+++ b/src/streamlink/plugins/bsyoshimoto.py
@@ -1,0 +1,32 @@
+"""
+$description Japanese Broadcast Satellite (BS) entertainment channel owned by Yoshimoto Kogyo Co. Ltd.
+$url video.bsy.co.jp
+$type live
+"""
+
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+
+@pluginmatcher(re.compile(
+    r"https?://video\.bsy\.co\.jp/?",
+))
+class BSYoshimoto(Plugin):
+    def _get_streams(self):
+        hls_url = self.session.http.get(self.url, schema=validate.Schema(
+            validate.transform(re.compile(r"hls\.loadSource\(\s*(?P<q>[\"'])(?P<url>\S+)(?P=q)\s*\)").search),
+            validate.none_or_all(
+                validate.get("url"),
+                validate.url(path=validate.endswith(".m3u8")),
+            ),
+        ))
+        if not hls_url:
+            return
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+
+__plugin__ = BSYoshimoto

--- a/tests/plugins/test_bsyoshimoto.py
+++ b/tests/plugins/test_bsyoshimoto.py
@@ -1,0 +1,15 @@
+from streamlink.plugins.bsyoshimoto import BSYoshimoto
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlBSYoshimoto(PluginCanHandleUrl):
+    __plugin__ = BSYoshimoto
+
+    should_match = [
+        "https://video.bsy.co.jp/",
+    ]
+
+    should_not_match = [
+        "https://bsy.co.jp/",
+        "https://www.bsy.co.jp/",
+    ]


### PR DESCRIPTION
Resolves #4898 

Just a simple Japanese live TV stream which matches the plugin request criteria. There seem to be VODs, but I can't access them. My browser's translations don't work on the alert popups that show up when trying to access the VODs, so I don't care about a VOD implementation.

The plugin description should be correct according to my research (no information in the plugin request):
- https://bsy.co.jp/corporate/company
- https://en.wikipedia.org/wiki/Yoshimoto_Kogyo

I also had to look up the "BS" term in order to decide on the name of the plugin:
- https://en.wikipedia.org/wiki/Television_in_Japan#Satellite_IPTV_television
- https://www.reddit.com/r/japanlife/comments/1gxtk2/question_what_is_bscs_tv_how_can_i_check_if_i_can/caow7a0/

HLS URL extraction is very simple. The URLs seem to be token-based though, and I don't know if there is any expiration time. The "drm" part of the HLS URLs can be ignored, as it's just a regular encrypted HLS stream.

```
$ streamlink -l debug https://video.bsy.co.jp/ best
[cli][debug] OS:         Linux-5.17.0-rc6-1-git-01595-gf3fa490960e8-x86_64-with-glibc2.36
[cli][debug] Python:     3.10.8
[cli][debug] Streamlink: 5.0.1+21.g780a10b4
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.1
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.2
[cli][debug] Arguments:
[cli][debug]  url=https://video.bsy.co.jp/
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin bsyoshimoto for URL https://video.bsy.co.jp/
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 270p (worst), 360p, 720p (best)
[cli][info] Opening stream: 720p (hls)
[cli][info] Starting player: mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] First Sequence: 4171840; Last Sequence: 4171849
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 4171847; End Sequence: None
[stream.hls][debug] Adding segment 4171847 to queue
[stream.hls][debug] Adding segment 4171848 to queue
[stream.hls][debug] Adding segment 4171849 to queue
[stream.hls][debug] Segment 4171847 complete
[cli.output][debug] Opening subprocess: mpv --force-media-title=https://video.bsy.co.jp/ -
[stream.hls][debug] Segment 4171848 complete
[stream.hls][debug] Segment 4171849 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] Adding segment 4171850 to queue
[stream.hls][debug] Segment 4171850 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] Adding segment 4171851 to queue
[stream.hls][debug] Adding segment 4171852 to queue
[stream.hls][debug] Segment 4171851 complete
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```