### PR TITLE
build: update version range of urllib3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
   pycryptodome >=3.4.3,<4
   PySocks !=1.5.7,>=1.5.6
   requests >=2.26.0,<3.0
-  urllib3 >=1.26.0
+  urllib3 >=1.26.0,<2
   websocket-client >=1.2.1,<2.0
 
 [options.packages.find]


### PR DESCRIPTION
`urllib3` is a transitive dependency of `streamlink`, via `requests`.

We define it here too because of the main CLI module which lists all direct dependencies from the package's metadata (via `importlib.metadata`) when the log level is <= debug, and listing urllib3 is useful. Another reason is that we're applying a couple of urllib3 overrides.

We don't specify an upper version limit though. This is only done by requests, namely `<1.27`. Now that urllib3 has published its 2.0 release last week, there are some issues. For some reason, the version doesn't always get resolved correctly by pip. I just noticed that in the `get-dependencies.sh` script of the Windows builds which unnecessarily downloads and tries to build urllib3 2.x until it falls back to 1.x. And then there was #5324 yesterday.

So let's set the max version here too in order to avoid any confusion and to fix any dependency resolving issues. `requests` won't bump `urllib3` without having a major version bump on its own.