### PR TITLE
session: refactor option getter+setter methods

### DIFF
--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -424,7 +424,7 @@ class TestSessionOptionHttpProxy:
     def logs_deprecation(self, caplog: pytest.LogCaptureFixture):
         yield
         assert [(record.levelname, record.message) for record in caplog.get_records("call")] == [
-            ("warning", "The https-proxy option has been deprecated in favor of a single http-proxy option"),
+            ("warning", "The `https-proxy` option has been deprecated in favor of a single `http-proxy` option"),
         ]
 
     def test_https_proxy_default(self, session: Streamlink, no_deprecation):
@@ -464,6 +464,16 @@ class TestSessionOptionHttpProxy:
 
         assert session.http.proxies["http"] == "socks5://localhost:1234"
         assert session.http.proxies["https"] == "socks5://localhost:1234"
+
+    def test_get_http_proxy(self, session: Streamlink, no_deprecation):
+        session.http.proxies["http"] = "http://testproxy1.com"
+        session.http.proxies["https"] = "http://testproxy2.com"
+        assert session.get_option("http-proxy") == "http://testproxy1.com"
+
+    def test_get_https_proxy(self, session: Streamlink, logs_deprecation):
+        session.http.proxies["http"] = "http://testproxy1.com"
+        session.http.proxies["https"] = "http://testproxy2.com"
+        assert session.get_option("https-proxy") == "http://testproxy2.com"
 
 
 @pytest.mark.parametrize("option", [


### PR DESCRIPTION
This replaces the logic of the `Streamlink.{get,set}_option()` methods with a new `StreamlinkOptions` subclass which uses mapped option getters+setters that apply the custom option logic instead.

The motivation for this is that this improves the runtime of said methods, as option mappers are looked up in Python dictionaries in constant time, so option names don't have to be checked one after another. The old implementation is also really really bad code-wise and not extensible.

In order to do this, the `Options` class had to be refactored a bit and extended:
1. Previously, the internally stored option keys were normalized with argument names of the `argparse.Namespace` in mind, so dashes were replaced with underscores. Since Streamlink's session options are defined using dashes, I changed the normalization the other way around, to make it consistent. For various plugin options, this doesn't have any effect (e.g. see various "purge_credentials" options). This is all properly tested and no further changes are required.
2. The second commit adds support for mapped getter and setter functions, so that keys can be looked up in O(1). This is why the change of key-name normalization was necessary, to be able to define getters and setters in a normalized way that's consistent with the default options of the Streamlink session.

The third commit then finally cleans up the Streamlink session and moves the special option logic into the newly added `StreamlinkOptions` subclass, and it also adds new deprecation messages (see commit message). The individual getters and setters were not modified except for
- `http-disable-dh`, which now has a proper getter
- `https-proxy`, which now shows a deprecation message on its getter (still returns the "https" proxy, even though both "http" and "https" get set by the setter, because the proxies can also be defined by requests via env vars)

I only added new tests for the mapped options implementation and `http{,s}-proxy` getter. Some of the Streamlink session options are not actually tested, e.g. some HTTP session attributes, but all the getters and setters should be covered, and adding tests for simple setattr/getattr calls isn't too important. Current code coverage (can't permalink with commit-id, so this will change):
https://app.codecov.io/gh/streamlink/streamlink/blob/master/src/streamlink/session.py

----

If this PR gets merged, then this will cause merge conflicts with two of my other open (draft) PRs and those will need a quick update:
- #5072 (deprecation messages)
- #5033 (`Argument.is_global` removal and `Streamlink.{get,set}_plugin_option()` removal)