### PR TITLE
plugins.twitch: add --twitch-access-token-param

### DIFF
--- a/docs/cli/plugins/twitch.rst
+++ b/docs/cli/plugins/twitch.rst
@@ -80,9 +80,9 @@ segments from Twitch's HLS streams and pauses the stream output until regular co
 logic has seen several iterations since then, with the latest big overhaul in
 :ref:`Streamlink 1.7.0 in 2020 <changelog:streamlink 1.7.0 (2020-10-18)>`.
 
-**In addition to that**, special API request headers can be set via :option:`--twitch-api-header` that can prevent ads from
-being embedded into the stream, either :ref:`authentication data <cli/plugins/twitch:Authentication>` or other data discovered
-by the community.
+**In addition to that**, special API request headers can be set via :option:`--twitch-api-header` or special API request
+parameters can be set via :option:`--twitch-access-token-param` that can prevent ads from being embedded into the stream,
+either :ref:`authentication data <cli/plugins/twitch:Authentication>` or other data discovered by the community.
 
 
 Low latency streaming

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -234,6 +234,8 @@ class TwitchAPI:
             "Client-ID": "kimne78kx3ncx6brgo4mv6wki5h1ko",
         }
         self.headers.update(**dict(session.get_plugin_option("twitch", "api-header") or []))
+        self.access_token_params = dict(session.get_plugin_option("twitch", "access-token-param") or [])
+        self.access_token_params.setdefault("playerType", "embed")
 
     def call(self, data, schema=None):
         res = self.session.http.post(
@@ -386,7 +388,7 @@ class TwitchAPI:
             login=channel_or_vod if is_live else "",
             isVod=not is_live,
             vodID=channel_or_vod if not is_live else "",
-            playerType="embed"
+            **self.access_token_params,
         )
         subschema = validate.none_or_all(
             {
@@ -513,6 +515,17 @@ class TwitchAPI:
         A header to add to each Twitch API HTTP request.
 
         Can be repeated to add multiple headers.
+    """,
+)
+@pluginargument(
+    "access-token-param",
+    metavar="KEY=VALUE",
+    type=keyvalue,
+    action="append",
+    help="""
+        A parameter to add to the API request for acquiring the streaming access token.
+
+        Can be repeated to add multiple parameters.
     """,
 )
 class Twitch(Plugin):


### PR DESCRIPTION
Since authentication data for example can be set via `--twitch-api-header="Authorization=OAuth some-token"` and it is thus a useful generic plugin parameter, adding `--twitch-access-token-param` could be useful as well.

Having `--twitch-access-token-param` allows setting different `playerType` API request parameter values for example. The default value of this is `embed`, which makes Streamlink retrieve an access token for Twitch's embeddable web player. `site` is another valid value.

In the past we've had to change this multiple times and reverted everything back again (see #3210). Adding this parameter allows for customizations made by users without having to modify the plugin itself. Should there be any new developments in terms of special Twitch players with access tokens without embedded ads, then this parameter is a way to quickly test and adapt to that, without having to publish new releases and having to potentially revert stuff.