### PR TITLE
plugins.niconicochannelplus: add support for "nicochannel.jp"

### DIFF
--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -1,5 +1,5 @@
 """
-$description NicoNico Channel Plus (ニコニコチャンネルプラス, nicochannel+) is a new feature of Niconico Channel.
+$description NicoNico Channel Plus (nicochannel+) is a new feature of Niconico Channel.
 $url nicochannel.jp
 $type vod
 $account Not required. Full-length videos are accessible.

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(
     re.compile(
-        r"^https?://nicochannel\.jp/(?P<channel>[a-z0-9\._-]+)/(?:video|live)/(?P<id>sm[a-zA-Z0-9]+)$"
+        r"https?://nicochannel\.jp/(?P<channel>[a-z0-9\._-]+)/(?:video|live)/(?P<id>sm[a-zA-Z0-9]+)"
     )
 )
 class NicoNicoChannelPlus(Plugin):

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -1,0 +1,67 @@
+"""
+$description NicoNico Channel Plus (ニコニコチャンネルプラス, nicochannel+) is a new feature of Niconico Channel.
+$url nicochannel.jp
+$type vod
+$account Not required. Full-length videos are accessible.
+$notes Downloading non-free content is not recommended.
+"""
+
+import json
+import logging
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import HTTPSession
+from streamlink.stream.hls import HLSStream
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(
+    re.compile(
+        r'^https?://nicochannel\.jp/(?P<channel>[a-z0-9_-]+)/video/(?P<id>sm[a-zA-Z0-9]+)$'
+    )
+)
+class NicoNicoChannelPlus(Plugin):
+    def get_video_page_info(self, http: HTTPSession, video_id: str) -> dict:
+        video_page_json = json.loads(
+            http.get(
+                url=f'https://nfc-api.nicochannel.jp/fc/video_pages/{video_id}',
+            ).content
+        )['data']['video_page']
+
+        return video_page_json
+
+    def get_master_playlist_url(self, http: HTTPSession, video_id: str) -> str:
+        session_id = json.loads(
+            http.post(
+                url=f'https://nfc-api.nicochannel.jp/fc/video_pages/{video_id}/session_ids',
+                data=str({}).encode('ascii'),
+                headers={
+                    'content-type': 'application/json',
+                }
+            ).content
+        )['data']['session_id']
+
+        return f'https://hls-auth.cloud.stream.co.jp/auth/index.m3u8?session_id={session_id}'
+
+    def _get_streams(self):
+        self.id = self.match.group('id')
+        self.author = self.match.group('channel')
+
+        video_info = self.get_video_page_info(self.session.http, self.id)
+        playlist_url = self.get_master_playlist_url(self.session.http, self.id)
+
+        self.title = video_info['title']
+
+        log.info(f'ID:      {self.id}')
+        log.info(f'Channel: {self.author}')
+        log.info(f'Title:   {self.title}')
+
+        for name, stream in HLSStream.parse_variant_playlist(
+            self.session, playlist_url
+        ).items():
+            yield name, stream
+
+
+__plugin__ = NicoNicoChannelPlus

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -17,67 +17,67 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(
     re.compile(
-        r'^https?://nicochannel\.jp/(?P<channel>[a-z0-9_-]+)/(?:video|live)/(?P<id>sm[a-zA-Z0-9]+)$'
+        r"^https?://nicochannel\.jp/(?P<channel>[a-z0-9_-]+)/(?:video|live)/(?P<id>sm[a-zA-Z0-9]+)$"
     )
 )
 class NicoNicoChannelPlus(Plugin):
-    _URL_API_VIDEO_PAGE_INFO = 'https://nfc-api.nicochannel.jp/fc/video_pages/{video_id}'
-    _URL_API_SESSION_ID = 'https://nfc-api.nicochannel.jp/fc/video_pages/{video_id}/session_ids'
-    _URL_API_MASTER_PLAYLIST = 'https://hls-auth.cloud.stream.co.jp/auth/index.m3u8?session_id={session_id}'
+    _URL_API_VIDEO_PAGE_INFO = "https://nfc-api.nicochannel.jp/fc/video_pages/{video_id}"
+    _URL_API_SESSION_ID = "https://nfc-api.nicochannel.jp/fc/video_pages/{video_id}/session_ids"
+    _URL_API_MASTER_PLAYLIST = "https://hls-auth.cloud.stream.co.jp/auth/index.m3u8?session_id={session_id}"
 
     def get_video_page_info(self, video_id: str) -> dict:
         return self.session.http.get(
             self._URL_API_VIDEO_PAGE_INFO.format(video_id=video_id),
             schema=validate.Schema(
                 validate.parse_json(),
-                {'data': {'video_page': {
-                    'title': str,
-                    'type': str,
-                    'live_started_at': validate.any(str, None),
-                    'live_finished_at': validate.any(str, None),
+                {"data": {"video_page": {
+                    "title": str,
+                    "type": str,
+                    "live_started_at": validate.any(str, None),
+                    "live_finished_at": validate.any(str, None),
                 }}},
-                validate.get(('data', 'video_page')),
+                validate.get(("data", "video_page")),
             ),
         )
 
     def get_master_playlist_url(self, video_id: str, video_info: dict) -> str:
-        video_type = video_info['type']
+        video_type = video_info["type"]
 
-        if video_type == 'vod':
+        if video_type == "vod":
             payload: dict = {}
-        elif video_type == 'live':
-            if not video_info['live_started_at']:
-                raise PluginError('Live is not started yet.')
+        elif video_type == "live":
+            if not video_info["live_started_at"]:
+                raise PluginError("Live is not started yet.")
 
-            if not video_info['live_finished_at']:
+            if not video_info["live_finished_at"]:
                 # Live is available.
                 payload = {}
             else:
                 # Live is already ended, try DVR.
-                payload = {'broadcast_type': 'dvr'}
+                payload = {"broadcast_type": "dvr"}
         else:
-            raise PluginError(f'Unknown video type: {video_type}')
+            raise PluginError(f"Unknown video type: {video_type}")
 
         session_id = self.session.http.post(
             self._URL_API_SESSION_ID.format(video_id=video_id),
             json=payload,
             schema=validate.Schema(
                 validate.parse_json(),
-                {'data': {'session_id': str}},
-                validate.get(('data', 'session_id')),
+                {"data": {"session_id": str}},
+                validate.get(("data", "session_id")),
             ),
         )
 
         return self._URL_API_MASTER_PLAYLIST.format(session_id=session_id)
 
     def _get_streams(self):
-        self.id = self.match.group('id')
-        self.author = self.match.group('channel')
+        self.id = self.match.group("id")
+        self.author = self.match.group("channel")
 
         video_info = self.get_video_page_info(self.id)
         playlist_url = self.get_master_playlist_url(self.id, video_info)
 
-        self.title = video_info['title']
+        self.title = video_info["title"]
 
         return HLSStream.parse_variant_playlist(self.session, playlist_url)
 

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(
     re.compile(
-        r"^https?://nicochannel\.jp/(?P<channel>[a-z0-9_-]+)/(?:video|live)/(?P<id>sm[a-zA-Z0-9]+)$"
+        r"^https?://nicochannel\.jp/(?P<channel>[a-z0-9\._-]+)/(?:video|live)/(?P<id>sm[a-zA-Z0-9]+)$"
     )
 )
 class NicoNicoChannelPlus(Plugin):

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -36,8 +36,8 @@ class NicoNicoChannelPlus(Plugin):
                     "live_started_at": validate.any(str, None),
                     "live_finished_at": validate.any(str, None),
                     "video": {
-                        "allow_dvr_flg": bool,
-                        "convert_to_vod_flg": bool,
+                        "allow_dvr_flg": validate.any(bool, None),
+                        "convert_to_vod_flg": validate.any(bool, None),
                     },
                 }}},
                 validate.get(("data", "video_page")),

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -58,9 +58,7 @@ class NicoNicoChannelPlus(Plugin):
 
         self.title = video_info['title']
 
-        log.info(f'ID:      {self.id}')
-        log.info(f'Channel: {self.author}')
-        log.info(f'Title:   {self.title}')
+        log.debug(f'Title: {self.title}')
 
         return HLSStream.parse_variant_playlist(self.session, playlist_url)
 

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -79,8 +79,6 @@ class NicoNicoChannelPlus(Plugin):
 
         self.title = video_info['title']
 
-        log.debug(f'Title: {self.title}')
-
         return HLSStream.parse_variant_playlist(self.session, playlist_url)
 
 

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -44,7 +44,7 @@ class NicoNicoChannelPlus(Plugin):
         video_type = video_info['type']
 
         if video_type == 'vod':
-            payload = {}
+            payload: dict = {}
         elif video_type == 'live':
             if not video_info['live_started_at']:
                 raise PluginError('Live is not started yet.')

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -2,8 +2,6 @@
 $description NicoNico Channel Plus (nicochannel+) is a new feature of Niconico Channel.
 $url nicochannel.jp
 $type vod
-$account Not required. Full-length videos are accessible.
-$notes Downloading non-free content is not recommended.
 """
 
 import logging

--- a/src/streamlink/plugins/niconicochannelplus.py
+++ b/src/streamlink/plugins/niconicochannelplus.py
@@ -35,6 +35,10 @@ class NicoNicoChannelPlus(Plugin):
                     "type": str,
                     "live_started_at": validate.any(str, None),
                     "live_finished_at": validate.any(str, None),
+                    "video": {
+                        "allow_dvr_flg": bool,
+                        "convert_to_vod_flg": bool,
+                    },
                 }}},
                 validate.get(("data", "video_page")),
             ),
@@ -53,8 +57,18 @@ class NicoNicoChannelPlus(Plugin):
                 # Live is available.
                 payload = {}
             else:
-                # Live is already ended, try DVR.
-                payload = {"broadcast_type": "dvr"}
+                # Live is already ended.
+                video_allow_dvr_flg = video_info["video"]["allow_dvr_flg"]
+                video_convert_to_vod_flg = video_info["video"]["convert_to_vod_flg"]
+
+                # These two fields are not visible for normal users.
+                log.debug(f"allow_dvr_flg = {video_allow_dvr_flg}, convert_to_vod_flg = {video_convert_to_vod_flg}.")
+
+                if video_allow_dvr_flg and video_convert_to_vod_flg:
+                    # Try DVR.
+                    payload = {"broadcast_type": "dvr"}
+                else:
+                    raise PluginError("Live was ended.")
         else:
             raise PluginError(f"Unknown video type: {video_type}")
 

--- a/tests/plugins/test_niconicochannelplus.py
+++ b/tests/plugins/test_niconicochannelplus.py
@@ -8,55 +8,55 @@ class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
     should_match = [
         # video urls
         #   normal channel name.
-        'https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo',
+        "https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo",
         #   numbers in channel name.
-        'https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y',
+        "https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y",
         #   hyphens in channel name.
-        'https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L',
+        "https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L",
         #   underscores in channel name.
-        'https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ',
+        "https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ",
 
         # live urls
         #   normal channel name.
-        'https://nicochannel.jp/example/live/sm3Xample',
+        "https://nicochannel.jp/example/live/sm3Xample",
     ]
 
     should_match_groups = [
         # video urls
         (
-            'https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo',
+            "https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo",
             {
-                'id': 'smq9UriUQ9PU65jTjVxh2PVo',
-                'channel': 'olchannel',
+                "id": "smq9UriUQ9PU65jTjVxh2PVo",
+                "channel": "olchannel",
             }
         ),
         (
-            'https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y',
+            "https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y",
             {
-                'id': 'smVGqtKpdmva4Mcrw7rbeQ8Y',
-                'channel': 'dateno8noba',
+                "id": "smVGqtKpdmva4Mcrw7rbeQ8Y",
+                "channel": "dateno8noba",
             }
         ),
         (
-            'https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L',
+            "https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L",
             {
-                'id': 'smRS96YpmDJr24YpWFZziG4L',
-                'channel': 'mimimoto-ayaka',
+                "id": "smRS96YpmDJr24YpWFZziG4L",
+                "channel": "mimimoto-ayaka",
             }
         ),
         (
-            'https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ',
+            "https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ",
             {
-                'id': 'smnSFttxbkjZDBwZMMj8CgsJ',
-                'channel': 'sakaguchi_kugimiya',
+                "id": "smnSFttxbkjZDBwZMMj8CgsJ",
+                "channel": "sakaguchi_kugimiya",
             }
         ),
         # live urls
         (
-            'https://nicochannel.jp/example/live/sm3Xample',
+            "https://nicochannel.jp/example/live/sm3Xample",
             {
-                'id': 'sm3Xample',
-                'channel': 'example',
+                "id": "sm3Xample",
+                "channel": "example",
             }
         ),
     ]
@@ -64,22 +64,22 @@ class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
     should_not_match = [
         # Niconico Channel Plus
         #   portal
-        'https://portal.nicochannel.jp/',
+        "https://portal.nicochannel.jp/",
         #   channel home pages
-        'https://nicochannel.jp/example',
+        "https://nicochannel.jp/example",
         #   channel live list
-        'https://nicochannel.jp/example/lives',
+        "https://nicochannel.jp/example/lives",
         #   channel video list
-        'https://nicochannel.jp/example/videos',
+        "https://nicochannel.jp/example/videos",
         #   invalid urls
-        'https://nicochannel.jp/'
-        'https://nicochannel.jp/example/live',
-        'https://nicochannel.jp/example/video',
+        "https://nicochannel.jp/"
+        "https://nicochannel.jp/example/live",
+        "https://nicochannel.jp/example/video",
 
         # Niconico Channel
         #   portal
-        'https://ch.nicovideo.jp/',
+        "https://ch.nicovideo.jp/",
         #   channel home pages
-        'https://ch.nicovideo.jp/ch0000000',
-        'https://ch.nicovideo.jp/example',
+        "https://ch.nicovideo.jp/ch0000000",
+        "https://ch.nicovideo.jp/example",
     ]

--- a/tests/plugins/test_niconicochannelplus.py
+++ b/tests/plugins/test_niconicochannelplus.py
@@ -15,6 +15,8 @@ class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
         "https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L",
         #   underscores in channel name.
         "https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ",
+        #   dots in channel name.
+        "https://nicochannel.jp/kanase.ito/video/smWCdanZc5bJYMPYhpVp6Sn6",
 
         # live urls
         #   normal channel name.

--- a/tests/plugins/test_niconicochannelplus.py
+++ b/tests/plugins/test_niconicochannelplus.py
@@ -1,0 +1,76 @@
+from streamlink.plugins.niconicochannelplus import NicoNicoChannelPlus
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
+    __plugin__ = NicoNicoChannelPlus
+
+    should_match = [
+        # normal channel name.
+        'https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo',
+
+        # numbers in channel name.
+        'https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y',
+
+        # hyphens in channel name.
+        'https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L',
+
+        # underscores in channel name.
+        'https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ',
+    ]
+
+    should_match_groups = [
+        (
+            'https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo',
+            {
+                'id': 'smq9UriUQ9PU65jTjVxh2PVo',
+                'channel': 'olchannel',
+            }
+        ),
+        (
+            'https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y',
+            {
+                'id': 'smVGqtKpdmva4Mcrw7rbeQ8Y',
+                'channel': 'dateno8noba',
+            }
+        ),
+        (
+            'https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L',
+            {
+                'id': 'smRS96YpmDJr24YpWFZziG4L',
+                'channel': 'mimimoto-ayaka',
+            }
+        ),
+        (
+            'https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ',
+            {
+                'id': 'smnSFttxbkjZDBwZMMj8CgsJ',
+                'channel': 'sakaguchi_kugimiya',
+            }
+        ),
+    ]
+
+    should_not_match = [
+        # Niconico Channel Plus
+        #   portal
+        'https://portal.nicochannel.jp/',
+        #   channel home pages
+        'https://nicochannel.jp/example',
+        #   channel live list
+        'https://nicochannel.jp/example/lives',
+        #   channel video list
+        'https://nicochannel.jp/example/videos',
+        #   invalid urls
+        'https://nicochannel.jp/'
+        'https://nicochannel.jp/example/live',
+        'https://nicochannel.jp/example/video',
+        #   live urls (move it to "should_match*" if the plugin supports live-streaming)
+        'https://nicochannel.jp/example/live/sm3Xample',
+
+        # Niconico Channel
+        #   portal
+        'https://ch.nicovideo.jp/',
+        #   channel home pages
+        'https://ch.nicovideo.jp/ch0000000',
+        'https://ch.nicovideo.jp/example',
+    ]

--- a/tests/plugins/test_niconicochannelplus.py
+++ b/tests/plugins/test_niconicochannelplus.py
@@ -6,20 +6,23 @@ class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
     __plugin__ = NicoNicoChannelPlus
 
     should_match = [
-        # normal channel name.
+        # video urls
+        #   normal channel name.
         'https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo',
-
-        # numbers in channel name.
+        #   numbers in channel name.
         'https://nicochannel.jp/dateno8noba/video/smVGqtKpdmva4Mcrw7rbeQ8Y',
-
-        # hyphens in channel name.
+        #   hyphens in channel name.
         'https://nicochannel.jp/mimimoto-ayaka/video/smRS96YpmDJr24YpWFZziG4L',
-
-        # underscores in channel name.
+        #   underscores in channel name.
         'https://nicochannel.jp/sakaguchi_kugimiya/video/smnSFttxbkjZDBwZMMj8CgsJ',
+
+        # live urls
+        #   normal channel name.
+        'https://nicochannel.jp/example/live/sm3Xample',
     ]
 
     should_match_groups = [
+        # video urls
         (
             'https://nicochannel.jp/olchannel/video/smq9UriUQ9PU65jTjVxh2PVo',
             {
@@ -48,6 +51,14 @@ class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
                 'channel': 'sakaguchi_kugimiya',
             }
         ),
+        # live urls
+        (
+            'https://nicochannel.jp/example/live/sm3Xample',
+            {
+                'id': 'sm3Xample',
+                'channel': 'example',
+            }
+        ),
     ]
 
     should_not_match = [
@@ -64,8 +75,6 @@ class TestPluginCanHandleUrlNicoNicoChannelPlus(PluginCanHandleUrl):
         'https://nicochannel.jp/'
         'https://nicochannel.jp/example/live',
         'https://nicochannel.jp/example/video',
-        #   live urls (move it to "should_match*" if the plugin supports live-streaming)
-        'https://nicochannel.jp/example/live/sm3Xample',
 
         # Niconico Channel
         #   portal


### PR DESCRIPTION
For VoD and live on "[Niconico Channel Plus](https://portal.nicochannel.jp/)" (Japanese: ニコニコチャンネルプラス).

Thanks to the following people who provided useful information:

- @lokilin, raised a request in yt-dlp/yt-dlp#2537;
- 雷兰濑 (@railannad), raised a request in #4366;
- @Trung0246, analyzed HTTP data in #4366;
- @Lesmiscore, made [cross-reference](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) between the above two issues.

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
closes  #4366