### PR TITLE
tools: add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,17 @@
+# .git-blame-ignore-revs
+# commits ordered by commit-date, in descending order
+
+# chore: add "COM" rules to ruff config
+57fa6f80e8defa12dde4e6bbc7a1df7a3c492a9a
+# chore: add "Q" rules to ruff config
+9fd14e3f9d2ff129e71686c85e21745688531784
+# chore: use yield from where possible
+6700a2f985f0dc43f207052df392794612bac74a
+# chore: inherit from object implicitly
+bf5d3efa6ce8058d769290e4cd64f98a4bd920f7
+# chore: remove u-strings
+fcda5b681422718cc0a95b3de45d3fe2698d8e29
+# chore: implicit py3 super() calls
+778e48f289b705bfa1df587c1f5440bb206b4f2e
+# chore: use new py3 yield from syntax
+ae920e12a7912d4b93be0032b9a20b7cbaa323bf


### PR DESCRIPTION
See `man git-blame`, `git blame --ignore-revs-file <file>` and the `blame.ignoreRevsFile` git config option.

----

- https://git-scm.com/docs/git-blame
- https://git-scm.com/docs/git-blame#Documentation/git-blame.txt-blameignoreRevsFile
- https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view

----

Step 3 of 3+x, as detailed in #5145 

These are currently the commits with the biggest number of changed files:

```sh
git log --max-count=2000 --no-merges --shortstat --format='%H %cs' \
  | awk '/^[a-f0-9]{40}/ { c=$0 }; /^ [0-9]+ files? changed/ { print $1 " " c }' \
  | sort -nr \
  | awk '$1 >= 25 { print "- " $2 ": " $1 " (" $3 ")" }'
```
- 57fa6f80e8defa12dde4e6bbc7a1df7a3c492a9a: 203 (2023-02-09)
- a585e8829750d2e5bd68a3887efedf448283749e: 202 (2020-10-27)
- fb6a00c86bbf752b578ea317cdede242a2b4e836: 174 (2018-07-17)
- e8f7170adbbb07d50df9de5331a5d2ae3b028893: 171 (2021-02-19)
- a0437c2e7bd62bce744eb922951e2c7bf580fa1d: 163 (2021-09-20)
- faab9200c773157482fe4666129a13b164523882: 152 (2023-02-09)
- d0fb04dba4b790417c15b9a3ca31f593a1b0025f: 150 (2022-03-03)
- 90230e4c9dec12097bab93917dd3e396356d923a: 150 (2022-03-12)
- c9fff48e9a757d76219d48c3ee990af8e65e946c: 121 (2018-06-29)
- 9fd14e3f9d2ff129e71686c85e21745688531784: 121 (2023-02-09)
- c394b414f627a849650081517825be8321c43539: 95 (2018-07-05)
- 4be26868213b336541a3e9c96b765b0c92184013: 91 (2021-06-29)
- 55db9e0f1ee4457c1f0c1a91ed2a6a37f6bb1434: 71 (2018-01-15)
- 98428d663e1cac084c4597419445042e6a81f9fd: 66 (2021-06-29)
- 5149752f82aeb0e6774ddc7b6389d4b2dc1c85c4: 66 (2020-10-19)
- b325aff98d4002101b51b89246150d8d6f94dc99: 60 (2020-02-23)
- 57046e03d327435bfe63af037c15e52d1f1b01a8: 59 (2021-09-17)
- ae920e12a7912d4b93be0032b9a20b7cbaa323bf: 54 (2020-10-22)
- 15983c57ab2c5e749c050a9e390489b76d7ec5c2: 51 (2020-10-19)
- ed6bbb3a2d782744929c506b34e4a0d0c19cf9d7: 46 (2020-04-19)
- 2eb54a3d5117c0635380d2533f0c6f376e11ae14: 46 (2018-08-08)
- 46817a1cff822bf2fead4c07bd81ec058f5ea901: 39 (2021-11-12)
- 778e48f289b705bfa1df587c1f5440bb206b4f2e: 38 (2020-10-31)
- d7a27b31b0284670328f63e163a414f80db0afa5: 33 (2018-05-25)
- 76f162e04ceee635681e4d4457c09d19b99cca8e: 33 (2020-02-19)
- a7063e1d70eb6e0337f4007e3027404af0639e40: 31 (2021-11-13)
- 5a6398afb173e9fc56d1702838840b392edefa2a: 31 (2020-11-27)
- 24c59a23103922977991acc28741a323d8efa7a1: 31 (2021-09-17)
- 08209aecf41706dc1eb0171466d88d7fb02aefca: 31 (2022-08-06)
- f538d684df37e75078a2d6ea92c58c9d72affbe9: 30 (2020-10-19)
- fcda5b681422718cc0a95b3de45d3fe2698d8e29: 29 (2020-10-31)
- bf5d3efa6ce8058d769290e4cd64f98a4bd920f7: 29 (2020-11-27)
- b20b590b45f234666f5f531e6481d11d2b3d43bc: 29 (2020-10-19)
- c1489782cf2644e9194c4d2fdcc3f6198e49a538: 28 (2018-05-30)
- de5b27b480e0f421b312bbae82feb9ca5686de86: 27 (2021-09-14)
- 054b760ce7e9f43451eed08e9f39de440c3e5add: 26 (2020-11-03)
- 60efe3bfd491ad13a249f8ba73bd818148545a6a: 25 (2018-05-29)
- 32319770117559db194f1fd4cd50d8ca1fdeb49c: 25 (2021-08-31)

----

I had several different versions of the ignore list, but in the end I decided to remove some commit IDs again where non-syntax-related stuff was included or where the changes didn't affect the blame history much, like commits with many added new lines, or changes in terms of relevance, like import statements, etc.

I'm pretty confident with the current list of commit IDs now. Having a blame ignore list can already be confusing when checking a file's (blame-)history, so the ignored bulk-changes should all be trivial.

----

Example:

- With ignored revisions:
  https://github.com/bastimeyer/streamlink/blame/git-blame-ignore-revs/src/streamlink/plugins/adultswim.py#L46
- Without ignored revisions (appended `~`), same as current master:
  https://github.com/bastimeyer/streamlink/blame/git-blame-ignore-revs~/src/streamlink/plugins/adultswim.py#L46