### PR TITLE
chore: remove unneeded noinspection directives

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -3,7 +3,6 @@ import time
 from typing import Any, Dict, Pattern, Tuple
 
 import requests.adapters
-# noinspection PyPackageRequirements
 import urllib3
 from requests import PreparedRequest, Request, Session
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -4,9 +4,7 @@ from functools import lru_cache
 from socket import AF_INET, AF_INET6
 from typing import Any, Callable, ClassVar, Dict, Iterator, Mapping, Optional, Tuple, Type
 
-# noinspection PyPackageRequirements
 import urllib3.util.connection as urllib3_util_connection
-# noinspection PyPackageRequirements
 import urllib3.util.ssl_ as urllib3_util_ssl
 
 from streamlink import __version__, plugins
@@ -24,7 +22,6 @@ logging.setLoggerClass(StreamlinkLogger)
 log = logging.getLogger(__name__)
 
 
-# noinspection PyUnresolvedReferences
 _original_allowed_gai_family = urllib3_util_connection.allowed_gai_family  # type: ignore[attr-defined]
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, call, patch
 
 import pytest
 import requests_mock
-# noinspection PyPackageRequirements
 import urllib3
 
 import tests.plugin
@@ -19,7 +18,6 @@ from streamlink.stream.http import HTTPStream
 PATH_TESTPLUGINS = Path(tests.plugin.__path__[0])
 PATH_TESTPLUGINS_OVERRIDE = PATH_TESTPLUGINS / "override"
 
-# noinspection PyUnresolvedReferences
 _original_allowed_gai_family = urllib3.util.connection.allowed_gai_family  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION
Just a small correction after `urllib3` was added to the dependencies list in November (#4950)