### PR TITLE
stream.dash: add --dash-manifest-reload-attempts

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -224,6 +224,7 @@ class Streamlink:
             "hls-segment-ignore-names": [],
             "hls-segment-key-uri": None,
             "hls-audio-select": [],
+            "dash-manifest-reload-attempts": 3,
             "ffmpeg-ffmpeg": None,
             "ffmpeg-no-validation": False,
             "ffmpeg-verbose": False,
@@ -367,7 +368,7 @@ class Streamlink:
             * - hls-playlist-reload-attempts
               - ``int``
               - ``3``
-              - Number of HLS playlist reload attempts before giving up
+              - Max number of HLS playlist reload attempts before giving up
             * - hls-playlist-reload-time
               - ``str | float``
               - ``"default"``
@@ -395,6 +396,10 @@ class Streamlink:
               - ``[]``
               - Select a specific audio source or sources when multiple audio sources are available,
                 by language code or name, or ``"*"`` (asterisk)
+            * - dash-manifest-reload-attempts
+              - ``int``
+              - ``3``
+              - Max number of DASH manifest reload attempts before giving up
             * - hls-segment-attempts *(deprecated)*
               - ``int``
               - ``3``

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -808,6 +808,7 @@ def build_parser():
 
     transport = parser.add_argument_group("Stream transport options")
     transport_hls = parser.add_argument_group("HLS options", parent=transport)
+    transport_dash = parser.add_argument_group("DASH options", parent=transport)
     transport_ffmpeg = parser.add_argument_group("FFmpeg options", parent=transport)
 
     transport.add_argument(
@@ -923,7 +924,7 @@ def build_parser():
         type=num(int, min=0),
         metavar="ATTEMPTS",
         help="""
-        How many attempts should be done to reload the HLS playlist before giving up.
+        Max number of attempts when reloading the HLS playlist before giving up.
 
         Default is 3.
         """,
@@ -1029,11 +1030,22 @@ def build_parser():
         Skip to the beginning of a live stream, or as far back as possible.
         """,
     )
+
+    transport_dash.add_argument(
+        "--dash-manifest-reload-attempts",
+        type=num(int, min=0),
+        metavar="ATTEMPTS",
+        help="""
+        Max number of attempts when reloading the DASH manifest before giving up.
+
+        Default is 3.
+        """,
+    )
+
     transport_hls.add_argument("--hls-segment-attempts", help=argparse.SUPPRESS)
     transport_hls.add_argument("--hls-segment-threads", help=argparse.SUPPRESS)
     transport_hls.add_argument("--hls-segment-timeout", help=argparse.SUPPRESS)
     transport_hls.add_argument("--hls-timeout", help=argparse.SUPPRESS)
-
     transport.add_argument("--http-stream-timeout", help=argparse.SUPPRESS)
 
     transport_ffmpeg.add_argument(
@@ -1273,6 +1285,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("hls_segment_ignore_names", "hls-segment-ignore-names", None),
     ("hls_segment_key_uri", "hls-segment-key-uri", None),
     ("hls_audio_select", "hls-audio-select", None),
+    ("dash_manifest_reload_attempts", "dash-manifest-reload-attempts", None),
     ("ffmpeg_ffmpeg", "ffmpeg-ffmpeg", None),
     ("ffmpeg_no_validation", "ffmpeg-no-validation", None),
     ("ffmpeg_verbose", "ffmpeg-verbose", None),


### PR DESCRIPTION
This adds `--dash-manifest-reload-attempts` and the respective session option with a default value of 3, similar to `--hls-playlist-reload-attempts`.

HTTP requests of dynamic DASH stream manifests currently don't have a retry value set, so if a request fails due to a temporary connection/server issue, then no new segments can be queued. Failed requests still raise a `StreamError` on the worker thread, same as the HLS implementation, which needs to be fixed separately.