### PR TITLE
plugins.tvp: rewrite and fix plugin, add VODs

### DIFF
--- a/tests/plugins/test_tvp.py
+++ b/tests/plugins/test_tvp.py
@@ -5,12 +5,31 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlTVP(PluginCanHandleUrl):
     __plugin__ = TVP
 
-    should_match = [
-        'http://tvpstream.vod.tvp.pl/?channel_id=14327511',
-        'http://tvpstream.vod.tvp.pl/?channel_id=1455',
+    should_match_groups = [
+        # live
+        ("https://stream.tvp.pl", {}),
+        ("https://stream.tvp.pl/", {}),
+        ("https://stream.tvp.pl/?channel_id=63759349", {"video_id": "63759349"}),
+        ("https://stream.tvp.pl/?channel_id=14812849", {"video_id": "14812849"}),
+        # old live URLs
+        ("https://tvpstream.vod.tvp.pl", {}),
+        ("https://tvpstream.vod.tvp.pl/", {}),
+        ("https://tvpstream.vod.tvp.pl/?channel_id=63759349", {"video_id": "63759349"}),
+        ("https://tvpstream.vod.tvp.pl/?channel_id=14812849", {"video_id": "14812849"}),
+
+        # VOD
+        (
+            "https://vod.tvp.pl/filmy-dokumentalne,163/krolowa-wladczyni-i-matka,284734",
+            {"vod_id": "284734"},
+        ),
+        # VOD episode
+        (
+            "https://vod.tvp.pl/programy,88/z-davidem-attenborough-dokola-swiata-odcinki,284703/odcinek-2,S01E02,319220",
+            {"vod_id": "319220"},
+        ),
     ]
 
     should_not_match = [
-        'http://tvp.pl/',
-        'http://vod.tvp.pl/',
+        "https://tvp.pl/",
+        "https://vod.tvp.pl/",
     ]


### PR DESCRIPTION
Fixes #4904 

The old URLs get properly redirected, so I kept them in the plugin matcher regex.

When retrieving the video ID, the `Connection: close` header had to be set, because otherwise, the server would abort the next request for some reason. Took me a bit figure out, because I couldn't observe the behavior in my web browser or via curl, and it wasn't caused by session data like cookies, etc. Also had a look at urllib3's connection pool, but setting the header seems to work and is far easier than trying to close any connections in the connection pool, which is a private low-level API call anyway and probably not wise to use.

```
$ streamlink -l debug 'https://stream.tvp.pl/' best
[cli][debug] OS:         Linux-5.17.0-rc6-1-git-01595-gf3fa490960e8-x86_64-with-glibc2.36
[cli][debug] Python:     3.10.8
[cli][debug] Streamlink: 5.0.1+22.ge32d2dae
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.1
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.1
[cli][debug]  importlib-metadata: 5.0.0
[cli][debug] Arguments:
[cli][debug]  url=https://stream.tvp.pl/
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin tvp for URL https://stream.tvp.pl/
[plugins.tvp][debug] video ID: 14812849
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 288p_alt (worst), 288p, 404p_alt, 404p, 576p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: mpv
...
```

```
$ streamlink -l debug 'https://stream.tvp.pl/?channel_id=63759349' best
[cli][debug] OS:         Linux-5.17.0-rc6-1-git-01595-gf3fa490960e8-x86_64-with-glibc2.36
[cli][debug] Python:     3.10.8
[cli][debug] Streamlink: 5.0.1+22.ge32d2dae
[cli][debug] Dependencies:
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.1
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.14.1
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  websocket-client: 1.3.1
[cli][debug]  importlib-metadata: 5.0.0
[cli][debug] Arguments:
[cli][debug]  url=https://stream.tvp.pl/?channel_id=63759349
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin tvp for URL https://stream.tvp.pl/?channel_id=63759349
[plugins.tvp][debug] video ID: 63759349
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 288p_alt (worst), 288p, 404p_alt, 404p, 576p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: mpv
...
```