### PR TITLE
plugins.twitch: fix ad filtering bug

### DIFF
--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -330,34 +330,37 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
     @patch("streamlink.plugins.twitch.log")
     def test_hls_low_latency_has_prefetch_disable_ads_no_preroll_with_prefetch_ads(self, mock_log):
+        # segment 1 has a shorter duration, to mess with the extrapolation of the prefetch start times
         # segments 3-6 are ads
-        ads = TagDateRangeAd(start=DATETIME_BASE + timedelta(seconds=3), duration=4)
+        Seg, Pre = Segment, SegmentPrefetch
+        ads = [
+            Tag("EXT-X-DISCONTINUITY"),
+            TagDateRangeAd(start=DATETIME_BASE + timedelta(seconds=3), duration=4),
+        ]
+        # noinspection PyTypeChecker
         thread, segments = self.subject([
             # regular stream data with prefetch segments
-            Playlist(0, [Segment(0), Segment(1), SegmentPrefetch(2), SegmentPrefetch(3)]),
+            Playlist(0, [Seg(0), Seg(1, duration=0.5), Pre(2), Pre(3)]),
             # three prefetch segments, one regular (2) and two ads (3 and 4)
-            Playlist(1, [Segment(1), SegmentPrefetch(2), ads, SegmentPrefetch(3), SegmentPrefetch(4)]),
+            Playlist(1, [Seg(1, duration=0.5), Pre(2)] + ads + [Pre(3), Pre(4)]),
             # all prefetch segments are gone once regular prefetch segments have shifted
-            Playlist(2, [Segment(2), ads, Segment(3), Segment(4), Segment(5)]),
+            Playlist(2, [Seg(2, duration=1.5)] + ads + [Seg(3), Seg(4), Seg(5)]),
             # still no prefetch segments while ads are playing
-            Playlist(3, [ads, Segment(3), Segment(4), Segment(5), Segment(6)]),
+            Playlist(3, ads + [Seg(3), Seg(4), Seg(5), Seg(6)]),
             # new prefetch segments on the first regular segment occurrence
-            Playlist(4, [ads, Segment(4), Segment(5), Segment(6), Segment(7), SegmentPrefetch(8), SegmentPrefetch(9)]),
-            Playlist(5, [ads, Segment(5), Segment(6), Segment(7), Segment(8), SegmentPrefetch(9), SegmentPrefetch(10)]),
-            Playlist(6, [ads, Segment(6), Segment(7), Segment(8), Segment(9), SegmentPrefetch(10), SegmentPrefetch(11)]),
-            Playlist(7, [Segment(7), Segment(8), Segment(9), Segment(10), SegmentPrefetch(11), SegmentPrefetch(12)], end=True),
+            Playlist(4, ads + [Seg(4), Seg(5), Seg(6), Seg(7), Pre(8), Pre(9)]),
+            Playlist(5, ads + [Seg(5), Seg(6), Seg(7), Seg(8), Pre(9), Pre(10)]),
+            Playlist(6, ads + [Seg(6), Seg(7), Seg(8), Seg(9), Pre(10), Pre(11)]),
+            Playlist(7, [Seg(7), Seg(8), Seg(9), Seg(10), Pre(11), Pre(12)], end=True),
         ], disable_ads=True, low_latency=True)
 
         self.await_write(11)
         content = self.await_read(read_all=True)
-        self.assertEqual(
-            content,
-            self.content(segments, cond=lambda s: 2 <= s.num <= 3 or 7 <= s.num)
-        )
-        self.assertEqual(mock_log.info.mock_calls, [
+        assert content == self.content(segments, cond=lambda s: 2 <= s.num <= 3 or 7 <= s.num)
+        assert mock_log.info.mock_calls == [
             call("Will skip ad segments"),
             call("Low latency streaming (HLS live edge: 2)"),
-        ])
+        ]
 
     @patch("streamlink.plugins.twitch.log")
     def test_hls_low_latency_no_prefetch_disable_ads_has_preroll(self, mock_log):


### PR DESCRIPTION
Twitch doesn't include duration data for prefetch segments, which means when more than one prefetch segment is included in the HLS playlist, the start time of the second (or third) prefetch segment has to be guessed from the duration of the regular segments. This is done by calculating the average of all available regular segments and using that as an offset of the last regular segment for each prefetch segment.

This however can cause issues when segment durations vary a lot and the start time of an annotated ad block doesn't match the extrapolated start time of the first ad segment due to the miscalculation. The ad segment then gets incorrectly included in the output stream.

Since a discontinuity tag is always present, even between prefetch tags with ads, we can make use of it and treat prefetch segments after a discontinuity tag as ads. This won't cause any issues during the transition to the regular stream content, as it only affects the logic of prefetch segments.

----

Resolves #5006 

Don't merge yet, I will need to run further tests on live data.

Once the fix got merged, I'll be preparing a new bugfix release.