### PR TITLE
ci.github: temporarily downgrade Sphinx to 5.2.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
-          python -m pip install -r docs-requirements.txt
+          python -m pip install -r docs-requirements.txt sphinx==5.2.3
       - name: Build
         run: make --directory=docs html man
 
@@ -103,7 +103,7 @@ jobs:
       - name: Install dependencies
         run: |
           ./script/install-dependencies.sh
-          python -m pip install -r docs-requirements.txt
+          python -m pip install -r docs-requirements.txt sphinx==5.2.3
       - name: Build
         run: make --directory=docs html
       - name: Deploy


### PR DESCRIPTION
Resolves #4988 

I've created a bug report upstream, so if this gets fixed, I will be notified, so we can remove the downgraded version again. Only downgrading on the CI side, as I don't want to set the restriction in the docs-requirements.txt.

We should probably take a look at releasing 5.1.1 due to this issue.