### PR TITLE
utils.args: update num() argparse utility function

### DIFF
--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -1,5 +1,6 @@
 import argparse
 import re
+from typing import Optional, Type
 
 
 _filesize_re = re.compile(r"""
@@ -47,7 +48,7 @@ def filesize(value):
     elif modifier in ("K", "k"):
         size *= 1024
 
-    return num(int, min=0)(size)
+    return num(int, ge=1)(size)
 
 
 def keyvalue(value):
@@ -58,33 +59,37 @@ def keyvalue(value):
     return match.group("key", "value")
 
 
-# noinspection PyShadowingBuiltins
-def num(type, min=None, max=None):  # noqa: A002
+def num(
+    numtype: Type[float],
+    ge: Optional[float] = None,
+    gt: Optional[float] = None,
+    le: Optional[float] = None,
+    lt: Optional[float] = None,
+):
     def func(value):
-        value = type(value)
+        value = numtype(value)
 
-        if min is not None and not (value > min):
-            raise argparse.ArgumentTypeError(
-                "{0} value must be more than {1} but is {2}".format(
-                    type.__name__, min, value,
-                ),
-            )
-
-        if max is not None and not (value <= max):
-            raise argparse.ArgumentTypeError(
-                "{0} value must be at most {1} but is {2}".format(
-                    type.__name__, max, value,
-                ),
-            )
+        if ge is not None and value < ge:
+            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be >={ge}, but is {value}")
+        if gt is not None and value <= gt:
+            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be >{gt}, but is {value}")
+        if le is not None and value > le:
+            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be <={le}, but is {value}")
+        if lt is not None and value >= lt:
+            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be <{lt}, but is {value}")
 
         return value
 
-    func.__name__ = type.__name__
+    func.__name__ = numtype.__name__
 
     return func
 
 
 __all__ = [
-    "boolean", "comma_list", "comma_list_filter", "filesize", "keyvalue",
+    "boolean",
+    "comma_list",
+    "comma_list_filter",
+    "filesize",
+    "keyvalue",
     "num",
 ]

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -519,7 +519,7 @@ def build_parser():
     player.add_argument(
         "--player-external-http-port",
         metavar="PORT",
-        type=num(int, min=0, max=65535),
+        type=num(int, ge=0, le=65535),
         default=0,
         help="""
         A fixed port to use for the external HTTP server if that mode is
@@ -727,7 +727,7 @@ def build_parser():
     stream.add_argument(
         "--retry-streams",
         metavar="DELAY",
-        type=num(float, min=0),
+        type=num(float, gt=0),
         help="""
         Retry fetching the list of available streams until streams are found
         while waiting `DELAY` second(s) between each attempt. If unset, only one
@@ -739,7 +739,7 @@ def build_parser():
     stream.add_argument(
         "--retry-max",
         metavar="COUNT",
-        type=num(int, min=-1),
+        type=num(int, ge=0),
         help="""
         When using --retry-streams, stop retrying the fetch after `COUNT` retry
         attempt(s). Fetch will retry infinitely if `COUNT` is zero or unset.
@@ -751,7 +751,7 @@ def build_parser():
     stream.add_argument(
         "--retry-open",
         metavar="ATTEMPTS",
-        type=num(int, min=0),
+        type=num(int, ge=1),
         default=1,
         help="""
         After a successful fetch, try `ATTEMPTS` time(s) to open the stream until
@@ -836,7 +836,7 @@ def build_parser():
     )
     transport.add_argument(
         "--stream-segment-attempts",
-        type=num(int, min=0),
+        type=num(int, ge=1),
         metavar="ATTEMPTS",
         help="""
         How many attempts should be done to download each segment before giving up.
@@ -848,7 +848,7 @@ def build_parser():
     )
     transport.add_argument(
         "--stream-segment-threads",
-        type=num(int, max=10),
+        type=num(int, ge=1, le=10),
         metavar="THREADS",
         help="""
         The size of the thread pool used to download segments. Minimum value is `1` and maximum is `10`.
@@ -860,7 +860,7 @@ def build_parser():
     )
     transport.add_argument(
         "--stream-segment-timeout",
-        type=num(float, min=0),
+        type=num(float, gt=0),
         metavar="TIMEOUT",
         help="""
         Segment connect and read timeout.
@@ -872,7 +872,7 @@ def build_parser():
     )
     transport.add_argument(
         "--stream-timeout",
-        type=num(float, min=0),
+        type=num(float, gt=0),
         metavar="TIMEOUT",
         help="""
         Timeout for reading data from streams.
@@ -894,7 +894,7 @@ def build_parser():
 
     transport_hls.add_argument(
         "--hls-live-edge",
-        type=num(int, min=0),
+        type=num(int, ge=1),
         metavar="SEGMENTS",
         help="""
         Number of segments from the live stream's current live position to begin streaming.
@@ -921,7 +921,7 @@ def build_parser():
     )
     transport_hls.add_argument(
         "--hls-playlist-reload-attempts",
-        type=num(int, min=0),
+        type=num(int, ge=1),
         metavar="ATTEMPTS",
         help="""
         Max number of attempts when reloading the HLS playlist before giving up.
@@ -1033,7 +1033,7 @@ def build_parser():
 
     transport_dash.add_argument(
         "--dash-manifest-reload-attempts",
-        type=num(int, min=0),
+        type=num(int, ge=1),
         metavar="ATTEMPTS",
         help="""
         Max number of attempts when reloading the DASH manifest before giving up.
@@ -1223,7 +1223,7 @@ def build_parser():
     http.add_argument(
         "--http-timeout",
         metavar="TIMEOUT",
-        type=num(float, min=0),
+        type=num(float, gt=0),
         help="""
         General timeout used by all HTTP requests except the ones covered by
         other options.


### PR DESCRIPTION
- Replace `min` and `max` with `ge`, `gt`, `le` and `lt`
- Update and fix params/values of numeric CLI argparser arguments
- Rewrite `num()` tests

----

This rewrite is required for being able to add numeric CLI args which allow a min value of 0. This is currently not possible, as `num()` is checking for `value >= min`. Min values of int args were set to -1 because of this, but this doesn't work for float args (there currently are none of that kind, but I'm intending to add one).

- `--player-external-http-port` had an incorrect min value, as the default is set to 0
- `--stream-segment-threads` is now properly clamped between 1 and 10
- all int args have their min value set via `ge` instead of `gt`