### PR TITLE
tests: refactor thread handshakes

### DIFF
--- a/tests/testutils/handshake.py
+++ b/tests/testutils/handshake.py
@@ -1,0 +1,107 @@
+from asyncio import Future, get_event_loop
+from contextlib import contextmanager
+from dataclasses import dataclass
+from functools import wraps
+from threading import Event
+from typing import Awaitable, Callable, Generator, Optional, Type
+
+
+@dataclass
+class _HandshakeContext:
+    error: Optional[Exception] = None
+
+
+class Handshake:
+    """
+    Control execution flow between one producer thread (application logic) and one consumer thread (tests),
+    to be able to assert application state at certain points during execution.
+    """
+
+    def __init__(self) -> None:
+        self._ready = Event()
+        self._go = Event()
+        self._done = Event()
+        self._context = _HandshakeContext()
+
+    @contextmanager
+    def __call__(self, exception: Optional[Type[Exception]] = None) -> Generator[_HandshakeContext, None, None]:
+        """Execute application logic in this context manager and optionally capture exceptions."""
+        try:
+            self.ready()
+            yield self._context
+        except BaseException as err:
+            if exception is not None and isinstance(err, exception):
+                self._context.error = err
+            else:
+                raise
+        finally:
+            self.done()
+
+    def ready(self) -> None:
+        """Make producer thread wait indefinitely until consumer thread allows one execution step."""
+        self._ready.set()
+        self._go.wait()
+        self._go.clear()
+        self._context.error = None
+
+    def done(self):
+        """Tell the cosumer thread that execution has finished."""
+        self._ready.clear()
+        self._done.set()
+
+    def go(self):
+        """Allow producer thread to run."""
+        self._go.set()
+
+    def wait_ready(self, timeout: Optional[float] = None) -> bool:
+        """Wait for producer thread to be ready and return whether it is ready or not."""
+        return self._ready.wait(timeout=timeout)
+
+    def wait_done(self, timeout: Optional[float] = None) -> bool:
+        """Wait for producer thread to be done and return whether it is done or not. If an exception was captured, raise it."""
+        result = self._done.wait(timeout=timeout)
+        self._done.clear()
+
+        error = self._context.error
+        if error is not None:
+            self._context.error = None
+            raise error
+
+        return result
+
+    def step(self, timeout: Optional[float] = None) -> bool:
+        """Allow producer thread to run, wait for it to complete and return whether it has finished or not."""
+        self.go()
+        return self.wait_done(timeout=timeout)
+
+    is_ready: Callable[[Optional[float]], Awaitable[bool]]
+    is_done: Callable[[Optional[float]], Awaitable[bool]]
+    asyncstep: Callable[[Optional[float]], Awaitable[bool]]
+
+
+def _sync2async(obj, name, method):
+    meth = getattr(obj, method)
+
+    @wraps(meth)
+    async def wrapper(*args, **kwargs):
+        async def task():
+            try:
+                value = meth(*args, **kwargs)
+            except Exception as err:
+                future.set_exception(err)
+            else:
+                future.set_result(value)
+
+        future = Future()
+        get_event_loop().create_task(task())
+
+        return await future
+
+    setattr(obj, name, wrapper)
+
+
+_sync2async(Handshake, "is_ready", "wait_ready")
+_sync2async(Handshake, "is_done", "wait_done")
+_sync2async(Handshake, "asyncstep", "step")
+
+del _sync2async

--- a/tests/testutils/test_handshake.py
+++ b/tests/testutils/test_handshake.py
@@ -1,0 +1,150 @@
+from threading import Lock, Thread
+from unittest.mock import patch
+
+import pytest
+
+from tests.testutils.handshake import Handshake
+
+
+class Producer(Thread):
+    def __init__(self, exception=None):
+        super().__init__(daemon=True, name="ProducerThread")
+        self.handshake = Handshake()
+        self.lock = Lock()
+        self.value = 0
+        self.exception = exception
+        self.error = None
+
+    def run(self):
+        try:
+            for _ in range(2):
+                with self.handshake(self.exception):
+                    with self.lock:
+                        self.action()
+        except Exception as err:
+            self.error = err
+
+    def action(self):
+        self.value += 1
+
+
+@pytest.fixture
+def producer(request):
+    thread = Producer(**getattr(request, "param", {}))
+    yield thread
+    thread.join(1)
+    assert not thread.is_alive()
+
+
+class TestSynchronization:
+    def test_sync(self, producer: Producer):
+        assert not producer.handshake.wait_ready(0), "Producer is not yet ready"
+        assert not producer.handshake.wait_done(0), "Producer is not done"
+
+        producer.start()
+        assert producer.handshake.wait_ready(1), "Producer arrived in ready-state within at most 1 second"
+        assert not producer.handshake.wait_done(0), "Producer is not in done-state"
+        assert producer.value == 0
+
+        assert producer.handshake.step(1), "Producer manages to execute one iteration within at most 1 second"
+        assert not producer.handshake.wait_done(0), "Producer is not in done-state after completing one iteration"
+        assert producer.value == 1
+        assert producer.handshake.wait_ready(1), "Producer once again arrived in ready-state within at most 1 second"
+
+        # make producer and consumer threads increment the value independently
+        producer.handshake.go()
+        with producer.lock:
+            producer.value += 1
+        assert producer.handshake.wait_done(1), "Producer is done after at most 1 second"
+        assert producer.value == 3
+
+        assert not producer.handshake.wait_done(0), "Producer is not in done-state anymore"
+        assert not producer.handshake.wait_ready(0), "Producer's loop ended, not waiting in ready-state again"
+
+    @pytest.mark.asyncio
+    async def test_async(self, producer: Producer):
+        assert not await producer.handshake.is_ready(0), "Producer is not yet ready"
+        assert not await producer.handshake.is_done(0), "Producer is not done"
+
+        producer.start()
+        assert await producer.handshake.is_ready(1), "Producer arrived in ready-state within at most 1 second"
+        assert not await producer.handshake.is_done(0), "Producer is not in done-state"
+        assert producer.value == 0
+
+        assert await producer.handshake.asyncstep(1), "Producer manages to execute one iteration within at most 1 second"
+        assert not await producer.handshake.is_done(0), "Producer is not in done-state after completing one iteration"
+        assert producer.value == 1
+        assert await producer.handshake.is_ready(1), "Producer once again arrived in ready-state within at most 1 second"
+
+        # make producer and consumer threads increment the value independently
+        producer.handshake.go()
+        is_done = producer.handshake.is_done(1)
+        with producer.lock:
+            producer.value += 1
+        assert await is_done, "Producer is done after at most 1 second"
+        assert producer.value == 3
+
+        assert not await producer.handshake.is_done(0), "Producer is not in done-state anymore"
+        assert not await producer.handshake.is_ready(0), "Producer's loop ended, not waiting in ready-state again"
+
+
+class TestNoCaptureExceptions:
+    def test_sync(self, producer: Producer):
+        producer.start()
+
+        # doesn't catch exception and doesn't raise in consumer thread
+        with patch.object(producer, "action", side_effect=Exception):
+            assert producer.handshake.step(1), "Doesn't catch any exceptions, doesn't raise in consumer thread"
+        producer.join(1)
+        assert not producer.is_alive(), "Producer thread has raised exception and has terminated"
+        assert isinstance(producer.error, Exception)
+
+    @pytest.mark.asyncio
+    async def test_async(self, producer: Producer):
+        producer.start()
+
+        # doesn't catch exception and doesn't raise in consumer thread
+        with patch.object(producer, "action", side_effect=Exception):
+            assert await producer.handshake.asyncstep(1), "Doesn't catch any exceptions, doesn't raise in consumer thread"
+        producer.join(1)
+        assert not producer.is_alive(), "Producer thread has raised exception and has terminated"
+        assert isinstance(producer.error, Exception)
+
+
+class TestCaptureExceptions:
+    @pytest.mark.parametrize("producer", [{"exception": TypeError}], indirect=True)
+    def test_sync(self, producer: Producer):
+        producer.start()
+
+        # catches exception and raises in consumer thread
+        with patch.object(producer, "action", side_effect=TypeError):
+            with pytest.raises(TypeError):
+                producer.handshake.step(1)
+
+        assert not producer.handshake.wait_done(0), "Producer is not in done-state anymore after catching an exception"
+        assert producer.handshake.wait_ready(1), "Producer once again arrived in ready-state within at most 1 second"
+
+        with patch.object(producer, "action", side_effect=ValueError):
+            assert producer.handshake.step(1), "Doesn't catch different exceptions, doesn't raise in consumer thread"
+        producer.join(1)
+        assert not producer.is_alive(), "Producer thread has raised exception and has terminated"
+        assert isinstance(producer.error, ValueError)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("producer", [{"exception": TypeError}], indirect=True)
+    async def test_async(self, producer: Producer):
+        producer.start()
+
+        # catches exception and raises in consumer thread
+        with patch.object(producer, "action", side_effect=TypeError):
+            with pytest.raises(TypeError):
+                await producer.handshake.asyncstep(1)
+
+        assert not await producer.handshake.is_done(0), "Producer is not in done-state anymore after catching an exception"
+        assert await producer.handshake.is_ready(1), "Producer once again arrived in ready-state within at most 1 second"
+
+        with patch.object(producer, "action", side_effect=ValueError):
+            assert await producer.handshake.asyncstep(1), "Doesn't catch different exceptions, doesn't raise in consumer thread"
+        producer.join(1)
+        assert not producer.is_alive(), "Producer thread has raised exception and has terminated"
+        assert isinstance(producer.error, ValueError)


### PR DESCRIPTION
This cleans up and simplifies the HLS test mixins by implementing a generic thread-handshake class for synchronizing code execution between two threads: application logic (producer thread) and tests (consumer/main thread), with optional error capturing. The previous implementation was using a similar setup in multiple different classes. This is now defined with a proper interface and proper method names, for much better readability of the tests.

I've also added support for async coroutines in case this is required at some point. And I added tests for the new `tests.testutils.handshake.Handshake` class, so that it doesn't get tested implicitly via the other tests.

This work is required for my code refactoring of the CLI's `read_stream()` stuff (see #4974 - not yet finished), because I didn't want to redefine the same handshake stuff over and over again. Including this work in a single PR would've been a bit too much, so that's why I'm opening this one here first.