### PR TITLE
build: include py.typed in package_data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,10 @@ install_requires =
 [options.packages.find]
 where = src
 
+[options.package_data]
+streamlink =
+    py.typed
+
 [flake8]
 ignore =
   # W503 - line break before binary operator


### PR DESCRIPTION
`py.typed` should be included in setuptools' `package_data`, so it gets included in the source and binary distributions, so 3rd party applications can read Streamlink's typing informations ([PEP 561](https://peps.python.org/pep-0561/)). #4544 didn't include it when the file was added, because it was just meant to enable mypy back then (an incorrect decision).

The file of the `streamlink_cli` package is explicitly not included here, since that package is not considered a public interface, only the `streamlink` package is, hence the split of the two packages.

```sh
$ curl -sSL 'https://files.pythonhosted.org/packages/9e/0c/b8c90cda86583a141dcc584eb32838ed312fb8cd9d5aab20faaa7f49d5fb/streamlink-5.2.1.tar.gz' \
  | bsdtar -tf - \
  | grep py.typed
$ echo $?
1

$ python -m build --sdist --wheel >/dev/null 2>&1
$ bsdtar -tf dist/streamlink-*ga1b72436*.whl | grep py.typed
streamlink/py.typed
$ bsdtar -tf dist/streamlink-*ga1b72436*.tar.gz | grep py.typed
streamlink-5.2.1+10.ga1b72436/src/streamlink/py.typed
```