### PR TITLE
webbrowser: implement Webbrowser / ChromiumWebbrowser

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ pip>=9
 pytest >=6.0.0
 pytest-asyncio
 pytest-cov
+pytest-trio
 coverage[toml]
 requests-mock
 freezegun>=1.0.0
@@ -12,6 +13,7 @@ ruff ==0.0.272
 
 mypy
 lxml-stubs
+trio-typing
 types-freezegun
 types-requests
 types-urllib3

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -377,6 +377,7 @@ runtime   `pycountry`_              Used for localization settings, provides cou
 runtime   `pycryptodome`_           Used for decrypting encrypted streams
 runtime   `PySocks`_                Used for SOCKS Proxies
 runtime   `requests`_               Used for making any kind of HTTP/HTTPS request
+runtime   `trio`_                   Used for async concurrency and I/O in some parts of Streamlink
 runtime   `urllib3`_                Used internally by `requests`_, defined as direct dependency
 runtime   `websocket-client`_       Used for making websocket connections
 
@@ -402,6 +403,7 @@ optional  `FFmpeg`_                 Required for `muxing`_ multiple video/audio/
 .. _pycryptodome: https://pycryptodome.readthedocs.io/en/latest/
 .. _PySocks: https://github.com/Anorov/PySocks
 .. _requests: https://requests.readthedocs.io/en/latest/
+.. _trio: https://trio.readthedocs.io/en/stable/
 .. _urllib3: https://urllib3.readthedocs.io/en/stable/
 .. _websocket-client: https://pypi.org/project/websocket-client/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
   pycryptodome >=3.4.3,<4
   PySocks !=1.5.7,>=1.5.6
   requests >=2.26.0,<3.0
+  trio >=0.22.0,<1
   urllib3 >=1.26.0,<3
   websocket-client >=1.2.1,<2.0
 

--- a/src/streamlink/utils/path.py
+++ b/src/streamlink/utils/path.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from shutil import which
+from typing import List, Optional, Union
+
+
+def resolve_executable(
+    custom: Optional[Union[str, Path]] = None,
+    names: Optional[List[str]] = None,
+    fallbacks: Optional[List[Union[str, Path]]] = None,
+) -> Optional[Union[str, Path]]:
+    if custom:
+        return which(custom)
+
+    for item in (names or []) + (fallbacks or []):
+        executable = which(item)
+        if executable:
+            return executable
+
+    return None

--- a/src/streamlink/utils/socket.py
+++ b/src/streamlink/utils/socket.py
@@ -1,0 +1,23 @@
+from typing import Callable, Coroutine
+
+import trio
+
+
+def _factory_find_free_port(name: str, address_family: int) -> Callable[[str], Coroutine[None, None, int]]:
+    async def find_free_port(host: str) -> int:  # pragma: no cover
+        *_, (*_gai, address) = await trio.socket.getaddrinfo(host, None, address_family, trio.socket.SOCK_STREAM)
+        with trio.socket.socket(address_family, trio.socket.SOCK_STREAM) as s:
+            await s.bind(address)
+            s.listen()
+            return s.getsockname()[1]
+
+    find_free_port.__name__ = name
+
+    return find_free_port
+
+
+find_free_port_ipv4 = _factory_find_free_port("find_free_port_ipv4", trio.socket.AF_INET)
+find_free_port_ipv6 = _factory_find_free_port("find_free_port_ipv6", trio.socket.AF_INET6)
+
+
+del _factory_find_free_port

--- a/src/streamlink/webbrowser/__init__.py
+++ b/src/streamlink/webbrowser/__init__.py
@@ -3,5 +3,6 @@ The entire API of the ``streamlink.webbrowser`` package is considered unstable a
 Use at your own risk!
 """
 
+from streamlink.webbrowser.chromium import ChromiumWebbrowser
 from streamlink.webbrowser.exceptions import WebbrowserError
 from streamlink.webbrowser.webbrowser import Webbrowser

--- a/src/streamlink/webbrowser/__init__.py
+++ b/src/streamlink/webbrowser/__init__.py
@@ -1,0 +1,7 @@
+"""
+The entire API of the ``streamlink.webbrowser`` package is considered unstable and may change at any time.
+Use at your own risk!
+"""
+
+from streamlink.webbrowser.exceptions import WebbrowserError
+from streamlink.webbrowser.webbrowser import Webbrowser

--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -1,0 +1,178 @@
+import os
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import AsyncGenerator, List, Optional, Union
+
+import trio
+
+from streamlink.compat import is_darwin, is_win32
+from streamlink.plugin.api import validate
+from streamlink.session import Streamlink
+from streamlink.utils.socket import find_free_port_ipv4, find_free_port_ipv6
+from streamlink.webbrowser.webbrowser import Webbrowser
+
+
+class ChromiumWebbrowser(Webbrowser):
+    @classmethod
+    def names(cls) -> List[str]:
+        return [
+            "chromium",
+            "chromium-browser",
+            "chrome",
+            "google-chrome",
+            "google-chrome-stable",
+        ]
+
+    @classmethod
+    def fallback_paths(cls) -> List[Union[str, Path]]:
+        if is_win32:
+            return [
+                str(Path(base) / sub / "chrome.exe")
+                for sub in (
+                    "Google\\Chrome\\Application",
+                    "Google\\Chrome Beta\\Application",
+                    "Google\\Chrome Canary\\Application",
+                )
+                for base in [os.getenv(env) for env in (
+                    "PROGRAMFILES",
+                    "PROGRAMFILES(X86)",
+                    "LOCALAPPDATA",
+                )]
+                if base is not None
+            ]
+
+        if is_darwin:
+            return [
+                "/Applications/Chromium.app/Contents/MacOS/Chromium",
+                str(Path.home() / "Applications/Chromium.app/Contents/MacOS/Chromium"),
+                "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+                str(Path.home() / "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+            ]
+
+        return []
+
+    @classmethod
+    def launch_args(cls) -> List[str]:
+        # https://docs.google.com/spreadsheets/d/1n-vw_PCPS45jX3Jt9jQaAhFqBY6Ge1vWF_Pa0k7dCk4
+        # https://peter.sh/experiments/chromium-command-line-switches/
+        return [
+            # Don't auto-play videos
+            "--autoplay-policy=user-gesture-required",
+            # Suppress all permission prompts by automatically denying them
+            "--deny-permission-prompts",
+            # Disable various background network services, including
+            #   extension updating, safe browsing service, upgrade detector, translate, UMA
+            "--disable-background-networking",
+            # Chromium treats "foreground" tabs as "backgrounded" if the surrounding window is occluded by another window
+            "--disable-backgrounding-occluded-windows",
+            # Disable crashdump collection (reporting is already disabled in Chromium)
+            "--disable-breakpad",
+            # Disables client-side phishing detection
+            "--disable-client-side-phishing-detection",
+            # Disable some built-in extensions that aren't affected by `--disable-extensions`
+            "--disable-component-extensions-with-background-pages",
+            # Don't update the browser 'components' listed at chrome://components/
+            "--disable-component-update",
+            # Disable installation of default apps
+            "--disable-default-apps",
+            # Disable all chrome extensions
+            "--disable-extensions",
+            # Hide toolbar button that opens dialog for controlling media sessions
+            "--disable-features=GlobalMediaControls",
+            # Disable the "Chrome Media Router" which creates some background network activity to discover castable targets
+            "--disable-features=MediaRouter",
+            # Disables Chrome translation, both the manual option and the popup prompt
+            "--disable-features=Translate",
+            # Suppresses hang monitor dialogs in renderer processes
+            #   This flag may allow slow unload handlers on a page to prevent the tab from closing
+            "--disable-hang-monitor",
+            # Disables logging
+            "--disable-logging",
+            # Disables the Web Notification and the Push APIs
+            "--disable-notifications",
+            # Disable popup blocking. `--block-new-web-contents` is the strict version of this
+            "--disable-popup-blocking",
+            # Reloading a page that came from a POST normally prompts the user
+            "--disable-prompt-on-repost",
+            # Disable syncing with Google
+            "--disable-sync",
+            # Forces the maximum disk space to be used by the disk cache, in bytes
+            "--disk-cache-size=0",
+            # Disable reporting to UMA, but allows for collection
+            "--metrics-recording-only",
+            # Mute any audio
+            "--mute-audio",
+            # Disable the default browser check, do not prompt to set it as such
+            "--no-default-browser-check",
+            # Disables all experiments set on about:flags
+            "--no-experiments",
+            # Skip first run wizards
+            "--no-first-run",
+            # Disables the service process from adding itself as an autorun process
+            #   This does not delete existing autorun registrations, it just prevents the service from registering a new one
+            "--no-service-autorun",
+            # Avoid potential instability of using Gnome Keyring or KDE wallet
+            "--password-store=basic",
+            # No initial CDP target (no empty default tab)
+            "--silent-launch",
+            # Use mock keychain on Mac to prevent the blocking permissions dialog asking:
+            #   Do you want the application "Chromium.app" to accept incoming network connections?
+            "--use-mock-keychain",
+            # When not using headless mode, try to disrupt the user as little as possible
+            "--window-size=0,0",
+        ]
+
+    def __init__(
+        self,
+        *args,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        headless: bool = True,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.host = host or "127.0.0.1"
+        self.port = port
+        if headless:
+            self.arguments.append("--headless=new")
+
+    @asynccontextmanager
+    async def launch(self, timeout: Optional[float] = None) -> AsyncGenerator[trio.Nursery, None]:
+        if self.port is None:
+            if ":" in self.host:
+                self.port = await find_free_port_ipv6(self.host)
+            else:
+                self.port = await find_free_port_ipv4(self.host)
+
+        # no async rmtree
+        with self._create_temp_dir() as user_data_dir:
+            arguments = self.arguments.copy()
+            arguments.extend([
+                f"--remote-debugging-host={self.host}",
+                f"--remote-debugging-port={self.port}",
+                f"--user-data-dir={user_data_dir}",
+            ])
+
+            async with super()._launch(self.executable, arguments, timeout=timeout) as nursery:
+                yield nursery
+
+            # Even though we've awaited the process termination in the async generator above,
+            # the rmtree() call of the temp-dir's context manager can sometimes still fail.
+            # This is probably caused by filesystem commits of the OS, not sure,
+            # but we have to wait a bit in order to be able to gracefully remove the temp user data dir.
+            # A terrible solution to use a static timer :(
+            await trio.sleep(0.5)
+
+    def get_websocket_url(self, session: Streamlink) -> str:
+        return session.http.get(
+            f"http://{f'[{self.host}]' if ':' in self.host else self.host}:{self.port}/json/version",
+            retries=10,
+            retry_backoff=0.25,
+            retry_max_backoff=0.25,
+            timeout=0.1,
+            schema=validate.Schema(
+                validate.parse_json(),
+                {"webSocketDebuggerUrl": validate.url(scheme="ws")},
+                validate.get("webSocketDebuggerUrl"),
+            ),
+        )

--- a/src/streamlink/webbrowser/exceptions.py
+++ b/src/streamlink/webbrowser/exceptions.py
@@ -1,0 +1,5 @@
+from streamlink.exceptions import StreamlinkError
+
+
+class WebbrowserError(StreamlinkError):
+    pass

--- a/src/streamlink/webbrowser/webbrowser.py
+++ b/src/streamlink/webbrowser/webbrowser.py
@@ -1,0 +1,115 @@
+import logging
+import sys
+import tempfile
+from contextlib import asynccontextmanager, contextmanager
+from functools import partial
+from pathlib import Path
+from subprocess import DEVNULL
+from typing import AsyncContextManager, AsyncGenerator, Generator, List, Optional, Union
+
+import trio
+
+from streamlink.utils.path import resolve_executable
+from streamlink.webbrowser.exceptions import WebbrowserError
+
+
+log = logging.getLogger(__name__)
+
+
+class Webbrowser:
+    TIMEOUT = 10
+
+    @classmethod
+    def names(cls) -> List[str]:
+        return []
+
+    @classmethod
+    def fallback_paths(cls) -> List[Union[str, Path]]:
+        return []
+
+    @classmethod
+    def launch_args(cls) -> List[str]:
+        return []
+
+    def __init__(self, executable: Optional[str] = None):
+        resolved = resolve_executable(executable, self.names(), self.fallback_paths())
+        if not resolved:
+            raise WebbrowserError(f"Could not resolve web browser executable{f': {executable}' if executable else ''}")
+
+        self.executable: Union[str, Path] = resolved
+        self.arguments: List[str] = self.launch_args().copy()
+
+    def launch(self, timeout: Optional[float] = None) -> AsyncContextManager[trio.Nursery]:
+        return self._launch(self.executable, self.arguments, timeout=timeout)
+
+    def _launch(
+        self,
+        executable: Union[str, Path],
+        arguments: List[str],
+        timeout: Optional[float] = None,
+    ) -> AsyncContextManager[trio.Nursery]:
+        if timeout is None:
+            timeout = self.TIMEOUT
+
+        launcher = _WebbrowserLauncher(executable, arguments, timeout)
+
+        # noinspection PyTypeChecker
+        return launcher.launch()
+
+    @staticmethod
+    @contextmanager
+    def _create_temp_dir() -> Generator[str, None, None]:
+        kwargs = {"ignore_cleanup_errors": True} if sys.version_info >= (3, 10) else {}
+        with tempfile.TemporaryDirectory(**kwargs) as temp_file:  # type: ignore[call-overload]
+            yield temp_file
+
+
+class _WebbrowserLauncher:
+    def __init__(self, executable: Union[str, Path], arguments: List[str], timeout: float):
+        self.executable = executable
+        self.arguments = arguments
+        self.timeout = timeout
+        self._process_ended_early = False
+
+    @asynccontextmanager
+    async def launch(self) -> AsyncGenerator[trio.Nursery, None]:
+        async with trio.open_nursery() as nursery:
+            log.info(f"Launching web browser: {self.executable}")
+            # the process is run in a separate task
+            run_process = partial(
+                trio.run_process,
+                [self.executable, *self.arguments],
+                check=False,
+                stdout=DEVNULL,
+                stderr=DEVNULL,
+            )
+            # trio ensures that the process gets terminated when the task group gets cancelled
+            process: trio.Process = await nursery.start(run_process)
+            # the process watcher task cancels the entire task group when the user terminates/kills the process
+            nursery.start_soon(self._task_process_watcher, process, nursery)
+            try:
+                # the application logic is run here
+                with trio.move_on_after(self.timeout) as cancel_scope:
+                    yield nursery
+            except BaseException:
+                # handle KeyboardInterrupt and SystemExit
+                raise
+            else:
+                # check if the application logic has timed out
+                if cancel_scope.cancelled_caught:
+                    log.warning("Web browser task group has timed out")
+            finally:
+                # check if the task group hasn't been cancelled yet in the process watcher task
+                if not self._process_ended_early:
+                    log.debug("Waiting for web browser process to terminate")
+                # once the application logic is done, cancel the entire task group and terminate/kill the process
+                nursery.cancel_scope.cancel()
+
+    async def _task_process_watcher(self, process: trio.Process, nursery: trio.Nursery) -> None:
+        """Task for cancelling the launch task group if the user closes the browser or if it exits early on its own"""
+        await process.wait()
+        # if the task group hasn't been cancelled yet, then the application logic was still running
+        if not nursery.cancel_scope.cancel_called:  # pragma: no branch
+            self._process_ended_early = True
+            log.warning("Web browser process ended early")
+            nursery.cancel_scope.cancel()

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+from typing import List, Optional, Union
+
+import pytest
+
+from streamlink.utils.path import resolve_executable
+
+
+RESOLVE_EXECUTABLE_LOOKUPS = {
+    "foo": "/usr/bin/foo",
+    "/usr/bin/foo": "/usr/bin/foo",
+    "/other/bar": "/other/bar",
+}
+
+@pytest.mark.parametrize(("custom", "names", "fallbacks", "expected"), [
+    pytest.param(
+        None,
+        [],
+        [],
+        None,
+        id="Empty",
+    ),
+    pytest.param(
+        "foo",
+        [],
+        [],
+        "/usr/bin/foo",
+        id="Custom executable success",
+    ),
+    pytest.param(
+        "bar",
+        [],
+        [],
+        None,
+        id="Custom executable failure",
+    ),
+    pytest.param(
+        "bar",
+        ["foo"],
+        ["/usr/bin/foo"],
+        None,
+        id="Custom executable overrides names+fallbacks",
+    ),
+    pytest.param(
+        None,
+        ["bar", "foo"],
+        [],
+        "/usr/bin/foo",
+        id="Default names success",
+    ),
+    pytest.param(
+        None,
+        ["bar", "baz"],
+        [],
+        None,
+        id="Default names failure",
+    ),
+    pytest.param(
+        None,
+        [],
+        ["/usr/bin/unknown", "/other/bar"],
+        "/other/bar",
+        id="Fallbacks success",
+    ),
+    pytest.param(
+        None,
+        [],
+        ["/usr/bin/unknown", "/other/baz"],
+        None,
+        id="Fallbacks failure",
+    ),
+    pytest.param(
+        None,
+        ["bar", "foo"],
+        ["/usr/bin/bar", "/other/baz"],
+        "/usr/bin/foo",
+        id="Successful name lookup with fallbacks",
+    ),
+    pytest.param(
+        None,
+        ["bar", "baz"],
+        ["/usr/bin/bar", "/other/bar"],
+        "/other/bar",
+        id="Unsuccessful name lookup with successful fallbacks",
+    ),
+    pytest.param(
+        None,
+        ["bar", "baz"],
+        ["/usr/bin/unknown", "/other/baz"],
+        None,
+        id="Failure",
+    ),
+])
+def test_resolve_executable(
+    monkeypatch: pytest.MonkeyPatch,
+    custom: Optional[str],
+    names: Optional[List[str]],
+    fallbacks: Optional[List[Union[str, Path]]],
+    expected: str,
+):
+    monkeypatch.setattr("streamlink.utils.path.which", RESOLVE_EXECUTABLE_LOOKUPS.get)
+    assert resolve_executable(custom, names, fallbacks) == expected

--- a/tests/webbrowser/conftest.py
+++ b/tests/webbrowser/conftest.py
@@ -1,0 +1,68 @@
+import sys
+from contextlib import asynccontextmanager
+from subprocess import PIPE
+from typing import Optional
+from unittest.mock import Mock
+
+import pytest
+import trio
+
+from streamlink.webbrowser.webbrowser import Webbrowser
+
+
+@pytest.fixture()
+def caplog(caplog: pytest.LogCaptureFixture):
+    caplog.set_level(1, "streamlink")
+    return caplog
+
+
+@pytest.fixture(autouse=True)
+def resolve_executable(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
+    return_value = getattr(request, "param", "default")
+    monkeypatch.setattr("streamlink.webbrowser.webbrowser.resolve_executable", Mock(return_value=return_value))
+    return return_value
+
+
+@pytest.fixture()
+def webbrowser_launch(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture):
+    trio_run_process = trio.run_process
+
+    # use a memory channel, so we can wait until the process has launched
+    sender: trio.MemorySendChannel[trio.Process]
+    receiver: trio.MemoryReceiveChannel[trio.Process]
+    sender, receiver = trio.open_memory_channel(1)
+
+    async def fake_trio_run_process(*args, task_status, **kwargs):
+        task_status_started = task_status.started
+
+        def fake_task_status_started(process: trio.Process):
+            task_status_started(process)
+            sender.send_nowait(process)
+
+        # intercept the task status report
+        task_status.started = fake_task_status_started
+        # override the stdin parameter, so we can send data to our dummy process
+        kwargs["stdin"] = PIPE
+
+        return await trio_run_process(*args, task_status=task_status, **kwargs)
+
+    monkeypatch.setattr("trio.run_process", fake_trio_run_process)
+
+    @asynccontextmanager
+    async def webbrowser_launch(*args, webbrowser: Optional[Webbrowser] = None, **kwargs):
+        # dummy web browser process, which idles until stdin receives input with an exit code
+        webbrowser = webbrowser or Webbrowser()
+        webbrowser.executable = sys.executable
+        webbrowser.arguments = ["-c", "import sys; sys.exit(int(sys.stdin.readline()))", *webbrowser.arguments]
+
+        async with webbrowser.launch(*args, **kwargs) as nursery:
+            assert isinstance(nursery, trio.Nursery)
+            assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
+                ("streamlink.webbrowser.webbrowser", "info", f"Launching web browser: {sys.executable}"),
+            ]
+            caplog.records.clear()
+            # wait until the process has launched, so we can test it
+            process = await receiver.receive()
+            yield nursery, process
+
+    return webbrowser_launch

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -1,0 +1,143 @@
+from contextlib import nullcontext
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from signal import SIGTERM
+from typing import Any, Dict, List
+
+import pytest
+import requests_mock as rm
+import trio
+from requests import Timeout
+
+from streamlink.compat import is_win32
+from streamlink.exceptions import PluginError
+from streamlink.session import Streamlink
+from streamlink.webbrowser.chromium import ChromiumWebbrowser
+
+
+class TestFallbacks:
+    def test_win32(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("streamlink.webbrowser.chromium.is_win32", True)
+        monkeypatch.setattr("streamlink.webbrowser.chromium.is_darwin", False)
+        monkeypatch.setattr("streamlink.webbrowser.chromium.Path", PureWindowsPath)
+        monkeypatch.setattr("os.getenv", {
+            "PROGRAMFILES": "C:\\Program Files",
+            "PROGRAMFILES(X86)": "C:\\Program Files (x86)",
+            "LOCALAPPDATA": "C:\\Users\\user\\AppData\\Local",
+        }.get)
+        assert ChromiumWebbrowser.fallback_paths() == [
+            "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Users\\user\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe",
+            "C:\\Program Files\\Google\\Chrome Beta\\Application\\chrome.exe",
+            "C:\\Program Files (x86)\\Google\\Chrome Beta\\Application\\chrome.exe",
+            "C:\\Users\\user\\AppData\\Local\\Google\\Chrome Beta\\Application\\chrome.exe",
+            "C:\\Program Files\\Google\\Chrome Canary\\Application\\chrome.exe",
+            "C:\\Program Files (x86)\\Google\\Chrome Canary\\Application\\chrome.exe",
+            "C:\\Users\\user\\AppData\\Local\\Google\\Chrome Canary\\Application\\chrome.exe",
+        ]
+
+    def test_darwin(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("streamlink.webbrowser.chromium.is_win32", False)
+        monkeypatch.setattr("streamlink.webbrowser.chromium.is_darwin", True)
+        monkeypatch.setattr("streamlink.webbrowser.chromium.Path", PurePosixPath)
+        PurePosixPath.home = lambda: PurePosixPath("/Users/user")  # type: ignore[attr-defined]
+        assert ChromiumWebbrowser.fallback_paths() == [
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Users/user/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Users/user/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+        ]
+
+    def test_other(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("streamlink.webbrowser.chromium.is_win32", False)
+        monkeypatch.setattr("streamlink.webbrowser.chromium.is_darwin", False)
+        assert ChromiumWebbrowser.fallback_paths() == []
+
+
+class TestLaunchArgs:
+    def test_launch_args(self):
+        webbrowser = ChromiumWebbrowser()
+        assert "--password-store=basic" in webbrowser.arguments
+        assert "--use-mock-keychain" in webbrowser.arguments
+        assert "--headless=new" in webbrowser.arguments
+        assert not any(arg.startswith("--remote-debugging-host") for arg in webbrowser.arguments)
+        assert not any(arg.startswith("--remote-debugging-port") for arg in webbrowser.arguments)
+        assert not any(arg.startswith("--user-data-dir") for arg in webbrowser.arguments)
+
+    @pytest.mark.parametrize("headless", [True, False])
+    def test_headless(self, headless: bool):
+        webbrowser = ChromiumWebbrowser(headless=headless)
+        assert ("--headless=new" in webbrowser.arguments) is headless
+
+
+@pytest.mark.trio()
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1"])
+@pytest.mark.parametrize("port", [None, 1234])
+async def test_launch(monkeypatch: pytest.MonkeyPatch, mock_clock, webbrowser_launch, host, port):
+    async def fake_find_free_port(_):
+        return 1234
+
+    monkeypatch.setattr("streamlink.webbrowser.chromium.find_free_port_ipv4", fake_find_free_port)
+    monkeypatch.setattr("streamlink.webbrowser.chromium.find_free_port_ipv6", fake_find_free_port)
+
+    webbrowser = ChromiumWebbrowser(host=host, port=port)
+
+    nursery: trio.Nursery
+    process: trio.Process
+    async with webbrowser_launch(webbrowser=webbrowser, timeout=999) as (nursery, process):  # noqa: F841
+        assert process.poll() is None, "process is still running"
+        assert f"--remote-debugging-host={host}" in process.args
+        assert "--remote-debugging-port=1234" in process.args
+        param_user_data_dir = next(  # pragma: no branch
+            (arg for arg in process.args if arg.startswith("--user-data-dir=")),
+            None,
+        )
+        assert param_user_data_dir is not None
+
+        user_data_dir = Path(param_user_data_dir[len("--user-data-dir="):])
+        assert user_data_dir.exists()
+
+        # turn the 0.5s sleep() call at the end into a 0.5ms sleep() call
+        # autojump_clock=0 would trigger the process's kill() fallback immediately and raise a warning
+        mock_clock.rate = 1000
+
+    assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
+    assert not user_data_dir.exists()
+
+
+@pytest.mark.parametrize(("host", "port"), [
+    pytest.param("127.0.0.1", 1234, id="IPv4"),
+    pytest.param("::1", 1234, id="IPv6"),
+])
+@pytest.mark.parametrize(("num", "raises"), [
+    pytest.param(10, nullcontext(), id="Success"),
+    pytest.param(11, pytest.raises(PluginError), id="Timeout/Failure"),
+])
+def test_get_websocket_address(
+    monkeypatch: pytest.MonkeyPatch,
+    requests_mock: rm.Mocker,
+    session: Streamlink,
+    host: str,
+    port: int,
+    num: int,
+    raises: nullcontext,
+):
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    payload = {
+      "Browser": "Chrome/114.0.5735.133",
+      "Protocol-Version": "1.3",
+      "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36",
+      "V8-Version": "11.4.183.23",
+      "WebKit-Version": "537.36 (@fbfa2ce68d01b2201d8c667c2e73f648a61c4f4a)",
+      "webSocketDebuggerUrl": f"ws://{host}:{port}/devtools/browser/some-uuid4",
+    }
+
+    for address in ("http://127.0.0.1:1234/json/version", "http://[::1]:1234/json/version"):
+        responses: List[Dict[str, Any]] = [{"exc": Timeout()} for _ in range(num)]
+        responses.append({"json": payload})
+        requests_mock.register_uri("GET", address, responses)
+
+    webbrowser = ChromiumWebbrowser(host=host, port=port)
+    with raises:
+        assert webbrowser.get_websocket_url(session) == f"ws://{host}:{port}/devtools/browser/some-uuid4"

--- a/tests/webbrowser/test_webbrowser.py
+++ b/tests/webbrowser/test_webbrowser.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from contextlib import AbstractContextManager, nullcontext
+from pathlib import Path
+from signal import SIGTERM
+from typing import List, Optional
+
+import pytest
+import trio
+
+from streamlink.compat import is_win32
+from streamlink.webbrowser.exceptions import WebbrowserError
+from streamlink.webbrowser.webbrowser import Webbrowser
+
+
+class _FakeWebbrowser(Webbrowser):
+    @classmethod
+    def launch_args(cls) -> List[str]:
+        return ["foo", "bar"]
+
+
+class TestInit:
+    @pytest.mark.parametrize(("executable", "resolve_executable", "raises"), [
+        pytest.param(
+            None,
+            None,
+            pytest.raises(WebbrowserError, match="Could not resolve web browser executable"),
+            id="Failure with default path",
+        ),
+        pytest.param(
+            "custom",
+            None,
+            pytest.raises(WebbrowserError, match="Could not resolve web browser executable: custom"),
+            id="Failure with custom path",
+        ),
+        pytest.param(
+            None,
+            "default",
+            nullcontext(),
+            id="Success with default path",
+        ),
+        pytest.param(
+            "custom",
+            "custom",
+            nullcontext(),
+            id="Success with custom path",
+        ),
+    ], indirect=["resolve_executable"])
+    def test_resolve_executable(self, resolve_executable, executable: Optional[str], raises: nullcontext):
+        with raises:
+            Webbrowser(executable=executable)
+
+    def test_arguments(self):
+        webbrowser = _FakeWebbrowser()
+        assert webbrowser.executable == "default"
+        assert webbrowser.arguments == ["foo", "bar"]
+        assert webbrowser.arguments is not _FakeWebbrowser.launch_args()
+
+
+class TestLaunch:
+    @pytest.mark.trio()
+    async def test_terminate_on_nursery_exit(self, caplog: pytest.LogCaptureFixture, webbrowser_launch):
+        nursery: trio.Nursery
+        process: trio.Process
+        async with webbrowser_launch() as (nursery, process):  # noqa: F841
+            assert process.poll() is None, "process is still running"
+
+        assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
+        assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
+            ("streamlink.webbrowser.webbrowser", "debug", "Waiting for web browser process to terminate"),
+        ]
+
+    @pytest.mark.trio()
+    async def test_terminate_on_nursery_cancellation(self, caplog: pytest.LogCaptureFixture, webbrowser_launch):
+        nursery: trio.Nursery
+        process: trio.Process
+        async with webbrowser_launch() as (nursery, process):
+            assert process.poll() is None, "process is still running"
+            nursery.cancel_scope.cancel()
+
+        assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
+        assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
+            ("streamlink.webbrowser.webbrowser", "debug", "Waiting for web browser process to terminate"),
+        ]
+
+    @pytest.mark.trio()
+    async def test_terminate_on_nursery_timeout(self, caplog: pytest.LogCaptureFixture, mock_clock, webbrowser_launch):
+        nursery: trio.Nursery
+        process: trio.Process
+        async with webbrowser_launch(timeout=10) as (nursery, process):  # noqa: F841
+            assert process.poll() is None, "process is still running"
+            mock_clock.jump(20)
+            await trio.sleep(0)
+
+        assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
+        assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
+            ("streamlink.webbrowser.webbrowser", "warning", "Web browser task group has timed out"),
+            ("streamlink.webbrowser.webbrowser", "debug", "Waiting for web browser process to terminate"),
+        ]
+
+    @pytest.mark.trio()
+    async def test_terminate_on_nursery_baseexception(self, caplog: pytest.LogCaptureFixture, webbrowser_launch):
+        class FakeBaseException(BaseException):
+            pass
+
+        nursery: trio.Nursery
+        process: trio.Process
+        with pytest.raises(FakeBaseException):  # noqa: PT012
+            async with webbrowser_launch() as (nursery, process):  # noqa: F841
+                assert process.poll() is None, "process is still running"
+                raise FakeBaseException()
+
+        assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
+        assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
+            ("streamlink.webbrowser.webbrowser", "debug", "Waiting for web browser process to terminate"),
+        ]
+
+    # don't run on Windows, because of some weird flaky subprocess early-termination issues
+    @pytest.mark.posix_only()
+    @pytest.mark.trio()
+    # don't check for non-zero exit codes - we don't care
+    @pytest.mark.parametrize("exit_code", [0, 1])
+    async def test_process_ended_early(self, caplog: pytest.LogCaptureFixture, webbrowser_launch, exit_code):
+        nursery: trio.Nursery
+        process: trio.Process
+        async with webbrowser_launch(timeout=10) as (nursery, process):  # noqa: F841
+            assert process.poll() is None, "process is still running"
+            assert process.stdin
+            await process.stdin.send_all(str(exit_code).encode() + b"\r\n")
+            await trio.sleep(5)
+
+        assert process.poll() == exit_code, "Process has ended with the right exit code"
+        assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
+            ("streamlink.webbrowser.webbrowser", "warning", "Web browser process ended early"),
+        ]
+
+
+def test_temp_dir():
+    webbrowser = Webbrowser()
+    temp_dir = webbrowser._create_temp_dir()
+    assert isinstance(temp_dir, AbstractContextManager)
+    with temp_dir as path:
+        assert Path(path).exists()
+    assert not Path(path).exists()


### PR DESCRIPTION
Part 2/4 of #5380 

Opening this as a draft was well until I have the rest finished.

----

This

1. Adds a utility executable resolver function with support for custom values, default names and fallback paths.
2. Adds a utility function for finding an available port on a specific network interface
   - No tests, because I don't think mocking everthing here makes sense, and neither does running this without mocking
3. Adds the `trio` dependency, as well as `pytest-trio` and `trio-typing`
   - `trio-typing` looks like it's going to get merged into `trio` soon
   - `pytest-trio` is used for initializing the runloop in async tests, similar to `pytest-asyncio`.
     Having implementations for both `asyncio` and `trio` seems to cause minor issues with trio's runloop in the tests, and on Windows it triggers a warning when asyncio was run prior to its own runloop. This is related to `signal.set_wakeup_fd()`. This can be resolved in the future by re-implementing the `utils.processoutput` based on trio instead of asyncio. The other asyncio stuff is purely concurrency related and not I/O related, so it's irrelevant which runloop we're using. The warning can be ignored for now.
4. Adds the `Webbrowser` base class with the basic launch implementation
   - I initially had custom process cancellation logic added, when the process doesn't end on SIGTERM on POSIX systems. The default behavior of trio waits for 5 seconds and then sends SIGKILL. My plan was to wait a bit less and log a warning instead of triggering a warning via the warnings system, but I ran into issues with the custom implementation while testing. Some weird internal issues with trio and the stdlib subprocess module. Doesn't matter though.
5. Adds the `ChromiumWebbrowser` class
   - This includes a list of all known Chromium/Chrome executable names (with Chromium having higher priority)
   - With fallback paths for Windows and macOS (because of `PATH` env var nonsense)
   - I carefully selected launch parameters for disabling lots of unneeded features and behaviors which we don't need or which are bad for our purposes. This is all annotated and linked. There's probably more that could be added.
   - ~~Headless mode is currently not added, but this can be done with a simple class argument. I can't get a valid client-integrity token on Twitch with headless mode, regardless of what others are saying, so I don't see the point right now.~~
   - Chromium-based browsers I tested (CLI arguments for custom paths are not included in this PR):
     - Chromium (Arch): worked
     - Google Chrome (Windows): worked
     - Brave (Windows): worked
     - Vivaldi (Windows): didn't work, despite a successful CDP session, didn't check further
     - Opera (Windows): didn't work, didn't check further