### PR TITLE
plugins.twitch: fix date offset of prefetch ads

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -94,7 +94,7 @@ class TwitchM3U8Parser(M3U8Parser):
     def get_segment(self, uri: str) -> TwitchSegment:  # type: ignore[override]
         extinf: ExtInf = self.state.pop("extinf", None) or ExtInf(0, None)
         date = self.state.pop("date", None)
-        ad = self._is_segment_ad(date)
+        ad = self._is_segment_ad(date, extinf.title)
 
         return TwitchSegment(
             uri=uri,
@@ -109,8 +109,11 @@ class TwitchM3U8Parser(M3U8Parser):
             prefetch=False,
         )
 
-    def _is_segment_ad(self, date: datetime) -> bool:
-        return any(self.m3u8.is_date_in_daterange(date, daterange) for daterange in self.m3u8.dateranges_ads)
+    def _is_segment_ad(self, date: datetime, title: Optional[str] = None) -> bool:
+        return (
+            title is not None and "Amazon" in title
+            or any(self.m3u8.is_date_in_daterange(date, daterange) for daterange in self.m3u8.dateranges_ads)
+        )
 
     @staticmethod
     def _is_daterange_ad(daterange: DateRange) -> bool:

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -10,7 +10,7 @@ import json
 import logging
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from random import random
 from typing import List, NamedTuple, Optional
 from urllib.parse import urlparse
@@ -19,7 +19,7 @@ from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker, HLSStreamWriter
-from streamlink.stream.hls_playlist import ByteRange, ExtInf, Key, M3U8, M3U8Parser, Map, load as load_hls_playlist
+from streamlink.stream.hls_playlist import ByteRange, DateRange, ExtInf, Key, M3U8, M3U8Parser, Map, load as load_hls_playlist
 from streamlink.stream.http import HTTPStream
 from streamlink.utils.args import keyvalue
 from streamlink.utils.parse import parse_json, parse_qsd
@@ -70,27 +70,31 @@ class TwitchM3U8Parser(M3U8Parser):
         # This is better than using the duration of the last segment when regular segment durations vary a lot.
         # In low latency mode, the playlist reload time is the duration of the last segment.
         duration = last.duration if last.prefetch else sum(segment.duration for segment in segments) / float(len(segments))
-        segments.append(last._replace(
+        # Use the last duration for extrapolating the start time of the prefetch segment, which is needed for checking
+        # whether it is an ad segment and matches the parsed date ranges or not
+        date = last.date + timedelta(seconds=last.duration)
+        ad = self._is_segment_ad(date)
+        segment = last._replace(
             uri=self.uri(value),
             duration=duration,
-            prefetch=True
-        ))
+            title=None,
+            discontinuity=self.state.pop("discontinuity", False),
+            date=date,
+            ad=ad,
+            prefetch=True,
+        )
+        segments.append(segment)
 
     def parse_tag_ext_x_daterange(self, value):
         super().parse_tag_ext_x_daterange(value)
         daterange = self.m3u8.dateranges[-1]
-        is_ad = (
-            daterange.classname == "twitch-stitched-ad"
-            or str(daterange.id or "").startswith("stitched-ad-")
-            or any(attr_key.startswith("X-TV-TWITCH-AD-") for attr_key in daterange.x.keys())
-        )
-        if is_ad:
+        if self._is_daterange_ad(daterange):
             self.m3u8.dateranges_ads.append(daterange)
 
     def get_segment(self, uri: str) -> TwitchSegment:  # type: ignore[override]
         extinf: ExtInf = self.state.pop("extinf", None) or ExtInf(0, None)
         date = self.state.pop("date", None)
-        ad = any(self.m3u8.is_date_in_daterange(date, daterange) for daterange in self.m3u8.dateranges_ads)
+        ad = self._is_segment_ad(date)
 
         return TwitchSegment(
             uri=uri,
@@ -102,7 +106,18 @@ class TwitchM3U8Parser(M3U8Parser):
             date=date,
             map=self.state.get("map"),
             ad=ad,
-            prefetch=False
+            prefetch=False,
+        )
+
+    def _is_segment_ad(self, date: datetime) -> bool:
+        return any(self.m3u8.is_date_in_daterange(date, daterange) for daterange in self.m3u8.dateranges_ads)
+
+    @staticmethod
+    def _is_daterange_ad(daterange: DateRange) -> bool:
+        return (
+            daterange.classname == "twitch-stitched-ad"
+            or str(daterange.id or "").startswith("stitched-ad-")
+            or any(attr_key.startswith("X-TV-TWITCH-AD-") for attr_key in daterange.x.keys())
         )
 
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -329,6 +329,37 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         ])
 
     @patch("streamlink.plugins.twitch.log")
+    def test_hls_low_latency_has_prefetch_disable_ads_no_preroll_with_prefetch_ads(self, mock_log):
+        # segments 3-6 are ads
+        ads = TagDateRangeAd(start=DATETIME_BASE + timedelta(seconds=3), duration=4)
+        thread, segments = self.subject([
+            # regular stream data with prefetch segments
+            Playlist(0, [Segment(0), Segment(1), SegmentPrefetch(2), SegmentPrefetch(3)]),
+            # three prefetch segments, one regular (2) and two ads (3 and 4)
+            Playlist(1, [Segment(1), SegmentPrefetch(2), ads, SegmentPrefetch(3), SegmentPrefetch(4)]),
+            # all prefetch segments are gone once regular prefetch segments have shifted
+            Playlist(2, [Segment(2), ads, Segment(3), Segment(4), Segment(5)]),
+            # still no prefetch segments while ads are playing
+            Playlist(3, [ads, Segment(3), Segment(4), Segment(5), Segment(6)]),
+            # new prefetch segments on the first regular segment occurrence
+            Playlist(4, [ads, Segment(4), Segment(5), Segment(6), Segment(7), SegmentPrefetch(8), SegmentPrefetch(9)]),
+            Playlist(5, [ads, Segment(5), Segment(6), Segment(7), Segment(8), SegmentPrefetch(9), SegmentPrefetch(10)]),
+            Playlist(6, [ads, Segment(6), Segment(7), Segment(8), Segment(9), SegmentPrefetch(10), SegmentPrefetch(11)]),
+            Playlist(7, [Segment(7), Segment(8), Segment(9), Segment(10), SegmentPrefetch(11), SegmentPrefetch(12)], end=True),
+        ], disable_ads=True, low_latency=True)
+
+        self.await_write(11)
+        content = self.await_read(read_all=True)
+        self.assertEqual(
+            content,
+            self.content(segments, cond=lambda s: 2 <= s.num <= 3 or 7 <= s.num)
+        )
+        self.assertEqual(mock_log.info.mock_calls, [
+            call("Will skip ad segments"),
+            call("Low latency streaming (HLS live edge: 2)"),
+        ])
+
+    @patch("streamlink.plugins.twitch.log")
     def test_hls_low_latency_no_prefetch_disable_ads_has_preroll(self, mock_log):
         daterange = TagDateRangeAd(duration=4)
         self.subject([


### PR DESCRIPTION
Resolves #4934
Resolves #4106 

**WORK IN PROGRESS**
Don't merge yet without strong confirmation that this is indeed working correctly. As mentioned in #4934, one of the mid-rolls I encountered resulted in the filtering not stopping. I don't know why, because I didn't run trace logs at the time. It's possible though that the streamer simply forgot to turn off ads. I'm saying that, because the last 8 mid-rolls or so I had on other channels were properly filtered out and the stream continued fine afterwards, hence why I'm opening this PR now. The added test fails without the modification made to the `TwitchM3U8Parser`. The test is derived from data I gathered earlier today.

**DEBUGGING**
Please apply the following diff first when testing this PR/branch and then set `--loglevel=trace` and `--logfile=/path/to/file.log` (remove the file first before running streamlink, because the log gets appended). Knowing the content of the HLS playlist when mid-roll ads occur is important, because there are lots of variations that need to be covered.

```diff
diff --git a/src/streamlink/stream/hls_playlist.py b/src/streamlink/stream/hls_playlist.py
index 9f193d80..633bec54 100644
--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -550,6 +550,7 @@ class M3U8Parser:
 
         parse_line = self.parse_line
         for line in lines:
+            log.trace(line)  # type: ignore[attr-defined]
             parse_line(line)
 
         # Associate Media entries with each Playlist
```

Btw, the branch of this PR is different from the one I posted in #4934, because I had to refactor stuff.

----

As explained in #4934, the issue was that when cloning the last regular segment in the playlist for generating a prefetch segment from the provided prefetch URL, timestamps were not updated. Twitch now includes ads in the prefetch data and fortunately, they include proper dateranges which can be used for filtering those prefetch ads. The bad news is that prefetch data only consists of a URL, so the program date time of the cloned prefetch segment needs to be calculated from the program date time of the last segment with its duration added to it. Since there's more than one prefetch segments, this may be an issue, but it will most likely be fine.

In #4106 I've explained that an alternative solution would be strictly caching the prefetch data and not shifting the live-edge of the HLS stream. Then all the metadata of the regular segments would always be available. However, this adds more delay, because the playlist needs to be refreshed during the runtime of the latest segment, which is two seconds.