### PR TITLE
build: update build script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           ./script/install-dependencies.sh
           python -m pip install -r docs-requirements.txt
-          python -m pip install --upgrade Jinja2 wheel twine
+          python -m pip install --upgrade Jinja2 build wheel twine
       - name: Build shell completions
         run: ./script/build-shell-completions.sh
       - name: Build man page


### PR DESCRIPTION
Use `build` to build sdist and wheels instead of calling setuptools directly, which is deprecated.

See
https://github.com/pypa/build

----

I've checked the sdist tarball and the built wheels, and everything looked okay to me. The win32 and win-amd64 wheels also have the correct GUI entry scripts (streamlink**w**).