### PR TITLE
plugins.svtplay: rewrite plugin and add HLS

### DIFF
--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -13,114 +13,145 @@ from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
+from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
 
 log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r'https?://(?:www\.)?svtplay\.se(/(kanaler/)?.*)'
+    r"https?://(?:www\.)?svtplay\.se/(?P<live>kanaler/)?"
 ))
 @pluginargument(
     "mux-subtitles",
     is_global=True,
 )
 class SVTPlay(Plugin):
-    api_url = 'https://api.svt.se/videoplayer-api/video/{0}'
+    _URL_API_VIDEO = "https://api.svt.se/videoplayer-api/video/{item}"
+    _MAP_CHANNEL_NAMES = {
+        "svt1": "ch-svt1",
+        "svt2": "ch-svt2",
+        "svtbarn": "ch-barnkanalen",
+        "kunskapskanalen": "ch-kunskapskanalen",
+        "svt24": "ch-svt24",
+    }
 
-    latest_episode_url_re = re.compile(r'''
-        data-rt="top-area-play-button"\s+href="(?P<url>[^"]+)"
-    ''', re.VERBOSE)
+    def _api_call(self, item):
+        _schema_items = validate.all(
+            [
+                validate.all(
+                    {
+                        "format": str,
+                        "url": validate.url(),
+                    },
+                    validate.union_get("format", "url"),
+                ),
+            ],
+            validate.transform(dict),
+        )
 
-    live_id_re = re.compile(r'.*/(?P<live_id>[^?]+)')
+        self.author, self.title, videos, subtitles = self.session.http.get(
+            self._URL_API_VIDEO.format(item=item),
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    validate.optional("programTitle"): str,
+                    validate.optional("episodeTitle"): str,
+                    "videoReferences": _schema_items,
+                    validate.optional("subtitleReferences"): _schema_items,
+                },
+                validate.union_get(
+                    "programTitle",
+                    "episodeTitle",
+                    "videoReferences",
+                    "subtitleReferences",
+                ),
+            ),
+        )
 
-    _video_schema = validate.Schema({
-        validate.optional('programTitle'): validate.text,
-        validate.optional('episodeTitle'): validate.text,
-        'videoReferences': [{
-            'url': validate.url(),
-            'format': validate.text,
-        }],
-        validate.optional('subtitleReferences'): [{
-            'url': validate.url(),
-            'format': validate.text,
-        }],
-    })
+        return videos, subtitles
 
-    def _set_metadata(self, data, category):
-        if 'programTitle' in data:
-            self.author = data['programTitle']
-
-        self.category = category
-
-        if 'episodeTitle' in data:
-            self.title = data['episodeTitle']
-
-    def _get_live(self, path):
-        match = self.live_id_re.search(path)
-        if match is None:
+    def _get_live(self):
+        live_id = "/".join(urlparse(self.url).path.split("/")[2:])
+        if not live_id:
             return
 
-        live_id = "ch-{0}".format(match.group('live_id'))
-        log.debug("Live ID={0}".format(live_id))
+        live_id = self._MAP_CHANNEL_NAMES.get(live_id, f"ch-{live_id}")
+        log.debug(f"Live ID={live_id}")
+        self.category = "Live"
+        videos, subtitles = self._api_call(live_id)
 
-        res = self.session.http.get(self.api_url.format(live_id))
-        api_data = self.session.http.json(res, schema=self._video_schema)
-
-        self._set_metadata(api_data, 'Live')
-
-        for playlist in api_data['videoReferences']:
-            if playlist['format'] == 'dashhbbtv':
-                yield from DASHStream.parse_manifest(self.session, playlist['url']).items()
+        return self._select_streams(videos, subtitles)
 
     def _get_vod(self):
-        vod_id = self._get_vod_id(self.url)
+        def get_vod_id(url):
+            return dict(parse_qsl(urlparse(url).query)).get("id")
+
+        vod_id = get_vod_id(self.url)
 
         if vod_id is None:
-            res = self.session.http.get(self.url)
-            match = self.latest_episode_url_re.search(res.text)
-            if match is None:
-                return
-            vod_id = self._get_vod_id(match.group("url"))
+            vod_url = self.session.http.get(self.url, schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//*[@data-rt='top-area-play-button'][@href][1]/@href"),
+            ))
+            if vod_url:
+                vod_id = get_vod_id(vod_url)
 
         if vod_id is None:
             return
 
-        log.debug("VOD ID={0}".format(vod_id))
+        log.debug(f"VOD ID={vod_id}")
+        self.category = "Live"
+        videos, subtitles = self._api_call(vod_id)
 
-        res = self.session.http.get(self.api_url.format(vod_id))
-        api_data = self.session.http.json(res, schema=self._video_schema)
+        return self._select_streams(videos, subtitles)
 
-        self._set_metadata(api_data, 'VOD')
+    def _select_streams(self, videos, subtitles):
+        # the goal is to have streams with the widest range of qualities/substreams and highest bitrate at the top
+        stream_priorities = {
+            "dashhbbtv": DASHStream,  # DASH AVC
+            "dash-hbbtv-avc": DASHStream,  # DASH AVC
+            "dash-avc": DASHStream,  # DASH AVC
+            "dash-full": DASHStream,  # DASH AVC
+            "dash": DASHStream,  # DASH AVC
 
-        substreams = {}
-        if 'subtitleReferences' in api_data:
-            for subtitle in api_data['subtitleReferences']:
-                if subtitle['format'] == 'webvtt':
-                    log.debug("Subtitle={0}".format(subtitle['url']))
-                    substreams[subtitle['format']] = HTTPStream(
-                        self.session,
-                        subtitle['url'],
-                    )
+            "hlswebvtt": HLSStream,  # HLS with subtitles
+            "hls-cmaf-live-vtt": HLSStream,  # HLS with subtitles
+            "hls-ts-avc": HLSStream,  # HLS with MPEG-TS
+            "hls-ts-full": HLSStream,  # HLS with MPEG-TS
+            "hls": HLSStream,  # HLS with MPEG-TS
+            "hls-cmaf-live": HLSStream,  # HLS with fMP4
+            "hls-cmaf-full": HLSStream,  # HLS with fMP4
 
-        for manifest in api_data['videoReferences']:
-            if manifest['format'] == 'dashhbbtv':
-                for q, s in DASHStream.parse_manifest(self.session, manifest['url']).items():
-                    if self.get_option('mux_subtitles') and substreams:
-                        yield q, MuxedStream(self.session, s, subtitles=substreams)
-                    else:
-                        yield q, s
+            "dash-hbbtv-hevc": DASHStream,  # DASH HEVC (low prio, because of potential user decoder issues)
 
-    def _get_vod_id(self, url):
-        qs = dict(parse_qsl(urlparse(url).query))
-        return qs.get("id")
+            "hls-ts-lb-full": HLSStream,  # low bitrate
+            "hls-cmaf-lb-full": HLSStream,  # low bitrate
+            "dash-lb-full": DASHStream,  # low bitrate
+        }
+
+        for fmt, streamtype in stream_priorities.items():
+            if fmt not in videos:
+                continue
+
+            if streamtype is HLSStream:
+                return HLSStream.parse_variant_playlist(self.session, videos[fmt], name_fmt="{pixels}_{bitrate}")
+
+            if streamtype is DASHStream:
+                mux_subtitles = self.get_option("mux_subtitles")
+                subtitlestreams = {}
+                if mux_subtitles and "webvtt" in subtitles:
+                    subtitlestreams["webvtt"] = HTTPStream(self.session, subtitles["webvtt"])
+
+                dash_streams = DASHStream.parse_manifest(self.session, videos[fmt])
+                if not subtitlestreams:
+                    return dash_streams
+
+                return {q: MuxedStream(self.session, s, subtitles=subtitlestreams) for q, s in dash_streams.items()}
 
     def _get_streams(self):
-        path, live = self.match.groups()
-        log.debug("Path={0}".format(path))
-
-        if live:
-            return self._get_live(path)
+        if self.match["live"]:
+            return self._get_live()
         else:
             return self._get_vod()
 


### PR DESCRIPTION
Resolves #4992 

This is a full plugin rewrite which cleans up the API request and validation schema, and it adds support for HLS streams.

As you can see, there's a stream priority list, because apparently there's a difference between the available qualities of the available stream types, and for some reason, some DASH streams offer higher resolutions and bitrates. It's probably an overkill having all kinds of formats there, but whatever... Also a pretty good reason for a rewrite of the stream selection, as described in #4902.

I can access the API and VOD content with my VPN, but HLS live streams return a 403, so I can't actually test all plugin changes.

@mkbloke, please have a look, thanks.