### PR TITLE
plugins.bloomberg: update/fix headers to avoid bot detection

### DIFF
--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -102,17 +102,7 @@ class Bloomberg(Plugin):
         return secureStreams or streams
 
     def _get_streams(self):
-        self.session.http.headers.update({
-            "authority": "www.bloomberg.com",
-            "upgrade-insecure-requests": "1",
-            "dnt": "1",
-            "accept": ";".join([
-                "text/html,application/xhtml+xml,application/xml",
-                "q=0.9,image/webp,image/apng,*/*",
-                "q=0.8,application/signed-exchange",
-                "v=b3"
-            ])
-        })
+        del self.session.http.headers["Accept-Encoding"]
 
         try:
             data = self.session.http.get(self.url, schema=validate.Schema(


### PR DESCRIPTION
As far as my testing goes, all the previously added headers seem to be unnecessary.  Adding the `Accept-Encoding` header back seems to trigger bot detection, possibly because with requests it only includes `gzip` and `deflate`, but not `br`, which Firefox also includes.  Removing the header entirely seems to work.
```
$ streamlink https://www.bloomberg.com/live
[cli][info] Found matching plugin bloomberg for URL https://www.bloomberg.com/live
Available streams: 272p (worst), 360p, 720p_alt, 720p, 1080p (best)

$ streamlink https://www.bloomberg.com/news/videos/2022-10-26/rishi-sunak-and-the-uk-economy-showdown
[cli][info] Found matching plugin bloomberg for URL https://www.bloomberg.com/news/videos/2022-10-26/rishi-sunak-and-the-uk-economy-showdown
Available streams: 100k (worst), 176p, 272p, 360p, 540p, 720p_alt, 720p, 1080p (best)
```
