### PR TITLE
cli: add --progress={yes,no,force} CLI argument

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,15 @@
 Deprecations
 ============
 
+streamlink 5.4.0
+----------------
+
+Deprecation of --force-progress
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``--force-progress`` CLI argument has been deprecated in favor of :option:`--progress=force`.
+
+
 streamlink 5.3.0
 ----------------
 

--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -22,7 +22,7 @@ _block_re = re.compile(r":\n{2}\s{2}")
 _default_re = re.compile(r"Default is (.+)\.\n")
 _note_re = re.compile(r"Note: (.*)(?:\n\n|\n*$)", re.DOTALL)
 _option_line_re = re.compile(r"^(?!\s{2,}%\(prog\)s|\s{2,}--\w[\w-]*\w\b|Example: )(.+)$", re.MULTILINE)
-_option_re = re.compile(r"(?:^|(?<=\s))(--\w[\w-]*\w)\b")
+_option_re = re.compile(r"(?:^|(?<=\s))(?P<arg>--\w[\w-]*\w)(?P<val>=\w+)?\b")
 _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")
 _cli_metadata_variables_section_cross_link_re = re.compile(r"the \"Metadata variables\" section")
@@ -67,15 +67,9 @@ class ArgparseDirective(Directive):
         # Replace option references with links.
         # Do this before indenting blocks and notes.
         helptext = _option_line_re.sub(
-            lambda m: (
-                _option_re.sub(
-                    lambda m2: (
-                        ":option:`{0}`".format(m2.group(1))
-                        if m2.group(1) in self._available_options
-                        else m2.group(0)
-                    ),
-                    m.group(1),
-                )
+            lambda m: _option_re.sub(
+                lambda m2: f":option:`{m2['arg']}{m2['val'] or ''}`" if m2["arg"] in self._available_options else m2[0],
+                m[1],
             ),
             helptext,
         )

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -604,21 +604,6 @@ def build_parser():
         """,
     )
     output.add_argument(
-        "-f", "--force",
-        action="store_true",
-        help="""
-        When using --output or --record, always write to file even if it already exists (overwrite).
-        """,
-    )
-    output.add_argument(
-        "--force-progress",
-        action="store_true",
-        help="""
-        When using --output or --record,
-        show the download progress bar even if there is no terminal.
-        """,
-    )
-    output.add_argument(
         "-O", "--stdout",
         action="store_true",
         help="""
@@ -681,6 +666,31 @@ def build_parser():
 
         - POSIX: `\\x00-\\x1F /`
         - Windows: `\\x00-\\x1F \\x7F " * / : < > ? \\ |`
+        """,
+    )
+    output.add_argument(
+        "-f", "--force",
+        action="store_true",
+        help="""
+        When using --output or --record, always write to file even if it already exists (overwrite).
+        """,
+    )
+    output.add_argument(
+        "--progress",
+        metavar="{yes,force,no}",
+        choices=("yes", "force", "no"),
+        default="yes",
+        help="""
+        When using --output or --record, show or hide the download progress bar, or force it if there's no terminal.
+
+        Default is yes.
+        """,
+    )
+    output.add_argument(
+        "--force-progress",
+        action="store_true",
+        help="""
+        Deprecated in favor of --progress=force.
         """,
     )
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -364,9 +364,17 @@ def output_stream(stream, formatter: Formatter):
     try:
         with closing(output):
             log.debug("Writing stream to output")
+            show_progress = args.progress == "force" or args.progress == "yes" and sys.stderr.isatty()
+            if args.force_progress:
+                show_progress = True
+                warnings.warn(
+                    "The --force-progress option has been deprecated in favor of --progress=force",
+                    StreamlinkDeprecationWarning,
+                    stacklevel=1,
+                )
             # TODO: finally clean up the global variable mess and refactor the streamlink_cli package
             # noinspection PyUnboundLocalVariable
-            stream_runner = StreamRunner(stream_fd, output, args.force_progress)
+            stream_runner = StreamRunner(stream_fd, output, show_progress=show_progress)
             # noinspection PyUnboundLocalVariable
             stream_runner.run(prebuffer)
     except OSError as err:

--- a/src/streamlink_cli/streamrunner.py
+++ b/src/streamlink_cli/streamrunner.py
@@ -80,7 +80,7 @@ class StreamRunner:
         self,
         stream: StreamIO,
         output: Union[PlayerOutput, FileOutput, HTTPServer],
-        force_progress: bool = False,
+        show_progress: bool = False,
     ):
         self.stream = stream
         self.output = output
@@ -99,7 +99,7 @@ class StreamRunner:
             elif output.record:
                 filename = output.record.filename
 
-        if filename and (sys.stdout.isatty() or force_progress):
+        if filename and show_progress:
             self.progress = Progress(sys.stderr, filename)
 
     def run(


### PR DESCRIPTION
This adds support for suppressing the progress output when writing to a file by setting `--progress=no`.

Instead of adding a new `--no-progress` CLI argument, I decided to add `--progress={yes,no,force}` with default value `yes` and deprecate `--force-progress`.

```
$ streamlink --output=/dev/null httpstream://file:///dev/zero best
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/dev/null
[download] Written 989.41 MiB to /dev/null (1s)
^C
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```

```
$ streamlink --progress=no --output=/dev/null httpstream://file:///dev/zero best
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/dev/null
^C
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```

```
$ streamlink --progress=force --output=/dev/null httpstream://file:///dev/zero best
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/dev/null
[download] Written 950.36 MiB to /dev/null (1s)
^C
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```

```
$ streamlink --force-progress --output=/dev/null httpstream://file:///dev/zero best
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/dev/null
[warnings][streamlinkdeprecation] The --force-progress option has been deprecated in favor of --progress=force
[download] Written 1005.53 MiB to /dev/null (1s)
^C
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```