### PR TITLE
tools: check typing in docs dir separately

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,3 +50,4 @@ jobs:
       - name: mypy
         run: |
           python -m mypy --no-incremental
+          python -m mypy --no-incremental docs

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -112,6 +112,8 @@ performing these checks locally avoids unnecessary build failures.
     flake8
     # check code for typing errors
     mypy
+    # optionally check for typing errors if changes were made to the docs extensions
+    mypy docs
 
     # build the documentation
     make --directory=docs clean html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,5 @@ files = [
   "src/streamlink/",
   "src/streamlink_cli/",
   "tests/",
-  "docs/",
   "setup.py",
 ]


### PR DESCRIPTION
Mypy currently checks the `docs` directory by default via the included `tool.mypy.files` entry in `pyproject.toml`.

However, when no `docs-requirements.txt` were installed, no Sphinx and related packages as well as docs typing stub packages are available in the environment, which leads to an error when just running `mypy`:
```
$ python3.11 -m venv ~/foo
$ source ~/foo/bin/activate
$ pip install -U --upgrade-strategy=eager -r dev-requirements.txt -e .
$ mypy
docs/ext_releaseref.py:6:1: error: Library stubs not installed for "docutils.nodes"  [import]
docs/ext_releaseref.py:6:1: error: Library stubs not installed for "docutils"  [import]
docs/ext_releaseref.py:7:1: error: Cannot find implementation or library stub for module named "sphinx.util.nodes"  [import]
docs/ext_html_template_vars.py:3:1: error: Cannot find implementation or library stub for module named "sphinx.addnodes"  [import]
docs/ext_html_template_vars.py:4:1: error: Cannot find implementation or library stub for module named "sphinx.application"  [import]
docs/ext_github.py:9:1: error: Library stubs not installed for "docutils.nodes"  [import]
docs/ext_github.py:9:1: error: Library stubs not installed for "docutils"  [import]
docs/ext_github.py:10:1: error: Library stubs not installed for "docutils.transforms"  [import]
docs/ext_argparse.py:14:1: error: Library stubs not installed for "docutils"  [import]
docs/ext_argparse.py:15:1: error: Library stubs not installed for "docutils.parsers.rst"  [import]
docs/ext_argparse.py:16:1: error: Library stubs not installed for "docutils.parsers.rst.directives"  [import]
docs/ext_argparse.py:16:1: note: Hint: "python3 -m pip install types-docutils"
docs/ext_argparse.py:16:1: note: (or run "mypy --install-types" to install all missing stub packages)
docs/ext_argparse.py:16:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
docs/ext_argparse.py:17:1: error: Library stubs not installed for "docutils.statemachine"  [import]
docs/ext_argparse.py:18:1: error: Cannot find implementation or library stub for module named "sphinx.util.nodes"  [import]
docs/ext_plugins.py:9:1: error: Library stubs not installed for "docutils"  [import]
docs/ext_plugins.py:10:1: error: Library stubs not installed for "docutils.parsers.rst"  [import]
docs/ext_plugins.py:11:1: error: Library stubs not installed for "docutils.statemachine"  [import]
docs/ext_plugins.py:12:1: error: Cannot find implementation or library stub for module named "sphinx.errors"  [import]
docs/ext_plugins.py:13:1: error: Cannot find implementation or library stub for module named "sphinx.util.nodes"  [import]
```

In order to fix that, `docs-requirements.txt` also have to be installed, but this is not ideal, because those packages are meant for building the docs only, not for installing type-checking stuff. Otherwise, `docs-requirements.txt` is a dependency of `dev-requirements.txt`.

So let's remove the `docs` dir from the default files list and run `mypy docs` explicitly in the CI runner. This also means that the docs dir also needs to be explicitly checked locally if one makes changes to the custom Sphinx extensions.

----

ref #4621