### PR TITLE
stream.ffmpegmux: refactor errorlog fd

### DIFF
--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -5,19 +5,8 @@ import sys
 is_darwin = sys.platform == "darwin"
 is_win32 = os.name == "nt"
 
-# win/nix compatible devnull
-try:
-    from subprocess import DEVNULL
-
-    def devnull():
-        return DEVNULL
-except ImportError:
-    def devnull():
-        return open(os.path.devnull, "w")
-
 
 __all__ = [
     "is_darwin",
     "is_win32",
-    "devnull",
 ]


### PR DESCRIPTION
- Change priority of --ffmpeg-verbose-path and --ffmpeg-verbose
- Remove unneeded subprocess.DEVNULL compatibility export
- Suppress OSError when closing fd of --ffmpeg-verbose-path
- Update tests