### PR TITLE
chore: update issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_plugin_issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_plugin_issue.yml
@@ -1,5 +1,5 @@
-name: Plugin issue
-description: One of Streamlink's plugins doesn't work correctly
+name: 🧩 Plugin issue
+description: One of Streamlink's plugins doesn't work correctly.
 title: "plugins.plugin-name-here: A very brief summary of what's broken"
 labels:
   - plugin issue
@@ -9,7 +9,9 @@ body:
       value: |
         ## Thanks for reporting a plugin issue!
 
-        Plugin issues describe broken functionality within a plugin's code base, eg. the streaming site has made breaking changes, streams don't get resolved correctly, or authentication has stopped working, etc.
+        Plugin issues describe broken functionality within a plugin's code base, e.g. the streaming site has made breaking changes, streams don't get resolved correctly, or authentication has stopped working, etc.
+
+        ----
 
         **DON'T IGNORE this template and fill in all the required details.**
         **Issues that don't adhere to our request will be closed and ignored.**
@@ -43,23 +45,23 @@ body:
       label: Description
       description: |
         Explain the plugin issue as thoroughly as you can.
-        Please also provide the exact steps for reproducing the issue, eg. a list of input URLs.
+        Please also provide the exact steps for reproducing the issue, e.g. a list of input URLs.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Debug log
       description: |
-        DEBUG LOG OUTPUT IS REQUIRED for plugin issues!
+        **DEBUG LOG OUTPUT IS REQUIRED for plugin issues!**
         INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
 
-        Use the [`--loglevel debug`](https://streamlink.github.io/latest/cli.html#cmdoption-loglevel) parameter and avoid using parameters which suppress log output.
-        Debug log includes important details about your platform. Don't remove it.
+        Use the [`--loglevel=debug`](https://streamlink.github.io/latest/cli.html#cmdoption-loglevel) parameter and avoid using parameters which suppress log output.
+        Debug log includes important details about your platform and the version you're using. Don't remove it.
 
         If the log output is too long and repetitive parts can't be truncated, or if you have multiple log outputs to share, please post a link to a [GitHub gist](https://gist.github.com/) with the log output instead.
-      placeholder: |
-        Don't post screenshots of the log output and instead copy the text from your terminal application.
 
+        **DO NOT post screenshots of the log output and instead copy the text from your terminal application.**
+      placeholder: |
         The content will be rendered as code block.
       render: text
     validations:
@@ -70,9 +72,9 @@ body:
         ### Before submitting
 
         Make sure that you have
-        - properly filled in the title of this plugin issue
-        - checked the rendered text previews to avoid unnecessary formatting errors
+        - [ ] properly filled in the title of this plugin issue (at the very top of this page)
+        - [ ] checked the rendered text previews to avoid unnecessary formatting errors
 
         ----
 
-        [Love Streamlink? Please consider supporting our collective. Thanks!](https://opencollective.com/streamlink/donate)
+        [❤️ Love Streamlink? Please consider supporting the project maintainers. Thanks! ❤️](https://streamlink.github.io/donate.html)

--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -1,5 +1,5 @@
-name: Bug Report
-description: A core functionality of Streamlink is broken
+name: 🐛 Bug Report
+description: A core functionality of Streamlink is broken.
 title: "A very brief summary of what's broken"
 labels:
   - bug
@@ -9,7 +9,11 @@ body:
       value: |
         ## Thanks for reporting a bug!
 
-        Bugs are the result of broken functionality within Streamlink's main code base. Use the plugin issue template if your report is about a broken plugin.
+        Bugs are the result of broken functionality within Streamlink's main code base.
+
+        **Use the [plugin issue template](https://github.com/streamlink/streamlink/issues/new/choose) if your report is about a broken plugin.**
+
+        ----
 
         **DON'T IGNORE this template and fill in all the required details.**
         **Issues that don't adhere to our request will be closed and ignored.**
@@ -44,22 +48,24 @@ body:
       description: |
         Explain the bug as thoroughly as you can.
         Please also provide the exact steps for reproducing the issue.
+
+        Any kind of packaging issue except for Streamlink's own sdist/bdist packages on PyPI does not belong here and should be reported on the respecting issue tracker or to the respecting third-party packager.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Debug log
       description: |
-        DEBUG LOG OUTPUT IS REQUIRED for bug reports!
+        **DEBUG LOG OUTPUT IS REQUIRED for bug reports!**
         INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
 
-        Use the [`--loglevel debug`](https://streamlink.github.io/latest/cli.html#cmdoption-loglevel) parameter and avoid using parameters which suppress log output.
-        Debug log includes important details about your platform. Don't remove it.
+        Use the [`--loglevel=debug`](https://streamlink.github.io/latest/cli.html#cmdoption-loglevel) parameter and avoid using parameters which suppress log output.
+        Debug log includes important details about your platform and the version you're using. Don't remove it.
 
         If the log output is too long and repetitive parts can't be truncated, or if you have multiple log outputs to share, please post a link to a [GitHub gist](https://gist.github.com/) with the log output instead.
-      placeholder: |
-        Don't post screenshots of the log output and instead copy the text from your terminal application.
 
+        **DO NOT post screenshots of the log output and instead copy the text from your terminal application.**
+      placeholder: |
         The content will be rendered as code block.
       render: text
     validations:
@@ -70,9 +76,9 @@ body:
         ### Before submitting
 
         Make sure that you have
-        - properly filled in the title of this bug report
-        - checked the rendered text previews to avoid unnecessary formatting errors
+        - [ ] properly filled in the title of this bug report (at the very top of this page)
+        - [ ] checked the rendered text previews to avoid unnecessary formatting errors
 
         ----
 
-        [Love Streamlink? Please consider supporting our collective. Thanks!](https://opencollective.com/streamlink/donate)
+        [❤️ Love Streamlink? Please consider supporting the project maintainers. Thanks! ❤️](https://streamlink.github.io/donate.html)

--- a/.github/ISSUE_TEMPLATE/3_plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/3_plugin_request.yml
@@ -1,5 +1,5 @@
-name: Plugin request
-description: Discuss adding a new plugin to Streamlink
+name: 🧩 Plugin request
+description: Discuss adding a new plugin to Streamlink.
 title: "Name of the website / streaming provider"
 labels:
   - plugin request
@@ -10,6 +10,8 @@ body:
         ## Thanks for requesting a plugin!
 
         [READ THE PLUGIN REQUEST REQUIREMENTS IN THE CONTRIBUTION GUIDELINES BEFORE POSTING!](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#plugin-requests)
+
+        ----
 
         **DON'T IGNORE this template and fill in all the required details.**
         **Issues that don't adhere to our request will be closed and ignored.**
@@ -29,19 +31,21 @@ body:
     attributes:
       label: Description
       description: |
-        Explain the plugin and site as clearly as you can.
+        Explain the plugin and site as clearly as you can according to the plugin request guidelines. For example:
 
-        What is the site about?
-        Who is it run by?
-        What content does it provide?
-        etc.
+        - What is the site about?
+        - Who is it run by?
+        - What kind of content does it provide?
+        - Are there any access restrictions like logins or region checks?
     validations:
       required: true
   - type: textarea
     attributes:
       label: Input URLs
       description: |
-        Please provide a list of example stream input URLs
+        Please provide a list of example input URLs.
+
+        **DO NOT post screenshots of the site or your web browser.**
       placeholder: |
         1. ...
         2. ...
@@ -55,9 +59,9 @@ body:
         ### Before submitting
 
         Make sure that you have
-        - properly filled in the title of this plugin request
-        - checked the rendered text previews to avoid unnecessary formatting errors
+        - [ ] properly filled in the title of this plugin request (at the very top of this page)
+        - [ ] checked the rendered text previews to avoid unnecessary formatting errors
 
         ----
 
-        [Love Streamlink? Please consider supporting our collective. Thanks!](https://opencollective.com/streamlink/donate)
+        [❤️ Love Streamlink? Please consider supporting the project maintainers. Thanks! ❤️](https://streamlink.github.io/donate.html)

--- a/.github/ISSUE_TEMPLATE/4_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/4_feature_request.yml
@@ -1,5 +1,5 @@
-name: Feature request
-description: Discuss adding new functionality to Streamlink
+name: ⚙️ Feature request
+description: Discuss adding new functionality to Streamlink.
 title: "A very brief summary of your request"
 labels:
   - feature request
@@ -9,7 +9,9 @@ body:
       value: |
         ## Thanks for filing a feature request!
 
-        Open a plugin request if you're requesting a new plugin instead of a new feature.
+        Use the [plugin request template](https://github.com/streamlink/streamlink/issues/new/choose) if you're requesting a new plugin instead of a new feature.
+
+        ----
 
         **DON'T IGNORE this template and fill in all the required details.**
         **Issues that don't adhere to our request will be closed and ignored.**
@@ -29,13 +31,12 @@ body:
     attributes:
       label: Description
       description: |
-        Explain the feature as clearly as you can.
+        Explain the feature as clearly as you can. For example:
 
-        What is it?
-        How would you expect it to work?
-        What value does it bring to Streamlink?
-        Does it fit into the scope and aims of the project?
-        etc.
+        - What is it?
+        - How would you expect it to work?
+        - What value does it bring to Streamlink?
+        - Does it fit into the scope and aims of the project?
     validations:
       required: true
   - type: markdown
@@ -44,9 +45,9 @@ body:
         ### Before submitting
 
         Make sure that you have
-        - properly filled in the title of this feature request
-        - checked the rendered text previews to avoid unnecessary formatting errors
+        - [ ] properly filled in the title of this feature request (at the very top of this page)
+        - [ ] checked the rendered text previews to avoid unnecessary formatting errors
 
         ----
 
-        [Love Streamlink? Please consider supporting our collective. Thanks!](https://opencollective.com/streamlink/donate)
+        [❤️ Love Streamlink? Please consider supporting the project maintainers. Thanks! ❤️](https://streamlink.github.io/donate.html)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,17 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "Help"
-    about: "The issue tracker is only meant for bug reports, feature/plugin requests and plugin issues. Please ask your questions on the discussions forum and look for already existing answers."
+  - name: "📝 New empty issue (maintainers only)"
+    about: "Create an empty issue without using a form/template. Only accessible by maintainers."
+    url: https://github.com/streamlink/streamlink/issues/new
+  - name: "❓ Help"
+    about: "The issue tracker is only meant for bug reports, feature/plugin requests and plugin issues. Please ask your questions on the discussions forum and look for already existing answers. If you're unsure whether XYZ is a bug or plugin issue, please just open a regular issue thread."
     url: https://github.com/streamlink/streamlink/discussions
-  - name: "Documentation"
+  - name: "📖 Documentation"
     about: "Please refer to Streamlink's documentation first before opening new issues or asking questions."
     url: https://streamlink.github.io/
-  - name: "Gitter channel"
+  - name: "💬 Gitter channel"
     about: "Get in touch with other Streamlink users."
     url: https://gitter.im/streamlink/streamlink
-  - name: "Matrix channel (Gitter bridge)"
+  - name: "💬 Matrix channel (Gitter bridge)"
     about: "Get in touch with other Streamlink users."
     url: https://matrix.to/#/#streamlink_streamlink:gitter.im


### PR DESCRIPTION
Let's update the issue forms and fix some minor issues.

This PR

1. fixes the order of issue templates: 1. Plugin issue 2. Bug 3. Plugin request 4. Feature request
2. adds a link for empty/blank issues that can only be accessed by maintainers
3. adds emojis to the issue selection titles for better visual clarity and separation of the kinds of issues
4. fixes some (missing) punctuation
5. improves text + markdown in some form description with more emphasis on important parts, and adds proper lists
6. addresses incorrect usage of new threads on the discussion forum
7. addresses packaging issues
8. makes the checklist at the bottom more visible by adding non-interactive checkboxes
9. updates the donation/support text+link

preview:
https://github.com/bastimeyer-test/streamlink-test/issues/new/choose