### PR TITLE
stream.hls: fix parse_hex warning message

### DIFF
--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -285,7 +285,10 @@ class M3U8Parser:
 
     @staticmethod
     def parse_hex(value: Optional[str]) -> Optional[bytes]:
-        if value and value[:2] in ("0x", "0X"):
+        if value is None:
+            return None
+
+        if value[:2] in ("0x", "0X"):
             try:
                 return unhexlify(f"{'0' * (len(value) % 2)}{value[2:]}")
             except BinasciiError:

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -113,9 +113,9 @@ def test_split_tag(string: str, expected: Union[Tuple[str, str], Tuple[None, Non
 ])
 def test_parse_attributes(caplog: pytest.LogCaptureFixture, attributes: str, log: bool, expected: dict):
     assert M3U8Parser.parse_attributes(attributes) == expected
-    assert not log or [(r.module, r.levelname, r.message) for r in caplog.records] == [
+    assert [(r.module, r.levelname, r.message) for r in caplog.records] == ([
         ("hls_playlist", "warning", "Discarded invalid attributes list"),
-    ]
+    ] if log else [])
 
 
 @pytest.mark.parametrize("string,expected", [
@@ -159,9 +159,9 @@ def test_parse_extinf(string: str, expected: ExtInf):
 ])
 def test_parse_hex(caplog: pytest.LogCaptureFixture, string: Optional[str], log: bool, expected: Optional[bytes]):
     assert M3U8Parser.parse_hex(string) == expected
-    assert not log or [(r.module, r.levelname, r.message) for r in caplog.records] == [
+    assert [(r.module, r.levelname, r.message) for r in caplog.records] == ([
         ("hls_playlist", "warning", "Discarded invalid hexadecimal-sequence attribute value"),
-    ]
+    ] if log else [])
 
 
 @pytest.mark.parametrize("string,log,expected", [
@@ -173,9 +173,9 @@ def test_parse_hex(caplog: pytest.LogCaptureFixture, string: Optional[str], log:
 ])
 def test_parse_iso8601(caplog: pytest.LogCaptureFixture, string: Optional[str], log: bool, expected: Optional[datetime]):
     assert M3U8Parser.parse_iso8601(string) == expected
-    assert not log or [(r.module, r.levelname, r.message) for r in caplog.records] == [
+    assert [(r.module, r.levelname, r.message) for r in caplog.records] == ([
         ("hls_playlist", "warning", "Discarded invalid ISO8601 attribute value"),
-    ]
+    ] if log else [])
 
 
 @pytest.mark.parametrize("string,expected", [


### PR DESCRIPTION
I made a mistake in #5125.

A warning should not be logged when the input value of `parse_hex()` is `None`, which is the case when `#EXT-X-KEY:METHOD=NONE` is set for example, because it's missing the `IV` attribute.

The `not log or log-records-comp` assertion in the tests was also pretty stupid because it misses the case when a warning does get logged when it's not supposed to log anything...