### PR TITLE
tools: remove export-subst from .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 * text=auto eol=lf
-src/streamlink/_version.py export-subst


### PR DESCRIPTION
Added by 416c834 and made obsolete by 9b0815d

----

https://git-scm.com/docs/gitattributes#_export_subst
