### PR TITLE
plugins.ceskatelevize: update for ct24, sport and sportplus; add decko

### DIFF
--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -5,25 +5,138 @@ $type live
 $region Czechia
 """
 
+import json
 import logging
 import re
+from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(re.compile(
-    r"https://(?:www\.)?ceskatelevize\.cz/zive/\w+"
-))
+@pluginmatcher(re.compile(r"https?://ct24\.ceskatelevize\.cz/"))
+@pluginmatcher(re.compile(r"https?://decko\.ceskatelevize\.cz/"))
+@pluginmatcher(re.compile(r"https?://sport\.ceskatelevize\.cz/"))
+@pluginmatcher(re.compile(r"https?://(?:www\.)?ceskatelevize\.cz/zive/\w+"))
 class Ceskatelevize(Plugin):
-    _re_playlist_info = re.compile(r"{\"type\":\"([a-z]+)\",\"id\":\"([0-9]+)\"")
+    schema_playlist = {
+        "playlist": [{
+            "streamUrls": {
+                "main": validate.url(),
+            },
+        }],
+    }
 
-    def _get_streams(self):
-        self.session.http.headers.update({"Referer": self.url})
-        schema_data = validate.Schema(
+    def get_stream_url(self, video_id):
+        url = self.session.http.post(
+            "https://www.ceskatelevize.cz/ivysilani/ajax/get-client-playlist/",
+            data={
+                "playlist[0][type]": "channel",
+                "playlist[0][id]": video_id,
+                "requestUrl": "/ivysilani/embed/iFramePlayer.php",
+                "requestSource": "iVysilani",
+                "type": "html",
+                "canPlayDRM": "false",
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "url": validate.url(),
+                },
+                validate.get("url"),
+            ),
+        )
+
+        return self.session.http.get(
+            url,
+            schema=validate.Schema(
+                validate.parse_json(),
+                self.schema_playlist,
+                validate.get(("playlist", 0, "streamUrls", "main")),
+            ),
+        )
+
+    def get_ct24(self):
+        self.id = 24
+        self.title = "ČT24"
+        return self.get_stream_url(self.id)
+
+    def get_decko(self):
+        self.id = 5
+        self.title = "Déčko"
+        return self.get_stream_url(self.id)
+
+    def get_sport(self, content):
+        video_id, key, date = validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath_string(".//section[@id='live']/@data-ctcomp-data"),
+            str,
+            validate.parse_json(),
+            {
+                "items": [{
+                    "items": [{
+                        validate.optional("video"): {
+                            "data": {
+                                "source": {
+                                    "playlist": [{
+                                        "id": int,
+                                        "key": str,
+                                        "date": str,
+                                        "noDrmData": {
+                                            "id": int,
+                                            "key": str,
+                                            "drm": int,
+                                            "quality": str,
+                                            "assetId": str,
+                                        },
+                                    }],
+                                },
+                            },
+                        },
+                    }],
+                }],
+            },
+            validate.get(("items", 0, "items", 0, "video", "data", "source", "playlist", 0)),
+            validate.union_get(("noDrmData", "id"), ("noDrmData", "key"), "date"),
+        ).validate(content)
+
+        self.id = video_id
+        self.title = "ČT sport"
+
+        return self.session.http.post(
+            "https://playlist.ceskatelevize.cz/",
+            data={
+                "data": json.dumps(
+                    {
+                        "contentType": "live",
+                        "items": [{
+                            "id": video_id,
+                            "key": f"{key}",
+                            "assetId": "CT4DRM",
+                            "playerType": "dash",
+                            "date": f"{date}",
+                            "requestSource": "front-sport",
+                            "drm": 0,
+                            "quality": "web",
+                        }],
+                    },
+                    separators=(',', ':'),
+                ),
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "RESULT": self.schema_playlist,
+                },
+                validate.get(("RESULT", "playlist", 0, "streamUrls", "main")),
+            ),
+        )
+
+    def get_channel(self, content):
+        data = validate.Schema(
             validate.parse_html(),
             validate.xml_xpath_string(".//script[@id='__NEXT_DATA__'][text()]/text()"),
             str,
@@ -31,105 +144,67 @@ class Ceskatelevize(Plugin):
             {
                 "props": {
                     "pageProps": {
-                        "data": {
+                        validate.optional("data"): {
                             "liveBroadcast": {
-                                # "id": str,
-                                "current": validate.any(None, {
-                                    "channel": str,
-                                    "channelName": str,
-                                    "legacyEncoder": str,
-                                }),
-                                "next": validate.any(None, {
-                                    "channel": str,
-                                    "channelName": str,
-                                    "legacyEncoder": str,
-                                })
-                            }
-                        }
-                    }
-                }
-            },
-            validate.get(("props", "pageProps", "data", "liveBroadcast")),
-            validate.union_get("current", "next"),
-        )
-
-        try:
-            data_current, data_next = self.session.http.get(
-                self.url, schema=schema_data)
-        except PluginError:
-            return
-
-        log.debug(f"current={data_current!r}")
-        log.debug(f"next={data_next!r}")
-
-        data = data_current or data_next
-        video_id = data["legacyEncoder"]
-        self.title = data["channelName"]
-
-        _hash = self.session.http.get(
-            "https://www.ceskatelevize.cz/v-api/iframe-hash/",
-            schema=validate.Schema(str))
-        res = self.session.http.get(
-            "https://www.ceskatelevize.cz/ivysilani/embed/iFramePlayer.php",
-            params={
-                "hash": _hash,
-                "origin": "iVysilani",
-                "autoStart": "true",
-                "videoID": video_id,
-            },
-        )
-
-        m = self._re_playlist_info.search(res.text)
-        if not m:
-            return
-        _type, _id = m.groups()
-
-        data = self.session.http.post(
-            "https://www.ceskatelevize.cz/ivysilani/ajax/get-client-playlist/",
-            data={
-                "playlist[0][type]": _type,
-                "playlist[0][id]": _id,
-                "requestUrl": "/ivysilani/embed/iFramePlayer.php",
-                "requestSource": "iVysilani",
-                "type": "html",
-                "canPlayDRM": "false",
-            },
-            headers={
-                "x-addr": "127.0.0.1",
-            },
-            schema=validate.Schema(
-                validate.parse_json(),
-                {
-                    validate.optional("streamingProtocol"): str,
-                    "url": validate.any(
-                        validate.url(),
-                        "Error",
-                        "error_region"
-                    )
-                }
-            ),
-        )
-
-        if data["url"] in ["Error", "error_region"]:
-            log.error("This stream is not available")
-            return
-
-        url = self.session.http.get(
-            data["url"],
-            schema=validate.Schema(
-                validate.parse_json(),
-                {
-                    "playlist": [{
-                        validate.optional("type"): str,
-                        "streamUrls": {
-                            "main": validate.url(),
-                        }
-                    }]
+                                "id": str,
+                                "current": validate.none_or_all(
+                                    {
+                                        "id": str,
+                                        "channelName": str,
+                                        "isPlayable": bool,
+                                    },
+                                ),
+                                "next": validate.none_or_all(
+                                    {
+                                        "id": str,
+                                        "channelName": str,
+                                        "isPlayable": bool,
+                                    },
+                                ),
+                            },
+                        },
+                    },
                 },
-                validate.get(("playlist", 0, "streamUrls", "main"))
-            )
-        )
-        return DASHStream.parse_manifest(self.session, url)
+            },
+            validate.get(("props", "pageProps")),
+        ).validate(content)
+
+        if not data:
+            return
+
+        log.debug(f"data={data}")
+        data = data.get("data").get("liveBroadcast")
+        self.id = data.get("id")
+
+        data = data.get("current") or data.get("next")
+        if not data:
+            return
+
+        self.title = data.get("channelName")
+
+        return self.get_stream_url(self.id)
+
+    def _get_streams(self):
+        res = self.session.http.get(self.url)
+
+        if "://ct24" in res.url:
+            url = self.get_ct24()
+        elif "://decko" in res.url:
+            url = self.get_decko()
+        elif "://sport" in res.url:
+            url = self.get_sport(res.content)
+        else:
+            url = self.get_channel(res.content)
+
+        if url:
+            res = self.session.http.head(url, allow_redirects=True)
+            log.debug(f"res.url={res.url}")
+            p = urlparse(res.url).path
+            if not p.split("/")[-1].startswith(str(self.id)):
+                log.error("This stream is not available")
+                return
+            else:
+                return DASHStream.parse_manifest(self.session, res.url)
 
 
 __plugin__ = Ceskatelevize

--- a/tests/plugins/test_ceskatelevize.py
+++ b/tests/plugins/test_ceskatelevize.py
@@ -6,23 +6,17 @@ class TestPluginCanHandleUrlCeskatelevize(PluginCanHandleUrl):
     __plugin__ = Ceskatelevize
 
     should_match = [
-        "https://www.ceskatelevize.cz/zive/ct1/",
-        "https://www.ceskatelevize.cz/zive/ct2/",
-        "https://www.ceskatelevize.cz/zive/ct24/",
-        "https://www.ceskatelevize.cz/zive/ct26/",
-        "https://www.ceskatelevize.cz/zive/ct27/",
-        "https://www.ceskatelevize.cz/zive/ct28/",
-        "https://www.ceskatelevize.cz/zive/ct31/",
-        "https://www.ceskatelevize.cz/zive/ct32/",
-        "https://www.ceskatelevize.cz/zive/decko/",
-        "https://www.ceskatelevize.cz/zive/sport/",
+        "https://ceskatelevize.cz/zive/any",
+        "https://www.ceskatelevize.cz/zive/any",
+        "https://ct24.ceskatelevize.cz/",
+        "https://ct24.ceskatelevize.cz/any",
+        "https://decko.ceskatelevize.cz/",
+        "https://decko.ceskatelevize.cz/any",
+        "https://sport.ceskatelevize.cz/",
+        "https://sport.ceskatelevize.cz/any",
     ]
 
     should_not_match = [
-        "http://decko.ceskatelevize.cz/zive/",
-        "http://www.ceskatelevize.cz/art/zive/",
-        "http://www.ceskatelevize.cz/ct1/zive/",
-        "http://www.ceskatelevize.cz/ct2/zive/",
-        "http://www.ceskatelevize.cz/ct24/",
-        "http://www.ceskatelevize.cz/sport/zive-vysilani/",
+        "https://ceskatelevize.cz/",
+        "https://www.ceskatelevize.cz/zive/",
     ]


### PR DESCRIPTION
@duunsupen, could you check this is working for all channels by [sideloading](https://streamlink.github.io/cli/plugin-sideloading.html) the updated plugin, please?  I think it's probably working OK, but they seem to detect VPS based proxies, so I just get the short clip telling me the channel isn't available for all except CT24.

---

For some reason, the subdomains are both different to the main channels in terms of HTML and JSON data, and different to each other as well.  The API response is slightly different for `sport` too.  All a bit strange.

I didn't bother going through the process of finding the id for CT24, as it seems unlikely it'll change.

I notice that sometimes the streaming URL gets an empty response, but it seems intermittent.  I've seen that happen in the web browser too via the network tab on the dev console.

closes #5055
