### PR TITLE
plugin.api.websocket: use certifi's cacert.pem

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -304,6 +304,7 @@ build     `wheel`_                  Used by the build frontend for creating Pyth
 build     `versioningit`_           At least version **2.0.0**. |br| Used for generating the version string from git
                                     when building, or when running in an editable install.
 
+runtime   `certifi`_                Used for loading the CA bundle extracted from the Mozilla Included CA Certificate List
 runtime   `isodate`_                Used for parsing ISO8601 strings
 runtime   `lxml`_                   Used for processing HTML and XML data
 runtime   `pycountry`_              Used for localization settings, provides country and language data
@@ -328,6 +329,7 @@ optional  `FFmpeg`_                 Required for `muxing`_ multiple video/audio/
 .. _wheel: https://wheel.readthedocs.io/en/stable/
 .. _versioningit: https://versioningit.readthedocs.io/en/stable/
 
+.. _certifi: https://certifiio.readthedocs.io/en/latest/
 .. _isodate: https://pypi.org/project/isodate/
 .. _lxml: https://lxml.de/
 .. _pycountry: https://pypi.org/project/pycountry/

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ package_dir =
   =src
 packages = find:
 install_requires =
+  certifi
   importlib-metadata ; python_version<"3.8"
   isodate
   lxml >=4.6.4,<5.0

--- a/src/streamlink/plugin/api/websocket.py
+++ b/src/streamlink/plugin/api/websocket.py
@@ -4,6 +4,7 @@ from threading import RLock, Thread, current_thread
 from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import unquote_plus, urlparse
 
+from certifi import where as certify_where
 from websocket import ABNF, STATUS_NORMAL, WebSocketApp, enableTrace  # type: ignore[import]
 
 from streamlink.logger import TRACE, root as rootlogger
@@ -64,6 +65,10 @@ class WebsocketClient(Thread):
 
         self._reconnect = False
         self._reconnect_lock = RLock()
+
+        if not sslopt:  # pragma: no cover
+            sslopt = {}
+        sslopt.setdefault("ca_certs", certify_where())
 
         self.session = session
         self._ws_init(url, subprotocols, header, cookie)

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -55,6 +55,7 @@ class TestWebsocketClient(unittest.TestCase):
             "User-Agent: bar"
         ])
 
+    @patch("streamlink.plugin.api.websocket.certify_where", Mock(side_effect=lambda: "/path/to/cacert.pem"))
     def test_args_and_proxy(self):
         self.session.set_option("http-proxy", "https://username:password@hostname:1234")
         client = WebsocketClient(
@@ -81,7 +82,10 @@ class TestWebsocketClient(unittest.TestCase):
         self.assertEqual(mock_ws_run_forever.call_args_list, [
             call(
                 sockopt=("sockopt1", "sockopt2"),
-                sslopt={"ssloptkey": "ssloptval"},
+                sslopt={
+                    "ssloptkey": "ssloptval",
+                    "ca_certs": "/path/to/cacert.pem",
+                },
                 host="customhost",
                 origin="customorigin",
                 suppress_origin=True,


### PR DESCRIPTION
- Add `certifi` as a direct dependency (already defined by `requests`) and don't set a version range
- Set the `ca_certs` SSL option in `WebsocketClient` which defaults to the CA certs file bundled by `certifi`, similar to HTTPS requests made by `requests`

----

Resolves streamlink/streamlink-appimage#1

While `requests` uses the bundled `cacert.pem` CA certificates file by the `certifi` dependency (via `certifi.where()`) for all HTTPS requests being made by Streamlink (since Streamlink doesn't set any custom paths), `websocket-client` defaults to the system's CA certs which get loaded by OpenSSL. Depending on the system config, this can cause issues, and it's also inconsistent with HTTPS requests made by `requests`. Streamlink should therefore load the same `cacert.pem` when making secure websocket connections via `websocket-client`, like `requests` does for all HTTPS requests.

Similar to `requests` and its `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` env vars, `WEBSOCKET_CLIENT_CA_BUNDLE` can be set to override the default path.

I have no idea though what changing this does to OpenSSL's `SSL_CERT_FILE` env var and whether this will still be supported.

- https://websocket-client.readthedocs.io/en/latest/faq.html#what-else-can-i-do-with-sslopts
- https://github.com/websocket-client/websocket-client/blob/v1.4.2/websocket/_http.py#L255-L273
- https://github.com/psf/requests/blob/v2.28.1/requests/utils.py#L58
- https://github.com/psf/requests/blob/v2.28.1/requests/sessions.py#L763-L770