### PR TITLE
plugins.vimeo: Fix unable to find configuration URL on some pages

### DIFF
--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -25,6 +25,7 @@ log = logging.getLogger(__name__)
     r"https?://(player\.vimeo\.com/video/\d+|(www\.)?vimeo\.com/.+)",
 ))
 class Vimeo(Plugin):
+    VIEWER_URL = "https://vimeo.com/_next/viewer"
     OEMBED_URL = "https://vimeo.com/api/oembed.json"
     API_URL = "https://{0}/{1}?fields=config_url"
     _uri_schema = validate.Schema(
@@ -81,12 +82,12 @@ class Vimeo(Plugin):
             data = self.session.http.get(self.url, schema=self._player_schema)
         else:
             viewer = self.session.http.get(
-                "https://vimeo.com/_next/viewer",
+                self.VIEWER_URL,
                 schema=self._viewer_schema,
             )
 
             uri = self.session.http.get(
-                "https://vimeo.com/api/oembed.json",
+                self.OEMBED_URL,
                 params={"url": self.url},
                 schema=self._uri_schema,
             )

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -82,20 +82,20 @@ class Vimeo(Plugin):
         else:
             viewer = self.session.http.get(
                 "https://vimeo.com/_next/viewer",
-                schema=self._viewer_schema
+                schema=self._viewer_schema,
             )
 
             uri = self.session.http.get(
                 "https://vimeo.com/api/oembed.json",
                 params={"url": self.url},
-                schema=self._uri_schema
+                schema=self._uri_schema,
             )
 
             if viewer and uri:
                 api_url = self.session.http.get(
-                    self.API_URL.format(viewer["apiUrl"], uri['uri']),
-                    headers={"Authorization": "jwt {}".format(viewer['jwt'])},
-                    schema=self._config_url_schema
+                    self.API_URL.format(viewer["apiUrl"], uri["uri"]),
+                    headers={"Authorization": "jwt {}".format(viewer["jwt"])},
+                    schema=self._config_url_schema,
                 )
 
             if not api_url:

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -8,7 +8,6 @@ $notes Password protected streams are not supported
 import logging
 import re
 from html import unescape as html_unescape
-from typing import Optional
 from urllib.parse import urljoin, urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
@@ -65,7 +64,7 @@ class Vimeo(Plugin):
         validate.any(None, validate.Schema(validate.get(1), _config_schema)),
     )
 
-    def get_config_url(self) -> Optional[str]:
+    def get_config_url(self) -> str:
         jwt, api_url = self.session.http.get(
             self.VIEWER_URL,
             schema=validate.Schema(

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -25,6 +25,21 @@ log = logging.getLogger(__name__)
     r"https?://(player\.vimeo\.com/video/\d+|(www\.)?vimeo\.com/.+)",
 ))
 class Vimeo(Plugin):
+    OEMBED_URL = "https://vimeo.com/api/oembed.json"
+    API_URL = "https://{0}/{1}?fields=config_url"
+    _uri_schema = validate.Schema(
+        validate.parse_json(),
+        validate.all({
+            "uri": str,
+        }),
+    )
+    _viewer_schema = validate.Schema(
+        validate.parse_json(),
+        validate.all({
+            "jwt": str,
+            "apiUrl": str,
+        }),
+    )
     _config_url_re = re.compile(r'(?:"config_url"|\bdata-config-url)\s*[:=]\s*(".+?")')
     _config_re = re.compile(r"playerConfig\s*=\s*({.+?})\s*var")
     _config_url_schema = validate.Schema(
@@ -65,7 +80,24 @@ class Vimeo(Plugin):
         if "player.vimeo.com" in self.url:
             data = self.session.http.get(self.url, schema=self._player_schema)
         else:
-            api_url = self.session.http.get(self.url, schema=self._config_url_schema)
+            viewer = self.session.http.get(
+                "https://vimeo.com/_next/viewer",
+                schema=self._viewer_schema
+            )
+
+            uri = self.session.http.get(
+                "https://vimeo.com/api/oembed.json",
+                params={"url": self.url},
+                schema=self._uri_schema
+            )
+
+            if viewer and uri:
+                api_url = self.session.http.get(
+                    self.API_URL.format(viewer["apiUrl"], uri['uri']),
+                    headers={"Authorization": "jwt {}".format(viewer['jwt'])},
+                    schema=self._config_url_schema
+                )
+
             if not api_url:
                 return
             data = self.session.http.get(api_url, schema=self._config_schema)

--- a/tests/plugins/test_vimeo.py
+++ b/tests/plugins/test_vimeo.py
@@ -6,10 +6,10 @@ class TestPluginCanHandleUrlVimeo(PluginCanHandleUrl):
     __plugin__ = Vimeo
 
     should_match = [
-        "https://vimeo.com/237163735",
+        "https://vimeo.com/783455878",
         "https://vimeo.com/channels/music/176894130",
         "https://vimeo.com/album/3706071/video/148903960",
-        "https://vimeo.com/ondemand/surveyopenspace/92630739",
+        "https://vimeo.com/ondemand/worldoftomorrow3/467204924",
         "https://vimeo.com/ondemand/100footsurfingdays",
         "https://player.vimeo.com/video/176894130",
         "https://vimeo.com/771745400/840d05200c",

--- a/tests/plugins/test_vimeo.py
+++ b/tests/plugins/test_vimeo.py
@@ -12,6 +12,7 @@ class TestPluginCanHandleUrlVimeo(PluginCanHandleUrl):
         "https://vimeo.com/ondemand/surveyopenspace/92630739",
         "https://vimeo.com/ondemand/100footsurfingdays",
         "https://player.vimeo.com/video/176894130",
+        "https://vimeo.com/771745400/840d05200c",
     ]
 
     should_not_match = [


### PR DESCRIPTION
The current implementation extracts the player configuration URL from the page itself. However it looks like not all the pages contain the URL itself. This PR changes the behaviour to 
1. Get the authorization token from the viewer API. This also grabs the API base-URL (although that probably could be hard-coded)
2. Grab the video URI from the oembed API.
3. Use the previously grabbed API base-URL, video URI and authorization token to request the configuration URL.

Let me know if there are any issues (not sure I've used the schema validation correctly).

Tested with some random URLs and seems to work fine:
```
streamlink https://vimeo.com/771745400/840d05200c -l debug   
[cli][debug] OS:         Windows 10
[cli][debug] Python:     3.10.11
[cli][debug] Streamlink: 1.7.0+1115.gd2251c01
[cli][debug] Dependencies:
[cli][debug]  certifi: 2022.12.7
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.2
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.15.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.2
[cli][debug]  urllib3: 1.26.15
[cli][debug]  websocket-client: 1.4.1
[cli][debug] Arguments:
[cli][debug]  url=https://vimeo.com/771745400/840d05200c
[cli][debug]  --loglevel=debug
[cli][debug]  --player="H:\Tresors\Dev\mpv\build\mpv.exe"
[cli][debug]  --ringbuffer-size=1073741824
[cli][info] Found matching plugin vimeo for URL https://vimeo.com/771745400/840d05200c
[utils.l10n][debug] Language code: de_DE
[stream.ffmpegmux][debug] ffmpeg version 6.0 Copyright (c) 2000-2023 the FFmpeg developers
[stream.ffmpegmux][debug]  built with gcc 12.2.0 (Rev10, Built by MSYS2 project)
[stream.ffmpegmux][debug]  configuration: --prefix=/mingw64 --target-os=mingw32 --arch=x86_64 --cc=gcc --cxx=g++ --disable-debug --disable-stripping --disable-doc --enable-dxva2 --enable-d3d11va --enable-fontconfig --enable-frei0r --enable-gmp --enable-gnutls --enable-gpl --enable-iconv --enable-libaom --enable-libass --enable-libbluray --enable-libcaca --enable-libdav1d --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopus --enable-libplacebo --enable-librsvg --enable-librtmp --enable-libssh --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libtheora --enable-libvidstab --enable-libvorbis --enable-libx264 --enable-libx265 --enable-libxvid --enable-libvpx --enable-libwebp --enable-libxml2 --enable-libzimg --enable-openal --enable-pic --enable-postproc --enable-runtime-cpudetect --enable-swresample --enable-version3 --enable-vulkan --enable-zlib --enable-librav1e --enable-libsvtav1 --enable-libmfx --enable-amf --enable-nvenc --logfile=config.log --enable-shared
[stream.ffmpegmux][debug]  libavutil      58.  2.100 / 58.  2.100
[stream.ffmpegmux][debug]  libavcodec     60.  3.100 / 60.  3.100
[stream.ffmpegmux][debug]  libavformat    60.  3.100 / 60.  3.100
[stream.ffmpegmux][debug]  libavdevice    60.  1.100 / 60.  1.100
[stream.ffmpegmux][debug]  libavfilter     9.  3.100 /  9.  3.100
[stream.ffmpegmux][debug]  libswscale      7.  1.100 /  7.  1.100
[stream.ffmpegmux][debug]  libswresample   4. 10.100 /  4. 10.100
[stream.ffmpegmux][debug]  libpostproc    57.  1.100 / 57.  1.100
[stream.hls][debug] Using external audio tracks for stream 540p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 1080p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 720p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 240p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 360p (language=None, name=audio)
[utils.l10n][debug] Language code: de_DE
[stream.hls][debug] Using external audio tracks for stream 540p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 1080p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 720p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 240p (language=None, name=audio)
[stream.hls][debug] Using external audio tracks for stream 360p (language=None, name=audio)
[utils.l10n][debug] Language code: de_DE
[stream.dash][debug] Available languages for DASH audio streams: NONE (using: n/a)
[utils.l10n][debug] Language code: de_DE
[stream.dash][debug] Available languages for DASH audio streams: NONE (using: n/a)
Available streams: 240p_alt (worst), 240p, 240p+a67k_alt, 240p+a67k, 240p+a99k_alt, 240p+a99k, 240p+a191k_alt, 240p+a191k, 360p_alt, 360p, 360p+a67k_alt, 360p+a67k, 360p+a99k_alt, 360p+a99k, 360p+a191k_alt, 360p+a191k, 540p_alt, 540p, 540p+a67k_alt, 540p+a67k, 540p+a99k_alt, 540p+a99k, 
540p+a191k_alt, 540p+a191k, 720p_alt, 720p, 720p+a67k_alt, 720p+a67k, 720p+a99k_alt, 720p+a99k, 720p+a191k_alt, 720p+a191k, 1080p_alt, 1080p, 1080p+a67k_alt, 1080p+a67k, 1080p+a99k_alt, 1080p+a99k, 1080p+a191k_alt, 1080p+a191k (best)
```

Resolves https://github.com/streamlink/streamlink/issues/5015.