### PR TITLE
plugin: add support for named plugin matchers

### DIFF
--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -187,7 +187,8 @@ Adding plugins
    Check the git log for recently added or modified plugins to help you get an overview of what's needed to properly implement
    a plugin. A complete guide is currently not available.
 
-   Each plugin class requires at least one ``pluginmatcher`` decorator which defines the URL regex and matching priority.
+   Each plugin class requires at least one ``pluginmatcher`` decorator which defines the URL regex, matching priority
+   and an optional name.
 
    Plugins need to implement the ``_get_streams()`` method which either returns a list of ``Stream`` instances or which yields
    ``Stream`` instances. ``Stream`` is the base class of ``HTTPStream``, ``HLSStream`` and ``DASHStream``.

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import time
-import unittest
 from typing import Type
 from unittest.mock import Mock, call, patch
 
@@ -103,24 +102,47 @@ class TestPlugin:
         assert mock_load_cookies.call_args_list == [call()]
 
 
-class TestPluginMatcher(unittest.TestCase):
-    @patch("builtins.repr", Mock(return_value="Foo"))
+class TestPluginMatcher:
+    # noinspection PyUnusedLocal
     def test_decorator(self):
-        with self.assertRaises(TypeError) as cm:
+        with pytest.raises(TypeError) as cm:
             @pluginmatcher(re.compile(""))
-            class Foo:
+            class MyPlugin:
                 pass
-        self.assertEqual(str(cm.exception), "Foo is not a Plugin")
+        assert str(cm.value) == "MyPlugin is not a Plugin"
 
-        @pluginmatcher(re.compile("foo", re.VERBOSE))
-        @pluginmatcher(re.compile("bar"), priority=HIGH_PRIORITY)
-        class Bar(FakePlugin):
+    # noinspection PyUnusedLocal
+    def test_named_duplicate(self):
+        with pytest.raises(ValueError) as cm:
+            @pluginmatcher(re.compile("http://foo"), name="foo")
+            @pluginmatcher(re.compile("http://foo"), name="foo")
+            class MyPlugin(FakePlugin):
+                pass
+        assert str(cm.value) == "A matcher named 'foo' has already been registered"
+
+    def test_no_matchers(self):
+        class MyPlugin(FakePlugin):
             pass
 
-        self.assertEqual(Bar.matchers, [
+        plugin = MyPlugin(Mock(), "http://foo")
+        assert plugin.url == "http://foo"
+        assert plugin.matchers is None
+        assert plugin.matches == []
+        assert plugin.matcher is None
+        assert plugin.match is None
+
+    def test_matchers(self):
+        @pluginmatcher(re.compile("foo", re.VERBOSE))
+        @pluginmatcher(re.compile("bar"), priority=HIGH_PRIORITY)
+        @pluginmatcher(re.compile("baz"), priority=HIGH_PRIORITY, name="baz")
+        class MyPlugin(FakePlugin):
+            pass
+
+        assert MyPlugin.matchers == [
             Matcher(re.compile("foo", re.VERBOSE), NORMAL_PRIORITY),
-            Matcher(re.compile("bar"), HIGH_PRIORITY)
-        ])
+            Matcher(re.compile("bar"), HIGH_PRIORITY),
+            Matcher(re.compile("baz"), HIGH_PRIORITY, "baz"),
+        ]
 
     def test_url_setter(self):
         @pluginmatcher(re.compile("http://(foo)"))
@@ -130,28 +152,60 @@ class TestPluginMatcher(unittest.TestCase):
             pass
 
         plugin = MyPlugin(Mock(), "http://foo")
-        self.assertEqual(plugin.url, "http://foo")
-        self.assertEqual([m is not None for m in plugin.matches], [True, False, False])
-        self.assertEqual(plugin.matcher, plugin.matchers[0].pattern)
-        self.assertEqual(plugin.match.group(1), "foo")
+        assert plugin.url == "http://foo"
+        assert [m is not None for m in plugin.matches] == [True, False, False]
+        assert plugin.matcher is plugin.matchers[0].pattern
+        assert plugin.match.group(1) == "foo"
 
         plugin.url = "http://bar"
-        self.assertEqual(plugin.url, "http://bar")
-        self.assertEqual([m is not None for m in plugin.matches], [False, True, False])
-        self.assertEqual(plugin.matcher, plugin.matchers[1].pattern)
-        self.assertEqual(plugin.match.group(1), "bar")
+        assert plugin.url == "http://bar"
+        assert [m is not None for m in plugin.matches] == [False, True, False]
+        assert plugin.matcher is plugin.matchers[1].pattern
+        assert plugin.match.group(1) == "bar"
 
         plugin.url = "http://baz"
-        self.assertEqual(plugin.url, "http://baz")
-        self.assertEqual([m is not None for m in plugin.matches], [False, False, True])
-        self.assertEqual(plugin.matcher, plugin.matchers[2].pattern)
-        self.assertEqual(plugin.match.group(1), "baz")
+        assert plugin.url == "http://baz"
+        assert [m is not None for m in plugin.matches] == [False, False, True]
+        assert plugin.matcher is plugin.matchers[2].pattern
+        assert plugin.match.group(1) == "baz"
 
         plugin.url = "http://qux"
-        self.assertEqual(plugin.url, "http://qux")
-        self.assertEqual([m is not None for m in plugin.matches], [False, False, False])
-        self.assertEqual(plugin.matcher, None)
-        self.assertEqual(plugin.match, None)
+        assert plugin.url == "http://qux"
+        assert [m is not None for m in plugin.matches] == [False, False, False]
+        assert plugin.matcher is None
+        assert plugin.match is None
+
+    def test_named_matchers_and_matches(self):
+        @pluginmatcher(re.compile("http://foo"), name="foo")
+        @pluginmatcher(re.compile("http://bar"), name="bar")
+        class MyPlugin(FakePlugin):
+            pass
+
+        plugin = MyPlugin(Mock(), "http://foo")
+
+        assert plugin.matchers["foo"] is plugin.matchers[0]
+        assert plugin.matchers["bar"] is plugin.matchers[1]
+        with pytest.raises(IndexError):
+            plugin.matchers.__getitem__(2)
+        with pytest.raises(KeyError):
+            plugin.matchers.__getitem__("baz")
+
+        assert plugin.matches["foo"] is plugin.matches[0]
+        assert plugin.matches["bar"] is plugin.matches[1]
+        assert plugin.matches["foo"] is not None
+        assert plugin.matches["bar"] is None
+        with pytest.raises(IndexError):
+            plugin.matches.__getitem__(2)
+        with pytest.raises(KeyError):
+            plugin.matches.__getitem__("baz")
+
+        plugin.url = "http://bar"
+        assert plugin.matches["foo"] is None
+        assert plugin.matches["bar"] is not None
+
+        plugin.url = "http://baz"
+        assert plugin.matches["foo"] is None
+        assert plugin.matches["bar"] is None
 
 
 class TestPluginArguments:


### PR DESCRIPTION
This adds support for optionally named plugin matchers, e.g.:

```py
@pluginmatcher(re.compile("http://foo"), name="foo")
@pluginmatcher(re.compile("http://bar"), name="bar")
class MyPlugin(Plugin):
    def _get_streams():
        if self.matches["foo"]:
            return self._get_streams_foo()
        else:
            return self._get_streams_bar()
```

Both `Plugin.matchers` and `Plugin.matches` can now be referenced by matcher index, like before, as well as matcher name, if it was set. Invalid values will raise an `IndexError` and `KeyError` respectively.

This is useful if multiple matchers are defined, so match results don't have to be referenced by matcher index, which depends on the (reverse) order of the pluginmatcher decorators.