### PR TITLE
plugins: more strict protocol plugin matchers

### DIFF
--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -11,10 +11,10 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"dash://(?P<url>\S+)(?:\s(?P<params>.+))?",
+    r"dash://(?P<url>\S+)(?:\s(?P<params>.+))?$",
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-    r"(?P<url>\S+\.mpd(?:\?\S*)?)(?:\s(?P<params>.+))?",
+    r"(?P<url>\S+\.mpd(?:\?\S*)?)(?:\s(?P<params>.+))?$",
 ))
 class MPEGDASH(Plugin):
     @classmethod

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -11,10 +11,10 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"hls(?:variant)?://(?P<url>\S+)(?:\s(?P<params>.+))?",
+    r"hls(?:variant)?://(?P<url>\S+)(?:\s(?P<params>.+))?$",
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-    r"(?P<url>\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?",
+    r"(?P<url>\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?$",
 ))
 class HLSPlugin(Plugin):
     def _get_streams(self):

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"httpstream://(?P<url>\S+)(?:\s(?P<params>.+))?",
+    r"httpstream://(?P<url>\S+)(?:\s(?P<params>.+))?$",
 ))
 class HTTPStreamPlugin(Plugin):
     def _get_streams(self):

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -11,13 +11,34 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
     __plugin__ = MPEGDASH
 
-    should_match = [
-        "example.com/foo.mpd",
-        "http://example.com/foo.mpd",
-        "https://example.com/foo.mpd",
-        "dash://example.com/foo",
-        "dash://http://example.com/foo",
-        "dash://https://example.com/foo",
+    should_match_groups = [
+        # implicit DASH URLs
+        ("example.com/foo.mpd", {"url": "example.com/foo.mpd"}),
+        ("example.com/foo.mpd?bar", {"url": "example.com/foo.mpd?bar"}),
+        ("http://example.com/foo.mpd", {"url": "http://example.com/foo.mpd"}),
+        ("http://example.com/foo.mpd?bar", {"url": "http://example.com/foo.mpd?bar"}),
+        ("https://example.com/foo.mpd", {"url": "https://example.com/foo.mpd"}),
+        ("https://example.com/foo.mpd?bar", {"url": "https://example.com/foo.mpd?bar"}),
+        # explicit DASH URLs with protocol prefix
+        ("dash://example.com/foo?bar", {"url": "example.com/foo?bar"}),
+        ("dash://http://example.com/foo?bar", {"url": "http://example.com/foo?bar"}),
+        ("dash://https://example.com/foo?bar", {"url": "https://example.com/foo?bar"}),
+        # optional parameters
+        ("example.com/foo.mpd?bar abc=def", {"url": "example.com/foo.mpd?bar", "params": "abc=def"}),
+        ("http://example.com/foo.mpd?bar abc=def", {"url": "http://example.com/foo.mpd?bar", "params": "abc=def"}),
+        ("https://example.com/foo.mpd?bar abc=def", {"url": "https://example.com/foo.mpd?bar", "params": "abc=def"}),
+        ("dash://https://example.com/foo?bar abc=def", {"url": "https://example.com/foo?bar", "params": "abc=def"}),
+    ]
+
+    should_not_match = [
+        # implicit DASH URLs must have their path end with ".mpd"
+        "example.com/mpd",
+        "example.com/mpd abc=def",
+        "example.com/foo.mpd,bar",
+        "example.com/foo.mpd,bar abc=def",
+        # missing parameters
+        "example.com/foo.mpd ",
+        "dash://example.com/foo ",
     ]
 
 

--- a/tests/plugins/test_hls.py
+++ b/tests/plugins/test_hls.py
@@ -12,16 +12,39 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlHLSPlugin(PluginCanHandleUrl):
     __plugin__ = HLSPlugin
 
-    should_match = [
-        "example.com/foo.m3u8",
-        "http://example.com/foo.m3u8",
-        "https://example.com/foo.m3u8",
-        "hls://example.com/foo",
-        "hls://http://example.com/foo",
-        "hls://https://example.com/foo",
-        "hlsvariant://example.com/foo",
-        "hlsvariant://http://example.com/foo",
-        "hlsvariant://https://example.com/foo",
+    should_match_groups = [
+        # implicit HLS URLs
+        ("example.com/foo.m3u8", {"url": "example.com/foo.m3u8"}),
+        ("example.com/foo.m3u8?bar", {"url": "example.com/foo.m3u8?bar"}),
+        ("http://example.com/foo.m3u8", {"url": "http://example.com/foo.m3u8"}),
+        ("http://example.com/foo.m3u8?bar", {"url": "http://example.com/foo.m3u8?bar"}),
+        ("https://example.com/foo.m3u8", {"url": "https://example.com/foo.m3u8"}),
+        ("https://example.com/foo.m3u8?bar", {"url": "https://example.com/foo.m3u8?bar"}),
+        # explicit HLS URLs with protocol prefix
+        ("hls://example.com/foo?bar", {"url": "example.com/foo?bar"}),
+        ("hls://http://example.com/foo?bar", {"url": "http://example.com/foo?bar"}),
+        ("hls://https://example.com/foo?bar", {"url": "https://example.com/foo?bar"}),
+        ("hlsvariant://example.com/foo?bar", {"url": "example.com/foo?bar"}),
+        ("hlsvariant://http://example.com/foo?bar", {"url": "http://example.com/foo?bar"}),
+        ("hlsvariant://https://example.com/foo?bar", {"url": "https://example.com/foo?bar"}),
+        # optional parameters
+        ("example.com/foo.m3u8?bar abc=def", {"url": "example.com/foo.m3u8?bar", "params": "abc=def"}),
+        ("http://example.com/foo.m3u8?bar abc=def", {"url": "http://example.com/foo.m3u8?bar", "params": "abc=def"}),
+        ("https://example.com/foo.m3u8?bar abc=def", {"url": "https://example.com/foo.m3u8?bar", "params": "abc=def"}),
+        ("hls://https://example.com/foo?bar abc=def", {"url": "https://example.com/foo?bar", "params": "abc=def"}),
+        ("hlsvariant://https://example.com/foo?bar abc=def", {"url": "https://example.com/foo?bar", "params": "abc=def"}),
+    ]
+
+    should_not_match = [
+        # implicit HLS URLs must have their path end with ".m3u8"
+        "example.com/m3u8",
+        "example.com/m3u8 abc=def",
+        "example.com/foo.m3u8,bar",
+        "example.com/foo.m3u8,bar abc=def",
+        # missing parameters
+        "example.com/foo.m3u8 ",
+        "hls://example.com/foo ",
+        "hlsvariant://example.com/foo ",
     ]
 
 

--- a/tests/plugins/test_http.py
+++ b/tests/plugins/test_http.py
@@ -11,10 +11,20 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlHTTPStreamPlugin(PluginCanHandleUrl):
     __plugin__ = HTTPStreamPlugin
 
-    should_match = [
-        "httpstream://example.com/foo",
-        "httpstream://http://example.com/foo",
-        "httpstream://https://example.com/foo",
+    should_match_groups = [
+        # explicit HTTPStream URLs
+        ("httpstream://example.com/foo", {"url": "example.com/foo"}),
+        ("httpstream://http://example.com/foo", {"url": "http://example.com/foo"}),
+        ("httpstream://https://example.com/foo", {"url": "https://example.com/foo"}),
+        # optional parameters
+        ("httpstream://example.com/foo abc=def", {"url": "example.com/foo", "params": "abc=def"}),
+        ("httpstream://http://example.com/foo abc=def", {"url": "http://example.com/foo", "params": "abc=def"}),
+        ("httpstream://https://example.com/foo abc=def", {"url": "https://example.com/foo", "params": "abc=def"}),
+    ]
+
+    should_not_match = [
+        # missing parameters
+        "httpstream://example.com/foo ",
     ]
 
 


### PR DESCRIPTION
Ensure that the entire input is matched.

----

Fixes #5366 

Previously it was possible to trick the implicit matcher of the HLS and DASH plugin to only match parts of the URL due to how the optional parameters are matched. Adding the end-of-string anchor to each regex fixes that.