### PR TITLE
stream.dash: fix old timeline ID workaround

### DIFF
--- a/tests/resources/dash/test_timeline_ids.mpd
+++ b/tests/resources/dash/test_timeline_ids.mpd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  id="Config part of url maybe?"
+  minBufferTime="PT2S"
+  minimumUpdatePeriod="PT0S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+  publishTime="2000-01-01T00:00:00Z"
+  timeShiftBufferDepth="PT5M"
+  type="dynamic"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+>
+  <Period id="period-0" start="PT0S">
+    <AdaptationSet
+      id="0"
+      contentType="audio"
+      lang="en"
+      mimeType="audio/mp4"
+      segmentAlignment="true"
+      startWithSAP="1"
+    >
+      <SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/t$Time$.m4s" timescale="48000">
+        <SegmentTimeline>
+          <S t="0" d="1" r="3"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="audio1" audioSamplingRate="44100" bandwidth="48000" codecs="mp4a.40.2"/>
+      <Representation id="audio2" audioSamplingRate="48000" bandwidth="96000" codecs="mp4a.40.2"/>
+    </AdaptationSet>
+    <AdaptationSet
+      contentType="video"
+      maxFrameRate="60/2"
+      maxHeight="360"
+      maxWidth="640"
+      mimeType="video/mp4"
+      minHeight="360"
+      minWidth="640"
+      par="16:9"
+      segmentAlignment="true"
+      startWithSAP="1"
+    >
+      <SegmentTemplate initialization="$RepresentationID$/init.mp4" media="$RepresentationID$/t$Time$.m4s" timescale="90000">
+        <SegmentTimeline>
+          <S t="0" d="1" r="3"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation id="video1" bandwidth="300000" codecs="avc1.64001e" frameRate="60/2" height="360" sar="1:1" width="640"/>
+      <Representation id="video2" bandwidth="500000" codecs="avc1.64001e" frameRate="60/2" height="360" sar="1:1" width="640"/>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
**stream.dash: fix old timeline ID workaround**

When building segment timelines, don't use the `mimeType` attribute of the `SegmentTemplate`'s parent node as a fallback when the parent's `id` attribute is missing.

This doesn't work if the parent node is a `Period`, as it doesn't have the `mimeType` attribute, and it also generates timeline keys which are not unique if two streams of the same `mimeType` would get muxed (currently not supported).

Instead, build an `ident` tuple on the `Representation` instance consisting of the ids of the parent `Period` and `AdaptationSet`, and the `Representation` itself, with its required `id` attribute. This ensures a unique key for the `timelines` dict.

Then simply pass the `ident` tuple to the `SegmentTemplate.segments()` generator, similar to the `BaseURL` fixes of e684913.

----

**stream.dash: refactor DASHStream{Reader,Worker}**

Use the newly added `Representation.ident` for finding the same `Representation` after a manifest reload of a dynamic DASH stream.

Also use the worker's `period` attribute instead of the hardcoded zero index, even though only the first period is supported.

----

The missing parent ID workaround was initially implemented in #2096.

There's still a lot to do to fix some of the biggest issues with the DASH implementation. For example, manifest reloads are only attempted once without any retries, and failed manifest reloads or segment downloads can cause a deadlock. And much more...
