### PR TITLE
build: update auth in sign+deploy scripts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,6 +147,6 @@ jobs:
         run: ./script/github-release.py "${STREAMLINK_DIST_DIR}"/*.tar.gz{,.asc}
       - name: PyPI release
         env:
-          PYPI_USER: streamlink
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: ./script/deploy-pypi.sh

--- a/script/build-and-sign.sh
+++ b/script/build-and-sign.sh
@@ -35,9 +35,10 @@ done
 if [[ "${CI}" = true ]] || [[ -n "${GITHUB_ACTIONS}" ]]; then
     echo >&2 "build: Decrypting signing key"
     gpg --quiet --batch --yes --decrypt \
-        --passphrase="${RELEASE_KEY_PASSPHRASE}" \
+        --passphrase-fd 0 \
         --output "${KEY_FILE}" \
-        "${KEY_FILE_ENC}"
+        "${KEY_FILE_ENC}" \
+        <<< "${RELEASE_KEY_PASSPHRASE}"
 fi
 
 if ! [[ -f "${KEY_FILE}" ]]; then

--- a/script/deploy-pypi.sh
+++ b/script/deploy-pypi.sh
@@ -8,25 +8,22 @@ dist_dir=${STREAMLINK_DIST_DIR:-dist}
 
 
 if [[ "${1}" = "-n" ]] || [[ "${1}" = "--dry-run" ]]; then
-    echo "deploy: dry-run (${version})" >&2
+    echo >&2 "deploy: dry-run (${version})"
     for file in "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}; do
-        echo "${file}" >&2
+        echo >&2 "${file}"
     done
 
 else
     if ! python -m pip -q show twine; then
-        echo "deploy: missing dependency 'twine'" >&2
+        echo >&2 "deploy: missing dependency 'twine'"
         exit 1
     fi
 
-    if [[ -z "${PYPI_USER}" ]] || [[ -z "${PYPI_PASSWORD}" ]]; then
-        echo "deploy: missing PYPI_USER or PYPI_PASSWORD env var" >&2
+    if [[ -z "${TWINE_USERNAME}" ]] || [[ -z "${TWINE_PASSWORD}" ]]; then
+        echo >&2 "deploy: missing TWINE_USERNAME or TWINE_PASSWORD env var"
         exit 1
     fi
 
-    echo "deploy: Uploading files to PyPI (${version})" >&2
-    twine upload \
-        --username "${PYPI_USER}" \
-        --password "${PYPI_PASSWORD}" \
-        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
+    echo >&2 "deploy: Uploading files to PyPI (${version})"
+    twine upload "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
 fi


### PR DESCRIPTION
Follow-up of #5077 

----

As said, I don't have the password for the signing key, so I can't actually test the changes to the gpg decryption command. That's just a trivial change though, and it reads the passphrase from stdin now, which is the preferred way. Just take a look at the manual.
https://man.archlinux.org/man/gpg.1#passphrase-fd

I've messaged @beardypig and asked him to post the password to the protonmail account, as a backup.

----

The second change is in regards to the PyPI deploy script.

The current authentication method when uploading release files to PyPI is password based. This will change it to a token-based authentication, with different env vars. I will add those to the secret env vars after this has been merged. The token has been sent to the protonmail mailbox.
https://twine.readthedocs.io/en/latest/index.html#configuration

I've also removed inactive collaborators from the PyPI package and made 2FA a requirement. Since the streamlink account doesn't have 2FA enabled, this account is now unable to make modifications to the package. This shouldn't affect the upload token, I hope.
https://pypi.org/help/#apitoken

There's a slight chance that these changes will cause issues with the next release, so we'll have to see.