### PR TITLE
plugins.mitele: fix/add Origin header

### DIFF
--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -113,7 +113,12 @@ class Mitele(Plugin):
             urls.add(update_qsd(stream["stream"], qsd, quote_via=lambda string, *_, **__: string))
 
         for url in urls:
-            yield from HLSStream.parse_variant_playlist(self.session, url, name_fmt="{pixels}_{bitrate}").items()
+            yield from HLSStream.parse_variant_playlist(
+                self.session,
+                url,
+                headers={"Origin": "https://www.mitele.es"},
+                name_fmt="{pixels}_{bitrate}",
+            ).items()
 
 
 __plugin__ = Mitele


### PR DESCRIPTION
```
$ streamlink --http-proxy "http://pass:user@host:8080/" https://www.mitele.es/directo/telecinco/ 360p_620k
[cli][info] Found matching plugin mitele for URL https://www.mitele.es/directo/telecinco/
[cli][info] Available streams: none_150k, 360p_620k_alt (worst), 360p_620k, 360p_1100k_alt, 360p_1100k, 576p_1900k_alt2, 576p_1900k_alt, 576p_1900k, 720p_3400k_alt, 720p_3400k, 720p_4800k_alt, 720p_4800k (best)
[cli][info] Opening stream: 360p_620k (hls)
[cli][info] Starting player: mpv
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[stream.hls_playlist][warning] Discarded invalid attributes list
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

closes #5203
related #5307