### PR TITLE
docs: remove solus from install docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -183,10 +183,6 @@ Python pip                           See the `PyPI package and source code`_ sec
 
                                         sudo zypper install streamlink
 
-`Solus`_                             .. code-block:: bash
-
-                                        sudo eopkg install streamlink
-
 `Void`_                              .. code-block:: bash
 
                                         sudo xbps-install streamlink
@@ -201,7 +197,6 @@ Python pip                           See the `PyPI package and source code`_ sec
 .. _NetBSD (pkgsrc): https://pkgsrc.se/multimedia/streamlink
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
 .. _openSUSE: https://build.opensuse.org/package/show/multimedia:apps/streamlink
-.. _Solus: https://dev.getsol.us/source/streamlink/
 .. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
 
 .. _Installing AUR packages: https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_packages
@@ -226,7 +221,6 @@ Gentoo                               soredake <fdsfgs at krutt.org>
 NetBSD                               Maya Rashish <maya at netbsd.org>
 NixOS                                Tuomas Tynkkynen <tuomas.tynkkynen at iki.fi>
 openSUSE                             Simon Puchert <simonpuchert at alice.de>
-Solus                                Joey Riches <josephriches at gmail.com>
 Void                                 Michal Vasilek <michal at vasilek.cz>
 Windows binaries                     Sebastian Meyer <mail at bastimeyer.de>
 Linux AppImages                      Sebastian Meyer <mail at bastimeyer.de>


### PR DESCRIPTION
Solus had a critical infrastructure outage in early January, and apart from switching their static homepage to GitHub pages, they still haven't been able to get their stuff back online, including packaging and package updates.

I've never used that distro, but I've been observing this whole situation since at least the end of January, and it doesn't look like this will be resolved any time soon, if at all. There's zero communication from their project lead, who's responsible for this mess.

Let's remove the Solus entry from the install docs, to avoid dead links and to avoid making distro suggestions to new users. If they manage to recover the distro and packages get updated again, the entry can be restored.