### PR TITLE
ci: add Python 3.12-dev test runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,10 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-#        include:
-#          - python: "3.12-dev"
-#            os: ubuntu-20.04
-#            continue: true
+        include:
+          - python: "3.12-dev"
+            os: ubuntu-latest
+            continue: true
 #          - python: "3.12-dev"
 #            os: windows-latest
 #            continue: true

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -6,6 +6,14 @@ set -ex
 
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 python -m pip install --upgrade -r dev-requirements.txt
+
+# install a custom-built lxml wheel for the py312 CI runner until an official one is available
+[[ "${GITHUB_ACTIONS}" && "$(uname)" == Linux && "$(python -V)" =~ 3.12. ]] \
+  && python -m pip install --require-hashes -r /dev/stdin <<EOF
+    https://github.com/streamlink/temp-lxml-wheel-DO-NOT-USE/releases/download/lxml-c6b7e62-1/lxml-5.0.0a0-cp312-cp312-linux_x86_64.whl \
+      --hash=sha256:52c42777484b9ab5dbc604583d007048a7d1e7cb0fd101ac063972da1b8e50fb
+EOF
+
 # https://github.com/streamlink/streamlink/issues/4021
 python -m pip install brotli
 python -m pip install -e .


### PR DESCRIPTION
Only add Linux test runner for now and install custom lxml wheel

----

Rel #5336

py312 is still alpha with the first beta release planned for 2023-05-22, but that doesn't matter. The dependency issues and test issues are all fixed on master now, so let's add a test runner to the CI config, so we can see if any further issues come up in the next couple of weeks/months.

The lxml wheel is built here (same repo as the old py311 temp lxml wheel repo, but renamed):
https://github.com/streamlink/temp-lxml-wheel-DO-NOT-USE
I couldn't manage to get the Windows wheel built, neither with the pre-built libxml2+libxslt libs, nor with self-built ones via vcpkg, so it's just the Linux wheel for now. Once there's an official lxml 5.0.0 release, this custom one can be removed and the Windows py312 CI runner be added.