### PR TITLE
plugins.tv8: add tv8bucuk.com/tv8-5-canli-yayin

### DIFF
--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -1,6 +1,7 @@
 """
-$description Turkish live TV channel owned by Acun Medya Group.
+$description Turkish live TV channels owned by Acun Medya Group.
 $url tv8.com.tr
+$url tv8bucuk.com
 $type live
 """
 
@@ -29,13 +30,12 @@ class TV8HLSStream(HLSStream):
     __reader__ = TV8HLSStreamReader
 
 
-@pluginmatcher(re.compile(
-    r"https?://www\.tv8\.com\.tr/canli-yayin"
-))
+@pluginmatcher(re.compile(r"https?://(?:www\.)?tv8\.com\.tr/canli-yayin"))
+@pluginmatcher(re.compile(r"https?://(?:www\.)?tv8bucuk\.com/tv8-5-canli-yayin"))
 class TV8(Plugin):
     def _get_streams(self):
         hls_url = self.session.http.get(self.url, schema=validate.Schema(
-            re.compile(r"""var\s+videoUrl\s*=\s*(?P<q>["'])(?P<hls_url>https?://.*?\.m3u8.*?)(?P=q)"""),
+            re.compile(r"""(?:var\s+videoUrl\s*=|'src':)\s*(?P<q>["'])(?P<hls_url>https?://.*?\.m3u8.*?)(?P=q)"""),
             validate.any(None, validate.get("hls_url")),
         ))
         if hls_url is not None:

--- a/tests/plugins/test_tv8.py
+++ b/tests/plugins/test_tv8.py
@@ -7,4 +7,5 @@ class TestPluginCanHandleUrlTV8(PluginCanHandleUrl):
 
     should_match = [
         'https://www.tv8.com.tr/canli-yayin',
+        "https://www.tv8bucuk.com/tv8-5-canli-yayin",
     ]


### PR DESCRIPTION
https://github.com/streamlink/streamlink/issues/4925#issuecomment-1385640799.  Close or merge.
```
$ streamlink --http-no-ssl-verify 'https://www.tv8bucuk.com/tv8-5-canli-yayin' 360p
[cli][info] Found matching plugin tv8 for URL https://www.tv8bucuk.com/tv8-5-canli-yayin
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.tv8bucuk.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
[cli][info] Available streams: 360p (worst), 576p (best)
[cli][info] Opening stream: 360p (hls)
[cli][info] Starting player: mpv
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
/home/user/sl-dev/lib/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'tv8-tb-live.ercdn.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```
closes #4925
