### PR TITLE
stream.segmented: properly fix wait() in writer

### DIFF
--- a/src/streamlink/stream/segmented.py
+++ b/src/streamlink/stream/segmented.py
@@ -138,8 +138,9 @@ class SegmentedStreamWriter(AwaitableMixin, Thread):
         log.debug("Closing writer thread")
 
         self.closed = True
-        self.reader.close()
         self._wait.set()
+
+        self.reader.close()
         self.executor.shutdown(wait=True, cancel_futures=True)
 
     def put(self, segment):


### PR DESCRIPTION
Follow-up of f234c690

Properly fix the `SegmentedStreamWriter`'s `_wait` Event when closing the thread.

Depending on which thread attempted to close the writer thread, the `close()` method's `self.reader.close()` call can block, leading to the `_wait` event to not get set until all threads have terminated and joined. So make sure to set the event first, so that all threads of the writer's thread-pool executor can be stopped first, for example segment downloads waiting for the segment's availability.

----

Follow-up of #5236 
