### PR TITLE
exceptions: update docs, fix NoPluginError and remove url arg from NoStreamsError

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -87,9 +87,11 @@ DASHStream
 Exceptions
 ----------
 
-Streamlink has three types of exceptions:
+Streamlink has multiple types of exceptions:
 
-.. autoexception:: streamlink.StreamlinkError
-.. autoexception:: streamlink.PluginError
-.. autoexception:: streamlink.NoPluginError
-.. autoexception:: streamlink.StreamError
+.. autoexception:: streamlink.exceptions.StreamlinkError
+.. autoexception:: streamlink.exceptions.PluginError
+.. autoexception:: streamlink.exceptions.FatalPluginError
+.. autoexception:: streamlink.exceptions.NoPluginError
+.. autoexception:: streamlink.exceptions.NoStreamsError
+.. autoexception:: streamlink.exceptions.StreamError

--- a/src/streamlink/exceptions.py
+++ b/src/streamlink/exceptions.py
@@ -35,10 +35,6 @@ class NoStreamsError(StreamlinkError):
     when returning ``None`` or an empty ``dict`` is not possible, e.g. in nested function calls.
     """
 
-    def __init__(self, url):
-        self.url = url
-        super().__init__(f"No streams found on this URL: {url}")
-
 
 class StreamError(StreamlinkError):
     """

--- a/src/streamlink/exceptions.py
+++ b/src/streamlink/exceptions.py
@@ -1,36 +1,56 @@
 class StreamlinkError(Exception):
-    """Any error caused by Streamlink will be caught
-       with this exception."""
+    """
+    Any error caused by Streamlink will be caught with this exception.
+    """
 
 
+# TODO: don't use PluginError for failed HTTP requests or validation schema failures
 class PluginError(StreamlinkError):
-    """Plugin related error."""
+    """
+    Plugin related error.
+    """
 
 
 class FatalPluginError(PluginError):
     """
-    Plugin related error that cannot be recovered from
+    Plugin related error that cannot be recovered from.
 
-    Plugin's should use this Exception when errors that can
+    Plugins should use this ``Exception`` when errors that can
     never be recovered from are encountered. For example, when
-    a user's input is required an none can be given.
+    a user's input is required and none can be given.
+    """
+
+
+class NoPluginError(StreamlinkError):
+    """
+    Error raised by :py:meth:`Streamlink.resolve_url() <streamlink.Streamlink.resolve_url()>`
+    and :py:meth:`Streamlink.resolve_url_no_redirect() <streamlink.Streamlink.resolve_url_no_redirect()>`
+    when no plugin could be found for the given input URL.
     """
 
 
 class NoStreamsError(StreamlinkError):
+    """
+    Plugins should use this ``Exception`` in :py:meth:`Plugin._get_streams() <streamlink.plugin.Plugin._get_streams()>`
+    when returning ``None`` or an empty ``dict`` is not possible, e.g. in nested function calls.
+    """
+
     def __init__(self, url):
         self.url = url
-        err = "No streams found on this URL: {0}".format(url)
-        Exception.__init__(self, err)
-
-
-class NoPluginError(PluginError):
-    """No relevant plugin has been loaded."""
+        super().__init__(f"No streams found on this URL: {url}")
 
 
 class StreamError(StreamlinkError):
-    """Stream related error."""
+    """
+    Stream related error.
+    """
 
 
-__all__ = ["StreamlinkError", "PluginError", "NoPluginError",
-           "NoStreamsError", "StreamError"]
+__all__ = [
+    "StreamlinkError",
+    "PluginError",
+    "FatalPluginError",
+    "NoPluginError",
+    "NoStreamsError",
+    "StreamError",
+]

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -234,7 +234,7 @@ class AbemaTV(Plugin):
                 if onair == channel["id"]:
                     break
             else:
-                raise NoStreamsError(self.url)
+                raise NoStreamsError
             playlisturl = channel["playback"]["hls"]
         elif matchresult.group("episode"):
             episode = matchresult.group("episode")

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -76,7 +76,7 @@ class OnePlusOneAPI:
             ),
         )
         if not url_parts:
-            raise NoStreamsError("Missing url_parts")
+            raise NoStreamsError
 
         log.trace(f"url_parts={url_parts}")
         self.session.http.headers.update({"Referer": self.url})

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -111,7 +111,7 @@ class Pixiv(Plugin):
             if item["owner"]["user"]["unique_name"] == self.match.group("user"):
                 return item
 
-        raise NoStreamsError(self.url)
+        raise NoStreamsError
 
     def _get_streams(self):
         login_session_id = self.get_option("sessionid")

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -637,7 +637,7 @@ class Twitch(Plugin):
                 raise PluginError
             sig, token = data
         except (PluginError, TypeError):
-            raise NoStreamsError(self.url)
+            raise NoStreamsError
 
         try:
             restricted_bitrates = self.api.parse_token(token)

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -71,7 +71,7 @@ class VK(Plugin):
         if self._has_video_id():
             return
 
-        raise NoStreamsError(self.url)
+        raise NoStreamsError
 
     def _get_streams(self):
         self._get_cookies()

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -51,7 +51,7 @@ class TestPlugin(Plugin):
             return gen()
 
         if "NoStreamsError" in self.url:
-            raise NoStreamsError(self.url)
+            raise NoStreamsError
 
         streams = {}
         streams["test"] = TestStream(self.session)

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -530,9 +530,8 @@ class TestTwitchAPIAccessToken:
         ),
     ], indirect=True)
     def test_auth_failure(self, caplog: pytest.LogCaptureFixture, plugin: Twitch, mock: requests_mock.Mocker, assert_live):
-        with pytest.raises(NoStreamsError) as cm:
+        with pytest.raises(NoStreamsError):
             plugin._access_token(True, "channelname")
-        assert str(cm.value) == "No streams found on this URL: https://twitch.tv/channelname"
         assert mock.last_request._request.headers["Authorization"] == "OAuth invalid-token"  # type: ignore[union-attr]
         assert [(record.levelname, record.module, record.message) for record in caplog.records] == [
             ("error", "twitch", "Unauthorized: The \"Authorization\" token is invalid."),

--- a/tests/plugins/test_vk.py
+++ b/tests/plugins/test_vk.py
@@ -29,44 +29,49 @@ class TestPluginCanHandleUrlVK(PluginCanHandleUrl):
     ]
 
 
-@pytest.mark.parametrize("url,newurl,raises", [
+@pytest.mark.parametrize("url,newurl", [
     # canonical video URL
-    ("https://vk.com/video-24136539_456241176",
-     "https://vk.com/video-24136539_456241176",
-     False),
+    pytest.param(
+        "https://vk.com/video-24136539_456241176",
+        "https://vk.com/video-24136539_456241176",
+    ),
 
     # video ID from URL
-    ("https://vk.com/videos-24136539?z=video-24136539_456241181%2Fpl_-24136539_-2",
-     "https://vk.com/video-24136539_456241181",
-     False),
-    ("https://vk.com/videos132886594?z=video132886594_167211693",
-     "https://vk.com/video132886594_167211693",
-     False),
-    ("https://vk.com/search?c%5Bq%5D=dota&c%5Bsection%5D=auto&z=video295508334_171402661",
-     "https://vk.com/video295508334_171402661",
-     False),
+    pytest.param(
+        "https://vk.com/videos-24136539?z=video-24136539_456241181%2Fpl_-24136539_-2",
+        "https://vk.com/video-24136539_456241181",
+    ),
+    pytest.param(
+        "https://vk.com/videos132886594?z=video132886594_167211693",
+        "https://vk.com/video132886594_167211693",
+    ),
+    pytest.param(
+        "https://vk.com/search?c%5Bq%5D=dota&c%5Bsection%5D=auto&z=video295508334_171402661",
+        "https://vk.com/video295508334_171402661",
+    ),
 
     # video ID from HTTP request
-    ("https://vk.com/dota2?w=wall-126093223_1057924",
-     "https://vk.com/video-126093223_1057924",
-     False),
+    pytest.param(
+        "https://vk.com/dota2?w=wall-126093223_1057924",
+        "https://vk.com/video-126093223_1057924",
+    ),
 
     # no video ID
-    ("https://vk.com/videos-0123456789?z=",
-     "",
-     True),
-    ("https://vk.com/video/for_kids?z=video%2Fpl_-22277933_51053000",
-     "",
-     True),
+    pytest.param(
+        "https://vk.com/videos-0123456789?z=",
+        "",
+        marks=pytest.mark.xfail(raises=NoStreamsError),
+    ),
+    pytest.param(
+        "https://vk.com/video/for_kids?z=video%2Fpl_-22277933_51053000",
+        "",
+        marks=pytest.mark.xfail(raises=NoStreamsError),
+    ),
 ])
-def test_url_redirect(url, newurl, raises, requests_mock):
+def test_url_redirect(url: str, newurl: str, requests_mock):
     session = Streamlink()
-    plugin = VK(session, url)
+    plugin: VK = VK(session, url)
     requests_mock.register_uri(rm.ANY, rm.ANY, exc=rm.exceptions.InvalidRequest)
     requests_mock.get(url, text=f"""<!DOCTYPE html><html><head><meta property="og:url" content="{newurl}"/></head></html>""")
-    try:
-        plugin.follow_vk_redirect()
-        assert not raises
-        assert plugin.url == newurl
-    except NoStreamsError:
-        assert raises
+    plugin.follow_vk_redirect()
+    assert plugin.url == newurl


### PR DESCRIPTION
- Make `NoPluginError` inherit from `StreamlinkError` instead of `PluginError`
- Update and fix docstrings of all Streamlink exception classes
- Update list of exceptions in API docs
- Fix exports

----

`NoPluginError` is only raised [here](https://github.com/streamlink/streamlink/blob/ae7583473626a09f870fbdb71e4a988a83664ea6/src/streamlink/session.py#L439) and caught in the main CLI module where URLs get resolved. It shouldn't inherit from `PluginError`, because it's something entirely different.