### PR TITLE
chore: add templates for GitHub discussions

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,52 @@
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for using the discussions forum!
+
+        **This place is only meant for help and support questions when using Streamlink, which can be answered by the community.**
+
+        Please [open a new thread on the issue tracker](https://github.com/streamlink/streamlink/issues/new/choose) and fill in all the required details if you want to
+
+        - **Report a plugin issue**
+          *One of [Streamlink's plugins](https://streamlink.github.io/plugins.html) doesn't work correctly*
+        - **Report a bug**
+          *A core functionality of Streamlink is broken*
+        - **Request a new plugin**
+          *Discuss adding a new plugin to Streamlink*
+        - **Request a feature**
+          *Discuss adding new functionality to Streamlink*
+
+        ----
+
+        Please keep your support questions within the scope of the project, read [Streamlink's documentation](https://streamlink.github.io/) and use your internet search engine of choice first before asking questions, as it might help you resolve your issue.
+
+        Low quality and low effort threads are noise and steal the time of the maintainers and contributors, so make sure to be as specific and detailed as possible when asking questions, and don't be vague. Don't ask other people to do your work/research, and be respectful.
+
+        Thank you.
+
+        ----
+
+        ## Checklist
+
+        - [ ] This post is not about a plugin issue, a bug report, a plugin request or a feature request
+        - [ ] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
+        - [ ] I have validated that I'm using the [latest version of Streamlink](https://streamlink.github.io/changelog.html) via the [`--version`](https://streamlink.github.io/cli.html#cmdoption-version) or [`--loglevel=debug`](https://streamlink.github.io/cli.html#cmdoption-loglevel) parameter
+        - [ ] [I have read the Streamlink documentation and tried looking for answers to my questions](https://streamlink.github.io/)
+  - type: textarea
+    attributes:
+      label: Description
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Before submitting
+
+        Make sure that you have
+        - [ ] properly filled in the title of this thread (at the very top of this page)
+        - [ ] checked the rendered text previews to avoid unnecessary formatting errors
+
+        ----
+
+        [❤️ Love Streamlink? Please consider supporting the project maintainers. Thanks! ❤️](https://streamlink.github.io/donate.html)

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,52 @@
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for using the discussions forum!
+
+        **This place is only meant for help and support questions when using Streamlink, which can be answered by the community.**
+
+        Please [open a new thread on the issue tracker](https://github.com/streamlink/streamlink/issues/new/choose) and fill in all the required details if you want to
+
+        - **Report a plugin issue**
+          *One of [Streamlink's plugins](https://streamlink.github.io/plugins.html) doesn't work correctly*
+        - **Report a bug**
+          *A core functionality of Streamlink is broken*
+        - **Request a new plugin**
+          *Discuss adding a new plugin to Streamlink*
+        - **Request a feature**
+          *Discuss adding new functionality to Streamlink*
+
+        ----
+
+        Please keep your support questions within the scope of the project, read [Streamlink's documentation](https://streamlink.github.io/) and use your internet search engine of choice first before asking questions, as it might help you resolve your issue.
+
+        Low quality and low effort threads are noise and steal the time of the maintainers and contributors, so make sure to be as specific and detailed as possible when asking questions, and don't be vague. Don't ask other people to do your work/research, and be respectful.
+
+        Thank you.
+
+        ----
+
+        ## Checklist
+
+        - [ ] This post is not about a plugin issue, a bug report, a plugin request or a feature request
+        - [ ] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
+        - [ ] I have validated that I'm using the [latest version of Streamlink](https://streamlink.github.io/changelog.html) via the [`--version`](https://streamlink.github.io/cli.html#cmdoption-version) or [`--loglevel=debug`](https://streamlink.github.io/cli.html#cmdoption-loglevel) parameter
+        - [ ] [I have read the Streamlink documentation and tried looking for answers to my questions](https://streamlink.github.io/)
+  - type: textarea
+    attributes:
+      label: Description
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        ### Before submitting
+
+        Make sure that you have
+        - [ ] properly filled in the title of this thread (at the very top of this page)
+        - [ ] checked the rendered text previews to avoid unnecessary formatting errors
+
+        ----
+
+        [❤️ Love Streamlink? Please consider supporting the project maintainers. Thanks! ❤️](https://streamlink.github.io/donate.html)


### PR DESCRIPTION
This adds templates to the discussions forum, similar to the issue templates.

The markdown header is mainly copied from the stickied thread which I will remove once merged:
https://github.com/streamlink/streamlink/discussions/4578

The checklist is a pseudo-checklist, so that the list doesn't get included in the discussion thread. The "description" header unfortunately gets included, as it's the title of the textarea, which is the only user input (required when using a template).

Both templates are idential, because there's not much difference between the two categories. The function of the Q&A category is already explained in its title description.

I've tested this on my fork repo, and everything worked just fine. The YML schema is still considered public beta, but I don't expect anything to break here, as it's basically the same as the issue template schema.
https://docs.github.com/en/discussions/managing-discussions-for-your-community/syntax-for-discussion-category-forms

Anything missing or wrong, or is there something that needs to be added or improved?