### PR TITLE
http_session: fix create_urllib3_context import

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -13,6 +13,13 @@ from streamlink.plugin.api import useragents
 from streamlink.utils.parse import parse_json, parse_xml
 
 
+try:
+    from urllib3.util import create_urllib3_context  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    # urllib3 <2.0.0 compat import
+    from urllib3.util.ssl_ import create_urllib3_context
+
+
 # urllib3>=2.0.0: enforce_content_length now defaults to True (keep the override for backwards compatibility)
 class _HTTPResponse(urllib3.response.HTTPResponse):
     def __init__(self, *args, **kwargs):
@@ -188,7 +195,7 @@ class HTTPSession(Session):
 
 class TLSNoDHAdapter(HTTPAdapter):
     def init_poolmanager(self, *args, **kwargs):
-        ctx = urllib3.util.create_urllib3_context()
+        ctx = create_urllib3_context()
         ctx.load_default_certs()
         ciphers = ":".join(cipher.get("name") for cipher in ctx.get_ciphers())
         ciphers += ":!DH"
@@ -199,7 +206,7 @@ class TLSNoDHAdapter(HTTPAdapter):
 
 class TLSSecLevel1Adapter(HTTPAdapter):
     def init_poolmanager(self, *args, **kwargs):
-        ctx = urllib3.util.create_urllib3_context()
+        ctx = create_urllib3_context()
         ctx.load_default_certs()
         ctx.set_ciphers("DEFAULT:@SECLEVEL=1")
         kwargs["ssl_context"] = ctx


### PR DESCRIPTION
Fix import of `create_urllib3_context` method on urllib3 <2.0.0. Only import from `urllib3.util.ssl_` module as a fallback.

----

Fixes #5332 

```
$ pip show urllib3 | grep Version
Version: 1.26.15
$ pytest -q tests/test_session.py | tail -n1
43 passed in 0.57s
```

```
$ pip show urllib3 | grep Version
Version: 2.0.2
$ pytest -q tests/test_session.py | tail -n1
43 passed in 0.57s
```