### PR TITLE
stream.ffmpegmux: abort on ValueError during read

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -139,7 +139,7 @@ class FFMPEGMuxer(StreamIO):
                     pipe.write(data)
                 else:
                     break
-            except OSError:
+            except (OSError, ValueError):
                 log.error(f"Pipe copy aborted: {pipe.path}")
                 break
         try:


### PR DESCRIPTION
See
- https://github.com/streamlink/streamlink/pull/4994#issuecomment-1327722034
- https://docs.python.org/3/library/io.html#io.IOBase

This fixes the `copy_to_pipe` thread reading the input stream after it has been closed, which in this case raises a `ValueError`:

> ValueError: read of closed file

This is another case of an ungraceful stream end where it aborts the pipe copying due to thread timing issues that are not being dealt with correctly.

No new tests, because there are no tests for the `copy_to_pipe` thread. :/