### PR TITLE
options: deprecate global plugin arguments

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,17 @@
 Deprecations
 ============
 
+streamlink 5.3.0
+----------------
+
+Deprecation of global plugin arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``is_global=True`` :py:class:`plugin argument <streamlink.options.Argument>` parameter has been deprecated.
+Instead of defining a global plugin argument to set a key-value pair on the plugin's options, use the respective option on
+the plugin's Streamlink session instance instead.
+
+
 streamlink 5.2.0
 ----------------
 

--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -138,9 +138,6 @@ class ArgparseDirective(Directive):
             for line in self.process_help(action.help).split("\n"):
                 yield line
             yield ""
-            if hasattr(action, "plugins") and len(action.plugins) > 0:
-                yield f"    **Supported plugins:** {', '.join(action.plugins)}"
-                yield ""
 
     def generate_parser_rst(self, parser, parent=None, depth=0):
         if depth >= len(self._headlines):

--- a/docs/ext_plugins.py
+++ b/docs/ext_plugins.py
@@ -104,9 +104,6 @@ class PluginArguments(ast.NodeVisitor, IDatalistItem):
             ):
                 continue
 
-            if any(kw.value.value for kw in decorator.keywords if kw.arg == "is_global" and type(kw.value) is ast.Constant):
-                continue
-
             if any(
                 True
                 for kw in decorator.keywords

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -1,4 +1,7 @@
+import warnings
 from typing import Any, Callable, ClassVar, Dict, Iterator, Mapping, Optional, Sequence, Union
+
+from streamlink.exceptions import StreamlinkDeprecationWarning
 
 
 class Options:
@@ -90,7 +93,7 @@ class Argument:
         :param sensitive: Whether the argument is sensitive (passwords, etc.) and should be masked
         :param argument_name: Custom CLI argument name without plugin name prefix
         :param dest: Custom plugin option name
-        :param is_global: Whether this plugin argument refers to a global CLI argument
+        :param is_global: Whether this plugin argument refers to a global CLI argument (deprecated)
         :param options: Arguments passed to :meth:`ArgumentParser.add_argument`, excluding ``requires`` and ``dest``
         """
 
@@ -105,6 +108,11 @@ class Argument:
         self.sensitive = sensitive
         self._default = options.get("default")
         self.is_global = is_global
+        if is_global:
+            warnings.warn(
+                "Defining global plugin arguments is deprecated. Use the session options instead.",
+                StreamlinkDeprecationWarning,
+            )
 
     @staticmethod
     def _normalize_name(name: str) -> str:

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -12,7 +12,7 @@ from io import BytesIO
 from typing import Iterator, Sequence, Tuple
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
+from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.ffmpegmux import MuxedStream
 from streamlink.stream.hls import HLSStream
@@ -129,10 +129,6 @@ class ZTNR:
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?rtve\.es/play/videos/.+"
 ))
-@pluginargument(
-    "mux-subtitles",
-    is_global=True,
-)
 class Rtve(Plugin):
     URL_M3U8 = "https://ztnr.rtve.es/ztnr/{id}.m3u8"
     URL_VIDEOS = "https://ztnr.rtve.es/ztnr/movil/thumbnail/rtveplayw/videos/{id}.png?q=v2"
@@ -178,7 +174,7 @@ class Rtve(Plugin):
 
         streams = HLSStream.parse_variant_playlist(self.session, url).items()
 
-        if self.options.get("mux-subtitles"):
+        if self.session.get_option("mux-subtitles"):
             subs = self.session.http.get(
                 self.URL_SUBTITLES.format(id=self.id),
                 schema=validate.Schema(

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -9,7 +9,7 @@ import logging
 import re
 from urllib.parse import parse_qsl, urlparse
 
-from streamlink.plugin import Plugin, pluginargument, pluginmatcher
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -22,10 +22,6 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(?:www\.)?svtplay\.se/(?P<live>kanaler/)?"
 ))
-@pluginargument(
-    "mux-subtitles",
-    is_global=True,
-)
 class SVTPlay(Plugin):
     _URL_API_VIDEO = "https://api.svt.se/videoplayer-api/video/{item}"
     _MAP_CHANNEL_NAMES = {
@@ -138,9 +134,8 @@ class SVTPlay(Plugin):
                 return HLSStream.parse_variant_playlist(self.session, videos[fmt], name_fmt="{pixels}_{bitrate}")
 
             if streamtype is DASHStream:
-                mux_subtitles = self.get_option("mux_subtitles")
                 subtitlestreams = {}
-                if mux_subtitles and "webvtt" in subtitles:
+                if self.session.get_option("mux-subtitles") and "webvtt" in subtitles:
                     subtitlestreams["webvtt"] = HTTPStream(self.session, subtitles["webvtt"])
 
                 dash_streams = DASHStream.parse_manifest(self.session, videos[fmt])

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -10,7 +10,7 @@ import re
 from html import unescape as html_unescape
 from urllib.parse import urlparse
 
-from streamlink.plugin import Plugin, pluginargument, pluginmatcher
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.ffmpegmux import MuxedStream
@@ -23,10 +23,6 @@ log = logging.getLogger(__name__)
 @pluginmatcher(re.compile(
     r"https?://(player\.vimeo\.com/video/\d+|(www\.)?vimeo\.com/.+)"
 ))
-@pluginargument(
-    "mux-subtitles",
-    is_global=True,
-)
 class Vimeo(Plugin):
     _config_url_re = re.compile(r'(?:"config_url"|\bdata-config-url)\s*[:=]\s*(".+?")')
     _config_re = re.compile(r"var\s+config\s*=\s*({.+?})\s*;")
@@ -104,7 +100,7 @@ class Vimeo(Plugin):
             for stream in videos.get("progressive", [])
         )
 
-        if self.get_option("mux_subtitles") and data["request"].get("text_tracks"):
+        if self.session.get_option("mux-subtitles") and data["request"].get("text_tracks"):
             substreams = {
                 s["lang"]: HTTPStream(self.session, "https://vimeo.com" + s["url"])
                 for s in data["request"]["text_tracks"]

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -727,11 +727,6 @@ def setup_plugin_args(session: Streamlink, parser: ArgumentParser):
                         continue
                     defaults[pargdest] = action.default
 
-                    # add plugin to global argument
-                    plugins = getattr(action, "plugins", [])
-                    plugins.append(pname)
-                    setattr(action, "plugins", plugins)
-
         plugin.options = PluginOptions(defaults)
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -10,7 +10,6 @@ import streamlink.plugins
 import tests.plugins
 from streamlink.plugin.plugin import Matcher, Plugin
 from streamlink.utils.module import load_module
-from streamlink_cli.argparser import build_parser
 
 
 plugins_path = streamlink.plugins.__path__[0]
@@ -51,14 +50,6 @@ class TestPlugins:
     def plugin(self, request):
         return load_module(f"streamlink.plugins.{request.param}", plugins_path)
 
-    @pytest.fixture(scope="class")
-    def parser(self):
-        return build_parser()
-
-    @pytest.fixture(scope="class")
-    def global_arg_dests(self, parser):
-        return [action.dest for action in parser._actions]
-
     def test_exports_plugin(self, plugin):
         assert hasattr(plugin, "__plugin__"), "Plugin module exports __plugin__"
         assert issubclass(plugin.__plugin__, Plugin), "__plugin__ is an instance of the Plugin class"
@@ -92,9 +83,8 @@ class TestPlugins:
         assert not hasattr(pluginclass, "priority"), "Does not implement deprecated priority(url)"
         assert callable(pluginclass._get_streams), "Implements _get_streams()"
 
-    def test_has_valid_global_args(self, global_arg_dests, plugin):
-        assert all(parg.dest in global_arg_dests for parg in plugin.__plugin__.arguments or [] if parg.is_global), \
-            "All plugin arguments with is_global=True are valid global arguments"
+    def test_no_global_args(self, plugin):
+        assert not [parg for parg in plugin.__plugin__.arguments or [] if parg.is_global], "Doesn't define global arguments"
 
 
 class TestPluginTests:


### PR DESCRIPTION
- Raise `StreamlinkDeprecationWarning` when `is_global=True`
- Remove all global plugin arguments and replace them with simple option lookups on the Streamlink session instance
- Remove global argument detection in custom Sphinx plugins extension
- Remove supported plugins list from custom Sphinx argparse extension and remove respective setup from `setup_plugin_args` in the CLI module
- Add deprecation note to the docs
- Update tests
  - Check whether builtin plugins define global plugin arguments
  - Capture deprecation warnings

----

This is partly cherry-picked from the (current state of the) first commit of #5033 where global plugin arguments get removed, and it instead deprecates the usage of global plugin arguments and just removes them from Streamlink's builtin plugins and the docs.

Very likely unnecessary, because I don't think global plugin arguments are used by third party plugin implementations, but just in case, deprecating them prior to publishing a release with a breaking change is probably a better idea.

----

Note that this will remove the "supported plugins" list from the [description of the `--mux-subtitles` CLI argument](https://streamlink.github.io/cli.html#cmdoption-mux-subtitles). In a future change, more metadata could be added to the plugin modules which chould then be shown in the docs and man page (via the custom argparse extension). The `--help` text however won't be able to read plugin module metadata like this.