### PR TITLE
chore: update GitHub release template

### DIFF
--- a/.github/release_template.md
+++ b/.github/release_template.md
@@ -4,9 +4,6 @@
 
 Please see the [installation instructions](https://streamlink.github.io/install.html) for a list of available install methods and packages on the supported operating systems.
 
-**⚠️ PLEASE NOTE ⚠️**  
-Streamlink's Windows installers have been moved to [streamlink/windows-builds](https://github.com/streamlink/windows-builds).
-
 ## ⚙️ Configuration and Usage
 
 Please see the [CLI documentation](https://streamlink.github.io/cli.html) for how to configure and use Streamlink.


### PR DESCRIPTION
Let's remove the Windows builds note from the GH release template.
It was added almost a year ago on 2022-04-24 in 7359444dcb3645a7bc4ca07aaf9f3ab336cc04e5