### PR TITLE
ci.github: ubuntu-20.04 -> ubuntu-latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       # when changing the build matrix and changing the number of test runners
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
           - windows-latest
         python:
           - "3.7"
@@ -67,7 +67,7 @@ jobs:
   documentation:
     name: Test docs
     if: github.event_name != 'schedule'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -90,7 +90,7 @@ jobs:
     needs:
       - test
       - documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
@@ -116,7 +116,7 @@ jobs:
     if: github.repository == 'streamlink/streamlink' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     needs:
       - deploy-documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Just wanted to update the master branch protection rules and noticed that the Ubuntu runners are still on 20.04.

Both Linux and Windows runners should use the latest OS release versions respectively. Upgrading from Ubuntu 20.04 to 22.04 shouldn't cause any issues.

After this has been merged, I will make Python 3.11 a requirement for PRs.