### PR TITLE
plugins.beyaztv: new plugin

### DIFF
--- a/src/streamlink/plugins/beyaztv.py
+++ b/src/streamlink/plugins/beyaztv.py
@@ -1,0 +1,29 @@
+"""
+$description Turkish live TV channel owned by Kanal Beyaz.
+$url beyaztv.com.tr
+$type live
+"""
+
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+
+
+@pluginmatcher(re.compile(
+    r"https?://(?:www\.|m\.)?beyaztv\.com\.tr/canli-yayin",
+))
+class BeyazTV(Plugin):
+    def _get_streams(self):
+        video_id = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"""data-video=(?P<q>["'])(?P<video_id>\S+)(?P=q)"""),
+            validate.any(None, validate.get("video_id")),
+        ))
+
+        if video_id:
+            return self.session.streams(
+                f"https://www.dailymotion.com/video/{video_id}",
+            )
+
+
+__plugin__ = BeyazTV

--- a/tests/plugins/test_beyaztv.py
+++ b/tests/plugins/test_beyaztv.py
@@ -1,0 +1,16 @@
+from streamlink.plugins.beyaztv import BeyazTV
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlBeyazTV(PluginCanHandleUrl):
+    __plugin__ = BeyazTV
+
+    should_match = [
+        "https://www.beyaztv.com.tr/canli-yayin",
+        "https://m.beyaztv.com.tr/canli-yayin/",
+    ]
+
+    should_not_match = [
+        # http error 404
+        "https://m.beyaztv.com.tr/canli-yayin",
+    ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Hello, I'm adding support for Beyaz TV, a Turkish live TV channel privately owned by Kanal Beyaz. I tested the plugin, it should work and I also fixed the issues pointed out by flake8. I'm new to all this (including programming) so excuse me if I did anything wrong. If you go to https://m.beyaztv.com.tr/canli-yayin it will give you a http error 404 but if you add / at the end it will work, that's why I included the should not match line in the test file but I'm not sure if I did it the right way. It's only with the mobile version of the site that I had this issue. With the desktop version, adding / or not at the end of the url doesn't change anything.