### PR TITLE
plugins.youtube: check playabilityStatus.reason

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -135,7 +135,7 @@ class YouTube(Plugin):
         schema = validate.Schema(
             {"playabilityStatus": {
                 "status": str,
-                validate.optional("reason"): str,
+                validate.optional("reason"): validate.any(str, None),
             }},
             validate.get("playabilityStatus"),
             validate.union_get("status", "reason"),
@@ -341,7 +341,8 @@ class YouTube(Plugin):
         if not data:
             return False
         status, reason = self._schema_playabilitystatus(data)
-        if status != "OK":
+        # assume that there's an error if reason is set (status will still be "OK" for some reason)
+        if status != "OK" or reason:
             if errorlog:
                 log.error(f"Could not get video info - {status}: {reason}")
             return False


### PR DESCRIPTION
For some reason, YouTube always sets the `playabilityStatus.status` value to `"OK"` on broken live streams, even if
`playabilityStatus.reason` is set to a specific error message.

Valid live streams and videos have set the `playabilityStatus.reason` value to `None`, so just check whether the value is truthy.

----

Resolves #5350 

I'd like to see a confirmation from someone else first that the assumption that `playabilityStatus.reason` is `None` on valid streams is actually correct. If it's not, then we unintentionally return no streams with these changes, which would be bad.
