### PR TITLE
http_session: refactor HTTPSession.json()

### DIFF
--- a/src/streamlink/plugin/api/http_session.py
+++ b/src/streamlink/plugin/api/http_session.py
@@ -1,5 +1,6 @@
 import re
 import time
+import warnings
 from typing import Any, Dict, Pattern, Tuple
 
 import requests.adapters
@@ -7,7 +8,7 @@ import urllib3
 from requests import PreparedRequest, Request, Session
 from requests.adapters import HTTPAdapter
 
-from streamlink.exceptions import PluginError
+from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.plugin.api import useragents
 from streamlink.utils.parse import parse_json, parse_xml
@@ -90,23 +91,27 @@ class HTTPSession(Session):
         self.mount("file://", FileAdapter())
 
     @classmethod
-    def determine_json_encoding(cls, sample):
+    def determine_json_encoding(cls, sample: bytes):
         """
         Determine which Unicode encoding the JSON text sample is encoded with
 
-        RFC4627 (http://www.ietf.org/rfc/rfc4627.txt) suggests that the encoding of JSON text can be determined
+        RFC4627 suggests that the encoding of JSON text can be determined
         by checking the pattern of NULL bytes in first 4 octets of the text.
+        https://datatracker.ietf.org/doc/html/rfc4627#section-3
+
         :param sample: a sample of at least 4 bytes of the JSON text
         :return: the most likely encoding of the JSON text
         """
-        nulls_at = [i for i, j in enumerate(bytearray(sample[:4])) if j == 0]
-        if nulls_at == [0, 1, 2]:
+        warnings.warn("Deprecated HTTPSession.determine_json_encoding() call", StreamlinkDeprecationWarning, stacklevel=1)
+        data = int.from_bytes(sample[:4], "big")
+
+        if data & 0xffffff00 == 0:
             return "UTF-32BE"
-        elif nulls_at == [0, 2]:
+        elif data & 0xff00ff00 == 0:
             return "UTF-16BE"
-        elif nulls_at == [1, 2, 3]:
+        elif data & 0x00ffffff == 0:
             return "UTF-32LE"
-        elif nulls_at == [1, 3]:
+        elif data & 0x00ff00ff == 0:
             return "UTF-16LE"
         else:
             return "UTF-8"
@@ -114,10 +119,12 @@ class HTTPSession(Session):
     @classmethod
     def json(cls, res, *args, **kwargs):
         """Parses JSON from a response."""
-        # if an encoding is already set then use the provided encoding
         if res.encoding is None:
-            res.encoding = cls.determine_json_encoding(res.content[:4])
-        return parse_json(res.text, *args, **kwargs)
+            # encoding is unknown: let ``json.loads`` figure it out from the bytes data via ``json.detect_encoding``
+            return parse_json(res.content, *args, **kwargs)
+        else:
+            # encoding is explicitly set: get the decoded string value and let ``json.loads`` parse it
+            return parse_json(res.text, *args, **kwargs)
 
     @classmethod
     def xml(cls, res, *args, **kwargs):

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -1,9 +1,10 @@
+from typing import Optional
 from unittest.mock import Mock, PropertyMock, call
 
 import pytest
 import requests
 
-from streamlink.exceptions import PluginError
+from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
 from streamlink.plugin.api.http_session import HTTPSession
 from streamlink.plugin.api.useragents import FIREFOX
 
@@ -62,19 +63,32 @@ class TestHTTPSession:
         ]
 
     @pytest.mark.parametrize("encoding", ["UTF-32BE", "UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"])
-    def test_json_encoding(self, monkeypatch: pytest.MonkeyPatch, encoding: str):
+    def test_determine_json_encoding(self, recwarn: pytest.WarningsRecorder, encoding: str):
+        data = "Hello world, Γειά σου Κόσμε, こんにちは世界".encode(encoding)
+        assert HTTPSession.determine_json_encoding(data) == encoding
+        assert [(record.category, str(record.message)) for record in recwarn.list] == [
+            (StreamlinkDeprecationWarning, "Deprecated HTTPSession.determine_json_encoding() call"),
+        ]
+
+    @pytest.mark.parametrize(("encoding", "override"), [
+        ("utf-32-be", None),
+        ("utf-32-le", None),
+        ("utf-16-be", None),
+        ("utf-16-le", None),
+        ("utf-8", None),
+        # With byte order mark (BOM)
+        ("utf-16", None),
+        ("utf-32", None),
+        ("utf-8-sig", None),
+        # Override
+        ("utf-8", "utf-8"),
+        ("cp949", "cp949"),
+    ])
+    def test_json(self, monkeypatch: pytest.MonkeyPatch, encoding: str, override: Optional[str]):
         mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode(encoding))
         monkeypatch.setattr("requests.Response.content", mock_content)
 
         res = requests.Response()
-
-        assert HTTPSession.json(res) == {"test": "Α and Ω"}
-
-    def test_json_encoding_override(self, monkeypatch: pytest.MonkeyPatch):
-        mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode("cp949"))
-        monkeypatch.setattr("requests.Response.content", mock_content)
-
-        res = requests.Response()
-        res.encoding = "cp949"
+        res.encoding = override
 
         assert HTTPSession.json(res) == {"test": "Α and Ω"}


### PR DESCRIPTION
- Refactor `HTTPSession.json()` classmethod:
  The JSON encoding already gets determined by `json.loads()` when passing bytes data, with support for byte order marks, so calling the `HTTPSession.determine_json_encoding()` classmethod is not needed.
- Improve performance of `HTTPSession.determine_json_encoding()`:
  Apply simple bitmasks on the first four bytes instead of building a list of bytes and checking for null-byte positions. Since this classmethod is not used anymore, deprecate it for now to avoid an unnecessary breaking change.

----

See `json.detect_encoding()` which gets called by `json.loads()` for `byte` inputs:
- https://github.com/python/cpython/blame/v3.12.0b1/Lib/json/__init__.py#L244-L271
- https://github.com/python/cpython/blame/v3.7.0/Lib/json/__init__.py#L244-L271