### PR TITLE
tests: ignore all pkg_resources warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ build-file = "streamlink/_version.py"
 [tool.pytest.ini_options]
 filterwarnings = [
   "always",
-  "ignore:.*pkg_resources\\.declare_namespace.*:DeprecationWarning",
+  "ignore:::pkg_resources",
 ]
 
 


### PR DESCRIPTION
Follow-up of c3ff5a0.

Ignore all warnings raised by `pkg_resources`:
New `DeprecationWarning`s were added by setuptools 67.5.0

----

- #5167
- https://setuptools.pypa.io/en/latest/history.html#v67-5-0

The reason why `pkg_resources` gets imported is `pycountry`:
`streamlink` -> `streamlink.session` -> `streamlink.l10n` -> `pycountry`
hence why the warnings occurred in every test module
