### PR TITLE
plugins.youtube: rewrite and fix matchers

### DIFF
--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -9,40 +9,54 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
     __plugin__ = YouTube
 
-    should_match = [
-        "https://www.youtube.com/CHANNELNAME",
-        "https://www.youtube.com/CHANNELNAME/",
-        "https://www.youtube.com/CHANNELNAME/live",
-        "https://www.youtube.com/CHANNELNAME/live/",
-        "https://www.youtube.com/c/CHANNELNAME",
-        "https://www.youtube.com/c/CHANNELNAME/",
-        "https://www.youtube.com/c/CHANNELNAME/live",
-        "https://www.youtube.com/c/CHANNELNAME/live/",
-        "https://www.youtube.com/user/CHANNELNAME",
-        "https://www.youtube.com/user/CHANNELNAME/",
-        "https://www.youtube.com/user/CHANNELNAME/live",
-        "https://www.youtube.com/user/CHANNELNAME/live/",
-        "https://www.youtube.com/channel/CHANNELID",
-        "https://www.youtube.com/channel/CHANNELID/",
-        "https://www.youtube.com/channel/CHANNELID/live",
-        "https://www.youtube.com/channel/CHANNELID/live/",
-        "https://www.youtube.com/embed/aqz-KE-bpKQ",
-        "https://www.youtube.com/embed/live_stream?channel=UCNye-wNBqNL5ZzHSJj3l8Bg",
-        "https://www.youtube.com/v/aqz-KE-bpKQ",
-        "https://www.youtube.com/watch?v=aqz-KE-bpKQ",
-        "https://www.youtube.com/watch?foo=bar&baz=qux&v=aqz-KE-bpKQ",
-        "https://youtu.be/0123456789A",
-    ]
-
     should_match_groups = [
-        ("https://www.youtube.com/v/aqz-KE-bpKQ", {
+        (("default", "https://www.youtube.com/v/aqz-KE-bpKQ"), {
             "video_id": "aqz-KE-bpKQ",
         }),
-        ("https://www.youtube.com/embed/aqz-KE-bpKQ", {
-            "embed": "embed",
+        (("default", "https://www.youtube.com/live/aqz-KE-bpKQ"), {
             "video_id": "aqz-KE-bpKQ",
         }),
-        ("https://www.youtube.com/watch?v=aqz-KE-bpKQ", {
+        (("default", "https://www.youtube.com/watch?foo=bar&baz=qux&v=aqz-KE-bpKQ&asdf=1234"), {
+            "video_id": "aqz-KE-bpKQ",
+        }),
+
+        (("channel", "https://www.youtube.com/CHANNELNAME"), {
+            "channel": "CHANNELNAME",
+        }),
+        (("channel", "https://www.youtube.com/CHANNELNAME/live"), {
+            "channel": "CHANNELNAME",
+            "live": "/live",
+        }),
+        (("channel", "https://www.youtube.com/@CHANNELNAME"), {
+            "channel": "CHANNELNAME",
+        }),
+        (("channel", "https://www.youtube.com/@CHANNELNAME/live"), {
+            "channel": "CHANNELNAME",
+            "live": "/live",
+        }),
+        (("channel", "https://www.youtube.com/c/CHANNELNAME"), {
+            "channel": "CHANNELNAME",
+        }),
+        (("channel", "https://www.youtube.com/c/CHANNELNAME/live"), {
+            "channel": "CHANNELNAME",
+            "live": "/live",
+        }),
+        (("channel", "https://www.youtube.com/channel/CHANNELID"), {
+            "channel": "CHANNELID",
+        }),
+        (("channel", "https://www.youtube.com/channel/CHANNELID/live"), {
+            "channel": "CHANNELID",
+            "live": "/live",
+        }),
+
+        (("embed", "https://www.youtube.com/embed/aqz-KE-bpKQ"), {
+            "video_id": "aqz-KE-bpKQ",
+        }),
+        (("embed", "https://www.youtube.com/embed/live_stream?channel=CHANNELNAME"), {
+            "live": "CHANNELNAME",
+        }),
+
+        (("shorthand", "https://youtu.be/aqz-KE-bpKQ"), {
             "video_id": "aqz-KE-bpKQ",
         }),
     ]


### PR DESCRIPTION
Fixes #5136 

This splits up the ugly verbose matcher regex into separate matchers for each URL type, and it adds the new `@`-URLs and `/live/video-id` URLs.

Before merging, please help me validate all the supported URLs, because splitting up the matchers required some refactoring, and not all `self.match[key]` keys are available anymore, which can lead to an unintended `IndexError` being raised.

----

Btw, this unrelated issue with the muxed adaptive streams and missing audio bitrates needs separate fixing:
```
$ streamlink 'https://www.youtube.com/embed/aqz-KE-bpKQ'
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/embed/aqz-KE-bpKQ
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-311/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 933, in main
    handle_url()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 549, in handle_url
    streams = fetch_streams(plugin)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 443, in fetch_streams
    return plugin.streams(stream_types=args.stream_types,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/plugin/plugin.py", line 420, in streams
    ostreams = self._get_streams()
               ^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/plugins/youtube.py", line 376, in _get_streams
    streams.update(self._create_adaptive_streams(adaptive_formats))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/plugins/youtube.py", line 236, in _create_adaptive_streams
    if best_audio_itag is None or self.adp_audio[itag] > self.adp_audio[best_audio_itag]:
                                  ~~~~~~~~~~~~~~^^^^^^
KeyError: 328
```