### PR TITLE
plugin.api.validate: deprecate text alias

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,16 @@
 Deprecations
 ============
 
+streamlink 5.2.0
+----------------
+
+Deprecation of plugin.api.validate.text
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``plugin.api.validate.text`` alias for ``str`` has been marked as deprecated, as it is a remnant of the py2 implementation.
+Simply replace ``validate.text`` with ``str`` in each validation schema.
+
+
 streamlink 5.0.0
 ----------------
 

--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 # noinspection PyPep8Naming,PyShadowingBuiltins
 from streamlink.plugin.api.validate._schemas import (  # noqa: I101, F401
     SchemaContainer,
@@ -41,4 +43,37 @@ from streamlink.plugin.api.validate._validators import (  # noqa: I101, F401
 )
 
 
-text = str
+if TYPE_CHECKING:
+    from typing import Type
+
+    text: Type[str]
+
+
+def _deprecations():
+    import sys
+
+    deprecations = {
+        "text": (str, f"`{__name__}.text` is deprecated. Use `str` instead."),
+    }
+
+    def __getattr__(_attr: str):
+        if _attr in deprecations:
+            import warnings
+            from streamlink.exceptions import StreamlinkDeprecationWarning
+
+            val, msg = deprecations[_attr]
+            warnings.warn(msg, StreamlinkDeprecationWarning)
+
+            return val
+
+        raise AttributeError
+
+    __all__ = [k for k in globals().keys() if not k.startswith("_")]
+    __all__.extend(deprecations.keys())
+
+    setattr(sys.modules[__name__], "__getattr__", __getattr__)
+    setattr(sys.modules[__name__], "__all__", __all__)
+
+
+_deprecations()
+del _deprecations

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -54,10 +54,9 @@ class AbemaTVLicenseAdapter(BaseAdapter):
 
     _LICENSE_API = "https://license.abema.io/abematv-hls"
 
-    _MEDIATOKEN_SCHEMA = validate.Schema({"token": validate.text})
+    _MEDIATOKEN_SCHEMA = validate.Schema({"token": str})
 
-    _LICENSE_SCHEMA = validate.Schema({"k": validate.text,
-                                       "cid": validate.text})
+    _LICENSE_SCHEMA = validate.Schema({"k": str, "cid": str})
 
     def __init__(self, session, deviceid, usertoken):
         self._session = session
@@ -145,14 +144,18 @@ class AbemaTV(Plugin):
                  b"Rbp5KwY4hEmcj5#fykMjJ=AuWz5GSMY-d@H7DMEh3M@9n2G552Us$$"
                  b"k9cD=3TxwWe86!x#Zyhe")
 
-    _USER_SCHEMA = validate.Schema({"profile": {"userId": validate.text},
-                                    "token": validate.text})
+    _USER_SCHEMA = validate.Schema({"profile": {"userId": str}, "token": str})
 
-    _CHANNEL_SCHEMA = validate.Schema({"channels": [{"id": validate.text,
-                                      "name": validate.text,
-                                       "playback": {validate.optional("dash"):
-                                                    validate.text,
-                                                    "hls": validate.text}}]})
+    _CHANNEL_SCHEMA = validate.Schema({
+        "channels": [{
+            "id": str,
+            "name": str,
+            "playback": {
+                validate.optional("dash"): str,
+                "hls": str,
+            },
+        }],
+    })
 
     _PRGM_SCHEMA = validate.Schema({"terms": [{validate.optional("onDemandType"): int}]})
 

--- a/src/streamlink/plugins/adultswim.py
+++ b/src/streamlink/plugins/adultswim.py
@@ -45,7 +45,7 @@ class AdultSwim(Plugin):
     _api_schema = validate.Schema({
         'media': {
             'desktop': {
-                validate.text: {
+                str: {
                     'url': validate.url()
                 }
             }
@@ -57,8 +57,8 @@ class AdultSwim(Plugin):
 
     _stream_data_schema = validate.Schema({
         'props': {'__REDUX_STATE__': {'streams': [{
-            'id': validate.text,
-            'stream': validate.text,
+            'id': str,
+            'stream': str,
         }]}}},
         validate.get('props'),
         validate.get('__REDUX_STATE__'),
@@ -67,17 +67,17 @@ class AdultSwim(Plugin):
 
     _token_schema = validate.Schema(
         validate.any(
-            {'auth': {'token': validate.text}},
-            {'auth': {'error': {'message': validate.text}}},
+            {'auth': {'token': str}},
+            {'auth': {'error': {'message': str}}},
         ),
         validate.get('auth'),
     )
 
     _video_data_schema = validate.Schema({
         'props': {'pageProps': {'__APOLLO_STATE__': {
-            validate.text: {
-                validate.optional('id'): validate.text,
-                validate.optional('slug'): validate.text,
+            str: {
+                validate.optional('id'): str,
+                validate.optional('slug'): str,
             }
         }}}},
         validate.get('props'),

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -65,7 +65,7 @@ class BBCiPlayer(Plugin):
 
     mediator_schema = validate.Schema(
         {
-            "versions": [{"id": validate.text}]
+            "versions": [{"id": str}]
         },
         validate.get("versions"), validate.get(0),
         validate.get("id")
@@ -76,9 +76,9 @@ class BBCiPlayer(Plugin):
             {"connection":
                 validate.all([{
                     validate.optional("href"): validate.url(),
-                    validate.optional("transferFormat"): validate.text
+                    validate.optional("transferFormat"): str
                 }], validate.filter(lambda c: c.get("href"))),
-                "kind": validate.text}
+                "kind": str}
         ]},
         validate.get("media"),
         validate.filter(lambda x: x["kind"] == "video")

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -39,26 +39,26 @@ def parse_timestamp(ts):
 
 _api_schema = validate.Schema({
     "error": bool,
-    validate.optional("code"): validate.text,
-    validate.optional("message"): validate.text,
+    validate.optional("code"): str,
+    validate.optional("message"): str,
     validate.optional("data"): object,
 })
 _media_schema = validate.Schema(
     {
-        validate.optional("name"): validate.any(validate.text, None),
-        validate.optional("series_name"): validate.any(validate.text, None),
-        validate.optional("media_type"): validate.any(validate.text, None),
+        validate.optional("name"): validate.any(str, None),
+        validate.optional("series_name"): validate.any(str, None),
+        validate.optional("media_type"): validate.any(str, None),
         "stream_data": validate.any(
             None,
             {
                 "streams": validate.all(
                     [{
-                        "quality": validate.any(validate.text, None),
+                        "quality": validate.any(str, None),
                         "url": validate.url(
                             scheme="http",
                             path=validate.endswith(".m3u8")
                         ),
-                        validate.optional("video_encode_id"): validate.text
+                        validate.optional("video_encode_id"): str
                     }]
                 )
             }
@@ -66,19 +66,19 @@ _media_schema = validate.Schema(
     }
 )
 _login_schema = validate.Schema({
-    "auth": validate.any(validate.text, None),
+    "auth": validate.any(str, None),
     "expires": validate.all(
-        validate.text,
+        str,
         validate.transform(parse_timestamp)
     ),
     "user": {
-        "username": validate.any(validate.text, None),
-        "email": validate.text
+        "username": validate.any(str, None),
+        "email": str,
     }
 })
 _session_schema = validate.Schema(
     {
-        "session_id": validate.text
+        "session_id": str,
     },
     validate.get("session_id")
 )

--- a/src/streamlink/plugins/funimationnow.py
+++ b/src/streamlink/plugins/funimationnow.py
@@ -32,8 +32,8 @@ class Experience:
 
     login_schema = validate.Schema(validate.any(
         {"success": False,
-         "error": validate.text},
-        {"token": validate.text,
+         "error": str},
+        {"token": str,
          "user": {"id": int}}
     ))
 

--- a/src/streamlink/plugins/kugou.py
+++ b/src/streamlink/plugins/kugou.py
@@ -38,7 +38,7 @@ class Kugou(Plugin):
         }],
     ))
     _stream_data_schema = validate.Schema({
-        "msg": validate.text,
+        "msg": str,
         "code": int,
         "data": {
             "status": int,

--- a/src/streamlink/plugins/n13tv.py
+++ b/src/streamlink/plugins/n13tv.py
@@ -34,18 +34,18 @@ class N13TV(Plugin):
     ))
 
     vod_schema = validate.Schema(validate.all([{
-        'ShowTitle': validate.text,
+        'ShowTitle': str,
         'ProtocolType': validate.all(
-            validate.text,
+            str,
             validate.transform(lambda x: x.replace("://", ""))
         ),
-        'ServerAddress': validate.text,
-        'MediaRoot': validate.text,
-        'MediaFile': validate.text,
-        'Bitrates': validate.text,
-        'StreamingType': validate.text,
+        'ServerAddress': str,
+        'MediaRoot': str,
+        'MediaFile': str,
+        'Bitrates': str,
+        'StreamingType': str,
         'Token': validate.all(
-            validate.text,
+            str,
             validate.transform(lambda x: x.lstrip("?"))
         )
     }], validate.get(0)))

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -38,11 +38,11 @@ class OPENRECtv(Plugin):
     login_url = "https://www.openrec.tv/viewapp/v4/mobile/user/login"
 
     _info_schema = validate.Schema({
-        validate.optional("id"): validate.text,
-        validate.optional("title"): validate.text,
-        validate.optional("movie_type"): validate.text,
+        validate.optional("id"): str,
+        validate.optional("title"): str,
+        validate.optional("movie_type"): str,
         validate.optional("onair_status"): validate.any(None, int),
-        validate.optional("public_type"): validate.text,
+        validate.optional("public_type"): str,
         validate.optional("media"): {
             "url": validate.any(None, validate.url()),
             "url_public": validate.any(None, validate.url()),
@@ -66,7 +66,7 @@ class OPENRECtv(Plugin):
     })
 
     _login_schema = validate.Schema({
-        validate.optional("error_message"): validate.text,
+        validate.optional("error_message"): str,
         "status": int,
         validate.optional("data"): object
     })

--- a/src/streamlink/plugins/pixiv.py
+++ b/src/streamlink/plugins/pixiv.py
@@ -48,11 +48,11 @@ class Pixiv(Plugin):
     _user_dict_schema = validate.Schema(
         {
             "user": {
-                "unique_name": validate.text,
-                "name": validate.text
+                "unique_name": str,
+                "name": str,
             },
             validate.optional("hls_movie"): {
-                "url": validate.text
+                "url": str,
             }
         }
     )

--- a/src/streamlink/plugins/rtbf.py
+++ b/src/streamlink/plugins/rtbf.py
@@ -50,8 +50,8 @@ class RTBF(Plugin):
 
     _geo_schema = validate.Schema(
         {
-            'country': validate.text,
-            'zone': validate.text
+            'country': str,
+            'zone': str,
         }
     )
 
@@ -64,14 +64,14 @@ class RTBF(Plugin):
                 validate.transform(html_unescape),
                 validate.parse_json(),
                 {
-                    'geoLocRestriction': validate.text,
+                    'geoLocRestriction': str,
                     validate.optional('isLive'): bool,
-                    validate.optional('startDate'): validate.text,
-                    validate.optional('endDate'): validate.text,
+                    validate.optional('startDate'): str,
+                    validate.optional('endDate'): str,
                     'sources': validate.any(
                         [],
                         validate.Schema({
-                            validate.text: validate.any(None, '', validate.url())
+                            str: validate.any(None, '', validate.url())
                         })
                     ),
                     validate.optional('urlHls'): validate.any(None, '', validate.url()),
@@ -89,7 +89,7 @@ class RTBF(Plugin):
             'audioUrls': validate.all(
                 [{
                     'url': validate.url(),
-                    'mimeType': validate.text
+                    'mimeType': str,
                 }]
             )
         }

--- a/src/streamlink/plugins/schoolism.py
+++ b/src/streamlink/plugins/schoolism.py
@@ -63,10 +63,10 @@ class Schoolism(Plugin):
                 validate.parse_json(),
                 [{
                     "sources": validate.all([{
-                        validate.optional("playlistTitle"): validate.text,
-                        "title": validate.text,
-                        "src": validate.text,
-                        "type": validate.text,
+                        validate.optional("playlistTitle"): str,
+                        "title": str,
+                        "src": str,
+                        "type": str,
                     }],
                         # only include HLS streams
                         # validate.filter(lambda s: s["type"] == "application/x-mpegurl")

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -36,9 +36,9 @@ class TV4Play(Plugin):
     _meta_schema = validate.Schema(
         {
             "metadata": {
-                "title": validate.text
+                "title": str,
             },
-            "mediaUri": validate.text
+            "mediaUri": str,
         }
     )
 

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -47,14 +47,14 @@ class Vimeo(Plugin):
         {
             "request": {
                 "files": {
-                    validate.optional("dash"): {"cdns": {validate.text: {"url": validate.url()}}},
-                    validate.optional("hls"): {"cdns": {validate.text: {"url": validate.url()}}},
+                    validate.optional("dash"): {"cdns": {str: {"url": validate.url()}}},
+                    validate.optional("hls"): {"cdns": {str: {"url": validate.url()}}},
                     validate.optional("progressive"): validate.all(
-                        [{"url": validate.url(), "quality": validate.text}]
+                        [{"url": validate.url(), "quality": str}]
                     ),
                 },
                 validate.optional("text_tracks"): validate.all(
-                    [{"url": validate.text, "lang": validate.text}]
+                    [{"url": str, "lang": str}]
                 ),
             }
         },

--- a/src/streamlink/plugins/wasd.py
+++ b/src/streamlink/plugins/wasd.py
@@ -20,14 +20,14 @@ log = logging.getLogger(__name__)
 class WASD(Plugin):
     _media_schema = validate.Schema({
         'user_id': int,
-        'media_container_online_status': validate.text,
-        'media_container_status': validate.text,
+        'media_container_online_status': str,
+        'media_container_status': str,
         'media_container_streams': [{
             'stream_media': [{
                 'media_id': int,
                 'media_meta': {
-                    'media_url': validate.any(validate.text, None),
-                    'media_archive_url': validate.any(validate.text, None),
+                    'media_url': validate.any(str, None),
+                    'media_archive_url': validate.any(str, None),
                 },
                 'media_status': validate.any('STOPPED', 'RUNNING'),
                 'media_type': 'HLS',

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -31,13 +31,13 @@ class WebTV(Plugin):
             "src": validate.any(
                 validate.contains("m3u8"),
                 validate.all(
-                    validate.text,
+                    str,
                     validate.transform(lambda x: WebTV.decrypt_stream_url(x)),
                     validate.contains("m3u8")
                 )
             ),
-            "type": validate.text,
-            "label": validate.text
+            "type": str,
+            "label": str,
         }
     ])
 

--- a/src/streamlink/plugins/zhanqi.py
+++ b/src/streamlink/plugins/zhanqi.py
@@ -23,10 +23,10 @@ _room_schema = validate.Schema(
     {
         "data": validate.any(None, {
             "status": validate.all(
-                validate.text,
+                str,
                 validate.transform(int)
             ),
-            "videoId": validate.text
+            "videoId": str,
         })
     },
     validate.get("data")

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import pytest
 from lxml.etree import Element, tostring as etree_tostring
 
-from streamlink.exceptions import PluginError
+from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
 from streamlink.plugin.api import validate
 # noinspection PyProtectedMember
 from streamlink.plugin.api.validate._exception import ValidationError
@@ -14,8 +14,16 @@ def assert_validationerror(exception, expected):
     assert str(exception) == dedent(expected).strip("\n")
 
 
-def test_text_is_str():
+def test_text_is_str(recwarn: pytest.WarningsRecorder):
+    assert "text" not in getattr(validate, "__dict__")
+    assert "text" in getattr(validate, "__all__")
     assert validate.text is str, "Exports text as str alias for backwards compatiblity"
+    assert [(record.category, str(record.message)) for record in recwarn.list] == [
+        (
+            StreamlinkDeprecationWarning,
+            "`streamlink.plugin.api.validate.text` is deprecated. Use `str` instead.",
+        ),
+    ]
 
 
 class TestSchema:


### PR DESCRIPTION
- Deprecate text alias and raise StreamlinkDeprecationWarning on access
- Add deprecation to docs
- Replace validate.text with str in remaining plugins
- Update test

----

The deprecation warning gets triggered when accessing `text` via the module's `__getattr__()` method. This is better than raising the warning when validating a specifc schema with a specific input.

Importing `*` from the validate module will also trigger the deprecation warning, but that's nothing that can be changed unless `text` gets removed from `__all__`, but that would be a breaking change from the previous implicit inclusion of all module namespace members. So if there are third-party plugins which import `*` and are not using `text`, then they will still trigger the warning. But since importing `*` is already considered bad practice, I don't care much about that.

As you can see from the number of plugin changes, there are quite a few plugins which haven't been touched in a long time, and I suspect that some of them are also broken. Either way, `validate.text` had to be replaced with `str`, even though I don't really like touching unmaintained plugin code with automated changes like this.