### PR TITLE
logger: capture warnings

### DIFF
--- a/src/streamlink/exceptions.py
+++ b/src/streamlink/exceptions.py
@@ -42,6 +42,21 @@ class StreamError(StreamlinkError):
     """
 
 
+# https://stackoverflow.com/a/49797717
+class _StreamlinkWarningMeta(type):
+    def __new__(mcs, name, bases, namespace, **kw):
+        name = namespace.get("__name__", name)
+        return super().__new__(mcs, name, bases, namespace, **kw)
+
+
+class StreamlinkWarning(UserWarning, metaclass=_StreamlinkWarningMeta):
+    pass
+
+
+class StreamlinkDeprecationWarning(StreamlinkWarning):
+    __name__ = "StreamlinkDeprecation"
+
+
 __all__ = [
     "StreamlinkError",
     "PluginError",
@@ -49,4 +64,6 @@ __all__ = [
     "NoPluginError",
     "NoStreamsError",
     "StreamError",
+    "StreamlinkWarning",
+    "StreamlinkDeprecationWarning",
 ]

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -10,6 +10,8 @@ from typing import IO, Iterator, List, Optional, TYPE_CHECKING, Union
 # noinspection PyProtectedMember
 from warnings import WarningMessage
 
+from streamlink.exceptions import StreamlinkWarning
+
 
 if TYPE_CHECKING:  # pragma: no cover
     _BaseLoggerClass = logging.Logger
@@ -136,6 +138,8 @@ class WarningLogRecord(logging.LogRecord):
         self.lineno = self.msg.lineno
 
     def getMessage(self) -> str:
+        if self.msg.category and issubclass(self.msg.category, StreamlinkWarning):
+            return f"{self.msg.message}"
         return f"{self.msg.message}\n  {self.pathname}:{self.lineno}"
 
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -4,6 +4,7 @@ import logging
 import operator
 import re
 import time
+import warnings
 from functools import partial
 from http.cookiejar import Cookie
 from typing import (
@@ -261,7 +262,10 @@ class Plugin:
                 # Take any arguments, but only pass the URL to the custom constructor of the deprecated plugin
                 # noinspection PyArgumentList
                 super().__init__(url)
-                log.warning(f"Initialized {self.module} plugin with deprecated constructor")
+                warnings.warn(
+                    f"Initialized {self.module} plugin with deprecated constructor",
+                    FutureWarning,
+                )
 
         # Wrapper class which comes after the deprecated plugin in the MRO
         # noinspection PyAbstractClass

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -1,5 +1,6 @@
 import logging
 import pkgutil
+import warnings
 from functools import lru_cache
 from socket import AF_INET, AF_INET6
 from typing import Any, Callable, ClassVar, Dict, Iterator, Mapping, Optional, Tuple, Type
@@ -62,7 +63,10 @@ class StreamlinkOptions(Options):
 
     def _get_http_proxy(self, key):
         if key == "https-proxy":
-            log.warning("The `https-proxy` option has been deprecated in favor of a single `http-proxy` option")
+            warnings.warn(
+                "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option",
+                FutureWarning,
+            )
         return self.session.http.proxies.get("https" if key == "https-proxy" else "http")
 
     def _get_http_attr(self, key):
@@ -97,7 +101,10 @@ class StreamlinkOptions(Options):
             = self.session.http.proxies["https"] \
             = update_scheme("https://", value, force=False)
         if key == "https-proxy":
-            log.warning("The `https-proxy` option has been deprecated in favor of a single `http-proxy` option")
+            warnings.warn(
+                "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option",
+                FutureWarning,
+            )
 
     def _set_http_attr_key_equals_value(self, key, value):
         getattr(self.session.http, self._OPTIONS_HTTP_ATTRS[key]).update(
@@ -122,7 +129,10 @@ class StreamlinkOptions(Options):
     def _factory_set_deprecated(name: str, mapper: Callable[[Any], Any]) -> Callable[["StreamlinkOptions", str, Any], None]:
         def inner(self: "StreamlinkOptions", key: str, value: Any) -> None:
             self.set_explicit(name, mapper(value))
-            log.warning(f"`{key}` has been deprecated in favor of the `{name}` option")
+            warnings.warn(
+                f"`{key}` has been deprecated in favor of the `{name}` option",
+                FutureWarning,
+            )
 
         return inner
 
@@ -415,7 +425,10 @@ class Streamlink:
             elif hasattr(plugin, "can_handle_url") and callable(plugin.can_handle_url) and plugin.can_handle_url(url):
                 prio = plugin.priority(url) if hasattr(plugin, "priority") and callable(plugin.priority) else NORMAL_PRIORITY
                 if prio > priority:
-                    log.warning(f"Resolved plugin {name} with deprecated can_handle_url API")
+                    warnings.warn(
+                        f"Resolved plugin {name} with deprecated can_handle_url API",
+                        FutureWarning,
+                    )
                     candidate = name, plugin
                     priority = prio
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -11,7 +11,7 @@ import urllib3.util.connection as urllib3_util_connection
 import urllib3.util.ssl_ as urllib3_util_ssl
 
 from streamlink import __version__, plugins
-from streamlink.exceptions import NoPluginError, PluginError
+from streamlink.exceptions import NoPluginError, PluginError, StreamlinkDeprecationWarning
 from streamlink.logger import StreamlinkLogger
 from streamlink.options import Options
 from streamlink.plugin.api.http_session import HTTPSession
@@ -65,7 +65,7 @@ class StreamlinkOptions(Options):
         if key == "https-proxy":
             warnings.warn(
                 "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option",
-                FutureWarning,
+                StreamlinkDeprecationWarning,
             )
         return self.session.http.proxies.get("https" if key == "https-proxy" else "http")
 
@@ -103,7 +103,7 @@ class StreamlinkOptions(Options):
         if key == "https-proxy":
             warnings.warn(
                 "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option",
-                FutureWarning,
+                StreamlinkDeprecationWarning,
             )
 
     def _set_http_attr_key_equals_value(self, key, value):
@@ -131,7 +131,7 @@ class StreamlinkOptions(Options):
             self.set_explicit(name, mapper(value))
             warnings.warn(
                 f"`{key}` has been deprecated in favor of the `{name}` option",
-                FutureWarning,
+                StreamlinkDeprecationWarning,
             )
 
         return inner
@@ -427,7 +427,7 @@ class Streamlink:
                 if prio > priority:
                     warnings.warn(
                         f"Resolved plugin {name} with deprecated can_handle_url API",
-                        FutureWarning,
+                        StreamlinkDeprecationWarning,
                     )
                     candidate = name, plugin
                     priority = prio

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 import streamlink.logger as logger
 from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __version__ as streamlink_version
-from streamlink.exceptions import FatalPluginError
+from streamlink.exceptions import FatalPluginError, StreamlinkDeprecationWarning
 from streamlink.plugin import Plugin, PluginOptions
 from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
@@ -612,7 +612,7 @@ def load_plugins(dirs: List[Path], showwarning: bool = True):
             if success and type(directory) is DeprecatedPath:
                 warnings.warn(
                     f"Loaded plugins from deprecated path, see CLI docs for how to migrate: {directory}",
-                    FutureWarning,
+                    StreamlinkDeprecationWarning,
                 )
         elif showwarning:
             log.warning(f"Plugin path {directory} does not exist or is not a directory!")
@@ -660,7 +660,7 @@ def setup_config_args(parser, ignore_unknown=False):
             if type(config_file) is DeprecatedPath:
                 warnings.warn(
                     f"Loaded config from deprecated path, see CLI docs for how to migrate: {config_file}",
-                    FutureWarning,
+                    StreamlinkDeprecationWarning,
                 )
             config_files.append(config_file)
             break
@@ -676,7 +676,7 @@ def setup_config_args(parser, ignore_unknown=False):
                 if type(config_file) is DeprecatedPath:
                     warnings.warn(
                         f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {config_file}",
-                        FutureWarning,
+                        StreamlinkDeprecationWarning,
                     )
                 config_files.append(config_file)
                 break

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -845,6 +845,7 @@ def setup_logger_and_console(stream=sys.stdout, filename=None, level="info", jso
         style="{",
         format=f"{'[{asctime}]' if verbose else ''}[{{name}}][{{levelname}}] {{message}}",
         datefmt=f"%H:%M:%S{'.%f' if verbose else ''}",
+        capture_warnings=True,
     )
 
     console = ConsoleOutput(streamhandler.stream, json)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -5,6 +5,7 @@ import platform
 import re
 import signal
 import sys
+import warnings
 from contextlib import closing, suppress
 from gettext import gettext
 from pathlib import Path
@@ -609,7 +610,10 @@ def load_plugins(dirs: List[Path], showwarning: bool = True):
         if directory.is_dir():
             success = streamlink.load_plugins(str(directory))
             if success and type(directory) is DeprecatedPath:
-                log.warning(f"Loaded plugins from deprecated path, see CLI docs for how to migrate: {directory}")
+                warnings.warn(
+                    f"Loaded plugins from deprecated path, see CLI docs for how to migrate: {directory}",
+                    FutureWarning,
+                )
         elif showwarning:
             log.warning(f"Plugin path {directory} does not exist or is not a directory!")
 
@@ -643,7 +647,7 @@ def setup_config_args(parser, ignore_unknown=False):
     config_files = []
 
     if args.config:
-        # We want the config specified last to get highest priority
+        # We want the config specified last to get the highest priority
         config_files.extend(
             config_file
             for config_file in map(lambda path: Path(path).expanduser(), reversed(args.config))
@@ -652,9 +656,12 @@ def setup_config_args(parser, ignore_unknown=False):
 
     else:
         # Only load first available default config
-        for config_file in filter(lambda path: path.is_file(), CONFIG_FILES):
+        for config_file in filter(lambda path: path.is_file(), CONFIG_FILES):  # pragma: no branch
             if type(config_file) is DeprecatedPath:
-                log.warning(f"Loaded config from deprecated path, see CLI docs for how to migrate: {config_file}")
+                warnings.warn(
+                    f"Loaded config from deprecated path, see CLI docs for how to migrate: {config_file}",
+                    FutureWarning,
+                )
             config_files.append(config_file)
             break
 
@@ -662,12 +669,15 @@ def setup_config_args(parser, ignore_unknown=False):
         # Only load first available plugin config
         with suppress(NoPluginError):
             pluginname, pluginclass, resolved_url = streamlink.resolve_url(args.url)
-            for config_file in CONFIG_FILES:
+            for config_file in CONFIG_FILES:  # pragma: no branch
                 config_file = config_file.with_name(f"{config_file.name}.{pluginname}")
                 if not config_file.is_file():
                     continue
                 if type(config_file) is DeprecatedPath:
-                    log.warning(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {config_file}")
+                    warnings.warn(
+                        f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {config_file}",
+                        FutureWarning,
+                    )
                 config_files.append(config_file)
                 break
 

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -20,6 +20,7 @@ def session(monkeypatch: pytest.MonkeyPatch):
     yield Streamlink()
 
 
+@pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize("argv,option,expected", [
     pytest.param(
         ["--locale", "xx_XX"],
@@ -48,13 +49,13 @@ def session(monkeypatch: pytest.MonkeyPatch):
     pytest.param(
         ["--hls-timeout", "123"],
         "stream-timeout",
-        123,
+        123.0,
         id="Deprecated argument",
     ),
     pytest.param(
         ["--hls-timeout", "123", "--stream-timeout", "456"],
         "stream-timeout",
-        456,
+        456.0,
         id="Deprecated argument with override",
     ),
 ])

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -15,7 +15,7 @@ import tests.resources
 from streamlink.exceptions import PluginError, StreamError
 from streamlink.session import Streamlink
 from streamlink.stream.stream import Stream
-from streamlink_cli.compat import DeprecatedPath, stdout
+from streamlink_cli.compat import stdout
 from streamlink_cli.main import (
     Formatter,
     NoPluginError,
@@ -26,7 +26,6 @@ from streamlink_cli.main import (
     handle_url,
     output_stream,
     resolve_stream_name,
-    setup_config_args
 )
 from streamlink_cli.output import FileOutput, PlayerOutput
 from tests import posix_only, windows_only
@@ -504,90 +503,6 @@ class TestCLIMainOutputStream(unittest.TestCase):
             call("Could not open stream fake-stream, tried 2 times, exiting")
         ])
         self.assertFalse(output.open.called, "Does not open the output on stream error")
-
-
-@patch("streamlink_cli.main.log")
-class TestCLIMainSetupConfigArgs(unittest.TestCase):
-    configdir = Path(tests.resources.__path__[0], "cli", "config")
-    parser = Mock()
-
-    @classmethod
-    def subject(cls, config_files, **args):
-        def resolve_url(name):
-            if name == "noplugin":
-                raise NoPluginError()
-            return name, Mock(__module__="testplugin"), name
-
-        session = Mock()
-        session.resolve_url.side_effect = resolve_url
-        args.setdefault("url", "testplugin")
-
-        with patch("streamlink_cli.main.setup_args") as mock_setup_args, \
-             patch("streamlink_cli.main.args", **args), \
-             patch("streamlink_cli.main.streamlink", session), \
-             patch("streamlink_cli.main.CONFIG_FILES", config_files):
-            setup_config_args(cls.parser)
-            return mock_setup_args
-
-    def test_no_plugin(self, mock_log):
-        mock_setup_args = self.subject(
-            [self.configdir / "primary", DeprecatedPath(self.configdir / "secondary")],
-            config=None,
-            url="noplugin"
-        )
-        expected = [self.configdir / "primary"]
-        mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        assert not mock_log.warning.mock_calls
-
-    def test_default_primary(self, mock_log):
-        mock_setup_args = self.subject(
-            [self.configdir / "primary", DeprecatedPath(self.configdir / "secondary")],
-            config=None
-        )
-        expected = [self.configdir / "primary", self.configdir / "primary.testplugin"]
-        mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        assert not mock_log.warning.mock_calls
-
-    def test_default_secondary_deprecated(self, mock_log):
-        mock_setup_args = self.subject(
-            [self.configdir / "non-existent", DeprecatedPath(self.configdir / "secondary")],
-            config=None
-        )
-        expected = [self.configdir / "secondary", self.configdir / "secondary.testplugin"]
-        mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        assert mock_log.warning.mock_calls == [
-            call(f"Loaded config from deprecated path, see CLI docs for how to migrate: {expected[0]}"),
-            call(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {expected[1]}"),
-        ]
-
-    def test_custom_with_primary_plugin(self, mock_log):
-        mock_setup_args = self.subject(
-            [self.configdir / "primary", DeprecatedPath(self.configdir / "secondary")],
-            config=[str(self.configdir / "custom")]
-        )
-        expected = [self.configdir / "custom", self.configdir / "primary.testplugin"]
-        mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        assert not mock_log.warning.mock_calls
-
-    def test_custom_with_deprecated_plugin(self, mock_log):
-        mock_setup_args = self.subject(
-            [self.configdir / "non-existent", DeprecatedPath(self.configdir / "secondary")],
-            config=[str(self.configdir / "custom")]
-        )
-        expected = [self.configdir / "custom", DeprecatedPath(self.configdir / "secondary.testplugin")]
-        mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        assert mock_log.warning.mock_calls == [
-            call(f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {expected[1]}"),
-        ]
-
-    def test_custom_multiple(self, mock_log):
-        mock_setup_args = self.subject(
-            [self.configdir / "primary", DeprecatedPath(self.configdir / "secondary")],
-            config=[str(self.configdir / "non-existent"), str(self.configdir / "primary"), str(self.configdir / "secondary")]
-        )
-        expected = [self.configdir / "secondary", self.configdir / "primary", self.configdir / "primary.testplugin"]
-        mock_setup_args.assert_called_once_with(self.parser, expected, ignore_unknown=False)
-        assert not mock_log.warning.mock_calls
 
 
 class _TestCLIMainLogging(unittest.TestCase):

--- a/tests/cli/test_main_setup_config_args.py
+++ b/tests/cli/test_main_setup_config_args.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call, patch
 import pytest
 
 import tests.resources
-from streamlink.exceptions import NoPluginError
+from streamlink.exceptions import NoPluginError, StreamlinkDeprecationWarning
 from streamlink_cli.compat import DeprecatedPath
 from streamlink_cli.main import setup_config_args
 
@@ -135,12 +135,12 @@ def session():
         ],
         [
             (
-                FutureWarning,
+                StreamlinkDeprecationWarning,
                 "Loaded config from deprecated path, see CLI docs for how to migrate: "
                 + f"{configdir / 'secondary'}",
             ),
             (
-                FutureWarning,
+                StreamlinkDeprecationWarning,
                 "Loaded plugin config from deprecated path, see CLI docs for how to migrate: "
                 + f"{configdir / 'secondary.testplugin'}",
             ),
@@ -182,7 +182,7 @@ def session():
         ],
         [
             (
-                FutureWarning,
+                StreamlinkDeprecationWarning,
                 "Loaded plugin config from deprecated path, see CLI docs for how to migrate: "
                 + f"{configdir / 'secondary.testplugin'}",
             ),

--- a/tests/cli/test_main_setup_config_args.py
+++ b/tests/cli/test_main_setup_config_args.py
@@ -1,0 +1,227 @@
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+import tests.resources
+from streamlink.exceptions import NoPluginError
+from streamlink_cli.compat import DeprecatedPath
+from streamlink_cli.main import setup_config_args
+
+
+configdir = Path(tests.resources.__path__[0], "cli", "config")
+
+
+@pytest.fixture
+def args(request: pytest.FixtureRequest):
+    with patch("streamlink_cli.main.args", Namespace(**getattr(request, "param", {}))):
+        yield
+
+
+@pytest.fixture
+def config_files(request: pytest.FixtureRequest):
+    with patch("streamlink_cli.main.CONFIG_FILES", getattr(request, "param", [])):
+        yield
+
+
+@pytest.fixture
+def setup_args():
+    with patch("streamlink_cli.main.setup_args") as mock_setup_args:
+        yield mock_setup_args
+
+
+@pytest.fixture(autouse=True)
+def session():
+    def resolve_url(name):
+        if name == "noplugin":
+            raise NoPluginError()
+        return name, Mock(__module__=name), name
+
+    with patch("streamlink_cli.main.streamlink") as mock_session:
+        mock_session.resolve_url.side_effect = resolve_url
+        yield
+
+
+@pytest.mark.parametrize("args,config_files,expected,deprecations", [
+    pytest.param(
+        {
+            "config": None,
+            "url": None,
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "primary",
+        ],
+        [],
+        id="No URL, default config",
+    ),
+    pytest.param(
+        {
+            "config": [
+                str(configdir / "non-existent"),
+            ],
+            "url": None,
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [],
+        [],
+        id="No URL, non-existent custom config",
+    ),
+    pytest.param(
+        {
+            "config": None,
+            "url": "noplugin",
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "primary",
+        ],
+        [],
+        id="No plugin, default config",
+    ),
+    pytest.param(
+        {
+            "config": [
+                str(configdir / "non-existent"),
+            ],
+            "url": "noplugin",
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [],
+        [],
+        id="No plugin, non-existent custom config",
+    ),
+    pytest.param(
+        {
+            "config": None,
+            "url": "testplugin",
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "primary",
+            configdir / "primary.testplugin",
+        ],
+        [],
+        id="Default primary config",
+    ),
+    pytest.param(
+        {
+            "config": None,
+            "url": "testplugin",
+        },
+        [
+            configdir / "non-existent",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "secondary",
+            configdir / "secondary.testplugin",
+        ],
+        [
+            (
+                FutureWarning,
+                "Loaded config from deprecated path, see CLI docs for how to migrate: "
+                + f"{configdir / 'secondary'}",
+            ),
+            (
+                FutureWarning,
+                "Loaded plugin config from deprecated path, see CLI docs for how to migrate: "
+                + f"{configdir / 'secondary.testplugin'}",
+            ),
+        ],
+        id="Default secondary config",
+    ),
+    pytest.param(
+        {
+            "config": [
+                str(configdir / "custom"),
+            ],
+            "url": "testplugin",
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "custom",
+            configdir / "primary.testplugin",
+        ],
+        [],
+        id="Custom config with primary plugin",
+    ),
+    pytest.param(
+        {
+            "config": [
+                str(configdir / "custom"),
+            ],
+            "url": "testplugin",
+        },
+        [
+            configdir / "non-existent",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "custom",
+            DeprecatedPath(configdir / "secondary.testplugin"),
+        ],
+        [
+            (
+                FutureWarning,
+                "Loaded plugin config from deprecated path, see CLI docs for how to migrate: "
+                + f"{configdir / 'secondary.testplugin'}",
+            ),
+        ],
+        id="Custom config with deprecated plugin",
+    ),
+    pytest.param(
+        {
+            "config": [
+                str(configdir / "non-existent"),
+                str(configdir / "primary"),
+                str(configdir / "secondary"),
+            ],
+            "url": "testplugin",
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [
+            configdir / "secondary",
+            configdir / "primary",
+            configdir / "primary.testplugin",
+        ],
+        [],
+        id="Multiple custom configs",
+    ),
+], indirect=["args", "config_files"])
+def test_setup_config_args(
+    recwarn: pytest.WarningsRecorder,
+    args: Namespace,
+    config_files: list,
+    setup_args: Mock,
+    expected: list,
+    deprecations: list,
+):
+    parser = Mock()
+    setup_config_args(parser)
+    assert setup_args.call_args_list == ([call(parser, expected, ignore_unknown=False)] if expected else []), \
+        "Calls setup_args with the correct list of config files"
+    assert [(record.category, str(record.message)) for record in recwarn.list] == deprecations, \
+        "Raises the correct deprecation warnings"

--- a/tests/stream/test_hls_filtered.py
+++ b/tests/stream/test_hls_filtered.py
@@ -35,7 +35,6 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
     def get_session(self, options=None, *args, **kwargs):
         session = super().get_session(options)
         session.set_option("hls-live-edge", 2)
-        session.set_option("hls-timeout", 0)
         session.set_option("stream-timeout", 0)
 
         return session

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,7 +77,8 @@ class TestPlugin:
 
         assert mock_load_cookies.call_args_list == [call()]
 
-    def test_constructor_wrapper(self, caplog: pytest.LogCaptureFixture):
+    @pytest.mark.filterwarnings("always")
+    def test_constructor_wrapper(self, recwarn: pytest.WarningsRecorder):
         session = Mock()
         with patch("streamlink.plugin.plugin.Cache") as mock_cache, \
              patch.object(DeprecatedPlugin, "load_cookies") as mock_load_cookies:
@@ -85,8 +86,8 @@ class TestPlugin:
 
         assert isinstance(plugin, DeprecatedPlugin)
         assert plugin.custom_attribute == "HTTP://LOCALHOST"
-        assert [(record.levelname, record.message) for record in caplog.records] == [
-            ("warning", "Initialized test_plugin plugin with deprecated constructor"),
+        assert [(record.category, str(record.message)) for record in recwarn.list] == [
+            (FutureWarning, "Initialized test_plugin plugin with deprecated constructor"),
         ]
 
         assert plugin.session is session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,5 +1,6 @@
 import re
 import unittest
+import warnings
 from pathlib import Path
 from socket import AF_INET, AF_INET6
 from unittest.mock import Mock, call, patch
@@ -34,6 +35,7 @@ class EmptyPlugin(Plugin):
         pass  # pragma: no cover
 
 
+# TODO: rewrite using pytest
 class TestSession(unittest.TestCase):
     mocker: requests_mock.Mocker
 
@@ -100,14 +102,15 @@ class TestSession(unittest.TestCase):
         session = self.subject()
         plugins = session.get_plugins()
 
-        with patch("streamlink.session.log") as mock_log:
+        with warnings.catch_warnings(record=True) as record_warnings:
+            warnings.filterwarnings("always")
             pluginname, pluginclass, resolved_url = session.resolve_url("http://test.se/channel")
 
         assert issubclass(pluginclass, Plugin)
         assert pluginclass is plugins["testplugin"]
         assert resolved_url == "http://test.se/channel"
         assert hasattr(session.resolve_url, "cache_info"), "resolve_url has a lookup cache"
-        assert not mock_log.warning.call_args_list
+        assert record_warnings == []
 
     def test_resolve_url__noplugin(self):
         session = self.subject()
@@ -247,13 +250,13 @@ class TestSession(unittest.TestCase):
             "dep-high": DeprecatedHighPriority,
         }
 
-        with patch("streamlink.session.log") as mock_log:
+        with pytest.warns() as recwarn:
             plugin = session.resolve_url_no_redirect("low")[1]
 
         assert plugin is DeprecatedHighPriority
-        assert mock_log.warning.call_args_list == [
-            call("Resolved plugin dep-normal-one with deprecated can_handle_url API"),
-            call("Resolved plugin dep-high with deprecated can_handle_url API"),
+        assert [(record.category, str(record.message)) for record in recwarn.list] == [
+            (FutureWarning, "Resolved plugin dep-normal-one with deprecated can_handle_url API"),
+            (FutureWarning, "Resolved plugin dep-high with deprecated can_handle_url API"),
         ]
 
     def test_options(self):
@@ -414,17 +417,18 @@ class TestSession(unittest.TestCase):
         assert mock_urllib3_util_ssl.DEFAULT_CIPHERS == "foo:!bar:baz"
 
 
+@pytest.mark.filterwarnings("always")
 class TestSessionOptionHttpProxy:
     @pytest.fixture
-    def no_deprecation(self, caplog: pytest.LogCaptureFixture):
+    def no_deprecation(self, recwarn: pytest.WarningsRecorder):
         yield
-        assert not caplog.get_records("call")
+        assert recwarn.list == []
 
     @pytest.fixture
-    def logs_deprecation(self, caplog: pytest.LogCaptureFixture):
+    def logs_deprecation(self, recwarn: pytest.WarningsRecorder):
         yield
-        assert [(record.levelname, record.message) for record in caplog.get_records("call")] == [
-            ("warning", "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option"),
+        assert [(record.category, str(record.message)) for record in recwarn.list] == [
+            (FutureWarning, "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option"),
         ]
 
     def test_https_proxy_default(self, session: Streamlink, no_deprecation):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ import urllib3
 
 import tests.plugin
 from streamlink import NoPluginError, Streamlink
+from streamlink.exceptions import StreamlinkDeprecationWarning
 from streamlink.plugin import HIGH_PRIORITY, LOW_PRIORITY, NORMAL_PRIORITY, NO_PRIORITY, Plugin, pluginmatcher
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
@@ -255,8 +256,8 @@ class TestSession(unittest.TestCase):
 
         assert plugin is DeprecatedHighPriority
         assert [(record.category, str(record.message)) for record in recwarn.list] == [
-            (FutureWarning, "Resolved plugin dep-normal-one with deprecated can_handle_url API"),
-            (FutureWarning, "Resolved plugin dep-high with deprecated can_handle_url API"),
+            (StreamlinkDeprecationWarning, "Resolved plugin dep-normal-one with deprecated can_handle_url API"),
+            (StreamlinkDeprecationWarning, "Resolved plugin dep-high with deprecated can_handle_url API"),
         ]
 
     def test_options(self):
@@ -428,7 +429,10 @@ class TestSessionOptionHttpProxy:
     def logs_deprecation(self, recwarn: pytest.WarningsRecorder):
         yield
         assert [(record.category, str(record.message)) for record in recwarn.list] == [
-            (FutureWarning, "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option"),
+            (
+                StreamlinkDeprecationWarning,
+                "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option",
+            ),
         ]
 
     def test_https_proxy_default(self, session: Streamlink, no_deprecation):


### PR DESCRIPTION
See #4785

This makes Streamlink's root logger capture warnings (disabled by default, enabled via streamlink_cli) and it replaces various warning log messages for deprecated (user-facing) stuff with `FutureWarning`s.
https://docs.python.org/3/library/exceptions.html#warnings
https://docs.python.org/3/library/warnings.html#warning-categories

The reason for this is that this allows for finer control over the kind of deprecation messages (API stuff for devs, or other stuff for end-users) and it uses the standard interfaces for warnings, which is preferred. Warnings from dependencies can also be caught this way, but I'm not sure how useful this is, because I modified the default warning message format, so it doesn't include the file+line of the warning, because it's not useful for Streamlink's deprecation messages (`FutureWarning`). This can be changed later on if it causes problems. I only realized this while writing this PR text.

----

Warnings can always be filtered via Python's `-W` parameter (in addition to the regular log level of Streamlink's root logger):
https://docs.python.org/3/library/warnings.html#describing-warning-filters

```
$ python -m streamlink --https-proxy ...
[warnings][futurewarning] The https-proxy option has been deprecated in favor of a single http-proxy option
usage: streamlink [OPTIONS] <URL> [STREAM]

$ python -W ignore -m streamlink --https-proxy socks5h://localhost:1920
usage: streamlink [OPTIONS] <URL> [STREAM]

$ python -W ignore::FutureWarning -m streamlink --https-proxy socks5h://localhost:1920
usage: streamlink [OPTIONS] <URL> [STREAM]
```

----

The changes of the logger's warning messages are this, when printed from a caught warning, not from regular `warning()` calls:

```
[streamlink][warning] The https-proxy option has been deprecated in favor of a single http-proxy option
-->
[warnings][futurewarning] The https-proxy option has been deprecated in favor of a single http-proxy option
```

So instead of the logger name and the "warning" log level, it logs "warnings" as logger name and uses the name of the warning as log level name.

----

As a next step, dedicated warning subclasses could be added for reusable code and better deprecation messages with links to the docs, and with better warning names, etc.

----

Opening as a draft for now...