### PR TITLE
tests: share session fixture

### DIFF
--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -14,12 +14,6 @@ def parser():
     return build_parser()
 
 
-@pytest.fixture()
-def session(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr("streamlink.session.Streamlink.load_builtin_plugins", lambda _: None)
-    return Streamlink()
-
-
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize(("argv", "option", "expected"), [
     pytest.param(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import os
 import sys
 from typing import Dict, List, Tuple
+from unittest.mock import patch
 
 import pytest
+
+from streamlink.session import Streamlink
 
 
 _TEST_CONDITION_MARKERS: Dict[str, Tuple[bool, str]] = {
@@ -54,3 +57,17 @@ def _check_test_condition(item: pytest.Item):  # pragma: no cover
         cond, msg = _TEST_CONDITION_MARKERS[m.name]
         if not cond:
             pytest.skip(msg if not m.args and not m.kwargs else f"{msg} ({m.kwargs.get('reason') or m.args[0]})")
+
+
+# ========================
+# globally shared fixtures
+# ========================
+
+
+@pytest.fixture()
+def session(request: pytest.FixtureRequest) -> Streamlink:
+    with patch.object(Streamlink, "load_builtin_plugins"):
+        session = Streamlink()
+        for key, value in getattr(request, "param", {}).items():
+            session.set_option(key, value)
+        return session

--- a/tests/stream/test_dash.py
+++ b/tests/stream/test_dash.py
@@ -13,12 +13,6 @@ from streamlink.utils.parse import parse_xml as original_parse_xml
 from tests.resources import text, xml
 
 
-@pytest.fixture()
-def session(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(Streamlink, "load_builtin_plugins", Mock())
-    return Streamlink()
-
-
 class TestDASHStreamParseManifest:
     @pytest.fixture(autouse=True)
     def _response(self, request: pytest.FixtureRequest, requests_mock: rm.Mocker):

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -22,9 +22,10 @@ def _logger(caplog: pytest.LogCaptureFixture):
 
 
 @pytest.fixture()
-def session():
-    with patch("streamlink.session.Streamlink.load_builtin_plugins"):
-        yield Streamlink({"ffmpeg-no-validation": True})
+def session(session: Streamlink):
+    session.set_option("ffmpeg-no-validation", True)
+
+    return session
 
 
 class TestCommand:

--- a/tests/stream/test_stream_json.py
+++ b/tests/stream/test_stream_json.py
@@ -13,9 +13,8 @@ from streamlink.stream.http import HTTPStream
 from streamlink.stream.stream import Stream
 
 
-@pytest.fixture(scope="module")
-def session():
-    session = Streamlink()
+@pytest.fixture()
+def session(session: Streamlink):
     session.set_option("http-cookies", {"sessioncookiekey": "sessioncookieval"})
     session.set_option("http-headers", {"sessionheaderkey": "sessionheaderval"})
     session.set_option("http-query-params", {"sessionqueryparamkey": "sessionqueryparamval"})

--- a/tests/stream/test_stream_to_url.py
+++ b/tests/stream/test_stream_to_url.py
@@ -2,17 +2,11 @@ from unittest.mock import Mock
 
 import pytest
 
-from streamlink import Streamlink
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.file import FileStream
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.stream import Stream
-
-
-@pytest.fixture(scope="module")
-def session():
-    return Streamlink()
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_api_websocket.py
+++ b/tests/test_api_websocket.py
@@ -24,14 +24,6 @@ def test_opcode_export(name, value):
 
 class TestWebsocketClient:
     @pytest.fixture()
-    def session(self, request: pytest.FixtureRequest):
-        with patch("streamlink.session.Streamlink.load_builtin_plugins"):
-            session = Streamlink()
-            for key, value in getattr(request, "param", {}).items():
-                session.set_option(key, value)
-            yield session
-
-    @pytest.fixture()
     def websocketapp(self):
         with patch("streamlink.plugin.api.websocket.WebSocketApp") as mock_websocketapp:
             yield mock_websocketapp

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -290,10 +290,6 @@ def _create_cookie_dict(name, value, expires=None):
 
 class TestCookies:
     @pytest.fixture()
-    def session(self):
-        return Streamlink()
-
-    @pytest.fixture()
     def pluginclass(self):
         class MyPlugin(FakePlugin):
             __module__ = "myplugin"

--- a/tests/test_plugin_userinput.py
+++ b/tests/test_plugin_userinput.py
@@ -16,10 +16,6 @@ def test_session():
 
 class TestPluginUserInput:
     @pytest.fixture()
-    def session(self):
-        return Streamlink()
-
-    @pytest.fixture()
     def testplugin(self, session: Streamlink):
         return _TestPlugin(session, "http://example.com/stream")
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -23,12 +23,6 @@ PATH_TESTPLUGINS_OVERRIDE = PATH_TESTPLUGINS / "override"
 _original_allowed_gai_family = urllib3.util.connection.allowed_gai_family  # type: ignore[attr-defined]
 
 
-@pytest.fixture()
-def session():
-    with patch("streamlink.session.Streamlink.load_builtin_plugins"):
-        yield Streamlink()
-
-
 class EmptyPlugin(Plugin):
     def _get_streams(self):
         pass  # pragma: no cover


### PR DESCRIPTION
No need to re-define the fixture multiple times