### PR TITLE
build: include icon.svg in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CHANGELOG.md
 include README.md
 include LICENSE*
 include *requirements.txt
+include icon.svg
 
 recursive-include completions *
 recursive-include docs *


### PR DESCRIPTION
For some reason, the `icon.svg` file was never added to the sdist manifest file, which meant the icon file was only included by accident in the docs dir, from the symlinked icon in the `_static` subdirectory. Let's fix this.

```sh
$ curl -sSL 'https://files.pythonhosted.org/packages/9e/0c/b8c90cda86583a141dcc584eb32838ed312fb8cd9d5aab20faaa7f49d5fb/streamlink-5.2.1.tar.gz' \
  | bsdtar -tf - \
  | grep -E '^streamlink-.+/icon.svg'
streamlink-5.2.1/docs/_static/icon.svg
```

```sh
$ python -m build --sdist >/dev/null 2>&1
$ bsdtar -tf dist/streamlink-5.2.1+1.gb5d5a042.tar.gz \
  | grep -E '^streamlink-.+/icon.svg'
streamlink-5.2.1+1.gb5d5a042/docs/_static/icon.svg
streamlink-5.2.1+1.gb5d5a042/icon.svg
```