### PR TITLE
ci.github: bump deps of useragents workflow

### DIFF
--- a/.github/workflows/useragents.yml
+++ b/.github/workflows/useragents.yml
@@ -12,12 +12,12 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: python -m pip install requests
       - run: python ./script/update-user-agents.py
         env:
           WHATISMYBROWSER_API_KEY: ${{ secrets.WHATISMYBROWSER_API_KEY }}
-      - uses: peter-evans/create-pull-request@3f9dbd5a76a3cb3e1d94af1115652b322e3a198c
+      - uses: peter-evans/create-pull-request@9e5b2344021c369f621dcb89ffde8fd910dac08c
         with:
           token: ${{ secrets.STREAMLINKBOT_USERAGENTS_PR }}
           add-paths: |


### PR DESCRIPTION
- bump Python to 3.11
- bump peter-evans/create-pull-request to v5 and resolve set-output GH actions deprecation

----

- https://github.com/streamlink/streamlink/actions/runs/4847083525
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/peter-evans/create-pull-request/commits/main
- https://github.com/peter-evans/create-pull-request/releases