### PR TITLE
chore: aware datetimes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,8 @@ select = [
   "COM",
   # flake8-comprehensions
   "C4",
+  # flake8-datetimez
+  "DTZ",
   # flake8-implicit-str-concat
   "ISC",
   # flake8-pie

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -1,7 +1,6 @@
 import logging
 import sys
 import warnings
-from datetime import datetime
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 from pathlib import Path
 from sys import version_info
@@ -12,6 +11,7 @@ from typing import IO, TYPE_CHECKING, Iterator, List, Optional, Union
 from warnings import WarningMessage
 
 from streamlink.exceptions import StreamlinkWarning
+from streamlink.utils.times import fromlocaltimestamp
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -107,7 +107,7 @@ class StringFormatter(logging.Formatter):
         return self._usesTime
 
     def formatTime(self, record, datefmt=None):
-        tdt = datetime.fromtimestamp(record.created)
+        tdt = fromlocaltimestamp(record.created)
 
         return tdt.strftime(datefmt or self.default_time_format)
 

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -4,7 +4,6 @@ $url crunchyroll.com
 $type vod
 """
 
-import datetime
 import logging
 import re
 from uuid import uuid4
@@ -12,6 +11,7 @@ from uuid import uuid4
 from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.times import parse_datetime
 
 
 log = logging.getLogger(__name__)
@@ -27,15 +27,6 @@ STREAM_NAMES = {
     "328k": "mid",
     "864k": "high",
 }
-
-
-def parse_timestamp(ts):
-    """Takes ISO 8601 format(string) and converts into a utc datetime(naive)"""
-    return (
-        datetime.datetime.strptime(ts[:-7], "%Y-%m-%dT%H:%M:%S")
-        + datetime.timedelta(hours=int(ts[-5:-3]), minutes=int(ts[-2:]))
-        * int(f"{ts[-6:-5]}1")
-    )
 
 
 _api_schema = validate.Schema({
@@ -70,7 +61,7 @@ _login_schema = validate.Schema({
     "auth": validate.any(str, None),
     "expires": validate.all(
         str,
-        validate.transform(parse_timestamp),
+        validate.transform(parse_datetime),
     ),
     "user": {
         "username": validate.any(str, None),

--- a/src/streamlink/plugins/htv.py
+++ b/src/streamlink/plugins/htv.py
@@ -7,11 +7,11 @@ $region Vietnam
 
 import logging
 import re
-from datetime import date
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.times import localnow
 
 
 log = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ class HTV(Plugin):
                 "channelid": channel_id,
                 "template": "AjaxSchedules.xslt",
                 "channelcode": channel_code,
-                "date": date.today().strftime("%d-%m-%Y"),
+                "date": localnow().strftime("%d-%m-%Y"),
             },
             schema=validate.Schema(
                 validate.parse_json(),

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -7,7 +7,6 @@ $type live
 import logging
 import re
 from base64 import b64decode
-from datetime import datetime
 from time import time
 from urllib.parse import urljoin, urlparse
 
@@ -15,6 +14,7 @@ from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.times import fromlocaltimestamp
 
 
 log = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class OnePlusOneHLS(HLSStream):
         self.api = OnePlusOneAPI(session_, self_url)
 
     def _next_watch_timeout(self):
-        _next = datetime.fromtimestamp(self.watch_timeout).isoformat(" ")
+        _next = fromlocaltimestamp(self.watch_timeout).isoformat(" ")
         log.debug(f"next watch_timeout at {_next}")
 
     def open(self):

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -8,15 +8,13 @@ $region France, Andorra, Monaco
 
 import logging
 import re
-from datetime import datetime
 from urllib.parse import urlparse
-
-from isodate import LOCAL as LOCALTIMEZONE  # type: ignore[import]
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.times import localnow
 from streamlink.utils.url import update_qsd
 
 
@@ -103,7 +101,7 @@ class Pluzz(Plugin):
             "browser": "chrome",
             "browser_version": CHROME_VERSION,
             "os": "ios",
-            "gmt": datetime.now(tz=LOCALTIMEZONE).strftime("%z"),
+            "gmt": localnow().strftime("%z"),
         })
         video_format, token_url, url, self.title = self.session.http.get(api_url, schema=validate.Schema(
             validate.parse_json(),

--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -8,7 +8,7 @@ $type live, vod
 import logging
 import re
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from random import randint
 from threading import Event, RLock
 from typing import Any, Callable, Deque, Dict, List, NamedTuple, Optional, Union
@@ -295,7 +295,7 @@ class UStreamTVWsClient(WebsocketClient):
         if self.stream_initial_id is None:
             self.stream_initial_id = current_id
 
-        current_time = datetime.now()
+        current_time = datetime.now(timezone.utc)
 
         # lock the stream segments deques for the worker threads
         with self.stream_segments_lock:
@@ -362,7 +362,7 @@ class UStreamTVStreamWriter(SegmentedStreamWriter):
         if self.closed:  # pragma: no cover
             return
 
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         if segment.available_at > now:
             time_to_wait = (segment.available_at - now).total_seconds()
             log.debug(f"Waiting for {self.stream.kind} segment: {segment.num} ({time_to_wait:.01f}s)")

--- a/src/streamlink/utils/times.py
+++ b/src/streamlink/utils/times.py
@@ -1,4 +1,26 @@
 import re
+from datetime import datetime, timezone, tzinfo
+
+from isodate import LOCAL, parse_datetime  # type: ignore[import]
+
+
+UTC = timezone.utc
+
+
+def now(tz: tzinfo = UTC) -> datetime:
+    return datetime.now(tz=tz)
+
+
+def localnow() -> datetime:
+    return datetime.now(tz=LOCAL)
+
+
+def fromtimestamp(timestamp: float, tz: tzinfo = UTC) -> datetime:
+    return datetime.fromtimestamp(timestamp, tz=tz)
+
+
+def fromlocaltimestamp(timestamp: float) -> datetime:
+    return datetime.fromtimestamp(timestamp, tz=LOCAL)
 
 
 _hours_minutes_seconds_re = re.compile(r"""
@@ -60,6 +82,13 @@ def seconds_to_hhmmss(seconds):
 
 
 __all__ = [
+    "UTC",
+    "LOCAL",
+    "parse_datetime",
+    "now",
+    "localnow",
+    "fromtimestamp",
+    "fromlocaltimestamp",
     "hours_minutes_seconds",
     "seconds_to_hhmmss",
 ]

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -18,6 +18,7 @@ from streamlink.exceptions import FatalPluginError, StreamlinkDeprecationWarning
 from streamlink.plugin import Plugin, PluginOptions
 from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
+from streamlink.utils.times import LOCAL as LOCALTIMEZONE
 from streamlink_cli.argparser import ArgumentParser, build_parser, setup_session_options
 from streamlink_cli.compat import DeprecatedPath, importlib_metadata, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
@@ -51,7 +52,7 @@ def get_formatter(plugin: Plugin):
             "category": lambda: plugin.get_category(),
             "game": lambda: plugin.get_category(),
             "title": lambda: plugin.get_title(),
-            "time": lambda: datetime.now(),
+            "time": lambda: datetime.now(tz=LOCALTIMEZONE),
         },
         {
             "time": lambda dt, fmt: dt.strftime(fmt),
@@ -834,7 +835,7 @@ def setup_logger_and_console(stream=sys.stdout, filename=None, level="info", jso
     global console
 
     if filename == "-":
-        filename = LOG_DIR / f"{datetime.now()}.log"
+        filename = LOG_DIR / f"{datetime.now(tz=LOCALTIMEZONE)}.log"
     elif filename:
         filename = Path(filename).expanduser().resolve()
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import os
 import re
@@ -803,7 +802,7 @@ class TestCLIMainLoggingLogfilePosix(_TestCLIMainLogging):
     @patch("sys.stdout")
     @patch("builtins.open")
     @patch("pathlib.Path.mkdir", Mock())
-    @freezegun.freeze_time(datetime.datetime(2000, 1, 2, 3, 4, 5))
+    @freezegun.freeze_time("2000-01-02T03:04:05Z")
     def test_logfile_path_auto(self, mock_open, mock_stdout):
         with patch("streamlink_cli.constants.LOG_DIR", PosixPath("/foo")):
             self.subject(["streamlink", "--logfile", "-"])
@@ -842,7 +841,7 @@ class TestCLIMainLoggingLogfileWindows(_TestCLIMainLogging):
     @patch("sys.stdout")
     @patch("builtins.open")
     @patch("pathlib.Path.mkdir", Mock())
-    @freezegun.freeze_time(datetime.datetime(2000, 1, 2, 3, 4, 5))
+    @freezegun.freeze_time("2000-01-02T03:04:05Z")
     def test_logfile_path_auto(self, mock_open, mock_stdout):
         with patch("streamlink_cli.constants.LOG_DIR", WindowsPath("C:\\foo")):
             self.subject(["streamlink", "--logfile", "-"])

--- a/tests/plugins/test_filmon.py
+++ b/tests/plugins/test_filmon.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import freezegun
@@ -42,7 +42,7 @@ class TestPluginCanHandleUrlFilmon(PluginCanHandleUrl):
 
 @pytest.fixture()
 def filmonhls():
-    with freezegun.freeze_time(datetime.datetime(2000, 1, 1, 0, 0, 0, 0)), \
+    with freezegun.freeze_time("2000-01-01T00:00:00Z"), \
          patch("streamlink.plugins.filmon.FilmOnHLS._get_stream_data", return_value=[]):
         session = Streamlink()
         api = FilmOnAPI(session)
@@ -50,30 +50,30 @@ def filmonhls():
 
 
 def test_filmonhls_to_url(filmonhls):
-    filmonhls.watch_timeout = datetime.datetime(2000, 1, 1, 0, 0, 0, 0).timestamp()
+    filmonhls.watch_timeout = datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc).timestamp()
     assert filmonhls.to_url() == "http://fake/one.m3u8"
 
 
 def test_filmonhls_to_url_updated(filmonhls):
-    filmonhls.watch_timeout = datetime.datetime(1999, 12, 31, 23, 59, 59, 9999).timestamp()
+    filmonhls.watch_timeout = datetime(1999, 12, 31, 23, 59, 59, 9999, timezone.utc).timestamp()
 
     filmonhls._get_stream_data.return_value = [
-        ("high", "http://fake/two.m3u8", datetime.datetime(2000, 1, 1, 0, 0, 0, 0).timestamp()),
+        ("high", "http://fake/two.m3u8", datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc).timestamp()),
     ]
     assert filmonhls.to_url() == "http://fake/two.m3u8"
 
-    filmonhls.watch_timeout = datetime.datetime(1999, 12, 31, 23, 59, 59, 9999).timestamp()
+    filmonhls.watch_timeout = datetime(1999, 12, 31, 23, 59, 59, 9999, timezone.utc).timestamp()
     filmonhls._get_stream_data.return_value = [
-        ("high", "http://another-fake/three.m3u8", datetime.datetime(2000, 1, 1, 0, 0, 0, 0).timestamp()),
+        ("high", "http://another-fake/three.m3u8", datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc).timestamp()),
     ]
     assert filmonhls.to_url() == "http://fake/three.m3u8"
 
 
 def test_filmonhls_to_url_missing_quality(filmonhls):
-    filmonhls.watch_timeout = datetime.datetime(1999, 12, 31, 23, 59, 59, 9999).timestamp()
+    filmonhls.watch_timeout = datetime(1999, 12, 31, 23, 59, 59, 9999, timezone.utc).timestamp()
 
     filmonhls._get_stream_data.return_value = [
-        ("low", "http://fake/two.m3u8", datetime.datetime(2000, 1, 1, 0, 0, 0, 0).timestamp()),
+        ("low", "http://fake/two.m3u8", datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc).timestamp()),
     ]
     with pytest.raises(TypeError) as cm:
         filmonhls.to_url()

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -52,7 +52,7 @@ class TestPluginCanHandleUrlTwitch(PluginCanHandleUrl):
     ]
 
 
-DATETIME_BASE = datetime(2000, 1, 1, 0, 0, 0, 0)
+DATETIME_BASE = datetime(2000, 1, 1, 0, 0, 0, 0, timezone.utc)
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 

--- a/tests/utils/test_formatter.py
+++ b/tests/utils/test_formatter.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -27,7 +27,7 @@ class TestFormatter:
                 {
                     "prop": prop,
                     "obj": lambda: obj,
-                    "time": datetime.now,
+                    "time": lambda: datetime.now(timezone.utc),
                     "empty": lambda: "",
                     "none": lambda: None,
                 },
@@ -57,14 +57,15 @@ class TestFormatter:
         assert prop.call_count == 1
 
     def test_format_spec(self, formatter: Formatter):
-        assert formatter.format("{time}") == "2000-01-02 03:04:05.000006"
-        assert formatter.cache == dict(time=datetime(2000, 1, 2, 3, 4, 5, 6, None))
+        assert formatter.format("{time}") == "2000-01-02 03:04:05.000006+00:00"
+        assert formatter.cache == dict(time=datetime(2000, 1, 2, 3, 4, 5, 6, timezone.utc))
         assert formatter.format("{time:%Y}") == "2000"
         assert formatter.format("{time:%Y-%m-%d}") == "2000-01-02"
         assert formatter.format("{time:%H:%M:%S}") == "03:04:05"
+        assert formatter.format("{time:%Z}") == "UTC"
         with patch("datetime.datetime.strftime", side_effect=ValueError):
             assert formatter.format("{time:foo:bar}") == "{time:foo:bar}"
-        assert formatter.cache == dict(time=datetime(2000, 1, 2, 3, 4, 5, 6, None))
+        assert formatter.cache == dict(time=datetime(2000, 1, 2, 3, 4, 5, 6, timezone.utc))
 
         assert formatter.format("{prop:foo}") == "prop"
         assert formatter.format("{none:foo}") == ""


### PR DESCRIPTION
- Add "DTZ" ruff rule
- Add utility functions to `streamlink.utils.times` which use "aware" datetimes with explicit timezone information, and use `isodate`'s local timezone implementation
- Replace all "naive" datetimes without timezone information
- Replace all custom ISO8601 parsers with `isodate`'s implementation
- Add tests for new utility functions

----

https://docs.python.org/3/library/datetime.html#aware-and-naive-objects
https://beta.ruff.rs/docs/rules/#flake8-datetimez-dtz