### PR TITLE
plugins.dailymotion: fix validation schema

### DIFF
--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -45,7 +45,9 @@ class DailyMotion(Plugin):
                         "error": {"title": str},
                     },
                     {
-                        "owner.username": str,
+                        "owner": {
+                            "username": str,
+                        },
                         "title": str,
                         "qualities": {
                             str: [{
@@ -67,7 +69,7 @@ class DailyMotion(Plugin):
             return
 
         self.id = media_id
-        self.author = media["owner.username"]
+        self.author = media["owner"]["username"]
         self.title = media["title"]
 
         for quality, streams in media["qualities"].items():


### PR DESCRIPTION
Fixes #4909 

The JSON response data format has changed.

```
$ streamlink --http-proxy socks5h://localhost:1920 'https://www.dailymotion.com/video/x2lefik'
[cli][info] Found matching plugin dailymotion for URL https://www.dailymotion.com/video/x2lefik
Available streams: 180p_alt2 (worst), 180p_alt, 180p, 288p_alt2, 288p_alt, 288p, 477p_alt2, 477p_alt, 477p, 720p_alt2, 720p_alt, 720p, 1080p_alt, 1080p (best)
```

```
$ streamlink -j --http-proxy socks5h://localhost:1920 'https://www.dailymotion.com/video/x2lefik' | jq .metadata
{
  "id": "x2lefik",
  "author": "lachainelequipe",
  "category": null,
  "title": "la chaine L'Équipe en direct"
}
```