### PR TITLE
tools: bump ruff to 0.0.259

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ freezegun>=1.0.0
 shtab
 versioningit >=2.0.0, <3
 
-ruff ==0.0.255
+ruff ==0.0.259
 
 mypy
 lxml-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,7 @@ select = [
   # flake8-commas
   "COM",
   # flake8-comprehensions
-  "C40",
-  "C41",
+  "C4",
   # flake8-datetimez
   "DTZ",
   # flake8-implicit-str-concat


### PR DESCRIPTION
Just a simple version bump and revert of the workaround needed for the previous version