### PR TITLE
tools: bump ruff to >=0.0.252 and ignore PLW2901

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ freezegun>=1.0.0
 shtab
 versioningit >=2.0.0, <3
 
-ruff
+ruff >=0.0.252
 
 mypy
 lxml-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ extend-ignore = [
   "A003",  # builtin-attribute-shadowing
   "C408",  # unnecessary-collection-call
   "ISC003",  # explicit-string-concatenation
+  "PLW2901",  # redefined-loop-name
 ]
 extend-exclude = [
   "docs/conf.py",


### PR DESCRIPTION
Fixes issue introduced in ruff's 0.0.250 release yesterday.
https://github.com/charliermarsh/ruff/releases/tag/v0.0.252

PLW2901 is a nonsense rule, so it gets ignored now:
https://beta.ruff.rs/docs/rules/redefined-loop-name/

Otherwise, it'll raise errors on stuff like this:
https://github.com/streamlink/streamlink/blob/d33df662a4f4f28332ec3980b6dd964f990c7a35/src/streamlink/plugin/api/validate/_validate.py#L379-L382