### PR TITLE
stream.dash: fix dynamic timeline-less streams

### DIFF
--- a/tests/resources/dash/test_segments_dynamic_number.mpd
+++ b/tests/resources/dash/test_segments_dynamic_number.mpd
@@ -5,15 +5,15 @@
   xmlns="urn:mpeg:dash:schema:mpd:2011"
   xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
   type="dynamic"
-  availabilityStartTime="2018-05-04T13:20:07Z"
-  publishTime="2018-05-10T09:27:09"
+  availabilityStartTime="2000-01-01T00:00:00Z"
+  publishTime="2000-01-01T00:00:00Z"
   minimumUpdatePeriod="PT10S"
   minBufferTime="PT2S"
   suggestedPresentationDelay="PT40S"
   timeShiftBufferDepth="PT24H0M0S"
   profiles="urn:mpeg:dash:profile:isoff-live:2011"
 >
-  <Period id="1" start="PT12M34S">
+  <Period id="1" start="PT1M30S">
     <AdaptationSet
       mimeType="video/mp4"
       frameRate="25/1"
@@ -23,24 +23,24 @@
       subsegmentStartsWithSAP="1"
       bitstreamSwitching="false"
     >
-      <SegmentTemplate timescale="90000" duration="450000" startNumber="1"/>
+      <SegmentTemplate timescale="90000" duration="450000" startNumber="100"/>
       <Representation id="1" width="1280" height="720" bandwidth="2400000" codecs="avc1.64001f">
-        <SegmentTemplate duration="450000" startNumber="1" media="hd-5_$Number%09d$.mp4" initialization="hd-5-init.mp4"/>
+        <SegmentTemplate media="hd-5_$Number%09d$.mp4" initialization="hd-5-init.mp4"/>
       </Representation>
       <Representation id="2" width="1280" height="720" bandwidth="1250000" codecs="avc1.64001f">
-        <SegmentTemplate duration="450000" startNumber="1" media="hd-4_$Number%09d$.mp4" initialization="hd-4-init.mp4"/>
+        <SegmentTemplate media="hd-4_$Number%09d$.mp4" initialization="hd-4-init.mp4"/>
       </Representation>
       <Representation id="3" width="640" height="360" bandwidth="950000" codecs="avc1.4d401e">
-        <SegmentTemplate duration="450000" startNumber="1" media="hd-3_$Number%09d$.mp4" initialization="hd-3-init.mp4"/>
+        <SegmentTemplate media="hd-3_$Number%09d$.mp4" initialization="hd-3-init.mp4"/>
       </Representation>
       <Representation id="4" width="640" height="360" bandwidth="650000" codecs="avc1.4d401e">
-        <SegmentTemplate duration="450000" startNumber="1" media="hd-2_$Number%09d$.mp4" initialization="hd-2-init.mp4"/>
+        <SegmentTemplate media="hd-2_$Number%09d$.mp4" initialization="hd-2-init.mp4"/>
       </Representation>
       <Representation id="5" width="640" height="360" bandwidth="350000" codecs="avc1.4d401e">
-        <SegmentTemplate duration="450000" startNumber="1" media="hd-1_$Number%09d$.mp4" initialization="hd-1-init.mp4"/>
+        <SegmentTemplate media="hd-1_$Number%09d$.mp4" initialization="hd-1-init.mp4"/>
       </Representation>
       <Representation id="6" width="160" height="90" bandwidth="110000" codecs="avc1.4d400b">
-        <SegmentTemplate duration="450000" startNumber="1" media="hd-0_$Number%09d$.mp4" initialization="hd-0-init.mp4"/>
+        <SegmentTemplate media="hd-0_$Number%09d$.mp4" initialization="hd-0-init.mp4"/>
       </Representation>
     </AdaptationSet>
     <AdaptationSet

--- a/tests/stream/test_dash_parser.py
+++ b/tests/stream/test_dash_parser.py
@@ -109,8 +109,9 @@ class TestMPDParser(unittest.TestCase):
             ]
 
     def test_segments_dynamic_number(self):
+        # access manifest one hour after its availabilityStartTime
         with xml("dash/test_segments_dynamic_number.mpd") as mpd_xml, \
-             freeze_time("2018-05-22T13:37:00Z"):
+             freeze_time("2000-01-01T01:00:00Z"):
             mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd")
             stream_urls = [
                 (segment.url, segment.available_at)
@@ -118,25 +119,21 @@ class TestMPDParser(unittest.TestCase):
             ]
 
         assert stream_urls == [
-            # The initialization segment gets its availability time from
-            # the sum of the manifest's availabilityStartTime value and the period's start value, similar to static manifests
             (
                 "http://test/hd-5-init.mp4",
-                datetime.datetime(2018, 5, 4, 13, 32, 41, tzinfo=UTC),
-            ),
-            # The segment number also takes the availabilityStartTime and period start sum into consideration,
-            # but the availability time depends on the current time and the segment durations
-            (
-                "http://test/hd-5_000311084.mp4",
-                datetime.datetime(2018, 5, 22, 13, 37, 0, tzinfo=UTC),
+                datetime.datetime(2000, 1, 1, 0, 1, 30, tzinfo=UTC),
             ),
             (
-                "http://test/hd-5_000311085.mp4",
-                datetime.datetime(2018, 5, 22, 13, 37, 5, tzinfo=UTC),
+                "http://test/hd-5_000000794.mp4",
+                datetime.datetime(2000, 1, 1, 0, 59, 15, tzinfo=UTC),
             ),
             (
-                "http://test/hd-5_000311086.mp4",
-                datetime.datetime(2018, 5, 22, 13, 37, 10, tzinfo=UTC),
+                "http://test/hd-5_000000795.mp4",
+                datetime.datetime(2000, 1, 1, 0, 59, 20, tzinfo=UTC),
+            ),
+            (
+                "http://test/hd-5_000000796.mp4",
+                datetime.datetime(2000, 1, 1, 0, 59, 25, tzinfo=UTC),
             ),
         ]
 


### PR DESCRIPTION
- Fix segment number iterator and segment availability-time iterator for dynamic timeline-less DASH streams by calculating the right segment number offset and basing the segment availability-time on the segment number, and not just on the current time alone
- Set a default value of 0 seconds for presentationTimeOffset
- Ensure that segment durations are known
- Never calculate negative segment number offsets
- Reduce unnecessary delay by starting with the upcoming segment in the generated timeline to be as close to the live-edge as possible (with minBufferTime and presentation offset+delay in mind)
- Add debug log output
- Update MPD manifest test fixture with better time data

Next:

- Consider removing the default value of suggestedPresentationDelay, as it seems to be a relict of Streamlink's initial DASH implementation
- Also take a look at properly synchronizing the generated timeline between multiple substreams, so that the correct segment numbers always get calculated in all threads
- Avoid interweaving debug log and make it flush per-thread

----

Closes #4607

Not 100% sure whether this will fix #4607, but the data in that thread is not enough to confirm that, so let's close it. Since this PR adds more debug log messages with actual timestamps, new issue threads can be opened if there's still a problem with DASH streams of that particular kind.

At least this PR fixes all issues with DASH streams from the steam plugin, and the correct segment numbers at the correct times should be queued and requested by the worker and writer threads respectively.