### PR TITLE
tests: set filterwarnings=always via pytest config

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 pip>=9
-pytest
+pytest >=6.0.0
 pytest-asyncio
 pytest-cov
 coverage[toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,14 @@ source-file = "src/streamlink/_version.py"
 build-file = "streamlink/_version.py"
 
 
+# https://docs.pytest.org/en/latest/reference/customize.html#configuration
+# https://docs.pytest.org/en/latest/reference/reference.html#ini-options-ref
+[tool.pytest.ini_options]
+filterwarnings = [
+  "always",
+]
+
+
 # https://coverage.readthedocs.io/en/latest/config.html
 [tool.coverage.run]
 branch = true

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -32,6 +32,9 @@ from tests import posix_only, windows_only
 from tests.plugin.testplugin import TestPlugin as _TestPlugin
 
 
+# TODO: rewrite the entire mess
+
+
 class FakePlugin(_TestPlugin):
     __module__ = "fake"
     _streams = {}  # type: ignore
@@ -272,6 +275,7 @@ class TestCLIMainCheckFileOutput(unittest.TestCase):
         self.assertEqual(mock_console.ask.call_args_list, [])
 
 
+# TODO: don't use Mock() for mocking args, use a custom argparse.Namespace instead
 class TestCLIMainCreateOutput(unittest.TestCase):
     @patch("streamlink_cli.main.args")
     @patch("streamlink_cli.main.console", Mock())
@@ -285,6 +289,7 @@ class TestCLIMainCreateOutput(unittest.TestCase):
         args.record = None
         args.record_and_pipe = None
         args.player_fifo = False
+        args.player_http = False
         args.title = None
         args.url = "URL"
         args.player = "mpv"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -77,7 +77,6 @@ class TestPlugin:
 
         assert mock_load_cookies.call_args_list == [call()]
 
-    @pytest.mark.filterwarnings("always")
     def test_constructor_wrapper(self, recwarn: pytest.WarningsRecorder):
         session = Mock()
         with patch("streamlink.plugin.plugin.Cache") as mock_cache, \

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -104,7 +104,6 @@ class TestSession(unittest.TestCase):
         plugins = session.get_plugins()
 
         with warnings.catch_warnings(record=True) as record_warnings:
-            warnings.filterwarnings("always")
             pluginname, pluginclass, resolved_url = session.resolve_url("http://test.se/channel")
 
         assert issubclass(pluginclass, Plugin)
@@ -418,7 +417,6 @@ class TestSession(unittest.TestCase):
         assert mock_urllib3_util_ssl.DEFAULT_CIPHERS == "foo:!bar:baz"
 
 
-@pytest.mark.filterwarnings("always")
 class TestSessionOptionHttpProxy:
     @pytest.fixture
     def no_deprecation(self, recwarn: pytest.WarningsRecorder):


### PR DESCRIPTION
See the individual commit messages...

TL;DR: file handles and sockets were not closed in some tests

This once again demonstrates the need for a rewrite of the PlayerOutput and the main CLI module :disappointed: 

Not tested on Windows, let's see if I made a mistake while rewriting the playeroutput tests...