### PR TITLE
stream.dash: fix and refactor

### DIFF
--- a/src/streamlink/plugins/vinhlongtv.py
+++ b/src/streamlink/plugins/vinhlongtv.py
@@ -7,10 +7,8 @@ $region Vietnam
 
 import logging
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import md5
-
-from isodate import UTC  # type: ignore[import]
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -30,7 +28,7 @@ class VinhLongTV(Plugin):
     _API_KEY_SECRET = "Kh0aAnT0an"
 
     def _get_headers(self):
-        now = datetime.now(tz=UTC)
+        now = datetime.now(tz=timezone.utc)
         date = now.strftime("%Y%m%d")
         time = now.strftime("%H%M%S")
         dtstr = f"{date}{time}"

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional
 from urllib.parse import urlparse, urlunparse
 
 from streamlink import PluginError, StreamError
-from streamlink.stream.dash_manifest import MPD, Representation, Segment, freeze_timeline, utc
+from streamlink.stream.dash_manifest import MPD, Representation, Segment, freeze_timeline
 from streamlink.stream.ffmpegmux import FFMPEGMuxer
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.stream.stream import Stream
@@ -19,6 +19,8 @@ from streamlink.utils.parse import parse_xml
 
 
 log = logging.getLogger(__name__)
+
+UTC = datetime.timezone.utc
 
 
 class DASHStreamWriter(SegmentedStreamWriter):
@@ -36,7 +38,7 @@ class DASHStreamWriter(SegmentedStreamWriter):
         try:
             request_args = copy.deepcopy(self.reader.stream.args)
             headers = request_args.pop("headers", {})
-            now = datetime.datetime.now(tz=utc)
+            now = datetime.datetime.now(tz=UTC)
             if segment.available_at > now:
                 time_to_wait = (segment.available_at - now).total_seconds()
                 fname = self._get_segment_name(segment)

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 
 UTC = datetime.timezone.utc
 epoch_start = datetime.datetime(1970, 1, 1, tzinfo=UTC)
+ONE_SECOND = datetime.timedelta(seconds=1)
 
 
 # TODO: use NamedTuple or dataclass
@@ -34,11 +35,11 @@ def datetime_to_seconds(dt):
     return (dt - epoch_start).total_seconds()
 
 
-def count_dt(firstval=datetime.datetime.now(tz=UTC), step=datetime.timedelta(seconds=1)):
-    x = firstval
+def count_dt(firstval: Optional[datetime.datetime] = None, step: datetime.timedelta = ONE_SECOND):
+    current = datetime.datetime.now(tz=UTC) if firstval is None else firstval
     while True:
-        yield x
-        x += step
+        yield current
+        current += step
 
 
 @contextmanager

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -15,14 +15,14 @@ from isodate import Duration, parse_datetime, parse_duration  # type: ignore[imp
 log = logging.getLogger(__name__)
 
 UTC = datetime.timezone.utc
-epoch_start = datetime.datetime(1970, 1, 1, tzinfo=UTC)
+EPOCH_START = datetime.datetime(1970, 1, 1, tzinfo=UTC)
 ONE_SECOND = datetime.timedelta(seconds=1)
 
 
 # TODO: use NamedTuple or dataclass
 class Segment:
     # noinspection PyShadowingBuiltins
-    def __init__(self, url, duration, init=False, content=True, available_at=epoch_start, range=None):  # noqa: A002
+    def __init__(self, url, duration, init=False, content=True, available_at=EPOCH_START, range=None):  # noqa: A002
         self.url = url
         self.duration = duration
         self.init = init
@@ -32,7 +32,7 @@ class Segment:
 
 
 def datetime_to_seconds(dt):
-    return (dt - epoch_start).total_seconds()
+    return (dt - EPOCH_START).total_seconds()
 
 
 def count_dt(firstval: Optional[datetime.datetime] = None, step: datetime.timedelta = ONE_SECOND):
@@ -445,7 +445,7 @@ class SegmentTemplate(MPDNode):
         """
         log.debug("Generating segment numbers for {0} playlist (id={1})".format(self.root.type, self.parent.id))
         if self.root.type == "static":
-            available_iter = repeat(epoch_start)
+            available_iter = repeat(EPOCH_START)
             duration = self.period.duration.seconds or self.root.mediaPresentationDuration.seconds
             if duration:
                 number_iter = range(self.startNumber, int(duration / self.duration_seconds) + 1)
@@ -493,7 +493,7 @@ class SegmentTemplate(MPDNode):
                 suggested_delay = datetime.timedelta(seconds=(self.root.suggestedPresentationDelay.total_seconds()
                                                               if self.root.suggestedPresentationDelay
                                                               else 3))
-                publish_time = self.root.publishTime or epoch_start
+                publish_time = self.root.publishTime or EPOCH_START
 
                 # transform the time line in to a segment list
                 timeline = []

--- a/tests/stream/test_dash_parser.py
+++ b/tests/stream/test_dash_parser.py
@@ -8,16 +8,14 @@ import pytest
 from freezegun import freeze_time
 from freezegun.api import FakeDatetime  # type: ignore[attr-defined]
 
-from streamlink.stream.dash_manifest import MPD, MPDParsers, MPDParsingError, Representation, utc
+from streamlink.stream.dash_manifest import MPD, MPDParsers, MPDParsingError, Representation
 from tests.resources import xml
 
 
-class TestMPDParsers(unittest.TestCase):
-    def test_utc(self):
-        assert utc.tzname(None) == "UTC"
-        assert utc.dst(None) == datetime.timedelta(0)
-        assert utc.utcoffset(None) == datetime.timedelta(0)
+UTC = datetime.timezone.utc
 
+
+class TestMPDParsers(unittest.TestCase):
     def test_bool_str(self):
         assert MPDParsers.bool_str("true")
         assert MPDParsers.bool_str("TRUE")
@@ -38,7 +36,7 @@ class TestMPDParsers(unittest.TestCase):
         assert MPDParsers.duration("PT1S") == datetime.timedelta(0, 1)
 
     def test_datetime(self):
-        assert MPDParsers.datetime("2018-01-01T00:00:00Z") == datetime.datetime(2018, 1, 1, 0, 0, 0, tzinfo=utc)
+        assert MPDParsers.datetime("2018-01-01T00:00:00Z") == datetime.datetime(2018, 1, 1, 0, 0, 0, tzinfo=UTC)
 
     def test_segment_template(self):
         assert MPDParsers.segment_template("$Time$-$Number$-$Other$")(Time=1, Number=2, Other=3) == "1-2-3"
@@ -112,7 +110,7 @@ class TestMPDParser(unittest.TestCase):
             ]
 
     def test_segments_dynamic_number(self):
-        with freeze_time(FakeDatetime(2018, 5, 22, 13, 37, 0, tzinfo=utc)):
+        with freeze_time(FakeDatetime(2018, 5, 22, 13, 37, 0, tzinfo=UTC)):
             with xml("dash/test_4.mpd") as mpd_xml:
                 mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")
 
@@ -129,15 +127,15 @@ class TestMPDParser(unittest.TestCase):
                 assert video_segments == [
                     (
                         "http://test.se/hd-5_000311235.mp4",
-                        datetime.datetime(2018, 5, 22, 13, 37, 0, tzinfo=utc),
+                        datetime.datetime(2018, 5, 22, 13, 37, 0, tzinfo=UTC),
                     ),
                     (
                         "http://test.se/hd-5_000311236.mp4",
-                        datetime.datetime(2018, 5, 22, 13, 37, 5, tzinfo=utc),
+                        datetime.datetime(2018, 5, 22, 13, 37, 5, tzinfo=UTC),
                     ),
                     (
                         "http://test.se/hd-5_000311237.mp4",
-                        datetime.datetime(2018, 5, 22, 13, 37, 10, tzinfo=utc),
+                        datetime.datetime(2018, 5, 22, 13, 37, 10, tzinfo=UTC),
                     ),
                 ]
 

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -1,9 +1,8 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple, Union
 
 import pytest
-from isodate import tzinfo  # type: ignore[import]
 
 from streamlink.stream.hls_playlist import (
     ByteRange,
@@ -17,6 +16,9 @@ from streamlink.stream.hls_playlist import (
     load,
 )
 from tests.resources import text
+
+
+UTC = timezone.utc
 
 
 def test_parse_tag_callback_cache():
@@ -169,7 +171,7 @@ def test_parse_hex(caplog: pytest.LogCaptureFixture, string: Optional[str], log:
     ("not an ISO8601 string", True, None),
     ("2000-01-01", True, None),
     ("2000-99-99T99:99:99.999Z", True, None),
-    ("2000-01-01T00:00:00.000Z", False, datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo.UTC)),
+    ("2000-01-01T00:00:00.000Z", False, datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=UTC)),
 ])
 def test_parse_iso8601(caplog: pytest.LogCaptureFixture, string: Optional[str], log: bool, expected: Optional[datetime]):
     assert M3U8Parser.parse_iso8601(string) == expected
@@ -372,8 +374,8 @@ class TestHLSPlaylist(unittest.TestCase):
         with text("hls/test_date.m3u8") as m3u8_fh:
             playlist = load(m3u8_fh.read(), "http://test.se/")
 
-        start_date = datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=tzinfo.UTC)
-        end_date = datetime(year=2000, month=1, day=1, hour=0, minute=1, second=0, microsecond=0, tzinfo=tzinfo.UTC)
+        start_date = datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=UTC)
+        end_date = datetime(year=2000, month=1, day=1, hour=0, minute=1, second=0, microsecond=0, tzinfo=UTC)
         delta_15 = timedelta(seconds=15)
         delta_30 = timedelta(seconds=30, milliseconds=500)
         delta_60 = timedelta(seconds=60)


### PR DESCRIPTION
1. Use the [`datetime.timezone.utc`](https://docs.python.org/3/library/datetime.html#datetime.timezone.utc) stdlib class instance instead of the custom `isodate.UTC` class instance (differs in `dst()`, but that's irrelevant) (`datetime.UTC` is only available on 3.11+)
   - https://github.com/python/cpython/blame/v3.11.0/Lib/datetime.py#L2409
   - https://github.com/python/cpython/blame/v3.10.0/Lib/datetime.py#L2301
   - https://github.com/gweis/isodate/blob/0.6.1/src/isodate/tzinfo.py#L13-L46
2. Fix default param in `stream.dash_manifest.count_dt()` (should be the current time when initializing)
3. Rename constants for consistency reasons
4. Use dataclass for DASH `Segment`s, add typing information, rename `range` to `byterange` (similar to HLS's `Segment` (currently still a NamedTuple)) and update old `range` references