### PR TITLE
tools: pinpoint ruff to 0.0.255 and fix rules

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ freezegun>=1.0.0
 shtab
 versioningit >=2.0.0, <3
 
-ruff >=0.0.252
+ruff ==0.0.255
 
 mypy
 lxml-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,8 @@ select = [
   # flake8-commas
   "COM",
   # flake8-comprehensions
-  "C4",
+  "C40",
+  "C41",
   # flake8-datetimez
   "DTZ",
   # flake8-implicit-str-concat
@@ -102,6 +103,7 @@ extend-ignore = [
   "A003",  # builtin-attribute-shadowing
   "C408",  # unnecessary-collection-call
   "ISC003",  # explicit-string-concatenation
+  "PLC1901",  # compare-to-empty-string
   "PLW2901",  # redefined-loop-name
 ]
 extend-exclude = [


### PR DESCRIPTION
Ruff 0.0.255 introduced some changes, one of them being an incorrectly deprecated selector alias and a new rule for empty string comparisons which we don't want in test assertions.

Let's pinpoint the version of ruff in the dev-requirements, so that new releases don't break our linting config here immediately. If there's anything new and interesting, ruff's version can be bumped manually and new errors can be fixed in one go.