### PR TITLE
stream.dash: fix SegmentTemplate's BaseURL context

### DIFF
--- a/tests/resources/dash/test_nested_baseurls.mpd
+++ b/tests/resources/dash/test_nested_baseurls.mpd
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  type="static"
+  mediaPresentationDuration="PT0H0M6.00S"
+  minBufferTime="PT6.0S"
+>
+  <BaseURL>https://hostname/</BaseURL>
+  <Period id="0" start="PT0.0S">
+    <BaseURL>period/</BaseURL>
+    <AdaptationSet
+      id="0"
+      mimeType="video/mp4"
+      maxWidth="1920"
+      maxHeight="1080"
+      par="16:9"
+      frameRate="60"
+      segmentAlignment="true"
+      startWithSAP="1"
+      subsegmentAlignment="true"
+      subsegmentStartsWithSAP="1"
+    >
+      <SegmentTemplate
+        presentationTimeOffset="0"
+        timescale="90000"
+        duration="540000"
+        startNumber="1"
+        media="media_$RepresentationID$-$Number$.m4s"
+        initialization="init_$RepresentationID$.m4s"
+      />
+      <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
+      <Representation id="video_9000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="9000000">
+        <BaseURL>representation/</BaseURL>
+      </Representation>
+    </AdaptationSet>
+    <AdaptationSet
+      id="1"
+      mimeType="audio/mp4"
+      lang="eng"
+      segmentAlignment="true"
+      startWithSAP="1"
+      subsegmentAlignment="true"
+      subsegmentStartsWithSAP="1"
+    >
+      <BaseURL>adaptationset/</BaseURL>
+      <SegmentTemplate
+        presentationTimeOffset="0"
+        timescale="44100"
+        duration="264600"
+        startNumber="1"
+        media="media_$RepresentationID$-$Number$.m4s"
+        initialization="init_$RepresentationID$.m4s"
+      />
+      <Representation id="audio_128kbps" codecs="mp4a.40.2" audioSamplingRate="44100" sar="1:1" bandwidth="128000"/>
+      <Representation id="audio_256kbps" codecs="mp4a.40.2" audioSamplingRate="44100" sar="1:1" bandwidth="256000">
+        <BaseURL>representation/</BaseURL>
+      </Representation>
+      <Representation id="audio_320kbps" codecs="mp4a.40.2" audioSamplingRate="44100" sar="1:1" bandwidth="320000">
+        <BaseURL>https://other/</BaseURL>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/stream/test_dash_parser.py
+++ b/tests/stream/test_dash_parser.py
@@ -287,3 +287,33 @@ class TestMPDParser(unittest.TestCase):
                 ("http://test/audio-frag.mp4", False, (374366, 471)),
             ],
         ]
+
+    def test_nested_baseurls(self):
+        with xml("dash/test_nested_baseurls.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="https://foo/", url="https://test/manifest.mpd")
+        segment_urls = [
+            [seg.url for seg in itertools.islice(representation.segments(), 2)]
+            for adaptationset in mpd.periods[0].adaptationSets for representation in adaptationset.representations
+        ]
+        assert segment_urls == [
+            [
+                "https://hostname/period/init_video_5000kbps.m4s",
+                "https://hostname/period/media_video_5000kbps-1.m4s",
+            ],
+            [
+                "https://hostname/period/representation/init_video_9000kbps.m4s",
+                "https://hostname/period/representation/media_video_9000kbps-1.m4s",
+            ],
+            [
+                "https://hostname/period/adaptationset/init_audio_128kbps.m4s",
+                "https://hostname/period/adaptationset/media_audio_128kbps-1.m4s",
+            ],
+            [
+                "https://hostname/period/adaptationset/representation/init_audio_256kbps.m4s",
+                "https://hostname/period/adaptationset/representation/media_audio_256kbps-1.m4s",
+            ],
+            [
+                "https://other/init_audio_320kbps.m4s",
+                "https://other/media_audio_320kbps-1.m4s",
+            ],
+        ]


### PR DESCRIPTION
Fixes #4586 

Previously, when formatting init/media segment URLs of a `SegmentTemplate`, its own inherited `base_url` property was used, which does only work in MPD documents where the next `BaseURL` node is a child node of one of the `SegmentTemplate`'s ancestor nodes, namely `AdaptationSet`, `Period` or `MPD`:
```xml
<MPD ...>
  <BaseURL>one</BaseURL>
  <Period ...>
    <BaseURL>two</BaseURL>
    <AdaptationSet>
      <BaseURL>three</BaseURL>
      <SegmentTemplate .../>
      <Representation .../>
    </AdaptationSet>
  </Period>
</MPD>
```

This left out potential `BaseURL` child-nodes in `Representation` nodes that are siblings of `SegmentTemplate` (and similar cases):

```xml
<MPD ...>
  <BaseURL>one</BaseURL>
  <Period ...>
    <BaseURL>two</BaseURL>
    <AdaptationSet>
      <BaseURL>three</BaseURL>
      <SegmentTemplate .../>
      <Representation ...>
        <BaseURL>four was ignored</BaseURL>
      </Representation>
    </AdaptationSet>
  </Period>
</MPD>
```

To fix the issue, just pass the resolved `base_url` from the `Representation` instance to the `SegmentTemplate`'s segment generator, where the init/media URLs are formatted.