### PR TITLE
ci: revert deploy-pypi changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,6 +147,6 @@ jobs:
         run: ./script/github-release.py "${STREAMLINK_DIST_DIR}"/*.tar.gz{,.asc}
       - name: PyPI release
         env:
-          TWINE_USERNAME: "__token__"
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          PYPI_USER: streamlink
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: ./script/deploy-pypi.sh

--- a/script/deploy-pypi.sh
+++ b/script/deploy-pypi.sh
@@ -19,11 +19,14 @@ else
         exit 1
     fi
 
-    if [[ -z "${TWINE_USERNAME}" ]] || [[ -z "${TWINE_PASSWORD}" ]]; then
-        echo >&2 "deploy: missing TWINE_USERNAME or TWINE_PASSWORD env var"
+    if [[ -z "${PYPI_USER}" ]] || [[ -z "${PYPI_PASSWORD}" ]]; then
+        echo >&2 "deploy: missing PYPI_USER or PYPI_PASSWORD env var"
         exit 1
     fi
 
     echo >&2 "deploy: Uploading files to PyPI (${version})"
-    twine upload "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
+    twine upload \
+        --username "${PYPI_USER}" \
+        --password "${PYPI_PASSWORD}" \
+        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
 fi


### PR DESCRIPTION
Partially reverts de5bda806d28d7c41879049237391c3dd68f01e4

----

Release 5.2.0 failed while uploading the files to PyPI due to the recent changes of #5081.
This switches the upload auth data back to username+password. I will also remove the 2FA restriction again from the streamlink PyPI repo.

Will publish a 5.2.1 release afterwards...

https://github.com/streamlink/streamlink/pull/5111#issuecomment-1401057624
https://github.com/streamlink/streamlink/actions/runs/3990883680/jobs/6845136470#step:10:1