### PR TITLE
plugins.openrectv: fix 401 error

### DIFF
--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -149,10 +149,10 @@ class OPENRECtv(Plugin):
                 log.error("There is no video file.")
 
             if m3u8_file is not None:
-                self.session.http.headers.update({"Referer": "https://www.openrec.tv/"})
                 yield from HLSStream.parse_variant_playlist(
                     self.session,
                     m3u8_file,
+                    headers={"Referer": self.url}
                 ).items()
 
         else:

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -149,6 +149,7 @@ class OPENRECtv(Plugin):
                 log.error("There is no video file.")
 
             if m3u8_file is not None:
+                self.session.http.headers.update({"Referer": "https://www.openrec.tv/"})
                 yield from HLSStream.parse_variant_playlist(
                     self.session,
                     m3u8_file,

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -152,7 +152,7 @@ class OPENRECtv(Plugin):
                 yield from HLSStream.parse_variant_playlist(
                     self.session,
                     m3u8_file,
-                    headers={"Referer": self.url}
+                    headers={"Referer": self.url},
                 ).items()
 
         else:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

OPENREC.tv recently made a small change.
When fetching m3u8, it now returns 401 if "https://www.openrec.tv" is not specified in the referer.
So I avoid that error by adding a referer.