### PR TITLE
tests: refactor unittest.TestCase tests

### DIFF
--- a/tests/stream/test_file.py
+++ b/tests/stream/test_file.py
@@ -1,22 +1,18 @@
-import unittest
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, call, mock_open, patch
 
 from streamlink import Streamlink
 from streamlink.stream.file import FileStream
 
 
-class TestFileStream(unittest.TestCase):
-    def setUp(self):
-        self.session = Streamlink()
+class TestFileStream:
+    def test_open_path(self, session: Streamlink):
+        mock = mock_open()
+        stream = FileStream(session, path="/test/path")
+        with patch("streamlink.stream.file.open", mock, create=True):
+            stream.open()
+        assert mock.call_args_list == [call("/test/path")]
 
-    def test_open_file_path(self):
-        m = mock_open()
-        s = FileStream(self.session, path="/test/path")
-        with patch("streamlink.stream.file.open", m, create=True):
-            s.open()
-            m.assert_called_with("/test/path")
-
-    def test_open_fileobj(self):
+    def test_open_fileobj(self, session: Streamlink):
         fileobj = Mock()
-        s = FileStream(self.session, fileobj=fileobj)
-        assert s.open() is fileobj
+        stream = FileStream(session, fileobj=fileobj)
+        assert stream.open() is fileobj

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -3,11 +3,12 @@ import typing
 import unittest
 from datetime import datetime, timedelta, timezone
 from threading import Event
+from typing import Dict
 from unittest.mock import Mock, call, patch
 
 import freezegun
 import pytest
-import requests_mock
+import requests_mock as rm
 from Crypto.Cipher import AES
 from Crypto.Util.Padding import pad
 from requests.exceptions import InvalidSchema
@@ -74,40 +75,33 @@ class SegmentEnc(EncryptedBase, Segment):
     pass
 
 
-class TestHLSStreamRepr(unittest.TestCase):
-    def test_repr(self):
-        session = Streamlink()
+def test_repr(session: Streamlink):
+    stream = HLSStream(session, "https://foo.bar/playlist.m3u8")
+    assert repr(stream) == "<HLSStream ['hls', 'https://foo.bar/playlist.m3u8']>"
 
-        stream = HLSStream(session, "https://foo.bar/playlist.m3u8")
-        assert repr(stream) == "<HLSStream ['hls', 'https://foo.bar/playlist.m3u8']>"
-
-        stream = HLSStream(session, "https://foo.bar/playlist.m3u8", "https://foo.bar/master.m3u8")
-        assert repr(stream) == "<HLSStream ['hls', 'https://foo.bar/playlist.m3u8', 'https://foo.bar/master.m3u8']>"
+    stream = HLSStream(session, "https://foo.bar/playlist.m3u8", "https://foo.bar/master.m3u8")
+    assert repr(stream) == "<HLSStream ['hls', 'https://foo.bar/playlist.m3u8', 'https://foo.bar/master.m3u8']>"
 
 
-class TestHLSVariantPlaylist(unittest.TestCase):
-    @classmethod
-    def get_master_playlist(cls, playlist):
-        with text(playlist) as pl:
-            return pl.read()
+class TestHLSVariantPlaylist:
+    @pytest.fixture()
+    def streams(self, request: pytest.FixtureRequest, requests_mock: rm.Mocker, session: Streamlink):
+        url = f"http://mocked/{request.node.originalname}/master.m3u8"
+        playlist = getattr(request, "param", "")
 
-    def subject(self, playlist, options=None):
-        with requests_mock.Mocker() as mock:
-            url = f"http://mocked/{self.id()}/master.m3u8"
-            content = self.get_master_playlist(playlist)
-            mock.get(url, text=content)
+        with text(playlist) as fd:
+            content = fd.read()
+        requests_mock.get(url, text=content)
 
-            session = Streamlink(options)
+        return HLSStream.parse_variant_playlist(session, url)
 
-            return HLSStream.parse_variant_playlist(session, url)
-
-    def test_variant_playlist(self):
-        streams = self.subject("hls/test_master.m3u8")
+    @pytest.mark.parametrize("streams", ["hls/test_master.m3u8"], indirect=True)
+    def test_variant_playlist(self, request: pytest.FixtureRequest, streams: Dict[str, HLSStream]):
         assert list(streams.keys()) == ["720p", "720p_alt", "480p", "360p", "160p", "1080p (source)", "90k"]
         assert all(isinstance(stream, HLSStream) for stream in streams.values())
         assert all(stream.multivariant is not None and stream.multivariant.is_master for stream in streams.values())
 
-        base = f"http://mocked/{self.id()}"
+        base = f"http://mocked/{request.node.originalname}"
         stream = next(iter(streams.values()))
         assert repr(stream) == f"<HLSStream ['hls', '{base}/720p.m3u8', '{base}/master.m3u8']>"
 
@@ -115,8 +109,7 @@ class TestHLSVariantPlaylist(unittest.TestCase):
         assert stream.multivariant.uri == f"{base}/master.m3u8"
         assert stream.url_master == f"{base}/master.m3u8"
 
-    def test_url_master(self):
-        session = Streamlink()
+    def test_url_master(self, session: Streamlink):
         stream = HLSStream(session, "http://mocked/foo", url_master="http://mocked/master.m3u8")
 
         assert stream.multivariant is None
@@ -824,10 +817,9 @@ class TestHlsExtAudio:
         monkeypatch.setattr("streamlink.stream.hls.FFMPEGMuxer.is_usable", Mock(return_value=True))
 
     @pytest.fixture(autouse=True)
-    def _playlist(self):
-        with text("hls/test_2.m3u8") as playlist, \
-             requests_mock.Mocker() as mock_requests:
-            mock_requests.get("http://mocked/path/master.m3u8", text=playlist.read())
+    def _playlist(self, requests_mock: rm.Mocker):
+        with text("hls/test_2.m3u8") as playlist:
+            requests_mock.get("http://mocked/path/master.m3u8", text=playlist.read())
             yield
 
     @pytest.fixture()

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime, timedelta, timezone
 from typing import Optional, Tuple, Union
 
@@ -200,7 +199,7 @@ def test_parse_resolution(string: str, expected: Resolution):
     assert M3U8Parser.parse_resolution(string) == expected
 
 
-class TestHLSPlaylist(unittest.TestCase):
+class TestHLSPlaylist:
     def test_load(self):
         with text("hls/test_1.m3u8") as m3u8_fh:
             playlist = load(m3u8_fh.read(), "http://test.se/")

--- a/tests/stream/test_stream_wrappers.py
+++ b/tests/stream/test_stream_wrappers.py
@@ -1,9 +1,7 @@
-import unittest
-
 from streamlink.stream.wrappers import StreamIOIterWrapper
 
 
-class TestPluginStream(unittest.TestCase):
+class TestPluginStream:
     def test_iter(self):
         def generator():
             yield b"1" * 8192

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -1,5 +1,4 @@
-import unittest
-from unittest.mock import PropertyMock, call, patch
+from unittest.mock import Mock, PropertyMock, call
 
 import pytest
 import requests
@@ -33,49 +32,49 @@ class TestUrllib3Overrides:
         assert prep.url == expected, assertion
 
 
-class TestPluginAPIHTTPSession(unittest.TestCase):
+class TestHTTPSession:
     def test_session_init(self):
         session = HTTPSession()
         assert session.headers.get("User-Agent") == FIREFOX
         assert session.timeout == 20.0
         assert "file://" in session.adapters.keys()
 
-    @patch("streamlink.plugin.api.http_session.time.sleep")
-    @patch("streamlink.plugin.api.http_session.Session.request", side_effect=requests.Timeout)
-    def test_read_timeout(self, mock_request, mock_sleep):
-        session = HTTPSession()
+    def test_read_timeout(self, monkeypatch: pytest.MonkeyPatch):
+        mock_sleep = Mock()
+        mock_request = Mock(side_effect=requests.Timeout)
+        monkeypatch.setattr("streamlink.plugin.api.http_session.time.sleep", mock_sleep)
+        monkeypatch.setattr("streamlink.plugin.api.http_session.Session.request", mock_request)
 
+        session = HTTPSession()
         with pytest.raises(PluginError, match=r"^Unable to open URL: http://localhost/"):
             session.get("http://localhost/", timeout=123, retries=3, retry_backoff=2, retry_max_backoff=5)
-        assert mock_request.mock_calls == [
+
+        assert mock_request.call_args_list == [
             call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
             call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
             call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
             call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
         ]
-        assert mock_sleep.mock_calls == [
+        assert mock_sleep.call_args_list == [
             call(2),
             call(4),
             call(5),
         ]
 
-    def test_json_encoding(self):
-        json_str = "{\"test\": \"Α and Ω\"}"
+    @pytest.mark.parametrize("encoding", ["UTF-32BE", "UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"])
+    def test_json_encoding(self, monkeypatch: pytest.MonkeyPatch, encoding: str):
+        mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode(encoding))
+        monkeypatch.setattr("requests.Response.content", mock_content)
 
-        # encode the json string with each encoding and assert that the correct one is detected
-        for encoding in ["UTF-32BE", "UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"]:
-            with patch("requests.Response.content", new_callable=PropertyMock) as mock_content:
-                mock_content.return_value = json_str.encode(encoding)
-                res = requests.Response()
+        res = requests.Response()
 
-                assert HTTPSession.json(res) == {"test": "Α and Ω"}
+        assert HTTPSession.json(res) == {"test": "Α and Ω"}
 
-    def test_json_encoding_override(self):
-        json_text = "{\"test\": \"Α and Ω\"}".encode("cp949")
+    def test_json_encoding_override(self, monkeypatch: pytest.MonkeyPatch):
+        mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode("cp949"))
+        monkeypatch.setattr("requests.Response.content", mock_content)
 
-        with patch("requests.Response.content", new_callable=PropertyMock) as mock_content:
-            mock_content.return_value = json_text
-            res = requests.Response()
-            res.encoding = "cp949"
+        res = requests.Response()
+        res.encoding = "cp949"
 
-            assert HTTPSession.json(res) == {"test": "Α and Ω"}
+        assert HTTPSession.json(res) == {"test": "Α and Ω"}

--- a/tests/utils/test_crypto.py
+++ b/tests/utils/test_crypto.py
@@ -1,10 +1,9 @@
 import base64
-import unittest
 
 from streamlink.utils.crypto import decrypt_openssl, evp_bytestokey
 
 
-class TestUtil(unittest.TestCase):
+class TestUtil:
     def test_evp_bytestokey(self):
         assert evp_bytestokey(b"hello", b"", 16, 16) == (
             b"]A@*\xbcK*v\xb9q\x9d\x91\x10\x17\xc5\x92",

--- a/tests/utils/test_module.py
+++ b/tests/utils/test_module.py
@@ -1,6 +1,5 @@
 import os.path
 import sys
-import unittest
 
 import pytest
 
@@ -11,7 +10,7 @@ from streamlink.utils.module import load_module
 __test_marker__ = "test_marker"
 
 
-class TestUtilsModule(unittest.TestCase):
+class TestUtilsModule:
     def test_load_module_non_existent(self):
         with pytest.raises(ImportError):
             load_module("non_existent_module", os.path.dirname(__file__))

--- a/tests/utils/test_parse.py
+++ b/tests/utils/test_parse.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 from lxml.etree import Element
 
@@ -9,7 +7,7 @@ from streamlink.plugin.api.validate import xml_element
 from streamlink.utils.parse import parse_html, parse_json, parse_qsd, parse_xml
 
 
-class TestUtilsParse(unittest.TestCase):
+class TestUtilsParse:
     def test_parse_json(self):
         assert parse_json("{}") == {}
         assert parse_json('{"test": 1}') == {"test": 1}


### PR DESCRIPTION
This refactors all remaining `unittest.TestCase`-based tests apart from those which

- are blocked by open PRs
  - `Options`/`Argument`/`Arguments` tests (#5033)
  - CLI `FileOutput`/`PlayerOutput` tests (#5310)
  - CLI -> player args acceptance tests (#5310)
- are `streamlink_cli.main` tests
- are HLSStream integration tests