### PR TITLE
plugins.cdnbg: update regex

### DIFF
--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -85,7 +85,7 @@ class CDNBG(Plugin):
             schema=validate.Schema(
                 validate.any(
                     self._find_url(
-                        re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>http.*?)(?P=q)")
+                        re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>.*?)(?P=q)")
                     ),
                     self._find_url(
                         re.compile(r"(src|file): (?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)")


### PR DESCRIPTION
I've not tested BNT3 via a proxy, as I have not found one that seems to be usable so far.  BNT4 is not geo-restricted, the rest are.
```
$ streamlink http://tv.bnt.bg/bnt3
[cli][info] Found matching plugin cdnbg for URL http://tv.bnt.bg/bnt3
[plugins.cdnbg][error] Geo-restricted content
error: No playable streams found on this URL: http://tv.bnt.bg/bnt3

$ streamlink http://tv.bnt.bg/bnt4
[cli][info] Found matching plugin cdnbg for URL http://tv.bnt.bg/bnt4
Available streams: 576p (worst, best)
```
closes #5039
