### PR TITLE
tests: add shared requests_mock fixture

### DIFF
--- a/tests/cli/utils/test_versioncheck.py
+++ b/tests/cli/utils/test_versioncheck.py
@@ -18,20 +18,13 @@ def test_logger_name():
 class TestGetLatest:
     @pytest.fixture()
     def pypi(self, request: pytest.FixtureRequest, requests_mock: rm.Mocker):
-        # TODO: add global requests_mock fixture which sets up InvalidRequest exceptions for unknown requests
-        invalid = requests_mock.register_uri(
-            rm.ANY,
-            rm.ANY,
-            exc=rm.exceptions.InvalidRequest("Invalid request"),
-        )
         response = requests_mock.register_uri(
             "GET",
             "https://pypi.python.org/pypi/streamlink/json",
             **getattr(request, "param", {}),
         )
         yield response
-        assert invalid.call_count == 0  # type: ignore[attr-defined]
-        assert response.call_count == 1  # type: ignore[attr-defined]
+        assert response.call_count == 1
 
     @pytest.mark.parametrize(("pypi", "error"), [
         (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple
 from unittest.mock import patch
 
 import pytest
+import requests_mock as rm
 
 from streamlink.session import Streamlink
 
@@ -71,3 +72,12 @@ def session(request: pytest.FixtureRequest) -> Streamlink:
         for key, value in getattr(request, "param", {}).items():
             session.set_option(key, value)
         return session
+
+
+@pytest.fixture()
+def requests_mock(requests_mock: rm.Mocker) -> rm.Mocker:  # noqa: PT004
+    """
+    Override of the default `requests_mock` fixture, with `InvalidRequest` raised on unknown requests
+    """
+    requests_mock.register_uri(rm.ANY, rm.ANY, exc=rm.exceptions.InvalidRequest)
+    return requests_mock

--- a/tests/plugins/test_vk.py
+++ b/tests/plugins/test_vk.py
@@ -86,7 +86,6 @@ def test_url_redirect(url: str, newurl: str, raises: nullcontext, requests_mock:
     session = Streamlink()
     # noinspection PyTypeChecker
     plugin: VK = VK(session, url)
-    requests_mock.register_uri(rm.ANY, rm.ANY, exc=rm.exceptions.InvalidRequest)
     requests_mock.get(url, text=f"""<!DOCTYPE html><html><head><meta property="og:url" content="{newurl}"/></head></html>""")
     with raises:
         plugin.follow_vk_redirect()

--- a/tests/stream/test_dash.py
+++ b/tests/stream/test_dash.py
@@ -24,11 +24,9 @@ def timestamp():
 class TestDASHStreamParseManifest:
     @pytest.fixture(autouse=True)
     def _response(self, request: pytest.FixtureRequest, requests_mock: rm.Mocker):
-        invalid = requests_mock.register_uri(rm.ANY, rm.ANY, exc=rm.exceptions.InvalidRequest("Invalid request"))
         response = requests_mock.register_uri("GET", "http://test/manifest.mpd", **getattr(request, "param", {}))
         called_once = "nomockedhttprequest" not in request.keywords
         yield
-        assert not invalid.called
         assert response.called_once is called_once
 
     @pytest.fixture()


### PR DESCRIPTION
- Add a globally shared `requests_mock` fixture which raises an `InvalidRequest` exception on unknown requests
- Replace similar fixture setups in various tests

