### PR TITLE
plugins.twitch: better access token error handling

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -28,6 +28,9 @@ class Options:
     def _normalise_dict(cls, src):
         return {_normalise_option_name(key): value for key, value in src.items()}
 
+    def clear(self):
+        self.options = self.defaults.copy()
+
     def set(self, key, value):
         self.options[_normalise_option_name(key)] = value
 


### PR DESCRIPTION
- Refactor `TwitchAPI` class:
  - Set `CLIENT_ID` as a class attribute (for test references)
  - Allow `call()` to pass custom headers (currently unused)
  - Remove unneeded `json.dumps()`
- Handle `PlaybackAccessToken` error response and log error messages
- Add `Options.clear()` for resetting plugin options state after tests
- Add access token API tests

----

Resolves #5009 

This adds error logging to the access token processing and also adds tests for the access token responses and how the `--twitch-api-header` and `--twitch-access-token-param` influence the access token request.

----

Small side-note in regards to the added `Options.clear()` method:

I've already mentioned somewhere in the `Plugin.bind()` removal in 5.0.0 (#4744 / #4768) that `Plugin.options` will also need to get fixed at some point. Similar to the previously bound class attributes, `Plugin.options` is a class attribute that gets shared accross all plugin classes unless it gets overridden by [`streamlink_cli.main.setup_plugin_args()`](https://github.com/streamlink/streamlink/blob/5.1.2/src/streamlink_cli/main.py#L783). This means that when streamlink_cli is not involved in plugin construction, e.g. in tests or when using the Streamlink session API directly, setting any kind of plugin option always requires clearing the options, which is bad. I'm pretty sure that there are a couple of tests which are polluting the shared plugin options dict. I'll check once I get the time.

The reason why I didn't touch `Plugin.options` at the time is that removing `Plugin.bind()` was already a lot of work. In hindsight, this should've been done in one go, because changing it will probably be a breaking API change, because of how the plugins will need to get initialized. Currently, the options are set by the session instance before plugins are initialized, and it expects the options dict to be available on the plugin class. Options should however only be set on plugin instances, so there's no shared options dict, neither between plugin classes, nor between different instances of the same plugin.

I will need to have a closer look at this and figure out a better solution before making any further comments. This PR should be fine though.