### PR TITLE
docs: fix and update man page

### DIFF
--- a/docs/_man.rst
+++ b/docs/_man.rst
@@ -11,6 +11,12 @@ Synopsis
 
    streamlink [OPTIONS] <URL> [STREAM]
 
+
+Examples
+--------
+
+.. code-block:: console
+
    streamlink --loglevel debug youtu.be/VIDEO-ID best
    streamlink --player mpv --player-args '--no-border --no-keepaspect-window' twitch.tv/CHANNEL 1080p60
    streamlink --player-external-http --player-external-http-port 8888 URL STREAM
@@ -18,12 +24,33 @@ Synopsis
    streamlink --stdout URL STREAM | ffmpeg -i pipe:0 ...
    streamlink --http-header 'Authorization=OAuth TOKEN' --http-header 'Referer=URL' URL STREAM
    streamlink --hls-live-edge 5 --stream-segment-threads 5 'hls://https://host/playlist.m3u8' best
-   streamlink --twitch-low-latency -p mpv -a '--cache=yes --demuxer-max-bytes=750k' twitch.tv/CHANNEL best
+   streamlink --twitch-low-latency -p mpv -a '--cache=yes --demuxer-max-back-bytes=2G' twitch.tv/CHANNEL best
 
 
 Options
-=======
+-------
 
 .. argparse::
     :module: streamlink_cli.main
     :attr: parser_helper
+
+
+Bugs
+----
+
+Please open a new issue on Streamlink's issue tracker on GitHub and use the appropriate issue forms:
+
+https://github.com/streamlink/streamlink/issues
+
+
+See also
+--------
+
+For more detailed information about config files, plugin sideloading, streaming protocols, proxy support, metadata,
+or plugin specific stuff, please see Streamlink's online CLI documentation here:
+
+https://streamlink.github.io/cli.html
+
+The list of available plugins and their descriptions can be found here:
+
+https://streamlink.github.io/plugins.html


### PR DESCRIPTION
- Split up synopsis and examples sections
- Add bugs section
- Add "see also" section
- Update some examples

----

The CLI synopsis should not be part of the list of examples. Footnotes should also be added.

Render the man page and check the results

```sh
$ make --directory=docs clean man
$ man docs/_build/man/streamlink.1
```

The current man page:
- https://man.archlinux.org/man/streamlink.1
- https://manpages.ubuntu.com/manpages/kinetic/man1/streamlink.1.html

The CLI parameter names and descriptions unfortunately get rendered in the most stupid way, and it depends on the length of the parameter name whether a line break gets included or not. That's nothing that can be fixed here though.