### PR TITLE
plugins.vtvgo: update to get required cookies

### DIFF
--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -21,6 +21,9 @@ class VTVgo(Plugin):
     AJAX_URL = "https://vtvgo.vn/ajax-get-stream"
 
     def _get_streams(self):
+        # get cookies
+        self.session.http.get("https://vtvgo.vn/")
+
         self.session.http.headers.update({
             "Origin": "https://vtvgo.vn",
             "Referer": self.url,


### PR DESCRIPTION
```
$ streamlink 'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html'
[cli][info] Found matching plugin vtvgo for URL https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html
Available streams: 360p (worst), 480p (best)

$ streamlink 'https://vtvgo.vn/xem-truc-tuyen-kenh-vtv3-3.html'
[cli][info] Found matching plugin vtvgo for URL https://vtvgo.vn/xem-truc-tuyen-kenh-vtv3-3.html
Available streams: 360p (worst), 480p, 720p (best)
```
closes #4948
