### PR TITLE
plugins.twitch: get access token error message

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -427,6 +427,11 @@ class TwitchAPI:
         return self.call(query, acceptable_status=(200, 400, 401, 403), schema=validate.Schema(
             validate.any(
                 validate.all(
+                    {"errors": [{"message": str}]},
+                    validate.get(("errors", 0, "message")),
+                    validate.transform(lambda data: ("error", None, data)),
+                ),
+                validate.all(
                     {"error": str, "message": str},
                     validate.union_get("error", "message"),
                     validate.transform(lambda data: ("error", *data)),


### PR DESCRIPTION
First things first, let's fix the error message not being parsed correctly in the access token error response...

#5370 

```
$ streamlink twitch.tv/gamesdonequick
[cli][info] Found matching plugin twitch for URL twitch.tv/gamesdonequick
[plugins.twitch][error] Error: failed integrity check
error: No playable streams found on this URL: twitch.tv/gamesdonequick
```