### PR TITLE
tests: change order of collected tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import sys
+from typing import List
+
+import pytest
+
+
+_TEST_PRIORITIES = (
+    "tests/testutils/",
+    "tests/utils/",
+    None,
+    "tests/stream/",
+    "tests/test_plugins.py",
+    "tests/plugins/",
+    "tests/cli/",
+)
+
+
+def pytest_collection_modifyitems(items: List[pytest.Item]):  # pragma: no cover
+    default = next((idx for idx, string in enumerate(_TEST_PRIORITIES) if string is None), sys.maxsize)
+    priorities = {
+        item: next(
+            (
+                idx
+                for idx, string in enumerate(_TEST_PRIORITIES)
+                if string is not None and item.nodeid.startswith(string)
+            ),
+            default,
+        )
+        for item in items
+    }
+    items.sort(key=lambda item: priorities.get(item, default))

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,15 +1,23 @@
+from typing import List
+
+import pytest
+
 from tests.plugins import PluginCanHandleUrl, generic_negative_matches
 
 
-def pytest_collection_modifyitems(session, config, items):  # pragma: no cover
+def pytest_collection_modifyitems(items: List[pytest.Item]):  # pragma: no cover
     # remove empty parametrized tests
-    session.items = list(filter(lambda item: not any(
-        marker.name == "skip" and str(marker.kwargs.get("reason", "")).startswith("got empty parameter set")
-        for marker in item.own_markers
-    ), items))
+    items[:] = [
+        item
+        for item in items
+        if not any(
+            marker.name == "skip" and str(marker.kwargs.get("reason", "")).startswith("got empty parameter set")
+            for marker in item.own_markers
+        )
+    ]
 
 
-def pytest_generate_tests(metafunc):  # pragma: no cover
+def pytest_generate_tests(metafunc: pytest.Metafunc):  # pragma: no cover
     if metafunc.cls is not None and issubclass(metafunc.cls, PluginCanHandleUrl):
         if metafunc.function.__name__ == "test_can_handle_url_positive":
             metafunc.parametrize("url", metafunc.cls.should_match + [url for url, groups in metafunc.cls.should_match_groups])


### PR DESCRIPTION
Tests should be run in the following order

1. test-utility tests
2. application-utility tests
3. \*
4. stream tests
5. plugin tests
6. cli tests

so that dependencies get tested first. If a dependency breaks, this makes it clear where the issue is coming from, should tests of dependent code also break.

For example, since certain tests require certain test utilities, those test utilities should be tested first, to ensure that everything is working when running the entire test suite.

