### PR TITLE
tools: bump ruff to 0.0.272 and fix issues

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,7 +9,7 @@ freezegun>=1.0.0
 shtab
 versioningit >=2.0.0, <3
 
-ruff ==0.0.269
+ruff ==0.0.272
 
 mypy
 lxml-stubs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,13 @@ select = [
   "Q",
   # flake8-tidy-imports
   "TID",
+  # explicitly select rules under the nursery-flag introduced in ruff 0.0.269
+  # remove once enabled via the "E" selector
+  "E111", "E112", "E113", "E114", "E115", "E116", "E117",
+  "E201", "E202", "E203", "E211", "E221", "E222", "E223",
+  "E224", "E225", "E226", "E227", "E228", "E231", "E251",
+  "E252", "E261", "E262", "E265", "E266", "E271", "E272",
+  "E273", "E274", "E275",
 ]
 extend-ignore = [
   "A003",  # builtin-attribute-shadowing

--- a/tests/plugins/test_turkuvaz.py
+++ b/tests/plugins/test_turkuvaz.py
@@ -7,23 +7,23 @@ class TestPluginCanHandleUrlTurkuvaz(PluginCanHandleUrl):
 
     should_match = [
         # canonical live links
-        "https://www.ahaber.com.tr/video/canli-yayin", # ahbr
-        "https://www.ahaber.com.tr/canli-yayin-aspor.html", # ahbr: aspor
-        "https://www.ahaber.com.tr/canli-yayin-anews.html", # ahbr: anews
-        "https://www.ahaber.com.tr/canli-yayin-a2tv.html", # ahbr: a2tv
-        "https://www.ahaber.com.tr/canli-yayin-minikago.html", # ahbr: minika go
-        "https://www.ahaber.com.tr/canli-yayin-minikacocuk.html", # ahbr: minika cocuk
-        "https://www.anews.com.tr/webtv/live-broadcast", # anews
-        "https://www.apara.com.tr/canli-yayin", # apara
-        "https://www.aspor.com.tr/webtv/canli-yayin", # aspor
-        "https://www.atv.com.tr/canli-yayin", # atv
-        "https://www.atv.com.tr/a2tv/canli-yayin", # a2tv
-        "https://www.atvavrupa.tv/canli-yayin", # atvavrupa
-        "https://www.minikacocuk.com.tr/webtv/canli-yayin", # minika cocuk
-        "https://www.minikago.com.tr/webtv/canli-yayin", # minika go
-        "https://vavtv.com.tr/canli-yayin", # vavtv
+        "https://www.ahaber.com.tr/video/canli-yayin",  # ahbr
+        "https://www.ahaber.com.tr/canli-yayin-aspor.html",  # ahbr: aspor
+        "https://www.ahaber.com.tr/canli-yayin-anews.html",  # ahbr: anews
+        "https://www.ahaber.com.tr/canli-yayin-a2tv.html",  # ahbr: a2tv
+        "https://www.ahaber.com.tr/canli-yayin-minikago.html",  # ahbr: minika go
+        "https://www.ahaber.com.tr/canli-yayin-minikacocuk.html",  # ahbr: minika cocuk
+        "https://www.anews.com.tr/webtv/live-broadcast",  # anews
+        "https://www.apara.com.tr/canli-yayin",  # apara
+        "https://www.aspor.com.tr/webtv/canli-yayin",  # aspor
+        "https://www.atv.com.tr/canli-yayin",  # atv
+        "https://www.atv.com.tr/a2tv/canli-yayin",  # a2tv
+        "https://www.atvavrupa.tv/canli-yayin",  # atvavrupa
+        "https://www.minikacocuk.com.tr/webtv/canli-yayin",  # minika cocuk
+        "https://www.minikago.com.tr/webtv/canli-yayin",  # minika go
+        "https://vavtv.com.tr/canli-yayin",  # vavtv
 
-        #vods
+        # vods
         "https://www.ahaber.com.tr/video/yasam-videolari/samsunda-sel-sularindan-kacma-ani-kamerada",
         "https://www.anews.com.tr/webtv/world/pro-ukraine-militia-says-it-has-captured-russian-soldiers",
         "https://www.apara.com.tr/video/ekonomide-bugun/bist-100de-kar-satislari-derinlesir-mi",
@@ -35,6 +35,6 @@ class TestPluginCanHandleUrlTurkuvaz(PluginCanHandleUrl):
         "https://vavtv.com.tr/vavradyo/video/guncel/munafiklarin-ozellikleri-nelerdir",
 
         # other links for info/doc
-        "https://www.atv.com.tr/webtv/canli-yayin", # redirect to atv.com.tr/canli-yayin
-        "https://www.ahaber.com.tr/canli-yayin-atv.html", # links to atv.com.tr/webtv/canli-yayin
+        "https://www.atv.com.tr/webtv/canli-yayin",  # redirect to atv.com.tr/canli-yayin
+        "https://www.ahaber.com.tr/canli-yayin-atv.html",  # links to atv.com.tr/webtv/canli-yayin
     ]


### PR DESCRIPTION
This explicitly adds the experimental rules added in ruff 0.0.269. I initially didn't want to add these because they will have to be removed again at some point when they are included in the "E" selector by default (which we already set). Since there are already code style cleanups required, let's just add them now, so linting issues get caught early.
https://github.com/astral-sh/ruff/releases/tag/v0.0.269