### PR TITLE
stream.segmented: properly close StreamIO

### DIFF
--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -247,6 +247,8 @@ class SegmentedStreamReader(StreamIO):
         if current is not self.writer:  # pragma: no branch
             self.writer.join(timeout=self.timeout)
 
+        super().close()
+
     def read(self, size):
         return self.buffer.read(
             size,

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -236,6 +236,7 @@ class TestMixinStreamHLS(unittest.TestCase):
         thread.reader.writer.join(timeout)
         thread.reader.worker.join(timeout)
         thread.join(timeout)
+        self.assertTrue(self.thread.reader.closed, "Stream reader is closed")
 
     # make write calls on the write-thread and wait until it has finished
     def await_write(self, write_calls=1, timeout=TIMEOUT_AWAIT_WRITE):


### PR DESCRIPTION
If `super().close()` doesn't get called in `SegmentedStreamReader.close()`, then `closed` won't be set to `True`.
https://docs.python.org/3/library/io.html#io.IOBase.close

Noticed that while working on a solution for #4642 