### PR TITLE
plugins.mediavitrina: update re_url_json

### DIFF
--- a/src/streamlink/plugins/mediavitrina.py
+++ b/src/streamlink/plugins/mediavitrina.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 )\.ru/(?:live|online)""", re.VERBOSE))
 @pluginmatcher(re.compile(r"https?://player\.mediavitrina\.ru/.+/player\.html"))
 class MediaVitrina(Plugin):
-    _re_url_json = re.compile(r"https://media\.mediavitrina\.ru/(?:proxy)?api/v3/\w+/playlist/[\w-]+_as_array\.json[^\"']+")
+    _re_url_json = re.compile(r"https://media\.mediavitrina\.ru/(?:proxy)?api/v3/[\w-]+/playlist/[\w-]+_as_array\.json[^\"']+")
 
     def _get_streams(self):
         self.session.http.headers.update({"Referer": self.url})

--- a/tests/plugins/test_mediavitrina.py
+++ b/tests/plugins/test_mediavitrina.py
@@ -34,6 +34,7 @@ class TestPluginCanHandleUrlMediaVitrina(PluginCanHandleUrl):
         "https://player.mediavitrina.ru/tvc/tvc/moretv_web/player.html",
         "https://player.mediavitrina.ru/tvzvezda/moretv_web/player.html",
         "https://player.mediavitrina.ru/u_ott/u/moretv_web/player.html",
+        "https://player.mediavitrina.ru/gpm_tnt_v2/tnt/vitrinatv_web/player.html",
     ]
 
     should_not_match = [


### PR DESCRIPTION
```
$ streamlink https://player.mediavitrina.ru/gpm_tnt_v2/tnt/vitrinatv_web/player.html best
[cli][info] Found matching plugin mediavitrina for URL https://player.mediavitrina.ru/gpm_tnt_v2/tnt/vitrinatv_web/player.html
[plugins.mediavitrina][error] Stream is geo-restricted
error: No playable streams found on this URL: https://player.mediavitrina.ru/gpm_tnt_v2/tnt/vitrinatv_web/player.html
```
```
$ streamlink-ssh https://player.mediavitrina.ru/gpm_tnt_v2/tnt/vitrinatv_web/player.html best
[cli][info] Found matching plugin mediavitrina for URL https://player.mediavitrina.ru/gpm_tnt_v2/tnt/vitrinatv_web/player.html
[cli][info] Available streams: 240p_710k (worst), 360p_1200k, 480p_3400k, 720p_5000k, 1080p_8500k (best)
[cli][info] Opening stream: 1080p_8500k (hls)
[cli][info] Starting player: mpv
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```
closes #5328
