### PR TITLE
tests: ignore setuptools 67.3.0 DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ build-file = "streamlink/_version.py"
 [tool.pytest.ini_options]
 filterwarnings = [
   "always",
+  "ignore:.*pkg_resources\\.declare_namespace.*:DeprecationWarning",
 ]
 
 


### PR DESCRIPTION
Ignore new `pkg_resources.declare_namespace` DeprecationWarning which was added in the setuptools 67.3.0 release.

----

The DeprecationWarning was added in the setuptools 67.3.0 release:
- https://setuptools.pypa.io/en/latest/history.html#v67-3-0
- https://github.com/pypa/setuptools/commit/925a792d8c7f69500c0169c932df08f73f30f6fe

And it gets triggered by the various `sphinxcontrib-*` **namespace packages** which are listed as dependencies of the sphinx package.
- https://github.com/sphinx-doc/sphinx/blob/v5.3.0/pyproject.toml#L60-L65
- https://github.com/sphinx-doc/sphinxcontrib-devhelp/blob/1.0.2/setup.py#L69
- https://github.com/sphinx-doc/sphinxcontrib-jsmath/blob/1.0.1/setup.py#L67
- https://github.com/sphinx-doc/sphinxcontrib-qthelp/blob/1.0.3/setup.py#L69
- https://github.com/sphinx-doc/sphinxcontrib-serializinghtml/blob/1.1.5/setup.py#L70

Namespace packages are packages which contain split up package contents that get then merged upon import, so something like `foo.bar` and `foo.baz` can be packaged separately while still being available on the single `foo` parent package.

Setuptools 67.3.0 wants those namespace packages to be declared implicitly.

----

I have no clue why it gets raised when running `pytest`. It does that with every single test module, not just the entire test suite, even though sphinx is completely unrelated to Streamlink's tests or code base. This must mean that pytest is looking up every package installed in the user's python environment, and since docs-requirements are included in the env, the deprecationwarning gets raised when these explicit namespace packages are encountered. Sphinx doesn't even use setuptools. It uses flit.

Example:

```
=============================================================== warnings summary ===============================================================
../../venv/streamlink-311/lib/python3.11/site-packages/pkg_resources/__init__.py:2804
../../venv/streamlink-311/lib/python3.11/site-packages/pkg_resources/__init__.py:2804
../../venv/streamlink-311/lib/python3.11/site-packages/pkg_resources/__init__.py:2804
../../venv/streamlink-311/lib/python3.11/site-packages/pkg_resources/__init__.py:2804
  /home/basti/venv/streamlink-311/lib/python3.11/site-packages/pkg_resources/__init__.py:2804: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages
    declare_namespace(pkg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 117 passed, 4 skipped, 4 warnings in 0.24s ==================================================
```

Btw, this doesn't come up in the GH test runners, because Sphinx doesn't get installed.