### PR TITLE
cli: add --no-config argument

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -269,6 +269,13 @@ def build_parser():
         """,
     )
     general.add_argument(
+        "--no-config",
+        action="store_true",
+        help="""
+        Disable loading any default or custom config files.
+        """,
+    )
+    general.add_argument(
         "-l", "--loglevel",
         metavar="LEVEL",
         choices=logger.levels,

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -641,6 +641,9 @@ def setup_args(
 
 
 def setup_config_args(parser, ignore_unknown=False):
+    if args.no_config:
+        return
+
     config_files = []
 
     if args.config:

--- a/tests/cli/test_main_setup_config_args.py
+++ b/tests/cli/test_main_setup_config_args.py
@@ -48,6 +48,7 @@ def _session():
 @pytest.mark.parametrize(("_args", "_config_files", "expected", "deprecations"), [
     pytest.param(
         {
+            "no_config": False,
             "config": None,
             "url": None,
         },
@@ -63,6 +64,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": [
                 str(configdir / "non-existent"),
             ],
@@ -78,6 +80,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": None,
             "url": "noplugin",
         },
@@ -93,6 +96,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": [
                 str(configdir / "non-existent"),
             ],
@@ -108,6 +112,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": None,
             "url": "testplugin",
         },
@@ -124,6 +129,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": None,
             "url": "testplugin",
         },
@@ -151,6 +157,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": [
                 str(configdir / "custom"),
             ],
@@ -169,6 +176,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": [
                 str(configdir / "custom"),
             ],
@@ -193,6 +201,7 @@ def _session():
     ),
     pytest.param(
         {
+            "no_config": False,
             "config": [
                 str(configdir / "non-existent"),
                 str(configdir / "primary"),
@@ -211,6 +220,45 @@ def _session():
         ],
         [],
         id="Multiple custom configs",
+    ),
+    pytest.param(
+        {
+            "no_config": True,
+            "config": [],
+            "url": "testplugin",
+        },
+        [],
+        [],
+        [],
+        id="No config",
+    ),
+    pytest.param(
+        {
+            "no_config": True,
+            "config": [
+                str(configdir / "primary"),
+                str(configdir / "secondary"),
+            ],
+            "url": "testplugin",
+        },
+        [],
+        [],
+        [],
+        id="No config with multiple custom configs",
+    ),
+    pytest.param(
+        {
+            "no_config": True,
+            "config": [],
+            "url": "testplugin",
+        },
+        [
+            configdir / "primary",
+            DeprecatedPath(configdir / "secondary"),
+        ],
+        [],
+        [],
+        id="No config with multiple default configs",
     ),
 ], indirect=["_args", "_config_files"])
 def test_setup_config_args(


### PR DESCRIPTION
This disables loading any default or custom config files. Only arguments set directly will be parsed.

----

Default config + plugin config
```
$ streamlink -l debug twitch.tv/...
...
[cli][debug] Arguments:
[cli][debug]  url=twitch.tv/...
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --player-args=--cache=yes --demuxer-max-back-bytes=2G
[cli][debug]  --stream-segment-threads=2
[cli][debug]  --hls-live-edge=2
[cli][debug]  --twitch-disable-ads=True
[cli][debug]  --twitch-disable-reruns=True
[cli][debug]  --twitch-low-latency=True
```

Disabled default config + plugin config
```
$ streamlink --no-config -l debug twitch.tv/...
...
[cli][debug] Arguments:
[cli][debug]  url=twitch.tv/...
[cli][debug]  --no-config=True
[cli][debug]  --loglevel=debug
```

Custom configs overrides
```
$ streamlink -l debug --config ~/.config/streamlink/config --config ~/.config/streamlink/config.twitch youtube.com/...
...
[cli][debug] Arguments:
[cli][debug]  url=youtube.com/...
[cli][debug]  --config=['/home/basti/.config/streamlink/config', '/home/basti/.config/streamlink/config.twitch']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --player-args=--cache=yes --demuxer-max-back-bytes=2G
[cli][debug]  --stream-segment-threads=2
[cli][debug]  --hls-live-edge=2
[cli][debug]  --twitch-disable-ads=True
[cli][debug]  --twitch-disable-reruns=True
[cli][debug]  --twitch-low-latency=True
```

Disabled custom config overrides
```
$ streamlink --no-config -l debug --config ~/.config/streamlink/config --config ~/.config/streamlink/config.twitch youtube.com/...
...
[cli][debug] Arguments:
[cli][debug]  url=youtube.com/...
[cli][debug]  --config=['/home/basti/.config/streamlink/config', '/home/basti/.config/streamlink/config.twitch']
[cli][debug]  --no-config=True
[cli][debug]  --loglevel=debug
```