### PR TITLE
stream.dash: fix stream request args

### DIFF
--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -211,7 +211,7 @@ class DASHStream(Stream):
         self.mpd = mpd
         self.video_representation = video_representation
         self.audio_representation = audio_representation
-        self.args = args
+        self.args = session.http.valid_request_args(**args)
 
     def __json__(self):
         json = dict(type=self.shortname())
@@ -275,7 +275,7 @@ class DASHStream(Stream):
         :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
-        manifest, mpd_params = cls.fetch_manifest(session, url_or_manifest)
+        manifest, mpd_params = cls.fetch_manifest(session, url_or_manifest, **args)
 
         try:
             mpd = cls.parse_mpd(manifest, mpd_params)


### PR DESCRIPTION
- Validate request args in DASHStream constuctor
- Pass request args when fetching initial manifest

----

Btw, I've already talked about it a couple of times. I really don't like the way the HTTP request args are passed to `DASHStream.__init__`, `DASHStream.parse_manifest`, `HLSStream.__init__`, `MuxedHLSStream.__init__`, `HLSStream.parse_variant_playlist` and `HTTPStream.__init__`. It's unnecessarily mixing HTTP request arguments with stream related args. HTTP request args should always be a TypedDict on a dedicated keyword argument. Fixing that is a breaking change of these `Stream` APIs which should be done after py37 support has been dropped (support for positional-only + keyword-only arguments and TypedDict without compat imports).