### PR TITLE
docs: rewrite Windows + AppImage install sections

### DIFF
--- a/docs/cli/config.rst
+++ b/docs/cli/config.rst
@@ -40,6 +40,17 @@ You can also specify the location yourself using the :option:`--config` option.
   Streamlink's Windows installers automatically create a config file if it doesn't exist yet, but on any
   other platform or installation method, you must create the file yourself.
 
+.. note::
+
+   The ``XDG_CONFIG_HOME`` environment variable is part of the `XDG base directory specification`_ (`Arch Wiki <xdg-base-dir-arch-wiki_>`_).
+
+   The ``${VARIABLENAME:-DEFAULTVALUE}`` syntax is explained `here <Parameter expansion_>`_.
+
+.. _XDG base directory specification: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+.. _xdg-base-dir-arch-wiki: https://wiki.archlinux.org/title/XDG_Base_Directory
+.. _Parameter expansion: https://wiki.bash-hackers.org/syntax/pe
+
+
 Syntax
 ------
 

--- a/docs/cli/config.rst
+++ b/docs/cli/config.rst
@@ -37,8 +37,8 @@ You can also specify the location yourself using the :option:`--config` option.
 
 .. warning::
 
-  On Windows, there is a default config created by the installer, but on any
-  other platform you must create the file yourself.
+  Streamlink's Windows installers automatically create a config file if it doesn't exist yet, but on any
+  other platform or installation method, you must create the file yourself.
 
 Syntax
 ------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -214,13 +214,6 @@ Streamlink can be installed via `pip`_, the Python package manager.
 Before running :command:`pip`, make sure that it's the Python 3 version of `pip`_ (to check, run :command:`pip --version`).
 On some systems, this isn't the case by default and an alternative, like :command:`pip3` for example, needs to be run instead.
 
-.. note::
-
-    On some Linux distributions, the Python headers package needs to be installed before installing Streamlink
-    (``python-devel`` on RedHat, Fedora, etc.).
-
-    Ensure that you are using an up-to-date version of `pip`_. At least version **6** is required.
-
 .. warning::
 
     On Linux, when not using a virtual environment, it is recommended to **install custom python packages like this

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,6 +2,10 @@
 
   <br />
 
+.. |icon-download| raw:: html
+
+  <i class="fa fa-download"></i>
+
 Installation
 ============
 
@@ -78,6 +82,8 @@ Linux and BSD
 Distribution                         Installing
 ==================================== ===========================================
 AppImage                             See the `AppImages`_ section below
+
+AppImage nightly builds              See the `AppImage nightly builds`_ section below
 
 Python pip                           See the `PyPI package and source code`_ section below
 
@@ -365,10 +371,10 @@ optional  `FFmpeg`_                 Required for `muxing`_ multiple video/audio/
 Windows binaries
 ----------------
 
-Windows installers and portable builds for Streamlink can be found at `streamlink/windows-builds`_,
+Windows installers and portable archives for Streamlink are built at `streamlink/windows-builds`_,
 with support for different architectures and different Python versions.
 
-These installers and portable builds contain:
+These installers and portable archives contain:
 
 - an embedded Python version, built at `streamlink/python-windows-embed`_
 - Streamlink and its dependencies
@@ -376,59 +382,102 @@ These installers and portable builds contain:
 
 and they are available in the following flavors:
 
-- Python 3.10 - x86_64 (64 bit)
-- Python 3.10 - x86 (32 bit)
+- Latest Python - x86_64 (64 bit) - recommended
+- Latest Python - x86 (32 bit)
 - Python 3.8 - x86_64 (64 bit) - for Windows 7
 - Python 3.8 - x86 (32 bit) - for Windows 7
 
-For further information, please see the README in the `streamlink/windows-builds`_ repository.
+.. note::
+
+   The installers automatically create a :ref:`config file <cli/config:Configuration file>` if it doesn't exist yet and set the
+   value of the :option:`--ffmpeg-ffmpeg` CLI parameter to the path of the included FFmpeg binary. The portable archives
+   can't do that, and users need to do that themselves.
+
+   Please see the README of the `streamlink/windows-builds`_ repository for further information.
 
 Windows stable builds
 ^^^^^^^^^^^^^^^^^^^^^
 
-Stable installers and stable portable builds of Streamlink's latest release can be
-`downloaded from the releases page of the streamlink/windows-builds <windows-stable_>`_ repository.
+|icon-download| `streamlink/windows-builds releases page <windows-stable_>`_
 
 Windows nightly builds
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Built once each day at midnight UTC from Streamlink's master branch. |br|
+|icon-download| `streamlink/windows-builds nightly builds artifacts <windows-nightly_>`_
+
+Built once each day at midnight UTC from Streamlink's `master branch <streamlink-master_>`_. |br|
 This includes the most recent changes, but is not considered "stable". |br|
-Download from the build-artifacts of the `scheduled nightly build runs <windows-nightly_>`_ (requires a GitHub login). |br|
-See the `commit log <streamlink-master_>`_ of Steamlink's master branch for all the recent changes.
+A GitHub account is required in order to access build artifacts.
 
 .. _streamlink/windows-builds: https://github.com/streamlink/windows-builds
 .. _streamlink/python-windows-embed: https://github.com/streamlink/python-windows-embed
 .. _streamlink/FFmpeg-Builds: https://github.com/streamlink/FFmpeg-Builds
 .. _windows-stable: https://github.com/streamlink/windows-builds/releases
 .. _windows-nightly: https://github.com/streamlink/windows-builds/actions?query=event%3Aschedule+is%3Asuccess+branch%3Amaster
-.. _streamlink-master: https://github.com/streamlink/streamlink/commits/master
 
 
 AppImages
 ---------
 
-Download & Setup
-^^^^^^^^^^^^^^^^
+Linux AppImages for Streamlink are built at `streamlink/streamlink-appimage`_.
 
-First, download the latest `Streamlink AppImage`_ which matches your system's
-architecture from the `Streamlink AppImage releases page`_. Then simply set the
-executable flag and run the app.
+These AppImages contain:
 
-.. code-block:: bash
+- a Python environment
+- Streamlink and its dependencies
 
-   # Set the executable flag. Note that all AppImage release file names include
-   # the release version, Python version, platform name and CPU architecture
-   chmod +x streamlink-2.0.0-1-cp39-cp39-manylinux2014_x86_64.AppImage
+and they are available for the following CPU architectures:
 
-   # Run the Streamlink AppImage with any parameter supported by Streamlink
-   ./streamlink-2.0.0-1-cp39-cp39-manylinux2014_x86_64.AppImage --version
+- x86_64
+- i686
+- aarch64
+
+1. **Download the latest Streamlink AppImage matching your CPU architecture**
+
+   If unsure, run :command:`uname -m` to check the CPU's architecture.
+
+2. **Set the executable flag**
+
+   This can either be done in a regular file browser, or a command line shell via :command:`chmod +x filename`.
+
+   .. code-block:: bash
+
+      # AppImage file names include the release version, Python version, platform name and CPU architecture
+      chmod +x streamlink-2.0.0-1-cp39-cp39-manylinux2014_x86_64.AppImage
+
+3. **Run the AppImage**
+
+   Set any command-line parameters supported by Streamlink, e.g. :option:`--version`:
+
+   .. code-block:: bash
+
+      # Run the Streamlink AppImage with any parameter supported by Streamlink
+      ./streamlink-2.0.0-1-cp39-cp39-manylinux2014_x86_64.AppImage --version
+
+
+AppImage stable builds
+^^^^^^^^^^^^^^^^^^^^^^
+
+|icon-download| `streamlink/streamlink-appimage releases page <appimage-stable_>`_
+
+AppImage nightly builds
+^^^^^^^^^^^^^^^^^^^^^^^
+
+|icon-download| `streamlink/streamlink-appimage nightly builds artifacts <appimage-nightly_>`_
+
+Built once each day at midnight UTC from Streamlink's `master branch <streamlink-master_>`_. |br|
+This includes the most recent changes, but is not considered "stable". |br|
+A GitHub account is required in order to access build artifacts.
+
 
 What are AppImages?
 ^^^^^^^^^^^^^^^^^^^
 
-AppImages are portable apps for Linux which are independent of the distro and
-package management.
+AppImages are portable applications which are independent of the Linux distribution in use and its package management.
+Just set the executable flag on the AppImage file and run it.
+
+The only requirement is having `FUSE`_ installed for being able to mount the contents of the AppImage's SquashFS,
+which is done automatically. Also, only glibc-based systems are currently supported.
 
 Note: Check out `AppImageLauncher`_, which automates the setup and system
 integration of AppImages. AppImageLauncher may also be available via your
@@ -438,8 +487,11 @@ Additional information, like for example how to inspect the AppImage contents or
 how to extract the contents if `FUSE`_ is not available on your system, can be
 found in the `AppImage documentation`_.
 
-.. _Streamlink AppImage: https://github.com/streamlink/streamlink-appimage
-.. _Streamlink AppImage releases page: https://github.com/streamlink/streamlink-appimage/releases
+.. _streamlink/streamlink-appimage: https://github.com/streamlink/streamlink-appimage
+.. _appimage-stable: https://github.com/streamlink/streamlink-appimage/releases
+.. _appimage-nightly: https://github.com/streamlink/streamlink-appimage/actions?query=event%3Aschedule+is%3Asuccess+branch%3Amaster
 .. _AppImageLauncher: https://github.com/TheAssassin/AppImageLauncher
 .. _FUSE: https://docs.appimage.org/user-guide/troubleshooting/fuse.html
 .. _AppImage documentation: https://docs.appimage.org/user-guide/run-appimages.html
+
+.. _streamlink-master: https://github.com/streamlink/streamlink/commits/master


### PR DESCRIPTION
I initially wanted to only update the AppImage section of the install docs, but then decided to also update the Windows binaries section and do some additional cleanup.

The main focus is to make finding the important information easier and quicker. This also involves adding an icon to the download links.

The third commit is not really important and could be ignored if anyone feels like it's unnecessary.