### PR TITLE
stream.dash: refactor and reformat code

### DIFF
--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -7,7 +7,7 @@ import re
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from itertools import count, repeat
-from typing import Optional, Tuple
+from typing import ClassVar, Optional, Tuple
 from urllib.parse import urljoin, urlparse, urlsplit, urlunparse, urlunsplit
 
 from isodate import Duration, parse_datetime, parse_duration  # type: ignore[import]
@@ -48,6 +48,9 @@ def freeze_timeline(mpd):
     mpd.timelines = timelines
 
 
+_re_segment_template = re.compile(r"(.*?)\$(\w+)(?:%([\w.]+))?\$")
+
+
 class MPDParsers:
     @staticmethod
     def bool_str(v):
@@ -71,11 +74,11 @@ class MPDParsers:
     def segment_template(url_template):
         end = 0
         res = ""
-        for m in re.compile(r"(.*?)\$(\w+)(?:%([\w.]+))?\$").finditer(url_template):
+        for m in _re_segment_template.finditer(url_template):
             _, end = m.span()
-            res += "{0}{{{1}{2}}}".format(m.group(1), m.group(2), f":{m.group(3)}" if m.group(3) else "")
+            res += f"{m[1]}{{{m[2]}{f':{m[3]}' if m[3] else ''}}}"
 
-        return (res + url_template[end:]).format
+        return f"{res}{url_template[end:]}".format
 
     @staticmethod
     def frame_rate(frame_rate):
@@ -96,7 +99,7 @@ class MPDParsers:
     def range(range_spec):
         r = range_spec.split("-")
         if len(r) != 2:
-            raise MPDParsingError("invalid byte-range-spec")
+            raise MPDParsingError("Invalid byte-range-spec")
 
         start, end = int(r[0]), r[1] and int(r[1]) or None
         return start, end and ((end - start) + 1)
@@ -107,7 +110,7 @@ class MPDParsingError(Exception):
 
 
 class MPDNode:
-    __tag__: Optional[str] = None
+    __tag__: ClassVar[str]
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         self.node = node
@@ -116,7 +119,7 @@ class MPDNode:
         self._base_url = kwargs.get("base_url")
         self.attributes = set()
         if self.__tag__ and self.node.tag.lower() != self.__tag__.lower():
-            raise MPDParsingError("root tag did not match the expected tag: {}".format(self.__tag__))
+            raise MPDParsingError(f"Root tag did not match the expected tag: {self.__tag__}")
 
     @property
     def attrib(self):
@@ -127,10 +130,7 @@ class MPDNode:
         return self.node.text
 
     def __str__(self):
-        return "<{tag} {attrs}>".format(
-            tag=self.__tag__,
-            attrs=" ".join("@{}={}".format(attr, getattr(self, attr)) for attr in self.attributes),
-        )
+        return f"<{self.__tag__} {' '.join(f'@{attr}={getattr(self, attr)}' for attr in self.attributes)}>"
 
     def attr(self, key, default=None, parser=None, required=False, inherited=False):
         self.attributes.add(key)
@@ -145,15 +145,14 @@ class MPDNode:
                 return getattr(self.parent, key)
 
         if required:
-            raise MPDParsingError("could not find required attribute {tag}@{attr} ".format(attr=key, tag=self.__tag__))
-        else:
-            return default
+            raise MPDParsingError(f"Could not find required attribute {self.__tag__}@{key} ")
+
+        return default
 
     def children(self, cls, minimum=0, maximum=None):
         children = self.node.findall(cls.__tag__)
         if len(children) < minimum or (maximum and len(children) > maximum):
-            raise MPDParsingError("expected to find {}/{} required [{}..{})".format(
-                self.__tag__, cls.__tag__, minimum, maximum or "unbound"))
+            raise MPDParsingError(f"Expected to find {self.__tag__}/{cls.__tag__} required [{minimum}..{maximum or 'unbound'})")
 
         return [
             cls(child, root=self.root, parent=self, i=i, base_url=self.base_url)
@@ -187,32 +186,67 @@ class MPD(MPDNode):
     """
     Represents the MPD as a whole
 
-    Should validate the XML input and provide methods to get segment URLs for each Period, AdaptationSet and
-    Representation.
-
+    Should validate the XML input and provide methods to get segment URLs for each Period, AdaptationSet and Representation.
     """
+
     __tag__ = "MPD"
 
     def __init__(self, node, root=None, parent=None, url=None, *args, **kwargs):
         # top level has no parent
         super().__init__(node, root=self, *args, **kwargs)
+
         # parser attributes
         self.url = url
         self.timelines = defaultdict(lambda: -1)
         self.timelines.update(kwargs.pop("timelines", {}))
+
         self.id = self.attr("id")
-        self.profiles = self.attr("profiles", required=True)
-        self.type = self.attr("type", default="static", parser=MPDParsers.type)
-        self.minimumUpdatePeriod = self.attr("minimumUpdatePeriod", parser=MPDParsers.duration, default=Duration())
-        self.minBufferTime = self.attr("minBufferTime", parser=MPDParsers.duration, required=True)
-        self.timeShiftBufferDepth = self.attr("timeShiftBufferDepth", parser=MPDParsers.duration)
-        self.availabilityStartTime = self.attr("availabilityStartTime", parser=MPDParsers.datetime,
-                                               default=datetime.datetime.fromtimestamp(0, UTC),  # earliest date
-                                               required=self.type == "dynamic")
-        self.publishTime = self.attr("publishTime", parser=MPDParsers.datetime, required=self.type == "dynamic")
-        self.availabilityEndTime = self.attr("availabilityEndTime", parser=MPDParsers.datetime)
-        self.mediaPresentationDuration = self.attr("mediaPresentationDuration", parser=MPDParsers.duration)
-        self.suggestedPresentationDelay = self.attr("suggestedPresentationDelay", parser=MPDParsers.duration)
+        self.profiles = self.attr(
+            "profiles",
+            required=True,
+        )
+        self.type = self.attr(
+            "type",
+            parser=MPDParsers.type,
+            default="static",
+        )
+        self.minimumUpdatePeriod = self.attr(
+            "minimumUpdatePeriod",
+            parser=MPDParsers.duration,
+            default=Duration(),
+        )
+        self.minBufferTime = self.attr(
+            "minBufferTime",
+            parser=MPDParsers.duration,
+            required=True,
+        )
+        self.timeShiftBufferDepth = self.attr(
+            "timeShiftBufferDepth",
+            parser=MPDParsers.duration,
+        )
+        self.availabilityStartTime = self.attr(
+            "availabilityStartTime",
+            parser=MPDParsers.datetime,
+            default=datetime.datetime.fromtimestamp(0, UTC),  # earliest date
+            required=self.type == "dynamic",
+        )
+        self.publishTime = self.attr(
+            "publishTime",
+            parser=MPDParsers.datetime,
+            required=self.type == "dynamic",
+        )
+        self.availabilityEndTime = self.attr(
+            "availabilityEndTime",
+            parser=MPDParsers.datetime,
+        )
+        self.mediaPresentationDuration = self.attr(
+            "mediaPresentationDuration",
+            parser=MPDParsers.duration,
+        )
+        self.suggestedPresentationDelay = self.attr(
+            "suggestedPresentationDelay",
+            parser=MPDParsers.duration,
+        )
 
         # parse children
         location = self.children(Location)
@@ -270,9 +304,20 @@ class Period(MPDNode):
         super().__init__(node, root, parent, *args, **kwargs)
         self.i = kwargs.get("i", 0)
         self.id = self.attr("id")
-        self.bitstreamSwitching = self.attr("bitstreamSwitching", parser=MPDParsers.bool_str)
-        self.duration = self.attr("duration", default=Duration(), parser=MPDParsers.duration)
-        self.start = self.attr("start", default=Duration(), parser=MPDParsers.duration)
+        self.bitstreamSwitching = self.attr(
+            "bitstreamSwitching",
+            parser=MPDParsers.bool_str,
+        )
+        self.duration = self.attr(
+            "duration",
+            parser=MPDParsers.duration,
+            default=Duration(),
+        )
+        self.start = self.attr(
+            "start",
+            parser=MPDParsers.duration,
+            default=Duration(),
+        )
 
         if self.start is None and self.i == 0 and self.root.type == "static":
             self.start = 0
@@ -319,7 +364,10 @@ class SegmentURL(MPDNode):
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super().__init__(node, root, parent, *args, **kwargs)
         self.media = self.attr("media")
-        self.media_range = self.attr("mediaRange", parser=MPDParsers.range)
+        self.media_range = self.attr(
+            "mediaRange",
+            parser=MPDParsers.range,
+        )
 
 
 class SegmentList(MPDNode):
@@ -329,9 +377,19 @@ class SegmentList(MPDNode):
         super().__init__(node, root, parent, *args, **kwargs)
 
         self.presentation_time_offset = self.attr("presentationTimeOffset")
-        self.timescale = self.attr("timescale", parser=int)
-        self.duration = self.attr("duration", parser=int)
-        self.start_number = self.attr("startNumber", parser=int, default=1)
+        self.timescale = self.attr(
+            "timescale",
+            parser=int,
+        )
+        self.duration = self.attr(
+            "duration",
+            parser=int,
+        )
+        self.start_number = self.attr(
+            "startNumber",
+            parser=int,
+            default=1,
+        )
 
         if self.duration:
             self.duration_seconds = self.duration / float(self.timescale)
@@ -344,9 +402,18 @@ class SegmentList(MPDNode):
     @property
     def segments(self):
         if self.initialization:
-            yield Segment(self.make_url(self.initialization.source_url), 0, init=True, content=False)
+            yield Segment(
+                url=self.make_url(self.initialization.source_url),
+                duration=0,
+                init=True,
+                content=False,
+            )
         for n, segment_url in enumerate(self.segment_urls, self.start_number):
-            yield Segment(self.make_url(segment_url.media), self.duration_seconds, byterange=segment_url.media_range)
+            yield Segment(
+                url=self.make_url(segment_url.media),
+                duration=self.duration_seconds,
+                byterange=segment_url.media_range,
+            )
 
     def make_url(self, url):
         return BaseURL.join(self.base_url, url)
@@ -366,16 +433,49 @@ class AdaptationSet(MPDNode):
         self.par = self.attr("par")
         self.minBandwidth = self.attr("minBandwidth")
         self.maxBandwidth = self.attr("maxBandwidth")
-        self.minWidth = self.attr("minWidth", parser=int)
-        self.maxWidth = self.attr("maxWidth", parser=int)
-        self.minHeight = self.attr("minHeight", parser=int)
-        self.maxHeight = self.attr("maxHeight", parser=int)
-        self.minFrameRate = self.attr("minFrameRate", parser=MPDParsers.frame_rate)
-        self.maxFrameRate = self.attr("maxFrameRate", parser=MPDParsers.frame_rate)
-        self.segmentAlignment = self.attr("segmentAlignment", default=False, parser=MPDParsers.bool_str)
-        self.bitstreamSwitching = self.attr("bitstreamSwitching", parser=MPDParsers.bool_str)
-        self.subsegmentAlignment = self.attr("subsegmentAlignment", default=False, parser=MPDParsers.bool_str)
-        self.subsegmentStartsWithSAP = self.attr("subsegmentStartsWithSAP", default=0, parser=int)
+        self.minWidth = self.attr(
+            "minWidth",
+            parser=int,
+        )
+        self.maxWidth = self.attr(
+            "maxWidth",
+            parser=int,
+        )
+        self.minHeight = self.attr(
+            "minHeight",
+            parser=int,
+        )
+        self.maxHeight = self.attr(
+            "maxHeight",
+            parser=int,
+        )
+        self.minFrameRate = self.attr(
+            "minFrameRate",
+            parser=MPDParsers.frame_rate,
+        )
+        self.maxFrameRate = self.attr(
+            "maxFrameRate",
+            parser=MPDParsers.frame_rate,
+        )
+        self.segmentAlignment = self.attr(
+            "segmentAlignment",
+            parser=MPDParsers.bool_str,
+            default=False,
+        )
+        self.bitstreamSwitching = self.attr(
+            "bitstreamSwitching",
+            parser=MPDParsers.bool_str,
+        )
+        self.subsegmentAlignment = self.attr(
+            "subsegmentAlignment",
+            parser=MPDParsers.bool_str,
+            default=False,
+        )
+        self.subsegmentStartsWithSAP = self.attr(
+            "subsegmentStartsWithSAP",
+            parser=int,
+            default=0,
+        )
 
         self.baseURLs = self.children(BaseURL)
         self.segmentTemplate = self.only_child(SegmentTemplate)
@@ -390,15 +490,33 @@ class SegmentTemplate(MPDNode):
         super().__init__(node, root, parent, *args, **kwargs)
         self.defaultSegmentTemplate = self.walk_back_get_attr("segmentTemplate")
 
-        self.initialization = self.attr("initialization", parser=MPDParsers.segment_template)
-        self.media = self.attr("media", parser=MPDParsers.segment_template)
-        self.duration = self.attr("duration", parser=int,
-                                  default=self.defaultSegmentTemplate.duration if self.defaultSegmentTemplate else None)
-        self.timescale = self.attr("timescale", parser=int,
-                                   default=self.defaultSegmentTemplate.timescale if self.defaultSegmentTemplate else 1)
-        self.startNumber = self.attr("startNumber", parser=int,
-                                     default=self.defaultSegmentTemplate.startNumber if self.defaultSegmentTemplate else 1)
-        self.presentationTimeOffset = self.attr("presentationTimeOffset", parser=MPDParsers.timedelta(self.timescale))
+        self.initialization = self.attr(
+            "initialization",
+            parser=MPDParsers.segment_template,
+        )
+        self.media = self.attr(
+            "media",
+            parser=MPDParsers.segment_template,
+        )
+        self.duration = self.attr(
+            "duration",
+            parser=int,
+            default=self.defaultSegmentTemplate.duration if self.defaultSegmentTemplate else None,
+        )
+        self.timescale = self.attr(
+            "timescale",
+            parser=int,
+            default=self.defaultSegmentTemplate.timescale if self.defaultSegmentTemplate else 1,
+        )
+        self.startNumber = self.attr(
+            "startNumber",
+            parser=int,
+            default=self.defaultSegmentTemplate.startNumber if self.defaultSegmentTemplate else 1,
+        )
+        self.presentationTimeOffset = self.attr(
+            "presentationTimeOffset",
+            parser=MPDParsers.timedelta(self.timescale),
+        )
 
         if self.duration:
             self.duration_seconds = self.duration / float(self.timescale)
@@ -414,9 +532,20 @@ class SegmentTemplate(MPDNode):
         if kwargs.pop("init", True):
             init_url = self.format_initialization(**kwargs)
             if init_url:
-                yield Segment(init_url, 0, True, False)
+                yield Segment(
+                    url=init_url,
+                    duration=0,
+                    init=True,
+                    content=False,
+                )
         for media_url, available_at in self.format_media(**kwargs):
-            yield Segment(media_url, self.duration_seconds, False, True, available_at)
+            yield Segment(
+                url=media_url,
+                duration=self.duration_seconds,
+                init=False,
+                content=True,
+                available_at=available_at,
+            )
 
     def make_url(self, url):
         """
@@ -424,6 +553,7 @@ class SegmentTemplate(MPDNode):
         :param url: maybe relative URL
         :return: joined URL
         """
+
         return BaseURL.join(self.base_url, url)
 
     def format_initialization(self, **kwargs):
@@ -432,17 +562,19 @@ class SegmentTemplate(MPDNode):
 
     def segment_numbers(self):
         """
-        yield the segment number and when it will be available
-        There are two cases for segment number generation, static and dynamic.
+        yield the segment number and when it will be available.
 
-        In the case of static stream, the segment number starts at the startNumber and counts
-        up to the number of segments that are represented by the periods duration.
+        There are two cases for segment number generation, "static" and "dynamic":
 
-        In the case of dynamic streams, the segments should appear at the specified time
-        in the simplest case the segment number is based on the time since the availabilityStartTime
-        :return:
+        In the case of static streams, the segment number starts at the startNumber and counts
+        up to the number of segments that are represented by the periods-duration.
+
+        In the case of dynamic streams, the segments should appear at the specified time.
+        In the simplest case, the segment number is based on the time since the availabilityStartTime.
         """
-        log.debug("Generating segment numbers for {0} playlist (id={1})".format(self.root.type, self.parent.id))
+
+        log.debug(f"Generating segment numbers for {self.root.type} playlist (id={self.parent.id})")
+
         if self.root.type == "static":
             available_iter = repeat(EPOCH_START)
             duration = self.period.duration.seconds or self.root.mediaPresentationDuration.seconds
@@ -461,72 +593,73 @@ class SegmentTemplate(MPDNode):
                 available_start = now
 
             # if there is no delay, use a delay of 3 seconds
-            suggested_delay = datetime.timedelta(seconds=(self.root.suggestedPresentationDelay.total_seconds()
-                                                          if self.root.suggestedPresentationDelay
-                                                          else 3))
+            seconds = self.root.suggestedPresentationDelay.total_seconds() if self.root.suggestedPresentationDelay else 3
+            suggested_delay = datetime.timedelta(seconds=seconds)
 
             # the number of the segment that is available at NOW - SUGGESTED_DELAY - BUFFER_TIME
-            number_iter = count(
-                self.startNumber
-                + int(
-                    (since_start - suggested_delay - self.root.minBufferTime).total_seconds()
-                    / self.duration_seconds,
-                ),
+            number_offset = int(
+                (since_start - suggested_delay - self.root.minBufferTime).total_seconds()
+                / self.duration_seconds,
             )
+            number_iter = count(self.startNumber + number_offset)
 
             # the time the segment number is available at NOW
-            available_iter = count_dt(available_start,
-                                      step=datetime.timedelta(seconds=self.duration_seconds))
+            available_iter = count_dt(
+                available_start,
+                datetime.timedelta(seconds=self.duration_seconds),
+            )
 
         yield from zip(number_iter, available_iter)
 
     def format_media(self, **kwargs):
-        if self.segmentTimeline:
-            if self.parent.id is None:
-                # workaround for invalid `self.root.timelines[self.parent.id]`
-                # creates a timeline for every mimeType instead of one for both
-                self.parent.id = self.parent.mimeType
-            log.debug("Generating segment timeline for {0} playlist (id={1}))".format(self.root.type, self.parent.id))
-            if self.root.type == "dynamic":
-                # if there is no delay, use a delay of 3 seconds
-                suggested_delay = datetime.timedelta(seconds=(self.root.suggestedPresentationDelay.total_seconds()
-                                                              if self.root.suggestedPresentationDelay
-                                                              else 3))
-                publish_time = self.root.publishTime or EPOCH_START
-
-                # transform the time line in to a segment list
-                timeline = []
-                available_at = publish_time
-                for segment, n in reversed(list(zip(self.segmentTimeline.segments, count(self.startNumber)))):
-                    # the last segment in the timeline is the most recent
-                    # so, work backwards and calculate when each of the segments was
-                    # available, based on the durations relative to the publish time
-                    url = self.make_url(self.media(Time=segment.t, Number=n, **kwargs))
-                    duration = datetime.timedelta(seconds=segment.d / self.timescale)
-
-                    # once the suggested_delay is reach stop
-                    if self.root.timelines[self.parent.id] == -1 and publish_time - available_at >= suggested_delay:
-                        break
-
-                    timeline.append((url, available_at, segment.t))
-
-                    available_at -= duration  # walk backwards in time
-
-                # return the segments in chronological order
-                for url, available_at, t in reversed(timeline):
-                    if t > self.root.timelines[self.parent.id]:
-                        self.root.timelines[self.parent.id] = t
-                        yield (url, available_at)
-
-            else:
-                for segment, n in zip(self.segmentTimeline.segments, count(self.startNumber)):
-                    yield (self.make_url(self.media(Time=segment.t, Number=n, **kwargs)),
-                           datetime.datetime.now(tz=UTC))
-
-        else:
+        if not self.segmentTimeline:
             for number, available_at in self.segment_numbers():
-                yield (self.make_url(self.media(Number=number, **kwargs)),
-                       available_at)
+                url = self.make_url(self.media(Number=number, **kwargs))
+                yield url, available_at
+            return
+
+        if self.parent.id is None:
+            # workaround for invalid `self.root.timelines[self.parent.id]`
+            # creates a timeline for every mimeType instead of one for both
+            self.parent.id = self.parent.mimeType
+
+        log.debug(f"Generating segment timeline for {self.root.type} playlist (id={self.parent.id}))")
+
+        if self.root.type == "static":
+            for segment, n in zip(self.segmentTimeline.segments, count(self.startNumber)):
+                url = self.make_url(self.media(Time=segment.t, Number=n, **kwargs))
+                available_at = datetime.datetime.now(tz=UTC)  # TODO: replace with EPOCH_START ?!
+                yield url, available_at
+            return
+
+        # if there is no delay, use a delay of 3 seconds
+        seconds = self.root.suggestedPresentationDelay.total_seconds() if self.root.suggestedPresentationDelay else 3
+        suggested_delay = datetime.timedelta(seconds=seconds)
+        publish_time = self.root.publishTime or EPOCH_START
+
+        # transform the timeline into a segment list
+        timeline = []
+        available_at = publish_time
+        for segment, n in reversed(list(zip(self.segmentTimeline.segments, count(self.startNumber)))):
+            # the last segment in the timeline is the most recent one
+            # so, work backwards and calculate when each of the segments was
+            # available, based on the durations relative to the publish-time
+            url = self.make_url(self.media(Time=segment.t, Number=n, **kwargs))
+            duration = datetime.timedelta(seconds=segment.d / self.timescale)
+
+            # once the suggested_delay is reach stop
+            if self.root.timelines[self.parent.id] == -1 and publish_time - available_at >= suggested_delay:
+                break
+
+            timeline.append((url, available_at, segment.t))
+
+            available_at -= duration  # walk backwards in time
+
+        # return the segments in chronological order
+        for url, available_at, t in reversed(timeline):
+            if t > self.root.timelines[self.parent.id]:
+                self.root.timelines[self.parent.id] = t
+                yield url, available_at
 
 
 class Representation(MPDNode):
@@ -534,24 +667,53 @@ class Representation(MPDNode):
 
     def __init__(self, node, root=None, parent=None, *args, **kwargs):
         super().__init__(node, root, parent, *args, **kwargs)
-        self.id = self.attr("id", required=True)
-        self.bandwidth = self.attr("bandwidth", parser=lambda b: float(b) / 1000.0, required=True)
-        self.mimeType = self.attr("mimeType", required=True, inherited=True)
+        self.id = self.attr(
+            "id",
+            required=True,
+        )
+        self.bandwidth = self.attr(
+            "bandwidth",
+            parser=lambda b: float(b) / 1000.0,
+            required=True,
+        )
+        self.mimeType = self.attr(
+            "mimeType",
+            required=True,
+            inherited=True,
+        )
 
         self.codecs = self.attr("codecs")
         self.startWithSAP = self.attr("startWithSAP")
 
         # video
-        self.width = self.attr("width", parser=int)
-        self.height = self.attr("height", parser=int)
-        self.frameRate = self.attr("frameRate", parser=MPDParsers.frame_rate)
+        self.width = self.attr(
+            "width",
+            parser=int,
+        )
+        self.height = self.attr(
+            "height",
+            parser=int,
+        )
+        self.frameRate = self.attr(
+            "frameRate",
+            parser=MPDParsers.frame_rate,
+        )
 
         # audio
-        self.audioSamplingRate = self.attr("audioSamplingRate", parser=int)
-        self.numChannels = self.attr("numChannels", parser=int)
+        self.audioSamplingRate = self.attr(
+            "audioSamplingRate",
+            parser=int,
+        )
+        self.numChannels = self.attr(
+            "numChannels",
+            parser=int,
+        )
 
         # subtitle
-        self.lang = self.attr("lang", inherited=True)
+        self.lang = self.attr(
+            "lang",
+            inherited=True,
+        )
 
         self.baseURLs = self.children(BaseURL)
         self.subRepresentation = self.children(SubRepresentation)
@@ -567,7 +729,7 @@ class Representation(MPDNode):
         """
         Segments are yielded when they are available
 
-        Segments appear on a time line, for dynamic content they are only available at a certain time
+        Segments appear on a timeline, for dynamic content they are only available at a certain time
         and sometimes for a limited time. For static content they are all available at the same time.
 
         :param kwargs: extra args to pass to the segment template
@@ -579,18 +741,21 @@ class Representation(MPDNode):
         segmentTemplate = self.segmentTemplate or self.walk_back_get_attr("segmentTemplate")
 
         if segmentTemplate:
-            for segment in segmentTemplate.segments(RepresentationID=self.id,
-                                                    Bandwidth=int(self.bandwidth * 1000),
-                                                    **kwargs):
-                if segment.init:
-                    yield segment
-                else:
-                    yield segment
+            yield from segmentTemplate.segments(
+                RepresentationID=self.id,
+                Bandwidth=int(self.bandwidth * 1000),
+                **kwargs,
+            )
         elif segmentLists:
             for segmentList in segmentLists:
                 yield from segmentList.segments
         else:
-            yield Segment(self.base_url, 0, True, True)
+            yield Segment(
+                url=self.base_url,
+                duration=0,
+                init=True,
+                content=True,
+            )
 
 
 class SubRepresentation(MPDNode):


### PR DESCRIPTION
- Fix incorrect typing
- Fix error messages, as well as docstrings and comments
- Fix indentation
- Replace str.format with f-strings
- Use consistent order of `MPDNode.attr()` call keywords, but keep the order of the method's arguments
- Use keywords when initializing the `Segment` dataclass
- Flatten nested if-blocks in `SegmentTemplate.format_media()`
- Remove unnecessary if-block in `Representation.segments()`