### PR TITLE
tests.session: refactor tests

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -636,8 +636,8 @@ class Streamlink:
             module_name = f"streamlink.plugins.{name}"
             try:
                 mod = load_module(module_name, path)
-            except ImportError:
-                log.exception(f"Failed to load plugin {name} from {path}\n")
+            except ImportError as err:
+                log.exception(f"Failed to load plugin {name} from {path}", exc_info=err)
                 continue
 
             if not hasattr(mod, "__plugin__") or not issubclass(mod.__plugin__, Plugin):

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -87,7 +87,7 @@ class StreamlinkOptions(Options):
             if scheme not in ("http://", "https://"):
                 continue
             if not value:
-                adapter.poolmanager.connection_pool_kw.pop("source_address")
+                adapter.poolmanager.connection_pool_kw.pop("source_address", None)
             else:
                 # https://docs.python.org/3/library/socket.html#socket.create_connection
                 adapter.poolmanager.connection_pool_kw.update(source_address=(value, 0))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Dict, List, Tuple
+from typing import Dict, Iterator, List, Tuple
 from unittest.mock import patch
 
 import pytest
@@ -66,12 +66,14 @@ def _check_test_condition(item: pytest.Item):  # pragma: no cover
 
 
 @pytest.fixture()
-def session(request: pytest.FixtureRequest) -> Streamlink:
+def session(request: pytest.FixtureRequest) -> Iterator[Streamlink]:
     with patch.object(Streamlink, "load_builtin_plugins"):
         session = Streamlink()
         for key, value in getattr(request, "param", {}).items():
             session.set_option(key, value)
-        return session
+        yield session
+
+    Streamlink.resolve_url.cache_clear()
 
 
 @pytest.fixture()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -254,18 +254,6 @@ class TestSession(unittest.TestCase):
             (StreamlinkDeprecationWarning, "Resolved plugin dep-high with deprecated can_handle_url API"),
         ]
 
-    def test_options(self):
-        session = self.subject()
-        session.set_option("test_option", "option")
-        assert session.get_option("test_option") == "option"
-        assert session.get_option("non_existing") is None
-
-        assert session.get_plugin_option("testplugin", "a_option") == "default"
-        session.set_plugin_option("testplugin", "another_option", "test")
-        assert session.get_plugin_option("testplugin", "another_option") == "test"
-        assert session.get_plugin_option("non_existing", "non_existing") is None
-        assert session.get_plugin_option("testplugin", "non_existing") is None
-
     def test_streams(self):
         session = self.subject()
         streams = session.streams("http://test.se/channel")
@@ -329,6 +317,24 @@ class TestSession(unittest.TestCase):
         assert "vod" in streams
         assert "vod_alt" in streams
         assert "vod_alt2" in streams
+
+
+def test_pluginoptions(session: Streamlink):
+    assert session.get_plugin_option("testplugin", "a_option") is None
+
+    session.load_plugins(str(PATH_TESTPLUGINS))
+    assert session.get_plugin_option("testplugin", "a_option") == "default"
+
+    session.set_plugin_option("testplugin", "another_option", "test")
+    assert session.get_plugin_option("testplugin", "another_option") == "test"
+    assert session.get_plugin_option("non_existing", "non_existing") is None
+    assert session.get_plugin_option("testplugin", "non_existing") is None
+
+
+def test_options(session: Streamlink):
+    session.set_option("test_option", "option")
+    assert session.get_option("test_option") == "option"
+    assert session.get_option("non_existing") is None
 
 
 def test_options_locale(monkeypatch: pytest.MonkeyPatch, session: Streamlink):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -254,8 +254,13 @@ class TestSession(unittest.TestCase):
             (StreamlinkDeprecationWarning, "Resolved plugin dep-high with deprecated can_handle_url API"),
         ]
 
-    def test_streams(self):
-        session = self.subject()
+
+class TestStreams:
+    @pytest.fixture(autouse=True)
+    def _load_builtins(self, session: Streamlink):
+        session.load_plugins(str(PATH_TESTPLUGINS))
+
+    def test_streams(self, session: Streamlink):
         streams = session.streams("http://test.se/channel")
 
         assert "best" in streams
@@ -265,9 +270,7 @@ class TestSession(unittest.TestCase):
         assert isinstance(streams["http"], HTTPStream)
         assert isinstance(streams["hls"], HLSStream)
 
-    def test_streams_stream_types(self):
-        session = self.subject()
-
+    def test_stream_types(self, session: Streamlink):
         streams = session.streams("http://test.se/channel", stream_types=["http", "hls"])
         assert isinstance(streams["480p"], HTTPStream)
         assert isinstance(streams["480p_hls"], HLSStream)
@@ -276,9 +279,7 @@ class TestSession(unittest.TestCase):
         assert isinstance(streams["480p"], HLSStream)
         assert isinstance(streams["480p_http"], HTTPStream)
 
-    def test_streams_stream_sorting_excludes(self):
-        session = self.subject()
-
+    def test_stream_sorting_excludes(self, session: Streamlink):
         streams = session.streams("http://test.se/channel", sorting_excludes=[])
         assert "best" in streams
         assert "worst" in streams

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -396,20 +396,20 @@ class TestSession(unittest.TestCase):
         assert session.get_option("ipv6") is False
         assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
 
-    def test_http_disable_dh(self):
-        session = self.subject(load_plugins=False)
-        assert isinstance(session.http.adapters["https://"], HTTPAdapter)
-        assert not isinstance(session.http.adapters["https://"], TLSNoDHAdapter)
 
-        session.set_option("http-disable-dh", True)
-        assert isinstance(session.http.adapters["https://"], TLSNoDHAdapter)
+def test_options_http_disable_dh(session: Streamlink):
+    assert isinstance(session.http.adapters["https://"], HTTPAdapter)
+    assert not isinstance(session.http.adapters["https://"], TLSNoDHAdapter)
 
-        session.set_option("http-disable-dh", False)
-        assert isinstance(session.http.adapters["https://"], HTTPAdapter)
-        assert not isinstance(session.http.adapters["https://"], TLSNoDHAdapter)
+    session.set_option("http-disable-dh", True)
+    assert isinstance(session.http.adapters["https://"], TLSNoDHAdapter)
+
+    session.set_option("http-disable-dh", False)
+    assert isinstance(session.http.adapters["https://"], HTTPAdapter)
+    assert not isinstance(session.http.adapters["https://"], TLSNoDHAdapter)
 
 
-class TestSessionOptionHttpProxy:
+class TestOptionsHttpProxy:
     @pytest.fixture()
     def _no_deprecation(self, recwarn: pytest.WarningsRecorder):
         yield

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -361,40 +361,42 @@ class TestSession(unittest.TestCase):
         assert adapter_foo.poolmanager.connection_pool_kw == {}
         assert session.get_option("interface") is None
 
-    @patch("streamlink.session.urllib3_util_connection", allowed_gai_family=_original_allowed_gai_family)
-    def test_ipv4_ipv6(self, mock_urllib3_util_connection):
-        session = self.subject(load_plugins=False)
-        assert session.get_option("ipv4") is False
-        assert session.get_option("ipv6") is False
-        assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
 
-        session.set_option("ipv4", True)
-        assert session.get_option("ipv4") is True
-        assert session.get_option("ipv6") is False
-        assert mock_urllib3_util_connection.allowed_gai_family is not _original_allowed_gai_family
-        assert mock_urllib3_util_connection.allowed_gai_family() is AF_INET
+def test_options_ipv4_ipv6(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
+    mock_urllib3_util_connection = Mock(allowed_gai_family=_original_allowed_gai_family)
+    monkeypatch.setattr("streamlink.session.urllib3_util_connection", mock_urllib3_util_connection)
 
-        session.set_option("ipv4", False)
-        assert session.get_option("ipv4") is False
-        assert session.get_option("ipv6") is False
-        assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
+    assert session.get_option("ipv4") is False
+    assert session.get_option("ipv6") is False
+    assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
 
-        session.set_option("ipv6", True)
-        assert session.get_option("ipv4") is False
-        assert session.get_option("ipv6") is True
-        assert mock_urllib3_util_connection.allowed_gai_family is not _original_allowed_gai_family
-        assert mock_urllib3_util_connection.allowed_gai_family() is AF_INET6
+    session.set_option("ipv4", True)
+    assert session.get_option("ipv4") is True
+    assert session.get_option("ipv6") is False
+    assert mock_urllib3_util_connection.allowed_gai_family is not _original_allowed_gai_family
+    assert mock_urllib3_util_connection.allowed_gai_family() is AF_INET
 
-        session.set_option("ipv6", False)
-        assert session.get_option("ipv4") is False
-        assert session.get_option("ipv6") is False
-        assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
+    session.set_option("ipv4", False)
+    assert session.get_option("ipv4") is False
+    assert session.get_option("ipv6") is False
+    assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
 
-        session.set_option("ipv4", True)
-        session.set_option("ipv6", False)
-        assert session.get_option("ipv4") is True
-        assert session.get_option("ipv6") is False
-        assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
+    session.set_option("ipv6", True)
+    assert session.get_option("ipv4") is False
+    assert session.get_option("ipv6") is True
+    assert mock_urllib3_util_connection.allowed_gai_family is not _original_allowed_gai_family
+    assert mock_urllib3_util_connection.allowed_gai_family() is AF_INET6
+
+    session.set_option("ipv6", False)
+    assert session.get_option("ipv4") is False
+    assert session.get_option("ipv6") is False
+    assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
+
+    session.set_option("ipv4", True)
+    session.set_option("ipv6", False)
+    assert session.get_option("ipv4") is True
+    assert session.get_option("ipv6") is False
+    assert mock_urllib3_util_connection.allowed_gai_family is _original_allowed_gai_family
 
 
 def test_options_http_disable_dh(session: Streamlink):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -330,12 +330,29 @@ class TestSession(unittest.TestCase):
         assert "vod_alt" in streams
         assert "vod_alt2" in streams
 
-    def test_set_and_get_locale(self):
-        session = Streamlink()
-        session.set_option("locale", "en_US")
-        assert session.localization.country.alpha2 == "US"
-        assert session.localization.language.alpha2 == "en"
-        assert session.localization.language_code == "en_US"
+
+def test_options_locale(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
+    monkeypatch.setattr("locale.getlocale", lambda: ("C", None))
+    assert session.get_option("locale") is None
+
+    localization = session.localization
+    assert localization.explicit is False
+    assert localization.language_code == "en_US"
+    assert localization.country.alpha2 == "US"
+    assert localization.country.name == "United States"
+    assert localization.language.alpha2 == "en"
+    assert localization.language.name == "English"
+
+    session.set_option("locale", "de_DE")
+    assert session.get_option("locale") == "de_DE"
+
+    localization = session.localization
+    assert localization.explicit is True
+    assert localization.language_code == "de_DE"
+    assert localization.country.alpha2 == "DE"
+    assert localization.country.name == "Germany"
+    assert localization.language.alpha2 == "de"
+    assert localization.language.name == "German"
 
 
 class TestOptionsInterface:


### PR DESCRIPTION
This rewrites the session tests using pytest.

Split up into multiple commits. Some of them could be squashed, but I didn't feel like doing that because it makes tracking the individual changes more difficult...

There's also a fix included for a KeyError being raised when the `interface` session option gets unset when it's already unset.