### PR TITLE
tools: ignore PLW0603 ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ extend-exclude = [
 "src/streamlink/__init__.py" = ["I"]
 "src/streamlink/_version.py" = ["I"]
 "src/streamlink/plugin/api/useragents.py" = ["E501"]
+"src/streamlink_cli/main.py" = ["PLW0603"]
 
 [tool.ruff.isort]
 known-first-party = ["streamlink", "streamlink_cli"]

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -166,11 +166,11 @@ def _showwarning(message, category, filename, lineno, file=None, line=None):
 
 
 def capturewarnings(capture=False):
-    global _showwarning_default
+    global _showwarning_default  # noqa: PLW0603
 
     if capture:
         if _showwarning_default is None:
-            _showwarning_default = warnings.showwarning
+            _showwarning_default = warnings.showwarning  # noqa: PLW0603
             warnings.showwarning = _showwarning
     else:
         if _showwarning_default is not None:

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -26,7 +26,7 @@ class NamedPipeBase(abc.ABC):
     path: Path
 
     def __init__(self):
-        global _id
+        global _id  # noqa: PLW0603
         with _lock:
             _id += 1
             self.name = f"streamlinkpipe-{os.getpid()}-{_id}-{random.randint(0, 9999)}"


### PR DESCRIPTION
New ruff version added `PLW0603`.

Global state gets legitimately/consciously set in the `logger` and `named_pipe` modules, so the new `PLW0603` rule gets ignored via the `noqa` annotations there. The `main` CLI module is unfortunately riddled with the `global` statement, so the rule gets ignored for the entire module until a much needed refactor happens at some future time (hopefully).