### PR TITLE
tools: add pylint, flake-pie and flake-builtins rules to ruff config

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -50,23 +50,23 @@ class ArgparseDirective(Directive):
 
     _headlines = ["^", "~"]
 
-    def process_help(self, help):
+    def process_help(self, helptext):
         # Dedent the help to make sure we are always dealing with
         # non-indented text.
-        help = dedent(help)
+        helptext = dedent(helptext)
 
-        help = _inline_code_block_re.sub(
+        helptext = _inline_code_block_re.sub(
             lambda m: (
                 ":code:`{0}`".format(m.group(1).replace("\\", "\\\\"))
             ),
-            help,
+            helptext,
         )
 
-        help = _example_inline_code_block_re.sub(r":code:`\1`", help)
+        helptext = _example_inline_code_block_re.sub(r":code:`\1`", helptext)
 
         # Replace option references with links.
         # Do this before indenting blocks and notes.
-        help = _option_line_re.sub(
+        helptext = _option_line_re.sub(
             lambda m: (
                 _option_re.sub(
                     lambda m2: (
@@ -77,34 +77,34 @@ class ArgparseDirective(Directive):
                     m.group(1),
                 )
             ),
-            help,
+            helptext,
         )
 
         # Create simple blocks.
-        help = _block_re.sub("::\n\n  ", help)
+        helptext = _block_re.sub("::\n\n  ", helptext)
 
         # Boldify the default value.
-        help = _default_re.sub(r"Default is: **\1**.\n", help)
+        helptext = _default_re.sub(r"Default is: **\1**.\n", helptext)
 
         # Create note directives from "Note: " paragraphs.
-        help = _note_re.sub(
+        helptext = _note_re.sub(
             lambda m: ".. note::\n\n" + indent(m.group(1)) + "\n\n",
-            help,
+            helptext,
         )
 
         # workaround to replace %(prog)s with streamlink
-        help = _prog_re.sub("streamlink", help)
+        helptext = _prog_re.sub("streamlink", helptext)
 
         # fix escaped chars for percent-formatted argparse help strings
-        help = _percent_re.sub("%", help)
+        helptext = _percent_re.sub("%", helptext)
 
         # create cross-link for the "Metadata variables" section
-        help = _cli_metadata_variables_section_cross_link_re.sub(
+        helptext = _cli_metadata_variables_section_cross_link_re.sub(
             "the \":ref:`Metadata variables <cli/metadata:Variables>`\" section",
-            help,
+            helptext,
         )
 
-        return indent(help)
+        return indent(helptext)
 
     def generate_group_rst(self, group):
         for action in group._group_actions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,10 @@ select = [
   "W",
   # pyflakes
   "F",
+  # pylint
+  "PLC",
+  "PLE",
+  "PLW",
   # isort
   "I",
   # flake8-tidy-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ select = [
   "C4",
   # flake8-implicit-str-concat
   "ISC",
+  # flake8-pie
+  "PIE",
   # flake8-pytest-style
   "PT",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,10 +79,8 @@ select = [
   "PLW",
   # isort
   "I",
-  # flake8-tidy-imports
-  "TID",
-  # flake8-quotes
-  "Q",
+  # flake8-builtins
+  "A",
   # flake8-commas
   "COM",
   # flake8-comprehensions
@@ -93,8 +91,13 @@ select = [
   "PIE",
   # flake8-pytest-style
   "PT",
+  # flake8-quotes
+  "Q",
+  # flake8-tidy-imports
+  "TID",
 ]
 extend-ignore = [
+  "A003",  # builtin-attribute-shadowing
   "C408",  # unnecessary-collection-call
   "ISC003",  # explicit-string-concatenation
 ]

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -184,7 +184,7 @@ def basicConfig(
     filemode: str = "a",
     stream: Optional[IO] = None,
     level: Optional[str] = None,
-    format: str = FORMAT_BASE,
+    format: str = FORMAT_BASE,  # noqa: A002  # TODO: rename to "fmt" (breaking)
     style: str = FORMAT_STYLE,  # TODO: py38: Literal["%", "{", "$"]
     datefmt: str = FORMAT_DATE,
     remove_base: Optional[List[str]] = None,

--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 
 # noinspection PyPep8Naming,PyShadowingBuiltins
-from streamlink.plugin.api.validate._schemas import (
+from streamlink.plugin.api.validate._schemas import (  # noqa: A001
     AllSchema as all,
     AnySchema as any,
     AttrSchema as attr,
@@ -22,7 +22,7 @@ from streamlink.plugin.api.validate._validate import (
 )
 
 # noinspection PyShadowingBuiltins
-from streamlink.plugin.api.validate._validators import (
+from streamlink.plugin.api.validate._validators import (  # noqa: A001
     validator_contains as contains,
     validator_endswith as endswith,
     validator_filter as filter,

--- a/src/streamlink/plugins/adultswim.py
+++ b/src/streamlink/plugins/adultswim.py
@@ -87,7 +87,7 @@ class AdultSwim(Plugin):
         validate.filter(lambda k, v: k.startswith("Video:")),
     )
 
-    def _get_stream_data(self, id):
+    def _get_stream_data(self, streamid):
         res = self.session.http.get(self.url)
         m = self.json_data_re.search(res.text)
         if m and m.group(1):
@@ -96,9 +96,8 @@ class AdultSwim(Plugin):
             raise PluginError("Failed to get json_data")
 
         for stream in streams:
-            if "id" in stream:
-                if id == stream["id"] and "stream" in stream:
-                    return stream["stream"]
+            if "id" in stream and streamid == stream["id"] and "stream" in stream:
+                return stream["stream"]
 
     def _get_video_data(self, slug):
         m = self.truncate_url_re.search(self.url)

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -73,8 +73,8 @@ class Booyah(Plugin):
         res = self.session.http.post(self.auth_api_url)
         self.session.http.json(res, self.auth_schema)
 
-    def get_vod(self, id):
-        res = self.session.http.get(self.vod_api_url.format(id))
+    def get_vod(self, vodid):
+        res = self.session.http.get(self.vod_api_url.format(vodid))
         user_data = self.session.http.json(res, schema=self.vod_schema)
 
         self.author = user_data["user"]["nickname"]
@@ -93,8 +93,8 @@ class Booyah(Plugin):
                     stream["stream_url"],
                 )
 
-    def get_live(self, id):
-        res = self.session.http.get(self.live_api_url.format(id))
+    def get_live(self, liveid):
+        res = self.session.http.get(self.live_api_url.format(liveid))
         user_data = self.session.http.json(res, schema=self.live_schema)
 
         if user_data["channel"]["is_streaming"]:

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -216,9 +216,9 @@ class TVP(Plugin):
             log.error("The content is not available in your region")
             return
 
-        for format in data.get("formats"):
-            if format.get("mimeType") == "application/x-mpegurl":
-                return HLSStream.parse_variant_playlist(self.session, format.get("url"))
+        for formatitem in data.get("formats"):
+            if formatitem.get("mimeType") == "application/x-mpegurl":
+                return HLSStream.parse_variant_playlist(self.session, formatitem.get("url"))
 
     def _get_streams(self):
         if self.matches["tvp_info"]:

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -16,8 +16,10 @@ log = logging.getLogger(__name__)
 epoch_start = datetime.datetime(1970, 1, 1, tzinfo=utc)
 
 
+# TODO: use NamedTuple or dataclass
 class Segment:
-    def __init__(self, url, duration, init=False, content=True, available_at=epoch_start, range=None):
+    # noinspection PyShadowingBuiltins
+    def __init__(self, url, duration, init=False, content=True, available_at=epoch_start, range=None):  # noqa: A002
         self.url = url
         self.duration = duration
         self.init = init

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -521,14 +521,12 @@ class M3U8Parser:
         EXT-X-SESSION-DATA
         https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.4
         """
-        pass
 
     def parse_tag_ext_x_session_key(self, value: str) -> None:
         """
         EXT-X-SESSION-KEY
         https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.4.5
         """
-        pass
 
     # 4.3.5: Media or Master Playlist Tags
 
@@ -537,7 +535,6 @@ class M3U8Parser:
         EXT-X-INDEPENDENT-SEGMENTS
         https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.5.1
         """
-        pass
 
     def parse_tag_ext_x_start(self, value: str) -> None:
         """

--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -178,14 +178,12 @@ class SegmentedStreamWriter(AwaitableMixin, Thread):
 
         Should be overridden by the inheriting class.
         """
-        pass
 
     def write(self, segment, result, *data):
         """Writes a segment to the buffer.
 
         Should be overridden by the inheriting class.
         """
-        pass
 
     def run(self):
         while not self.closed:

--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -58,7 +58,8 @@ def keyvalue(value):
     return match.group("key", "value")
 
 
-def num(type, min=None, max=None):
+# noinspection PyShadowingBuiltins
+def num(type, min=None, max=None):  # noqa: A002
     def func(value):
         value = type(value)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -808,7 +808,6 @@ def log_current_versions():
 
 
 def log_current_arguments(session: Streamlink, parser: argparse.ArgumentParser):
-    global args
     if not logger.root.isEnabledFor(logging.DEBUG):
         return
 

--- a/tests/cli/utils/test_formatter.py
+++ b/tests/cli/utils/test_formatter.py
@@ -70,7 +70,7 @@ class TestCLIFormatter:
         ]
 
     def test_path_substitute(self, formatter: Formatter):
-        formatter.mapping.update(**{
+        formatter.mapping.update({
             "current": lambda: ".",
             "parent": lambda: "..",
             "dots": lambda: "...",

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -57,9 +57,9 @@ DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class TagDateRangeAd(Tag):
-    def __init__(self, start=DATETIME_BASE, duration=1, id="stitched-ad-1234", classname="twitch-stitched-ad", custom=None):
+    def __init__(self, start=DATETIME_BASE, duration=1, attrid="stitched-ad-1234", classname="twitch-stitched-ad", custom=None):
         attrs = {
-            "ID": self.val_quoted_string(id),
+            "ID": self.val_quoted_string(attrid),
             "CLASS": self.val_quoted_string(classname),
             "START-DATE": self.val_quoted_string(start.strftime(DATETIME_FORMAT)),
             "DURATION": duration,
@@ -129,7 +129,14 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         return session
 
     def test_hls_disable_ads_daterange_unknown(self):
-        daterange = TagDateRangeAd(start=DATETIME_BASE, duration=1, id="foo", classname="bar", custom=None)
+        daterange = TagDateRangeAd(
+            start=DATETIME_BASE,
+            duration=1,
+            attrid="foo",
+            classname="bar",
+            custom=None,
+        )
+
         thread, segments = self.subject([
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True),
         ], disable_ads=True, low_latency=False)
@@ -140,7 +147,14 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert all(self.called(s) for s in segments.values()), "Downloads all segments"
 
     def test_hls_disable_ads_daterange_by_class(self):
-        daterange = TagDateRangeAd(start=DATETIME_BASE, duration=1, id="foo", classname="twitch-stitched-ad", custom=None)
+        daterange = TagDateRangeAd(
+            start=DATETIME_BASE,
+            duration=1,
+            attrid="foo",
+            classname="twitch-stitched-ad",
+            custom=None,
+        )
+
         thread, segments = self.subject([
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True),
         ], disable_ads=True, low_latency=False)
@@ -151,7 +165,14 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert all(self.called(s) for s in segments.values()), "Downloads all segments"
 
     def test_hls_disable_ads_daterange_by_id(self):
-        daterange = TagDateRangeAd(start=DATETIME_BASE, duration=1, id="stitched-ad-1234", classname="/", custom=None)
+        daterange = TagDateRangeAd(
+            start=DATETIME_BASE,
+            duration=1,
+            attrid="stitched-ad-1234",
+            classname="/",
+            custom=None,
+        )
+
         thread, segments = self.subject([
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True),
         ], disable_ads=True, low_latency=False)
@@ -162,7 +183,14 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert all(self.called(s) for s in segments.values()), "Downloads all segments"
 
     def test_hls_disable_ads_daterange_by_attr(self):
-        daterange = TagDateRangeAd(start=DATETIME_BASE, duration=1, id="foo", classname="/", custom={"X-TV-TWITCH-AD-URL": "/"})
+        daterange = TagDateRangeAd(
+            start=DATETIME_BASE,
+            duration=1,
+            attrid="foo",
+            classname="/",
+            custom={"X-TV-TWITCH-AD-URL": "/"},
+        )
+
         thread, segments = self.subject([
             Playlist(0, [daterange, Segment(0), Segment(1)], end=True),
         ], disable_ads=True, low_latency=False)


### PR DESCRIPTION
Just a couple of more linting rules for ensuring cleaner code, without major code changes.

pylint's "refactor" ruleset is not included in this PR, because its rules set a default function/method complexity limit and a max number of function/method parameters, and Streamlink's codebase violates most of those rules, so adding the ruleset just to suppress most rules of this set doesn't make much sense.
https://beta.ruff.rs/docs/rules/#pylint-pl

I'd also like to add flake8-bugbear in the future, but that will require more code changes which I didn't want to include here just yet.
https://beta.ruff.rs/docs/rules/#flake8-bugbear-b