### PR TITLE
stream.hls: stop stream early on missing segments

### DIFF
--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -365,8 +365,8 @@ class HLSStreamWorker(SegmentedStreamWorker):
             return sum(s.segment.duration for s in sequences[-max(1, self.live_edge - 1):])
         if type(self.playlist_reload_time_override) is float and self.playlist_reload_time_override > 0:
             return self.playlist_reload_time_override
-        if playlist.target_duration:
-            return playlist.target_duration
+        if playlist.targetduration:
+            return playlist.targetduration
         if sequences:
             return sum(s.segment.duration for s in sequences[-max(1, self.live_edge - 1):])
 

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -129,7 +129,7 @@ class M3U8:
         self.iframes_only: Optional[bool] = None  # version >= 4
         self.media_sequence: Optional[int] = None
         self.playlist_type: Optional[str] = None
-        self.target_duration: Optional[int] = None
+        self.targetduration: Optional[float] = None
         self.start: Optional[Start] = None
         self.version: Optional[int] = None
 
@@ -423,7 +423,7 @@ class M3U8Parser:
         EXT-X-TARGETDURATION
         https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.1
         """
-        self.m3u8.target_duration = int(value)
+        self.m3u8.targetduration = float(value)
 
     def parse_tag_ext_x_media_sequence(self, value: str) -> None:
         """

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -381,7 +381,7 @@ class TestHLSPlaylist(unittest.TestCase):
         delta_30 = timedelta(seconds=30, milliseconds=500)
         delta_60 = timedelta(seconds=60)
 
-        assert playlist.target_duration == 120
+        assert playlist.targetduration == 120
 
         assert list(playlist.dateranges) == [
             DateRange(


### PR DESCRIPTION
Stop the stream early if no new segments were queued by the worker after the playlist's `targetduration * 2` has passed.

Use the timing factor of `2` to prevent potential issues with the reload timing of the playlist or when a stream discontinuity occurs.

----

https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.1

> The `EXT-X-TARGETDURATION` tag **specifies the maximum Media Segment duration.**
> The EXTINF duration of **each Media Segment in the Playlist file, when rounded to the nearest integer, MUST be less than or equal to the target duration**; longer segments can trigger playback stalls or other errors. It applies to the entire Playlist file.

----

Resolves #2198
See https://github.com/streamlink/streamlink/issues/2198#issuecomment-1534150416

Before this can get merged, **lots of testing with real-world data needs to be done**. Stopping the stream early when there's no reason for it would be pretty bad.

These changes don't affect ad filtering, because this is done in the worker thread where it doesn't write the data to the output buffer. Ad segments still get queued by the worker, so the queue timing threshold won't be reached by filtering out ads.

**Please help me test this.**