### PR TITLE
chore: ignore coverage in TYPE_CHECKING blocks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ exclude_lines = [
   "def __repr__",
   "raise NotImplementedError",
   "if __name__ == \"__main__\":",
+  "if (?:typing\\.)?TYPE_CHECKING:",
 ]
 
 

--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -43,7 +43,7 @@ from streamlink.plugin.api.validate._validators import (  # noqa: I101, F401
 )
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Type
 
     text: Type[str]


### PR DESCRIPTION
Accidentally forgot to suppress coverage of the `TYPE_CHECKING` block added in #5090.
https://app.codecov.io/gh/streamlink/streamlink/pull/5090

This PR adds `TYPE_CHECKING` to the list of excluded lines via `pyproject.toml`. But since pycharm seems to ignore this when building coverage reports via the `coverage` module, I also added the regular `# pragma: no cover` directive.