### PR TITLE
tools: bump ruff to 0.0.269

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ freezegun>=1.0.0
 shtab
 versioningit >=2.0.0, <3
 
-ruff ==0.0.259
+ruff ==0.0.269
 
 mypy
 lxml-stubs

--- a/src/streamlink/plugins/dogan.py
+++ b/src/streamlink/plugins/dogan.py
@@ -43,7 +43,7 @@ class Dogan(Plugin):
 
     @staticmethod
     def _get_content_id(root):
-        schema=validate.Schema(
+        schema = validate.Schema(
             validate.any(
                 validate.all(
                     validate.xml_xpath_string("""

--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -102,7 +102,7 @@ class MildomAPI:
                     validate.optional("message"): str,
                     validate.optional("body"): {
                         "data": [
-                            {"token": str },
+                            {"token": str},
                         ],
                     },
                 },


### PR DESCRIPTION
No big changes, just a bump to ruff's latest version.
https://github.com/charliermarsh/ruff/releases/tag/v0.0.269

The included code changes aren't required right now and would only be needed in an upcoming version of ruff because some of the new/updated linting rules aren't selected by default now. See the release notes in regards to the updated `E` selector. I didn't feel like enabling everything explicitly now because these config changes would need to be reverted later again, which is unnecessary.