### PR TITLE
stream.hls: fix playlist_end on sequence.num==0

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -443,7 +443,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
                     return
 
                 # End of stream
-                stream_end = self.playlist_end and sequence.num >= self.playlist_end
+                stream_end = self.playlist_end is not None and sequence.num >= self.playlist_end
                 if self.closed or stream_end:
                     return
 

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -133,6 +133,14 @@ class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
         return session
 
+    def test_playlist_end(self):
+        thread, segments = self.subject([
+            # media sequence = 0
+            Playlist(0, [Segment(0)], end=True),
+        ])
+
+        assert self.await_read(read_all=True) == self.content(segments), "Stream ends and read-all handshake doesn't time out"
+
     def test_offset_and_duration(self):
         thread, segments = self.subject([
             Playlist(1234, [Segment(0), Segment(1, duration=0.5), Segment(2, duration=0.5), Segment(3)], end=True),


### PR DESCRIPTION
referring https://github.com/streamlink/streamlink/pull/5281#issuecomment-1501758127

----

While not super relevant outside of tests, this was broken since 2014:
https://github.com/streamlink/streamlink/blame/d372059127c1b8624a0956cf8b92589f86fb189c/src/streamlink/stream/hls.py#L445-L448