### PR TITLE
tests: fix plugins metadata encoding

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -143,9 +143,8 @@ class TestPluginMetadata:
 
     @pytest.fixture(scope="class", params=plugins_no_protocols)
     def tokeninfo(self, request):
-        with (Path(plugins_path) / f"{request.param}.py").open() as handle:
-            for tokeninfo in tokenize.generate_tokens(handle.readline):  # pragma: no branch
-                break
+        with (Path(plugins_path) / f"{request.param}.py").open(encoding="utf-8") as handle:
+            tokeninfo = next(tokenize.generate_tokens(handle.readline), None)
 
         assert type(tokeninfo) is tokenize.TokenInfo, "Parses the first token"
         assert tokeninfo.type == tokenize.STRING, "First token is a string"


### PR DESCRIPTION
See #4923 

- https://docs.python.org/3/library/tokenize.html#tokenize.tokenize
- https://docs.python.org/3/library/io.html#text-encoding