### PR TITLE
Move plugin options to plugin instances and remove global plugin arguments

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -1,7 +1,4 @@
-import warnings
 from typing import Any, Callable, ClassVar, Dict, Iterator, Mapping, Optional, Sequence, Union
-
-from streamlink.exceptions import StreamlinkDeprecationWarning
 
 
 class Options:
@@ -106,7 +103,6 @@ class Argument:
         sensitive: bool = False,
         argument_name: Optional[str] = None,
         dest: Optional[str] = None,
-        is_global: bool = False,
         **options,
     ):
         """
@@ -117,7 +113,6 @@ class Argument:
         :param sensitive: Whether the argument is sensitive (passwords, etc.) and should be masked
         :param argument_name: Custom CLI argument name without plugin name prefix
         :param dest: Custom plugin option name
-        :param is_global: Whether this plugin argument refers to a global CLI argument (deprecated)
         :param options: Arguments passed to :meth:`ArgumentParser.add_argument()`, excluding ``requires`` and ``dest``
         """
 
@@ -131,15 +126,6 @@ class Argument:
         self.prompt = prompt
         self.sensitive = sensitive
         self._default = options.get("default")
-        self.is_global = is_global
-        if is_global:
-            warnings.warn(
-                "Defining global plugin arguments is deprecated. Use the session options instead.",
-                StreamlinkDeprecationWarning,
-                # set stacklevel to 3 because of the @pluginargument decorator
-                # which is the public interface for defining plugin arguments
-                stacklevel=3,
-            )
 
     @staticmethod
     def _normalize_name(name: str) -> str:
@@ -153,7 +139,7 @@ class Argument:
         return self._argument_name or self._normalize_name(f"{plugin}-{self.name}")
 
     def argument_name(self, plugin):
-        return f"--{self.name if self.is_global else self._name(plugin)}"
+        return f"--{self._name(plugin)}"
 
     def namespace_dest(self, plugin):
         return self._normalize_dest(self._name(plugin))

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -708,7 +708,6 @@ def pluginargument(
     sensitive: bool = False,
     argument_name: Optional[str] = None,
     dest: Optional[str] = None,
-    is_global: bool = False,
     **options,
 ) -> Callable[[Type[Plugin]], Type[Plugin]]:
     """
@@ -746,7 +745,6 @@ def pluginargument(
         sensitive=sensitive,
         argument_name=argument_name,
         dest=dest,
-        is_global=is_global,
         **options,
     )
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -270,7 +270,6 @@ class Plugin:
     category: Optional[str] = None
     """Metadata 'category' attribute: name of a game being played, a music genre, etc."""
 
-    options = Options()
     _url: str = ""
 
     # deprecated
@@ -317,15 +316,17 @@ class Plugin:
 
         return cls.__new__(PluginWrapperBack, *args, **kwargs)
 
-    def __init__(self, session: "Streamlink", url: str):
+    def __init__(self, session: "Streamlink", url: str, options: Optional[Options] = None):
         """
         :param session: The Streamlink session instance
         :param url: The input URL used for finding and resolving streams
+        :param options: An optional :class:`Options` instance
         """
 
         modulename = self.__class__.__module__
         self.module = modulename.split(".")[-1]
         self.logger = logging.getLogger(modulename)
+        self.options = Options() if options is None else options
         self.cache = Cache(
             filename="plugin-cache.json",
             key_prefix=self.module,
@@ -353,13 +354,11 @@ class Plugin:
         if self.matchers:
             self.matcher, self.match = self.matches.update(self.matchers, value)
 
-    @classmethod
-    def set_option(cls, key, value):
-        cls.options.set(key, value)
+    def set_option(self, key, value):
+        self.options.set(key, value)
 
-    @classmethod
-    def get_option(cls, key):
-        return cls.options.get(key)
+    def get_option(self, key):
+        return self.options.get(key)
 
     @classmethod
     def get_argument(cls, key):

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -501,31 +501,6 @@ class Streamlink:
 
         return self.options.get(key)
 
-    def set_plugin_option(self, plugin: str, key: str, value: Any) -> None:
-        """
-        Sets plugin specific options used by plugins originating from this session object.
-
-        :param plugin: name of the plugin
-        :param key: key of the option
-        :param value: value to set the option to
-        """
-
-        if plugin in self.plugins:
-            plugincls = self.plugins[plugin]
-            plugincls.set_option(key, value)
-
-    def get_plugin_option(self, plugin: str, key: str) -> Optional[Any]:
-        """
-        Returns the current value of the plugin specific option.
-
-        :param plugin: name of the plugin
-        :param key: key of the option
-        """
-
-        if plugin in self.plugins:
-            plugincls = self.plugins[plugin]
-            return plugincls.get_option(key)
-
     @lru_cache(maxsize=128)  # noqa: B019
     def resolve_url(
         self,

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -3,7 +3,7 @@ import re
 import struct
 from concurrent.futures import Future
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
 from urllib.parse import urlparse
 
 # noinspection PyPackageRequirements
@@ -601,6 +601,7 @@ class HLSStream(HTTPStream):
         force_restart: bool = False,
         start_offset: float = 0,
         duration: Optional[float] = None,
+        # TODO: turn args into dedicated keyword
         **args,
     ):
         """
@@ -680,6 +681,8 @@ class HLSStream(HTTPStream):
         name_fmt: Optional[str] = None,
         start_offset: float = 0,
         duration: Optional[float] = None,
+        keywords: Optional[Mapping] = None,
+        # TODO: turn request_params into a dedicated keyword
         **request_params,
     ) -> Dict[str, Union["HLSStream", "MuxedHLSStream"]]:
         """
@@ -694,6 +697,7 @@ class HLSStream(HTTPStream):
         :param name_fmt: A format string for the name, allowed format keys are: name, pixels, bitrate
         :param start_offset: Number of seconds to be skipped from the beginning
         :param duration: Number of second until ending the stream
+        :param keywords: Optional keywords to be passed to the :class:`HLSStream` or :class:`MuxedHLSStream`
         :param request_params: Additional keyword arguments passed to :class:`HLSStream`, :class:`MuxedHLSStream`,
                                or :py:meth:`requests.Session.request`
         """
@@ -711,6 +715,7 @@ class HLSStream(HTTPStream):
         stream_name: Optional[str]
         stream: Union["HLSStream", "MuxedHLSStream"]
         streams: Dict[str, Union["HLSStream", "MuxedHLSStream"]] = {}
+        keywords = keywords or {}
 
         for playlist in filter(lambda p: not p.is_iframe, multivariant.playlists):
             names: Dict[str, Optional[str]] = dict(name=None, pixels=None, bitrate=None)
@@ -819,6 +824,7 @@ class HLSStream(HTTPStream):
                     force_restart=force_restart,
                     start_offset=start_offset,
                     duration=duration,
+                    **keywords,
                     **request_params,
                 )
             else:
@@ -829,6 +835,7 @@ class HLSStream(HTTPStream):
                     force_restart=force_restart,
                     start_offset=start_offset,
                     duration=duration,
+                    **keywords,
                     **request_params,
                 )
 

--- a/tests/cli/test_plugin_args_and_options.py
+++ b/tests/cli/test_plugin_args_and_options.py
@@ -1,0 +1,129 @@
+import argparse
+from typing import Type
+from unittest.mock import Mock, call
+
+import pytest
+
+from streamlink.plugin import Plugin, pluginargument
+from streamlink.session import Streamlink
+from streamlink_cli.argparser import ArgumentParser
+from streamlink_cli.main import setup_plugin_args, setup_plugin_options
+
+
+@pytest.fixture()
+def parser():
+    return ArgumentParser(add_help=False)
+
+
+@pytest.fixture(autouse=True)
+def _args(monkeypatch: pytest.MonkeyPatch):
+    args = argparse.Namespace(
+        mock_foo_bar=123,
+        mock_baz=654,
+        # mock_qux wouldn't be set by the parser if the argument is suppressed
+        # its value will be ignored
+        mock_qux=987,
+        mock_user="username",
+        mock_pass=None,
+        mock_captcha=None,
+    )
+    monkeypatch.setattr("streamlink_cli.main.args", args)
+
+
+@pytest.fixture()
+def plugin():
+    # simple argument which requires namespace-name normalization
+    @pluginargument("foo-bar")
+    # argument with default value
+    @pluginargument("baz", default=456)
+    # suppressed argument
+    @pluginargument("qux", default=789, help=argparse.SUPPRESS)
+    # required argument with dependencies
+    @pluginargument("user", required=True, requires=["pass", "captcha"])
+    # sensitive argument (using console.askpass if unset)
+    @pluginargument("pass", sensitive=True)
+    # argument with custom prompt (using console.ask if unset)
+    @pluginargument("captcha", prompt="CAPTCHA code")
+    class FakePlugin(Plugin):
+        def _get_streams(self):  # pragma: no cover
+            pass
+
+    return FakePlugin
+
+
+@pytest.fixture(autouse=True)
+def session(monkeypatch: pytest.MonkeyPatch, parser: ArgumentParser, plugin: Type[Plugin]):
+    monkeypatch.setattr("streamlink.session.Streamlink.load_builtin_plugins", Mock())
+    session = Streamlink()
+    session.plugins["mock"] = plugin
+
+    setup_plugin_args(session, parser)
+
+    return session
+
+
+@pytest.fixture()
+def console(monkeypatch: pytest.MonkeyPatch):
+    console = Mock()
+    monkeypatch.setattr("streamlink_cli.main.console", console)
+    return console
+
+
+class TestPluginArgs:
+    def test_arguments(self, parser: ArgumentParser, plugin: Type[Plugin]):
+        group_plugins = next((grp for grp in parser._action_groups if grp.title == "Plugin options"), None)  # pragma: no branch
+        assert group_plugins is not None, "Adds the 'Plugin options' arguments group"
+        assert group_plugins in parser.NESTED_ARGUMENT_GROUPS[None], "Adds the 'Plugin options' arguments group"
+
+        group_plugin = next((grp for grp in parser._action_groups if grp.title == "Mock"), None)  # pragma: no branch
+        assert group_plugin is not None, "Adds the 'Mock' arguments group"
+        assert group_plugin in parser.NESTED_ARGUMENT_GROUPS[group_plugins], "Adds the 'Mock' arguments group"
+
+        assert [
+            item
+            for action in parser._actions
+            for item in action.option_strings
+            if action.help != argparse.SUPPRESS
+        ] == [
+            "--mock-foo-bar",
+            "--mock-baz",
+            "--mock-user",
+            "--mock-pass",
+            "--mock-captcha",
+        ], "Parser has all arguments registered"
+
+
+class TestPluginOptions:
+    def test_empty(self, console: Mock):
+        options = setup_plugin_options("mock", Plugin)
+        assert not options.defaults
+        assert not options.options
+
+        assert not console.ask.called
+        assert not console.askpass.called
+
+    def test_options(self, plugin: Type[Plugin], console: Mock):
+        options = setup_plugin_options("mock", plugin)
+
+        assert console.ask.call_args_list == [call("CAPTCHA code: ")]
+        assert console.askpass.call_args_list == [call("Enter mock pass: ")]
+
+        assert plugin.arguments
+        arg_foo = plugin.arguments.get("foo-bar")
+        arg_baz = plugin.arguments.get("baz")
+        arg_qux = plugin.arguments.get("qux")
+        assert arg_foo
+        assert arg_baz
+        assert arg_qux
+        assert arg_foo.default is None
+        assert arg_baz.default == 456
+        assert arg_qux.default == 789
+
+        assert options.get("foo-bar") == 123, "Overrides the default plugin-argument value"
+        assert options.get("baz") == 654, "Uses the plugin-argument default value"
+        assert options.get("qux") == 789, "Ignores values of suppressed plugin-arguments"
+
+        options.clear()
+        assert options.get("foo-bar") == arg_foo.default
+        assert options.get("baz") == arg_baz.default
+        assert options.get("qux") == arg_qux.default

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,6 +9,7 @@ import freezegun
 import pytest
 import requests.cookies
 
+from streamlink.options import Options
 from streamlink.plugin import (
     HIGH_PRIORITY,
     NORMAL_PRIORITY,
@@ -106,6 +107,16 @@ class TestPlugin:
         assert plugin.cache == mock_cache()
 
         assert mock_load_cookies.call_args_list == [call()]
+
+    def test_constructor_options(self):
+        one = FakePlugin(Mock(), "https://mocked", Options({"key": "val"}))
+        two = FakePlugin(Mock(), "https://mocked")
+        assert one.get_option("key") == "val"
+        assert two.get_option("key") is None
+
+        one.set_option("key", "other")
+        assert one.get_option("key") == "other"
+        assert two.get_option("key") is None
 
 
 class TestPluginMatcher:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -84,9 +84,6 @@ class TestPlugins:
         assert not hasattr(pluginclass, "priority"), "Does not implement deprecated priority(url)"
         assert callable(pluginclass._get_streams), "Implements _get_streams()"
 
-    def test_no_global_args(self, plugin):
-        assert not [parg for parg in plugin.__plugin__.arguments or [] if parg.is_global], "Doesn't define global arguments"
-
 
 class TestPluginTests:
     @pytest.mark.parametrize("plugin", plugins)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -340,18 +340,6 @@ class TestStreams:
         assert "vod_alt2" in streams
 
 
-def test_pluginoptions(session: Streamlink):
-    assert session.get_plugin_option("testplugin", "a_option") is None
-
-    session.load_plugins(str(PATH_TESTPLUGINS))
-    assert session.get_plugin_option("testplugin", "a_option") == "default"
-
-    session.set_plugin_option("testplugin", "another_option", "test")
-    assert session.get_plugin_option("testplugin", "another_option") == "test"
-    assert session.get_plugin_option("non_existing", "non_existing") is None
-    assert session.get_plugin_option("testplugin", "non_existing") is None
-
-
 def test_options(session: Streamlink):
     session.set_option("test_option", "option")
     assert session.get_option("test_option") == "option"


### PR DESCRIPTION
These are breaking changes of the `Streamlink` session and `Plugin` APIs.

Opening this as a draft for now, even though it's pretty much final, because I don't think that this has to be merged now. It simply fixes an old design flaw and is not too important and should be included with other breaking changes in the future in one go.

----

Two separate changes:

### 1. Moving `Plugin.options` to plugin instances

As mentioned in #5011, turning `Plugin.options` from a plugin class attribute into a plugin instance attribute is related to the removal of the `Plugin.bind()` class method in #4744 / #4768, and ideally should've been part of the `5.0.0` release. While `5.0.0` removed `Plugin.bind()`, the breaking changes were actually in the `Streamlink` session class where `Plugin.bind()` was called internally, and compatibility wrappers were added to the `Plugin` constructor, with deprecation messages for old-style parameters. This here is another set of breaking changes on the `Streamlink` session class and `Plugin` class, but without any deprecations.

Just to recap what I've said in #5011 and what I've included in the commit messages of this PR, the `Plugin` class previously shared a common `Options` instance as the `Plugin.options` class attribute. This class attribute was then overridden by `streamlink_cli.main.setup_plugin_args()` where plugin arguments were processed and added to the argparser while reading default values of the plugin arguments that were added to a new `Options` instance.

This design is bad for several reasons. First, this makes `streamlink_cli` a "soft" dependency of the `Plugin` and `Streamlink` classes, as all plugin options would otherwise be shared between all plugins on the same `Options` instance. Second, multiple instances of the same plugin always have the same set of options set (not really important, but still bad). And third, tests and third party projects not using streamlink_cli need to manually override/clear the `Plugin.options` class attribute when initializing multiple plugins, which is bad.

Now, after these changes:

- The `Plugin` class can receive an optional `Options` instance as a parameter on its constructor, which streamlink_cli uses for setting up individual plugin options. Having it in the `Plugin` constructor is important, because plugin subclasses need to be able to read plugin options immediately (see Twitch and TwitchAPI), and not after initialization.
- Since plugin options are not stored on plugin classes anymore, `Streamlink.get_plugin_option()` and `Streamlink.set_plugin_option()` have been removed. These methods were useful for sharing state between different parts of Streamlink, e.g. plugins and streams (see Twitch and TwitchHLSStream), but this can be done in different ways. The PR therefore also adds the `keywords` parameter to `HLSStream.parse_variant_playlist()` to be able to pass keywords to the `{,Muxed}HLSStream` classes. In case of the Twitch plugin, these keywords are `disable_ads` and `low_latency` which are read from the plugin options instead of `session.get_plugin_option()`.

### 2. Removal of `Argument.is_global`

I've already had this on my radar for a while. Since the changed CLI methods already had to deal with global plugin arguments, I decided to include the removal of global plugin arguments in this PR.

The reason for the removal of global plugin arguments is simple: it adds unnecessary complexity for absolutely no gain. The value which a global plugin argument stores is already stored in the session options and should be read from there.

`is_global` was added when we removed individual plugin arguments for muxing subtitles, but no other global plugin arguments were ever added. The only benefit it had was being able to include a list of plugins in the docs which were making use of `--mux-subtitles`, as the global plugin arguments allowed for parsing this data. This additional data in the docs is now gone as well, but only affects four plugins. If we want to have a list of certain features a plugin uses, then this can be done by extending the regular plugin metadata.

What plugin implementors have to do to fix this is very simple, remove any global plugin arguments and change the option lookup, e.g. `self.get_option("mux_subtitles")` to `self.session.get_option("mux-subtitles")`.