### PR TITLE
tests: clean up root-logger state

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -920,6 +920,9 @@ class TestCLIMainPrint(unittest.TestCase):
                 mock_resolve_url.assert_not_called()
                 mock_resolve_url_no_redirect.assert_not_called()
 
+    def tearDown(self):
+        streamlink_cli.main.logger.root.handlers.clear()
+
     @staticmethod
     def get_stdout(mock_stdout):
         return "".join([call_arg[0][0] for call_arg in mock_stdout.write.call_args_list])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -27,9 +27,12 @@ def log(request, output: StringIO):
     fakeroot = logging.getLogger("streamlink.test")
     with patch("streamlink.logger.root", fakeroot), \
          patch("streamlink.utils.times.LOCAL", timezone.utc):
-        logger.basicConfig(stream=output, **params)
+        handler = logger.basicConfig(stream=output, **params)
+        assert isinstance(handler, logging.Handler)
         yield fakeroot
         logger.capturewarnings(False)
+        fakeroot.removeHandler(handler)
+        assert not fakeroot.handlers
 
 
 class TestLogging:


### PR DESCRIPTION
Remove the attached logging handler from the streamlink root logger again after running logger tests
