### PR TITLE
stream.dash: fix segment availability times

### DIFF
--- a/tests/resources/dash/test_nested_baseurls.mpd
+++ b/tests/resources/dash/test_nested_baseurls.mpd
@@ -6,11 +6,12 @@
   xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
   profiles="urn:mpeg:dash:profile:isoff-live:2011"
   type="static"
+  availabilityStartTime="2020-01-01T00:00:00Z"
   mediaPresentationDuration="PT0H0M6.00S"
   minBufferTime="PT6.0S"
 >
   <BaseURL>https://hostname/</BaseURL>
-  <Period id="0" start="PT0.0S">
+  <Period id="0" start="PT12M34S">
     <BaseURL>period/</BaseURL>
     <AdaptationSet
       id="0"

--- a/tests/resources/dash/test_segment_list.mpd
+++ b/tests/resources/dash/test_segment_list.mpd
@@ -5,13 +5,15 @@
      xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
      profiles="urn:mpeg:dash:profile:isoff-main:2011"
      type="static"
+     availabilityStartTime="2020-01-01T00:00:00Z"
      publishTime="2018-06-25T18:01:58Z"
      mediaPresentationDuration="PT53M18.059S"
-     minBufferTime="PT1.5S">
+     minBufferTime="PT1.5S"
+>
 <ProgramInformation>
     <Title>test/dash.smil</Title>
 </ProgramInformation>
-<Period id="0" start="PT0.0S">
+<Period id="0" start="PT12M34S">
     <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
         <Representation id="p0va0br4332748" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
             <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="1">

--- a/tests/resources/dash/test_segments_dynamic_number.mpd
+++ b/tests/resources/dash/test_segments_dynamic_number.mpd
@@ -1,7 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd" type="dynamic" publishTime="2018-05-10T09:27:09" minimumUpdatePeriod="PT10S" availabilityStartTime="2018-05-04T13:20:07Z" minBufferTime="PT2S" suggestedPresentationDelay="PT40S" timeShiftBufferDepth="PT24H0M0S" profiles="urn:mpeg:dash:profile:isoff-live:2011">
-  <Period start="PT0S" id="1">
-    <AdaptationSet mimeType="video/mp4" frameRate="25/1" segmentAlignment="true" subsegmentAlignment="true" startWithSAP="1" subsegmentStartsWithSAP="1" bitstreamSwitching="false">
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:cenc="urn:mpeg:cenc:2013"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
+  type="dynamic"
+  availabilityStartTime="2018-05-04T13:20:07Z"
+  publishTime="2018-05-10T09:27:09"
+  minimumUpdatePeriod="PT10S"
+  minBufferTime="PT2S"
+  suggestedPresentationDelay="PT40S"
+  timeShiftBufferDepth="PT24H0M0S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+>
+  <Period id="1" start="PT12M34S">
+    <AdaptationSet
+      mimeType="video/mp4"
+      frameRate="25/1"
+      segmentAlignment="true"
+      subsegmentAlignment="true"
+      startWithSAP="1"
+      subsegmentStartsWithSAP="1"
+      bitstreamSwitching="false"
+    >
       <SegmentTemplate timescale="90000" duration="450000" startNumber="1"/>
       <Representation id="1" width="1280" height="720" bandwidth="2400000" codecs="avc1.64001f">
         <SegmentTemplate duration="450000" startNumber="1" media="hd-5_$Number%09d$.mp4" initialization="hd-5-init.mp4"/>
@@ -22,13 +43,32 @@
         <SegmentTemplate duration="450000" startNumber="1" media="hd-0_$Number%09d$.mp4" initialization="hd-0-init.mp4"/>
       </Representation>
     </AdaptationSet>
-    <AdaptationSet mimeType="audio/mp4" lang="rus" segmentAlignment="0">
-      <SegmentTemplate timescale="48000" media="hd-audio_$Number%09d$.mp4" initialization="hd-audio-init.mp4" duration="240000" startNumber="1"/>
+    <AdaptationSet
+      mimeType="audio/mp4"
+      lang="rus"
+      segmentAlignment="0"
+    >
+      <SegmentTemplate
+        timescale="48000"
+        media="hd-audio_$Number%09d$.mp4"
+        initialization="hd-audio-init.mp4"
+        duration="240000"
+        startNumber="1"
+      />
       <Representation id="7" bandwidth="96000" audioSamplingRate="48000" codecs="mp4a.40.2"/>
     </AdaptationSet>
-    <AdaptationSet mimeType="application/mp4" lang="rus">
+    <AdaptationSet
+      mimeType="application/mp4"
+      lang="rus"
+    >
       <Role schemeIdUri="urn:mpeg:dash:role" value="subtitle"/>
-      <SegmentTemplate timescale="90000" media="hd-caption_$Number%09d$.mp4" initialization="hd-caption-init.mp4" duration="450000" startNumber="1"/>
+      <SegmentTemplate
+        timescale="90000"
+        media="hd-caption_$Number%09d$.mp4"
+        initialization="hd-caption-init.mp4"
+        duration="450000"
+        startNumber="1"
+      />
       <Representation id="8" bandwidth="256" codecs="stpp"/>
     </AdaptationSet>
   </Period>

--- a/tests/resources/dash/test_static_no_publish_time.mpd
+++ b/tests/resources/dash/test_static_no_publish_time.mpd
@@ -5,11 +5,13 @@
   xmlns="urn:mpeg:dash:schema:mpd:2011"
   xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
   type="static"
+  availabilityStartTime="2020-01-01T00:00:00Z"
   mediaPresentationDuration="PT1M23.847347S"
   maxSegmentDuration="PT3S"
   minBufferTime="PT10S"
-  profiles="urn:mpeg:dash:profile:isoff-live:2011">
-  <Period>
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+>
+  <Period start="PT12M34S">
     <BaseURL>dash/</BaseURL>
     <AdaptationSet
       group="1"


### PR DESCRIPTION
The segment availability "anchor time" depends on the sum of the manifest's `availabilityStartTime` and the period's `start` attribute, for both static and dynamic manifests.

Fix segment availability times:
- Set the correct `available_at` value for static manifests with segment templates and segment timelines instead of using the current time
- Set the `available_at` value for `SegmentList` segments instead of defaulting to `EPOCH_START`
- Set the `available_at` value for all initialization segments

Fix segment numbers:
- The number offset now also takes the period start into consideration

Also:
- Allow passing keywords to child node constructors
- Keep the `Period` reference on `SegmentList`, `SegmentTemplate` and `Representation`
- Check segment availability times in certain tests
- Rename DASH manifest fixture files of updated tests

----

These are just minor fixes because the period start time of the first period (which we only support anyway) is zero most of the time.

The segment number fix is a "side-effect" of this PR. However, **it's not a full fix** and there's still something wrong with the offset calculation.