### PR TITLE
build: add urllib3 directly and set it to >=1.26.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
   pycryptodome >=3.4.3,<4
   PySocks !=1.5.7,>=1.5.6
   requests >=2.26.0,<3.0
+  urllib3 >=1.26.0
   websocket-client >=1.2.1,<2.0
 
 [options.packages.find]

--- a/src/streamlink/plugin/api/http_session.pyi
+++ b/src/streamlink/plugin/api/http_session.pyi
@@ -71,9 +71,6 @@ _Exception: TypeAlias = type[Exception]
 # ----
 
 
-urllib3_version: tuple[int, int, int]
-
-
 class TLSSecLevel1Adapter(HTTPAdapter):
     ...
 

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -5,11 +5,10 @@ import pytest
 import requests
 
 from streamlink.exceptions import PluginError
-from streamlink.plugin.api.http_session import HTTPSession, urllib3_version
+from streamlink.plugin.api.http_session import HTTPSession
 from streamlink.plugin.api.useragents import FIREFOX
 
 
-@pytest.mark.skipif(urllib3_version < (1, 25, 4), reason="test only applicable on urllib3 >=1.25.4")
 class TestUrllib3Overrides:
     @pytest.fixture(scope="class")
     def httpsession(self) -> HTTPSession:


### PR DESCRIPTION
Streamlink currently sets the version range of its `requests` dependency to `>=2.26.0,<3.0`. `requests` however still defines its `urllib3` dependency version range as `>=1.21.1,<1.27` in its `2.26.0`-`2.28.1` releases, including its current state in git.

Recent fixes in Streamlink's HLS implementation unfortunately were made with methods which are only supported by `urllib3 >=1.26.0`. This obviously breaks installs with older versions of `urllib3` installed which are still supported by the defined version range.

In order to avoid having to backport more `urllib3` stuff, moving it from a transitive dependency and defining it as a direct dependency with a specific version range set to `>=1.26.0` makes more sense when fixing the issue. This doesn't conflict with the version range defined by `requests` and forces a bump of old installs of `urllib3`.

`urllib3==1.26.0` was released on 2020-11-10, whereas `requests==2.26.0`, was released on 2021-07-13, the lowest version of the version range defined by Streamlink.

---

In addition to defining the direct `urllib3` dependency, also remove old compatibility workarounds/bugfixes from `plugin.api.http_session`.

---

Resolves #4938 