### PR TITLE
tests: rewrite HLS external audio tests

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
 from shutil import which
-from typing import List, Optional, TextIO, Union
+from typing import Any, Dict, Generic, List, Optional, Sequence, TextIO, TypeVar, Union
 
 from streamlink import StreamError
 from streamlink.stream.stream import Stream, StreamIO
@@ -21,7 +21,10 @@ log = logging.getLogger(__name__)
 _lock_resolve_command = threading.Lock()
 
 
-class MuxedStream(Stream):
+TSubstreams = TypeVar("TSubstreams", bound=Stream)
+
+
+class MuxedStream(Stream, Generic[TSubstreams]):
     """
     Muxes multiple streams into one output stream.
     """
@@ -31,7 +34,7 @@ class MuxedStream(Stream):
     def __init__(
         self,
         session,
-        *substreams: Stream,
+        *substreams: TSubstreams,
         **options,
     ):
         """
@@ -42,9 +45,9 @@ class MuxedStream(Stream):
         """
 
         super().__init__(session)
-        self.substreams = substreams
-        self.subtitles = options.pop("subtitles", {})
-        self.options = options
+        self.substreams: Sequence[TSubstreams] = substreams
+        self.subtitles: Dict[str, Stream] = options.pop("subtitles", {})
+        self.options: Dict[str, Any] = options
 
     def open(self):
         fds = []

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -476,7 +476,7 @@ class HLSStreamReader(FilteredStream, SegmentedStreamReader):
         super().__init__(stream)
 
 
-class MuxedHLSStream(MuxedStream):
+class MuxedHLSStream(MuxedStream["HLSStream"]):
     """
     Muxes multiple HLS video and audio streams into one output stream.
     """


### PR DESCRIPTION
`ruff` 0.0.261 (not bumped in this PR) added some new rules which violate the access of class attributes without further usage. 

This is currently done in the HLS external audio tests, which access `master_stream.substreams` without being aware of the actual subclass, namely `HLSStream` or `MuxedHLSStream`. Since I didn't want to simply suppress the linting error, I decided to properly rewrite the tests using pytest. A bump of `ruff` is therefore not needed.

This then led to the generic type for `MuxedStream` being added in the first commit, with `MuxedHLSStream` defining `HLSSteam` as `TSubstreams`, so that `MuxedHLSStream.substreams[].url` can have proper typing information. Other usages of `MuxedStream` don't have the concrete substreams typing information added, because those usages are all in the plugin implementations, and there's no typing data set, so it's irrelevant.