### PR TITLE
tests: refactor named_pipe tests

### DIFF
--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -6,6 +6,7 @@ import tempfile
 import threading
 from contextlib import suppress
 from pathlib import Path
+from typing import Type
 
 from streamlink.compat import is_win32
 
@@ -133,4 +134,8 @@ class NamedPipeWindows(NamedPipeBase):
             self.pipe = None
 
 
-NamedPipe = NamedPipePosix if not is_win32 else NamedPipeWindows
+NamedPipe: Type[NamedPipeBase]
+if not is_win32:
+    NamedPipe = NamedPipePosix
+else:
+    NamedPipe = NamedPipeWindows


### PR DESCRIPTION
- Refactor tests using pytest
- Add missing tests for handling close() exceptions
- Fix typing information of OS-dependent `NamedPipe` export
