### PR TITLE
stream.hls: warn when writing after discontinuity

### DIFF
--- a/src/streamlink/buffers.py
+++ b/src/streamlink/buffers.py
@@ -27,6 +27,7 @@ class Buffer:
         self.current_chunk = None
         self.closed = False
         self.length = 0
+        self.written_once = False
 
     def _iterate_chunks(self, size):
         bytes_left = size
@@ -52,6 +53,7 @@ class Buffer:
             data = bytes(data)  # Copy so that original buffer may be reused
             self.chunks.append(data)
             self.length += len(data)
+            self.written_once = True
 
     def read(self, size=-1):
         if size < 0 or size > self.length:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -13,12 +13,15 @@ class TestBuffer:
 
     def test_write(self, buffer: Buffer):
         assert buffer.length == 0
+        assert not buffer.written_once
 
         buffer.write(b"1" * 8192)
         assert buffer.length == 8192
+        assert buffer.written_once
 
         buffer.write(b"2" * 4096)
         assert buffer.length == 8192 + 4096
+        assert buffer.written_once
 
     def test_read(self, buffer: Buffer):
         buffer.write(b"1" * 8192)
@@ -63,15 +66,19 @@ class TestBuffer:
 
     def test_close(self, buffer: Buffer):
         assert not buffer.closed
+        assert not buffer.written_once
 
         buffer.write(b"1" * 8192)
         assert buffer.length == 8192
+        assert buffer.written_once
 
         buffer.close()
         assert buffer.closed
+        assert buffer.written_once
 
         buffer.write(b"2" * 8192)
         assert buffer.length == 8192
+        assert buffer.written_once
 
         assert buffer.read() == b"1" * 8192
         assert buffer.length == 0


### PR DESCRIPTION
A warning message should've been added a while ago...

This adds the `written_once` attribute to the base `Buffer` class instead of the `HLSStreamWriter` class, because `HLSStreamWrite` would be the wrong place should a multi-buffer `HLSStream` ever get implemented for being able to write multiple files when a discontinuity occurs.