### PR TITLE
cli: add --player-external-http-interface argument

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -493,6 +493,9 @@ def build_parser():
         but no player program will be started, and the server will listen on all available
         connections instead of just in the local (loopback) interface.
 
+        See --player-external-http-interface for choosing a specific network interface, and
+        see --player-external-http-port for choosing a non-randomized port.
+
         Optionally, the --player-external-http-continuous option allows for disabling
         the continuous run-mode, so that Streamlink will stop when the stream ends.
 
@@ -514,6 +517,14 @@ def build_parser():
         If set to non-continuous, Streamlink will stop once the stream has ended.
 
         Default is true.
+        """,
+    )
+    player.add_argument(
+        "--player-external-http-interface",
+        metavar="INTERFACE",
+        help="""
+        The network interface on which the HTTP server will be listening on.
+        If unset or set to `0.0.0.0`, all available interfaces will be bound.
         """,
     )
     player.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -198,7 +198,7 @@ def output_stream_http(
         except OSError as err:
             console.exit(f"Failed to start player: {args.player} ({err})")
     else:
-        server = create_http_server(None, port)
+        server = create_http_server(args.player_external_http_interface, port)
         player = None
 
         log.info("Starting server, access with one of:")


### PR DESCRIPTION
Preferably, `--player-external-http` should be turned into a non-`store_true` argument with an argument value for being able to set the interface and port, so `--player-external-http-interface` and `--player-external-http-port` could be deprecated and removed eventually, but that would be an unnecessary breaking change. Making the value optional doesn't work either, e.g. when the following argv tokens are positional arguments like the stream URL or stream quality.

----

I also had a look at adding support for outputting the list of server URLs as JSON data, but I'm not sure how useful it is, considering that `--json` disables all logging output and considering that the process doesn't terminate after printing the JSON payload and keeps running.

----

```
$ streamlink --player-external-http twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:44083/
[cli][info]  http://172.17.0.1:44083/
[cli][info]  http://192.168.100.1:44083/
[cli][info]  http://192.168.178.99:44083/
^CInterrupted! Exiting...

$ streamlink --player-external-http --player-external-http-interface 0.0.0.0 twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:43373/
[cli][info]  http://172.17.0.1:43373/
[cli][info]  http://192.168.100.1:43373/
[cli][info]  http://192.168.178.99:43373/
^CInterrupted! Exiting...
```

```
$ streamlink --player-external-http --player-external-http-interface 127.0.0.1 twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:38465/
^CInterrupted! Exiting...

$ streamlink --player-external-http --player-external-http-interface localhost twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Starting server, access with one of:
[cli][info]  http://127.0.0.1:40993/
^CInterrupted! Exiting...
```

```
$ streamlink --player-external-http --player-external-http-interface foo twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
error: Failed to create HTTP server: [Errno -5] No address associated with hostname

$ streamlink --player-external-http --player-external-http-interface 1.1.1.1 twitch.tv/esl_dota2 best
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
error: Failed to create HTTP server: [Errno 99] Cannot assign requested address
```