### PR TITLE
tests: fix freezegun's default module ignore list

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,7 @@
 import os
 import signal
 
+import freezegun.config
 import pytest
 
 # import streamlink_cli as early as possible to execute its default signal overrides
@@ -11,6 +12,12 @@ import streamlink_cli  # noqa: F401
 # immediately restore default signal handlers for the test runner
 signal.signal(signal.SIGINT, signal.default_int_handler)
 signal.signal(signal.SIGTERM, signal.default_int_handler)
+
+
+# make freezegun ignore the following pytest modules, so it doesn't mess with pytest's --duration=N report
+# when freezing time in fixtures, even though ["_pytest.runner.", "_pytest.terminal."] is already included
+# in freezegun's default module ignore list (notice the trailing dots).
+freezegun.config.configure(extend_ignore_list=["_pytest.runner", "_pytest.terminal"])
 
 
 # make pytest rewrite assertions in dynamically parametrized plugin tests


### PR DESCRIPTION
**master**
```
$ pytest --durations=10 | tail -n12
============================= slowest 10 durations =============================
946550580.35s setup    tests/cli/utils/test_formatter.py::TestCLIFormatter::test_title
946550580.34s setup    tests/cli/utils/test_formatter.py::TestCLIFormatter::test_path
946550580.34s setup    tests/cli/utils/test_formatter.py::TestCLIFormatter::test_path_substitute
946550573.89s setup    tests/utils/test_formatter.py::TestFormatter::test_unknown
946550573.88s setup    tests/utils/test_formatter.py::TestFormatter::test_format
946550573.87s setup    tests/utils/test_formatter.py::TestFormatter::test_format_spec
946453134.91s setup    tests/plugins/test_filmon.py::test_filmonhls_to_url
946453134.88s setup    tests/plugins/test_filmon.py::test_filmonhls_to_url_updated
946453134.85s setup    tests/plugins/test_filmon.py::test_filmonhls_to_url_missing_quality
0.18s call     tests/stream/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_invalid_method
====================== 5282 passed, 32 skipped in 12.32s =======================
```

**PR**
```
$ pytest --durations=10 | tail -n12
============================= slowest 10 durations =============================
0.24s call     tests/stream/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_missing_uri
0.21s call     tests/stream/test_hls.py::TestHlsPlaylistReloadTime::test_hls_playlist_reload_time_live_edge_no_segments_no_targetduration
0.19s call     tests/stream/test_hls.py::TestHLSStreamEncrypted::test_hls_encrypted_invalid_method
0.17s call     tests/stream/test_hls_filtered.py::TestFilteredHLSStream::test_not_filtered
0.16s call     tests/plugins/test_twitch.py::TestTwitchHLSStream::test_hls_low_latency_has_prefetch_has_preroll
0.15s call     tests/cli/test_main.py::TestCLIMainLoggingInfos::test_log_current_arguments
0.13s call     tests/cli/test_main.py::TestCLIMainLoggingInfos::test_log_current_versions
0.12s call     tests/stream/test_ffmpegmux.py::TestOpen::test_stderr_path
0.12s setup    tests/plugins/test_filmon.py::test_filmonhls_to_url_missing_quality
0.10s call     tests/stream/test_hls.py::TestHlsPlaylistReloadTime::test_hls_playlist_reload_time_no_data
====================== 5282 passed, 32 skipped in 11.90s =======================
```