### PR TITLE
plugins.vimeo: fix playerConfig regex

### DIFF
--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 ))
 class Vimeo(Plugin):
     _config_url_re = re.compile(r'(?:"config_url"|\bdata-config-url)\s*[:=]\s*(".+?")')
-    _config_re = re.compile(r"var\s+config\s*=\s*({.+?})\s*;")
+    _config_re = re.compile(r"playerConfig\s*=\s*({.+?})\s*var")
     _config_url_schema = validate.Schema(
         validate.transform(_config_url_re.search),
         validate.any(


### PR DESCRIPTION
Parameters to reproduce

```
https://player.vimeo.com/video/803849296?h=1f71c5e810 best
```

<img width="886" alt="image" src="https://user-images.githubusercontent.com/7411362/223991529-80784ae8-24fd-479b-bc35-9f6487ff43a7.png">

