### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 10
+    after_n_builds: 8
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,4 @@ jobs:
       - name: mypy
         run: |
           python -m mypy --no-incremental
-          python -m mypy --no-incremental --python-version 3.8 docs
+          python -m mypy --no-incremental docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@ pytest >=6.0.0
 pytest-asyncio
 pytest-cov
 coverage[toml]
-mock ; python_version<"3.8"
 requests-mock
 freezegun>=1.0.0
 shtab

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -357,7 +357,7 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
 ========= ========================= ===========================================
 Type      Name                       Notes
 ========= ========================= ===========================================
-python    `Python`_                 At least version **3.7**.
+python    `Python`_                 At least version **3.8**.
 
 build     `setuptools`_             At least version **45.0.0**. |br| Used as build backend.
 build     `wheel`_                  Used by the build frontend for creating Python wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ exclude_lines = [
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
 src = ["src", "tests"]
-target-version = "py37"
+target-version = "py38"
 fix = false
 ignore-init-module-imports = true
 line-length = 128

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,7 @@ allow-multiline = false
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
-python_version = 3.7
+python_version = 3.8
 show_error_codes = true
 show_error_context = true
 show_column_numbers = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,6 @@ classifiers =
   Operating System :: Microsoft :: Windows
   Programming Language :: Python :: 3
   Programming Language :: Python :: 3 :: Only
-  Programming Language :: Python :: 3.7
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
@@ -34,7 +33,7 @@ classifiers =
   Topic :: Utilities
 
 [options]
-python_requires = >=3.7, <4
+python_requires = >=3.8, <4
 package_dir =
   =src
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ package_dir =
 packages = find:
 install_requires =
   certifi
-  importlib-metadata ; python_version<"3.8"
   isodate
   lxml >=4.6.4,<5.0
   pycountry

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def format_msg(text, *args, **kwargs):
 
 
 CURRENT_PYTHON = version_info[:2]
-REQUIRED_PYTHON = (3, 7)
+REQUIRED_PYTHON = (3, 8)
 
 # This check and everything above must remain compatible with older Python versions
 if CURRENT_PYTHON < REQUIRED_PYTHON:

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -5,7 +5,7 @@ from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 from pathlib import Path
 from sys import version_info
 from threading import Lock
-from typing import IO, TYPE_CHECKING, Iterator, List, Optional, Union
+from typing import IO, TYPE_CHECKING, Iterator, List, Literal, Optional, Union
 
 # noinspection PyProtectedMember
 from warnings import WarningMessage
@@ -34,7 +34,7 @@ class StreamlinkLogger(_BaseLoggerClass):
             yield message
 
 
-FORMAT_STYLE = "{"
+FORMAT_STYLE: Literal["%", "{", "$"] = "{"
 FORMAT_BASE = "[{name}][{levelname}] {message}"
 FORMAT_DATE = "%H:%M:%S"
 REMOVE_BASE = ["streamlink", "streamlink_cli"]
@@ -185,7 +185,7 @@ def basicConfig(
     stream: Optional[IO] = None,
     level: Optional[str] = None,
     format: str = FORMAT_BASE,  # noqa: A002  # TODO: rename to "fmt" (breaking)
-    style: str = FORMAT_STYLE,  # TODO: py38: Literal["%", "{", "$"]
+    style: Literal["%", "{", "$"] = FORMAT_STYLE,
     datefmt: str = FORMAT_DATE,
     remove_base: Optional[List[str]] = None,
     capture_warnings: bool = False,

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -180,8 +180,7 @@ class Arguments:
 
     def __iter__(self) -> Iterator[Argument]:
         # iterate in reverse order due to add() being called by multiple pluginargument decorators in reverse order
-        # TODO: Python 3.7 removal: remove list()
-        return reversed(list(self.arguments.values()))
+        return reversed(self.arguments.values())
 
     def add(self, argument: Argument) -> None:
         self.arguments[argument.name] = argument

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, FrozenSet, List, Optional, Pattern, Sequence, Set, Tuple, Type, Union
+from typing import Any, Callable, FrozenSet, List, Literal, Optional, Pattern, Sequence, Set, Tuple, Type, Union
 
 
 class SchemaContainer:
@@ -71,8 +71,7 @@ class RegexSchema:
     def __init__(
         self,
         pattern: Pattern,
-        # TODO: change type from str to Literal["search", "match", "fullmatch", "findall", "split", "sub", "subn"]
-        method: str = "search",
+        method: Literal["search", "match", "fullmatch", "findall", "split", "sub", "subn"] = "search",
     ):
         self.pattern = pattern
         self.method = method

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -145,7 +145,7 @@ class StreamlinkOptions(Options):
 
         return inner
 
-    # bind explicitly with dummy context, to prevent `TypeError: 'staticmethod' object is not callable` on py<310
+    # TODO: py39 support end: remove explicit dummy context binding of static method
     _factory_set_http_attr_key_equals_value = _factory_set_http_attr_key_equals_value.__get__(object)
     _factory_set_deprecated = _factory_set_deprecated.__get__(object)
 

--- a/src/streamlink/stream/dash_manifest.py
+++ b/src/streamlink/stream/dash_manifest.py
@@ -9,13 +9,13 @@ from datetime import datetime, timedelta
 from itertools import count, repeat
 from pathlib import Path
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
     Dict,
     Iterator,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
@@ -33,10 +33,6 @@ from isodate import Duration, parse_datetime, parse_duration  # type: ignore[imp
 from lxml.etree import _Attrib, _Element
 
 from streamlink.utils.times import UTC, fromtimestamp, now
-
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing_extensions import Literal
 
 
 log = logging.getLogger(__name__)
@@ -111,7 +107,7 @@ class MPDParsers:
         return v.lower() == "true"
 
     @staticmethod
-    def type(mpdtype: "Literal['static', 'dynamic']") -> "Literal['static', 'dynamic']":
+    def type(mpdtype: Literal["static", "dynamic"]) -> Literal["static", "dynamic"]:
         if mpdtype not in ("static", "dynamic"):
             raise MPDParsingError("@type must be static or dynamic")
         return mpdtype

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -3,12 +3,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 
-try:
-    import importlib.metadata as importlib_metadata  # type: ignore[import]  # noqa: F401
-except ImportError:
-    import importlib_metadata  # type: ignore[import,no-redef]  # noqa: F401
-
-
 stdout: BinaryIO = sys.stdout.buffer
 
 
@@ -23,7 +17,6 @@ class DeprecatedPath(_BasePath):
 
 
 __all__ = [
-    "importlib_metadata",
     "stdout",
     "DeprecatedPath",
 ]

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1,4 +1,5 @@
 import argparse
+import importlib.metadata
 import logging
 import os
 import platform
@@ -20,7 +21,7 @@ from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.times import LOCAL as LOCALTIMEZONE
 from streamlink_cli.argparser import ArgumentParser, build_parser, setup_session_options
-from streamlink_cli.compat import DeprecatedPath, importlib_metadata, stdout
+from streamlink_cli.compat import DeprecatedPath, stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.output import FileOutput, HTTPOutput, PlayerOutput
@@ -796,12 +797,12 @@ def log_current_versions():
     log.debug("Dependencies:")
     for name in [
         match.group(0)
-        for match in map(re_name.match, importlib_metadata.requires("streamlink"))
+        for match in map(re_name.match, importlib.metadata.requires("streamlink"))
         if match is not None
     ]:
         try:
-            version = importlib_metadata.version(name)
-        except importlib_metadata.PackageNotFoundError:
+            version = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
             continue
         log.debug(f" {name}: {version}")
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -550,6 +550,7 @@ class TestCLIMainOutputStream:
         assert mock_streamrunner.call_args_list == [call(streamio, output, show_progress=expected)]
 
 
+# TODO: rewrite using pytest (caplog+capsys fixtures) and move to separate test module
 class _TestCLIMainLogging(unittest.TestCase):
     # stop test execution at the setup_signals() call, as we're not interested in what comes afterwards
     class StopTest(Exception):
@@ -577,12 +578,7 @@ class _TestCLIMainLogging(unittest.TestCase):
     def tearDown(self):
         streamlink_cli.main.logger.root.handlers.clear()
 
-    # python >=3.7.2: https://bugs.python.org/issue35046
-    _write_call_log_cli_info = (
-        [call("[cli][info] foo\n")]
-        if sys.version_info >= (3, 7, 2) else
-        [call("[cli][info] foo"), call("\n")]
-    )
+    _write_call_log_cli_info = [call("[cli][info] foo\n")]
     _write_call_console_msg = [call("bar\n")]
     _write_call_console_msg_error = [call("error: bar\n")]
     _write_call_console_msg_json = [call("{\n  \"error\": \"bar\"\n}\n")]
@@ -598,12 +594,7 @@ class _TestCLIMainLogging(unittest.TestCase):
 
 
 class TestCLIMainLoggingStreams(_TestCLIMainLogging):
-    # python >=3.7.2: https://bugs.python.org/issue35046
-    _write_call_log_testcli_err = (
-        [call("[test_cli_main][error] baz\n")]
-        if sys.version_info >= (3, 7, 2) else
-        [call("[test_cli_main][error] baz"), call("\n")]
-    )
+    _write_call_log_testcli_err = [call("[test_cli_main][error] baz\n")]
 
     def subject(self, argv, stream=None):
         super().subject(argv)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -694,7 +694,7 @@ class TestCLIMainLoggingInfos(_TestCLIMainLogging):
 
     @patch("streamlink_cli.main.log")
     @patch("streamlink_cli.main.streamlink_version", "streamlink")
-    @patch("streamlink_cli.main.importlib_metadata")
+    @patch("streamlink_cli.main.importlib.metadata")
     @patch("streamlink_cli.main.log_current_arguments", Mock(side_effect=_TestCLIMainLogging.StopTest))
     @patch("platform.python_version", Mock(return_value="python"))
     def test_log_current_versions(self, mock_importlib_metadata: Mock, mock_log: Mock):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -273,26 +273,28 @@ def test_plugin_metadata(attr):
     assert getter() == "baz qux"
 
 
-# TODO: python 3.7 removal: move this as static method to the TestCookies class
-def _create_cookie_dict(name, value, expires=None):
-    return dict(
-        version=0,
-        name=name,
-        value=value,
-        port=None,
-        domain="test.se",
-        path="/",
-        secure=False,
-        expires=expires,
-        discard=True,
-        comment=None,
-        comment_url=None,
-        rest={"HttpOnly": None},
-        rfc2109=False,
-    )
-
-
 class TestCookies:
+    @staticmethod
+    def create_cookie_dict(name, value, expires=None):
+        return dict(
+            version=0,
+            name=name,
+            value=value,
+            port=None,
+            domain="test.se",
+            path="/",
+            secure=False,
+            expires=expires,
+            discard=True,
+            comment=None,
+            comment_url=None,
+            rest={"HttpOnly": None},
+            rfc2109=False,
+        )
+
+    # TODO: py39 support end: remove explicit dummy context binding of static method
+    _create_cookie_dict = create_cookie_dict.__get__(object)
+
     @pytest.fixture()
     def pluginclass(self):
         class MyPlugin(FakePlugin):
@@ -354,7 +356,7 @@ class TestCookies:
         plugin.save_cookies(lambda cookie: cookie.name == "test-name1", default_expires=3600)
         assert plugincache.set.call_args_list == [call(
             "__cookie:test-name1:test.se:80:/",
-            _create_cookie_dict("test-name1", "test-value1", None),
+            self.create_cookie_dict("test-name1", "test-value1", None),
             3600,
         )]
         assert logger.debug.call_args_list == [call("Saved cookies: test-name1")]
@@ -374,7 +376,7 @@ class TestCookies:
         plugin.save_cookies(default_expires=60)
         assert plugincache.set.call_args_list == [call(
             "__cookie:test-name:test.se:80:/",
-            _create_cookie_dict("test-name", "test-value", 3600),
+            self.create_cookie_dict("test-name", "test-value", 3600),
             3600,
         )]
 

--- a/tests/utils/test_processoutput.py
+++ b/tests/utils/test_processoutput.py
@@ -1,19 +1,13 @@
 import asyncio
 from collections import deque
 from typing import Iterable, Optional
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import freezegun
 import pytest
 import pytest_asyncio
 
 from streamlink.utils.processoutput import ProcessOutput
-
-
-try:
-    from unittest.mock import AsyncMock, Mock, call, patch  # type: ignore
-except ImportError:
-    # noinspection PyUnresolvedReferences
-    from mock import AsyncMock, Mock, call, patch  # type: ignore
 
 
 class AsyncIterator:


### PR DESCRIPTION
Opening this early as a draft.

py37 will see its EOL in about 2 months, on 2023-06-27
https://endoflife.date/python

The changes of this PR include:

1. Official removal of py37 support from the package metadata and docs, as well as updates to the CI config
2. Tooling config updates (mypy / ruff)
3. Removal of compat imports
4. Language/grammar updates of previously annotated stuff

This will obviously be a breaking change, so ideally, other breaking changes should be included in that release.

----

Additional tasks after merging these changes:

- Class/function signature changes with positional-only / keyword-only parameters (py38):
  Perfect opportunity to fix some old issues with certain public APIs, e.g. `HLSStream.parse_variant_playlist()`, and more.

----

Everything else in regards to py38 can be done gradually over time later.
https://docs.python.org/3/whatsnew/3.8.html