### PR TITLE
chore: update Gitter link in issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,9 +9,6 @@ contact_links:
   - name: "📖 Documentation"
     about: "Please refer to Streamlink's documentation first before opening new issues or asking questions."
     url: https://streamlink.github.io/
-  - name: "💬 Gitter channel"
-    about: "Get in touch with other Streamlink users."
-    url: https://gitter.im/streamlink/streamlink
-  - name: "💬 Matrix channel (Gitter bridge)"
+  - name: "💬 Gitter Matrix channel"
     about: "Get in touch with other Streamlink users."
     url: https://matrix.to/#/#streamlink_streamlink:gitter.im


### PR DESCRIPTION
Gitter is now a native Matrix server
https://blog.gitter.im/2023/02/13/gitter-has-fully-migrated-to-matrix/