### PR TITLE
stream.segmented: fix wait() in writer thread-pool

### DIFF
--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -139,8 +139,8 @@ class SegmentedStreamWriter(AwaitableMixin, Thread):
 
         self.closed = True
         self.reader.close()
-        self.executor.shutdown(wait=True, cancel_futures=True)
         self._wait.set()
+        self.executor.shutdown(wait=True, cancel_futures=True)
 
     def put(self, segment):
         """Adds a segment to the download pool and write queue."""


### PR DESCRIPTION
The `SegmentedStreamWriter`'s `_wait` event needs to be set before awaiting the shutdown of the thread-pool executor, otherwise the threads of the executor won't ever receive this signal. For example, queued segment downloads can't be cancelled because the event never gets set before awaiting the shutdown of the executor, so `wait()` calls in the executor's threads time out regularly and return `True`.

----

Fixes queued DASH segments being downloaded after closing the stream.
