### PR TITLE
cli.output: refactor HTTPOutput

### DIFF
--- a/src/streamlink_cli/output/__init__.py
+++ b/src/streamlink_cli/output/__init__.py
@@ -1,3 +1,4 @@
 from streamlink_cli.output.abc import Output
 from streamlink_cli.output.file import FileOutput
+from streamlink_cli.output.http import HTTPOutput
 from streamlink_cli.output.player import PlayerOutput

--- a/src/streamlink_cli/output/player.py
+++ b/src/streamlink_cli/output/player.py
@@ -173,6 +173,7 @@ class PlayerOutput(Output):
         if self.namedpipe:
             self.namedpipe.open()
         elif self.http:
+            self.http.accept_connection()
             self.http.open()
 
     def _close(self):
@@ -181,7 +182,7 @@ class PlayerOutput(Output):
         if self.namedpipe:
             self.namedpipe.close()
         elif self.http:
-            self.http.close()
+            self.http.shutdown()
         elif not self.filename:
             self.player.stdin.close()
 

--- a/src/streamlink_cli/streamrunner.py
+++ b/src/streamlink_cli/streamrunner.py
@@ -4,11 +4,10 @@ import sys
 from contextlib import suppress
 from pathlib import Path
 from threading import Event, Lock, Thread
-from typing import Optional, Union
+from typing import Optional
 
 from streamlink.stream.stream import StreamIO
-from streamlink_cli.output import FileOutput, PlayerOutput
-from streamlink_cli.utils.http_server import HTTPServer
+from streamlink_cli.output import FileOutput, HTTPOutput, Output, PlayerOutput
 from streamlink_cli.utils.progress import Progress
 
 
@@ -75,16 +74,15 @@ class StreamRunner:
     playerpoller: Optional[PlayerPollThread] = None
     progress: Optional[Progress] = None
 
-    # TODO: refactor all output implementations
     def __init__(
         self,
         stream: StreamIO,
-        output: Union[PlayerOutput, FileOutput, HTTPServer],
+        output: Output,
         show_progress: bool = False,
     ):
         self.stream = stream
         self.output = output
-        self.is_http = isinstance(output, HTTPServer)
+        self.is_http = isinstance(output, HTTPOutput)
 
         filename: Optional[Path] = None
 

--- a/src/streamlink_cli/utils/__init__.py
+++ b/src/streamlink_cli/utils/__init__.py
@@ -2,12 +2,11 @@ import json
 from datetime import datetime as _datetime
 
 from streamlink_cli.utils.formatter import Formatter
-from streamlink_cli.utils.http_server import HTTPServer
 from streamlink_cli.utils.player import find_default_player
 
 
 __all__ = [
-    "Formatter", "HTTPServer", "JSONEncoder",
+    "Formatter", "JSONEncoder",
     "datetime",
     "find_default_player",
 ]


### PR DESCRIPTION
- Move `streamlink_cli.utils.http_server` to `streamlink_cli.output.http`
- Rename `HTTPServer` to `HTTPOutput`
- Refactor `HTTPOutput`
  - Inherit from `Output`
  - Remove `bind()` and initialize socket in `start_server()`
  - Split up `open()` into `accept_connection()` and `_open()`
  - Split up `close()` into `_close()` and `shutdown()`
- Refactor `streamlink_cli.main`
  - Update signature of `create_http_server()` and fix initialization
  - Move `iter_http_requests()` logic into `output_stream_http()`
- Update http server logic in `PlayerOutput`
- Update `StreamRunner` according to new `Output` inheritance

----

Follow-up of #5288

Motivation: `HTTPServer` should inherit from `Output`, as it's used the same way in `StreamRunner` as the other output implementations.

Not 100% satisfied with these changes, but at least it's better than before. My idea was to split up `HTTPServer` and `HTTPOutput`, so that `HTTPOutput` only wraps the client connection with the `Output` interface. That however would've required importing `HTTPServer` from the `streamlink_cli.output` package for typing annotations in the main CLI module, which would've been kinda bad, or adding an alias / classmember re-export to `HTTPOutput`, but mypy complained about that despite using `TypeAlias`. So `HTTPOutput` now has three additional methods, `start_server()`, `accept_connection()` and `shutdown()`...

The main CLI implementation is still bad. There's no graceful HTTP server shutdown (#4979), and overall it's really really messy.

----

Since there are no tests for `HTTPOutput`, here's the log output of all possible use-cases

**--player-http** (HTTP server/output started via `PlayerOutput`)

```
$ streamlink --player-http twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: mpv
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

**--player-continuous-http** (player can reload HTTP connection)

```
$ streamlink --player-continuous-http twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting player: mpv
[cli][info] Got HTTP request from libmpv
[cli][info] Opening stream: 1080p60 (hls)
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
[cli][info] HTTP connection closed
[cli][info] Stream ended
[cli][info] Got HTTP request from libmpv
[cli][info] Opening stream: 1080p60 (hls)
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
[cli][info] HTTP connection closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

**--player-external-http** (external player can reload HTTP connection)

```
$ streamlink --player-external-http --player-external-http-continuous=yes --player-external-http-port=8888 twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:8888/
[cli][info]  http://172.17.0.1:8888/
[cli][info]  http://192.168.100.1:8888/
[cli][info]  http://192.168.178.99:8888/
[cli][info] Got HTTP request from libmpv
[cli][info] Opening stream: 1080p60 (hls)
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
[cli][info] HTTP connection closed
[cli][info] Stream ended
[cli][info] Got HTTP request from libmpv
[cli][info] Opening stream: 1080p60 (hls)
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
[cli][info] HTTP connection closed
[cli][info] Stream ended
^CInterrupted! Exiting...
[cli][info] Closing currently open stream...
```

**--player-external-http --player-external-http-continuous=no** (Streamlink stops once player stops/closes)

```
$ streamlink --player-external-http --player-external-http-continuous=no --player-external-http-port=8888 twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:8888/
[cli][info]  http://172.17.0.1:8888/
[cli][info]  http://192.168.100.1:8888/
[cli][info]  http://192.168.178.99:8888/
[cli][info] Got HTTP request from libmpv
[cli][info] Opening stream: 1080p60 (hls)
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] This is not a low latency stream
[cli][info] HTTP connection closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```