### PR TITLE
session: add support for urllib3 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
   pycryptodome >=3.4.3,<4
   PySocks !=1.5.7,>=1.5.6
   requests >=2.26.0,<3.0
-  urllib3 >=1.26.0,<2
+  urllib3 >=1.26.0,<3
   websocket-client >=1.2.1,<2.0
 
 [options.packages.find]

--- a/src/streamlink/plugin/api/http_session.pyi
+++ b/src/streamlink/plugin/api/http_session.pyi
@@ -71,6 +71,10 @@ _Exception: TypeAlias = type[Exception]
 # ----
 
 
+class TLSNoDHAdapter(HTTPAdapter):
+    ...
+
+
 class TLSSecLevel1Adapter(HTTPAdapter):
     ...
 


### PR DESCRIPTION
- Bump max version constraint from `<2` to `<3`
- Fix `_PERCENT_RE` constant name in URL percent encoding override
- Fix `StreamlinkOptions._set_http_disable_dh()`, remove the override of the old `urllib3.util._ssl.DEFAULT_CIPHERS` list and instead add `streamlink.plugin.api.http_session.TLSNoDHAdapter` which reads the ciphers returned by Python's default SSLContext, adds `:!DH` to the updated ciphers list, and finally replaces the HTTP session's `https://` adapter
- Use `urllib3.util.create_urllib3_context()` for creating `SSLContext` objects in custom `HTTPAdapter`s

----

Resolves #5324 

urllib3 migration guide here:
https://urllib3.readthedocs.io/en/stable/v2-migration-guide.html

