### PR TITLE
docs: bump furo to 2023.03.27

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,4 @@ jobs:
       - name: mypy
         run: |
           python -m mypy --no-incremental
-          python -m mypy --no-incremental docs
+          python -m mypy --no-incremental --python-version 3.8 docs

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,7 +1,7 @@
-sphinx >=4.0.0
-furo ==2022.09.15
-myst-parser >=0.18.0
-sphinx-design >=0.3.0
+sphinx >=5.0.0, <7
+furo ==2023.03.27
+myst-parser >=1.0.0, <2
+sphinx-design >=0.4.1, <1
 versioningit >=2.0.0, <3
 
 docutils-stubs

--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,6 +1,7 @@
 <a class="sidebar-brand centered" href="{{ pathto(master_doc) }}">
   <div class="sidebar-logo-container">
-    <img class="sidebar-logo" src="{{ pathto('_static/' + logo, 1) }}" alt="{{ project }}"/>
+    <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="{{ project }}"/>
+    <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="{{ project }}"/>
   </div>
   <p class="sidebar-brand-text">{{ project }}</p>
   <p class="sidebar-brand-oneliner">{{ oneliner }}</p>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -126,6 +126,8 @@ html_theme_options = {
     "source_repository": "https://github.com/streamlink/streamlink/",
     "source_branch": "master",
     "source_directory": "docs/",
+    "light_logo": "icon.svg",
+    "dark_logo": "icon.svg",
 }
 
 # Add any paths that contain custom themes here, relative to this directory.


### PR DESCRIPTION
This updates the furo docs theme to the latest version.

The main intention however is bumping Sphinx to 6.x, which drops the unnecessary jQuery+underscore.js bloat:
https://www.sphinx-doc.org/en/master/changes.html#release-6-0-0-released-dec-29-2022

Sphinx's minimum version requirement however is 5.x (defined by furo and the other build dependencies). I decided against bumping the min version to 6.x, because Sphinx is also used for building the man page. Some Linux distros are still on Sphinx 5 and I don't want to unnecessarily introduce incompatibilities for no reason.

Sphinx 6 also drops support for py37, but we've already dropped support for building docs on py37 a while ago in 46496db3698e4753154061aeb504e348270d3f9f

In order for being able to bump Sphinx to 5.x/6.x, myst-parser and sphinx-design needed an upgrade. Those have finally been published a couple of weeks and days ago respectively:
- https://github.com/executablebooks/MyST-Parser/releases
- https://github.com/executablebooks/sphinx-design/releases

----

Bumping furo also required some fixing due to changes of the theme's `logo` variable.

I couldn't spot any issues after the upgrade, but please check and compare the netlify preview build first.
https://deploy-preview-5301--streamlink.netlify.app/