### PR TITLE
logger: add new log level "all"

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -276,7 +276,7 @@ def build_parser():
         help="""
         Set the log message threshold.
 
-        Valid levels are: `none`, `error`, `warning`, `info`, `debug`, `trace`
+        Valid levels are: `none`, `error`, `warning`, `info`, `debug`, `trace`, `all`
         """
     )
     general.add_argument(


### PR DESCRIPTION
Logging extremely verbose data like HLS playlist contents for example doesn't really fit on the `trace` log level. Adding an ultimate verbosity log level makes more sense here, so we can add log calls to the HLS parser and similar things.

Is the name "all" fine? I've just renamed it from "paranoid" before submitting this PR, because I wasn't really happy with that name. "all" is the opposite of "none", which is at the other end of the log level list, and it's easier to remember, too.

Since there are two custom log levels now, I had to refactor a bit of code in order to prevent duplicate stuff and duplicate tests.