### PR TITLE
tools: move list of files to mypy config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,17 +42,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
           python -m pip install -r docs-requirements.txt
       - name: mypy
-        run: >
-          python -m mypy
-          --no-incremental
-          src/streamlink/
-          src/streamlink_cli/
-          tests/
-          docs/
-          setup.py
+        run: |
+          python -m mypy --no-incremental

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,10 @@ show_error_codes = true
 show_error_context = true
 show_column_numbers = true
 warn_no_return = false
+files = [
+  "src/streamlink/",
+  "src/streamlink_cli/",
+  "tests/",
+  "docs/",
+  "setup.py",
+]

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -5,7 +5,7 @@ from typing import BinaryIO, TYPE_CHECKING
 try:
     import importlib.metadata as importlib_metadata  # type: ignore[import]  # noqa: F401
 except ImportError:
-    import importlib_metadata  # type: ignore[import]  # noqa: F401
+    import importlib_metadata  # type: ignore[import,no-redef]  # noqa: F401
 
 
 stdout: BinaryIO = sys.stdout.buffer


### PR DESCRIPTION
- Move list of files from CI config to mypy config in pyproject.toml, so that mypy can be run locally without having to specificy the same inputs as CLI arguments. Keep --no-incremental exclusive to CI runner.
- Update Python version of mypy CI runner.
- Fix typing ignore comment when importing importlib_metadata fallback in the streamlink_cli.compat module.

----

See #4929 