### PR TITLE
webbrowser.cdp: implement CDP connection

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -378,6 +378,8 @@ runtime   `pycryptodome`_           Used for decrypting encrypted streams
 runtime   `PySocks`_                Used for SOCKS Proxies
 runtime   `requests`_               Used for making any kind of HTTP/HTTPS request
 runtime   `trio`_                   Used for async concurrency and I/O in some parts of Streamlink
+runtime   `trio-websocket`_         Used for WebSocket connections on top of the async trio framework
+runtime   `typing-extensions`_      Used for backporting runtime support of certain type hints on older Python versions
 runtime   `urllib3`_                Used internally by `requests`_, defined as direct dependency
 runtime   `websocket-client`_       Used for making websocket connections
 
@@ -404,6 +406,8 @@ optional  `FFmpeg`_                 Required for `muxing`_ multiple video/audio/
 .. _PySocks: https://github.com/Anorov/PySocks
 .. _requests: https://requests.readthedocs.io/en/latest/
 .. _trio: https://trio.readthedocs.io/en/stable/
+.. _trio-websocket: https://trio-websocket.readthedocs.io/en/stable/
+.. _typing-extensions: https://typing-extensions.readthedocs.io/en/stable/
 .. _urllib3: https://urllib3.readthedocs.io/en/stable/
 .. _websocket-client: https://pypi.org/project/websocket-client/
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ install_requires =
   PySocks !=1.5.7,>=1.5.6
   requests >=2.26.0,<3.0
   trio >=0.22.0,<1
+  trio-websocket >=0.9.0,<1
+  typing-extensions
   urllib3 >=1.26.0,<3
   websocket-client >=1.2.1,<2.0
 

--- a/src/streamlink/webbrowser/cdp/__init__.py
+++ b/src/streamlink/webbrowser/cdp/__init__.py
@@ -1,0 +1,2 @@
+from streamlink.webbrowser.cdp.connection import CDPConnection, CDPSession
+from streamlink.webbrowser.cdp.exceptions import CDPError

--- a/src/streamlink/webbrowser/cdp/connection.py
+++ b/src/streamlink/webbrowser/cdp/connection.py
@@ -1,0 +1,286 @@
+# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
+from __future__ import annotations
+
+import dataclasses
+import itertools
+import json
+import logging
+from collections import defaultdict
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator, Dict, Generator, Generic, Optional, Set, Type, TypeVar, Union, cast
+
+import trio
+from trio_websocket import ConnectionClosed, WebSocketConnection, connect_websocket_url  # type: ignore[import]
+
+from streamlink.logger import ALL
+from streamlink.webbrowser.cdp.devtools.target import SessionID, TargetID, attach_to_target, create_target
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, parse_json_event
+from streamlink.webbrowser.cdp.exceptions import CDPError
+
+
+try:
+    from typing import Self, TypeAlias  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from typing_extensions import Self, TypeAlias
+
+
+log = logging.getLogger(__name__)
+
+MAX_BUFFER_SIZE = 10
+MAX_MESSAGE_SIZE = 2 ** 24  # ~16MiB
+CMD_TIMEOUT = 2
+
+TCmdResponse = TypeVar("TCmdResponse")
+TEvent = TypeVar("TEvent")
+TEventChannels: TypeAlias = "Dict[Type[TEvent], Set[trio.MemorySendChannel[TEvent]]]"
+
+
+class CDPEventListener(Generic[TEvent]):
+    _sender: trio.MemorySendChannel[TEvent]
+    _receiver: trio.MemoryReceiveChannel[TEvent]
+
+    def __init__(self, event_channels: TEventChannels, event: Type[TEvent], max_buffer_size: int = MAX_BUFFER_SIZE):
+        self._sender, self._receiver = trio.open_memory_channel(max_buffer_size)
+        event_channels[event].add(self._sender)
+
+    async def receive(self) -> TEvent:
+        return await self._receiver.receive()
+
+    def close(self) -> None:
+        self._receiver.close()
+
+    async def __aenter__(self) -> TEvent:
+        return await self._receiver.receive()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        # sync
+        self.close()
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> TEvent:
+        try:
+            return await self._receiver.receive()
+        except trio.EndOfChannel as err:
+            self.close()
+            raise StopAsyncIteration from err
+
+    def __del__(self) -> None:
+        self.close()
+
+
+@dataclasses.dataclass
+class _CDPCmdBuffer(Generic[TCmdResponse]):
+    cmd: Generator[dict, dict, TCmdResponse]
+    response: Optional[Union[TCmdResponse, Exception]] = None
+    event: trio.Event = dataclasses.field(default_factory=trio.Event)
+
+    def set_response(self, response: Union[TCmdResponse, Exception]) -> None:
+        self.response = response
+        self.event.set()
+
+
+# The design of CDPBase/CDPConnection/CDPSession is based on the trio-chrome-devtools-protocol project version 0.6.0
+# https://github.com/HyperionGray/trio-chrome-devtools-protocol/blob/0.6.0/trio_cdp/__init__.py
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Hyperion Gray
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+
+class CDPBase:
+    def __init__(
+        self,
+        websocket: WebSocketConnection,
+        target_id: Optional[TargetID] = None,
+        session_id: Optional[SessionID] = None,
+        cmd_timeout: float = CMD_TIMEOUT,
+    ) -> None:
+        self.websocket = websocket
+        self.target_id = target_id
+        self.session_id = session_id
+        self.cmd_timeout = cmd_timeout
+        self.event_channels: TEventChannels = defaultdict(set)
+        self.cmd_buffers: Dict[int, _CDPCmdBuffer] = {}
+        self.cmd_id = itertools.count()
+
+    async def send(
+        self,
+        cmd: Generator[T_JSON_DICT, T_JSON_DICT, TCmdResponse],
+        timeout: Optional[float] = None,
+    ) -> TCmdResponse:
+        cmd_id = next(self.cmd_id)
+        cmd_buffer = _CDPCmdBuffer(cmd)
+
+        self.cmd_buffers[cmd_id] = cmd_buffer
+
+        cmd_data = next(cmd)
+        cmd_data["id"] = cmd_id
+        if self.session_id:
+            cmd_data["sessionId"] = self.session_id
+
+        message = json.dumps(cmd_data, separators=(",", ":"), sort_keys=True)
+        log.log(ALL, f"Sending message: {message}")
+        with trio.move_on_after(self.cmd_timeout if timeout is None else timeout) as cancel_scope:
+            try:
+                await self.websocket.send_message(message)
+            except ConnectionClosed as err:
+                self.cmd_buffers.pop(cmd_id, None)
+                raise CDPError(err.reason) from err
+
+            await cmd_buffer.event.wait()
+        if cancel_scope.cancel_called:
+            self.cmd_buffers.pop(cmd_id, None)
+            raise CDPError("Sending CDP message and receiving its response timed out")
+
+        response = cast(TCmdResponse, cmd_buffer.response)
+        self.cmd_buffers.pop(cmd_id, None)
+
+        if isinstance(response, Exception):
+            raise response
+
+        return response
+
+    def listen(self, event: Type[TEvent], max_buffer_size: int = MAX_BUFFER_SIZE) -> CDPEventListener[TEvent]:
+        return CDPEventListener(self.event_channels, event, max_buffer_size)
+
+    def _handle_data(self, data: T_JSON_DICT) -> None:
+        if "id" in data:
+            self._handle_cmd_response(data)
+        else:
+            self._handle_event(data)
+
+    def _handle_cmd_response(self, data: T_JSON_DICT) -> None:
+        try:
+            cmd_id: int = data["id"]
+            cmd_buffer = self.cmd_buffers.pop(cmd_id)
+        except KeyError:
+            log.warning(f"Got a CDP command response with an unknown ID: {data['id']}")
+            return
+
+        if "error" in data:
+            cmd_buffer.set_response(CDPError(f"Error in CDP command response {cmd_id}: {data['error']}"))
+            return
+        if "result" not in data:
+            cmd_buffer.set_response(CDPError(f"No result in CDP command response {cmd_id}"))
+            return
+
+        cmd_result: T_JSON_DICT = data["result"]
+        try:
+            # send the response to the command's generator function (the first send() must stop the generator)
+            cmd_buffer.cmd.send(cmd_result)
+        except StopIteration as cm:
+            # and on success, set the response result
+            cmd_buffer.set_response(cm.value)
+        except Exception as err:
+            # handle any errors raised by the generator's result logic
+            cmd_buffer.set_response(CDPError(f"Generator of CDP command ID {cmd_id} raised {type(err).__name__}: {err}"))
+        else:
+            cmd_buffer.set_response(CDPError(f"Generator of CDP command ID {cmd_id} did not exit when expected!"))
+
+    def _handle_event(self, data: T_JSON_DICT) -> None:
+        if "method" not in data or "params" not in data:
+            log.warning("Invalid CDP event message received without method or params")
+            return
+
+        try:
+            event = parse_json_event(data)
+        except KeyError:
+            log.warning(f"Unknown CDP event message received: {data['method']}")
+            return
+
+        log.log(ALL, f"Received event: {event!r}")
+        broken_channels = set()
+        for sender in self.event_channels[type(event)]:
+            try:
+                sender.send_nowait(event)
+            except trio.WouldBlock:
+                log.error(f"Unable to propagate CDP event {event!r} due to full channel")
+            except trio.BrokenResourceError:
+                broken_channels.add(sender)
+                sender.close()
+        self.event_channels[type(event)] -= broken_channels
+
+
+class CDPConnection(CDPBase, trio.abc.AsyncResource):
+    def __init__(self, websocket: WebSocketConnection, cmd_timeout: float) -> None:
+        super().__init__(websocket=websocket, cmd_timeout=cmd_timeout)
+        self.sessions: Dict[SessionID, CDPSession] = {}
+
+    @classmethod
+    @asynccontextmanager
+    async def create(cls, url: str, timeout: Optional[float] = None) -> AsyncGenerator[Self, None]:
+        async with trio.open_nursery() as nursery:
+            websocket = await connect_websocket_url(nursery, url, max_message_size=MAX_MESSAGE_SIZE)
+            cdp_connection = cls(websocket, timeout or CMD_TIMEOUT)
+            nursery.start_soon(cdp_connection._task_reader)
+            try:
+                yield cdp_connection
+            finally:
+                await cdp_connection.aclose()
+
+    async def aclose(self) -> None:
+        await self.websocket.aclose()
+        inst: CDPBase
+        for inst in (self, *self.sessions.values()):
+            for event_channels in inst.event_channels.values():
+                for event_channel in event_channels:
+                    event_channel.close()
+            inst.event_channels.clear()
+        self.sessions.clear()
+
+    async def new_target(self, url: str = "") -> CDPSession:
+        target_id = await self.send(create_target(url))
+
+        return await self.get_session(target_id)
+
+    async def get_session(self, target_id: TargetID) -> CDPSession:
+        session_id = await self.send(attach_to_target(target_id, True))
+        cdp_session = CDPSession(self.websocket, target_id=target_id, session_id=session_id, cmd_timeout=self.cmd_timeout)
+        self.sessions[session_id] = cdp_session
+
+        return cdp_session
+
+    async def _task_reader(self) -> None:
+        while True:
+            try:
+                message = await self.websocket.get_message()
+            except ConnectionClosed:
+                break
+
+            try:
+                data = json.loads(message)
+            except json.JSONDecodeError as err:
+                raise CDPError(f"Received invalid CDP JSON data: {err}") from err
+
+            log.log(ALL, f"Received message: {message}")
+            if "sessionId" not in data:
+                self._handle_data(data)
+            else:
+                session_id = SessionID(data["sessionId"])
+                if session_id not in self.sessions:
+                    raise CDPError(f"Unknown CDP session ID: {session_id!r}")
+                self.sessions[session_id]._handle_data(data)
+
+
+class CDPSession(CDPBase):
+    pass

--- a/src/streamlink/webbrowser/cdp/exceptions.py
+++ b/src/streamlink/webbrowser/cdp/exceptions.py
@@ -1,0 +1,5 @@
+from streamlink.webbrowser.exceptions import WebbrowserError
+
+
+class CDPError(WebbrowserError):
+    pass

--- a/tests/webbrowser/cdp/__init__.py
+++ b/tests/webbrowser/cdp/__init__.py
@@ -1,0 +1,33 @@
+# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
+from __future__ import annotations
+
+from typing import List
+
+import trio
+from trio_websocket import CloseReason, ConnectionClosed  # type: ignore[import]
+
+
+class FakeWebsocketConnection:
+    sender: trio.MemorySendChannel[str]
+    receiver: trio.MemoryReceiveChannel[str]
+
+    def __init__(self) -> None:
+        self.sender, self.receiver = trio.open_memory_channel(10)
+        self.sent: List[str] = []
+        self.closed: bool = False
+
+    async def send_message(self, message: str):
+        self.sent.append(message)
+
+    async def get_message(self):
+        try:
+            return await self.receiver.receive()
+        except BaseException:
+            # noinspection PyTypeChecker
+            raise ConnectionClosed(CloseReason(1000, None)) from None
+
+    async def aclose(self):
+        # sync
+        self.sender.close()
+        self.receiver.close()
+        self.closed = True

--- a/tests/webbrowser/cdp/conftest.py
+++ b/tests/webbrowser/cdp/conftest.py
@@ -1,0 +1,18 @@
+from unittest.mock import ANY, AsyncMock, call
+
+import pytest
+
+from tests.webbrowser.cdp import FakeWebsocketConnection
+
+
+@pytest.fixture()
+def websocket_connection(monkeypatch: pytest.MonkeyPatch):
+    fake_websocket_connection = FakeWebsocketConnection()
+    mock_connect_websocket_url = AsyncMock(return_value=fake_websocket_connection)
+    monkeypatch.setattr("streamlink.webbrowser.cdp.connection.connect_websocket_url", mock_connect_websocket_url)
+
+    try:
+        yield fake_websocket_connection
+    finally:
+        assert fake_websocket_connection.closed
+        assert mock_connect_websocket_url.call_args_list == [call(ANY, "ws://localhost:1234/fake", max_message_size=2 ** 24)]

--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -1,0 +1,763 @@
+from contextlib import nullcontext
+from dataclasses import dataclass
+from functools import partial
+from typing import Dict, Generator, Optional, Type
+from unittest.mock import AsyncMock
+
+import pytest
+import trio
+from trio.testing import MockClock, wait_all_tasks_blocked
+from trio_websocket import CloseReason, ConnectionClosed, ConnectionTimeout  # type: ignore[import]
+
+from streamlink.webbrowser.cdp.connection import CDPConnection, CDPEventListener, CDPSession
+from streamlink.webbrowser.cdp.devtools.target import SessionID, TargetID
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT
+from streamlink.webbrowser.cdp.exceptions import CDPError
+from tests.webbrowser.cdp import FakeWebsocketConnection
+
+
+EPSILON = 0.1
+
+
+@dataclass
+class FakeCommand(str):
+    value: str
+
+    def to_json(self) -> T_JSON_DICT:
+        return {"value": self.value}
+
+    @classmethod
+    def from_json(cls, data: T_JSON_DICT):
+        return cls(data["value"])
+
+
+def fake_command(command: FakeCommand) -> Generator[T_JSON_DICT, T_JSON_DICT, FakeCommand]:
+    json: T_JSON_DICT
+    json = yield {"method": "Fake.fakeCommand", "params": command.to_json()}
+    return FakeCommand.from_json(json)
+
+
+def bad_command() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    yield {"method": "Fake.badCommand", "params": {}}
+    yield {}
+
+
+@dataclass
+class FakeEvent:
+    value: str
+
+    @classmethod
+    def from_json(cls, data: T_JSON_DICT):
+        return cls(data["value"])
+
+
+@pytest.fixture()
+async def cdp_connection(websocket_connection: FakeWebsocketConnection):
+    try:
+        async with CDPConnection.create("ws://localhost:1234/fake") as cdp_connection:
+            assert isinstance(cdp_connection, CDPConnection)
+            assert not websocket_connection.closed
+            try:
+                yield cdp_connection
+            finally:
+                await cdp_connection.aclose()
+                assert cdp_connection.sessions == {}
+    finally:
+        assert websocket_connection.closed
+
+
+class TestCreateConnection:
+    @pytest.mark.trio()
+    async def test_success(self, cdp_connection: CDPConnection):
+        assert cdp_connection.target_id is None
+        assert cdp_connection.session_id is None
+
+    @pytest.mark.trio()
+    async def test_failure(self, monkeypatch: pytest.MonkeyPatch):
+        fake_connect_websocket_url = AsyncMock(side_effect=ConnectionTimeout)
+        monkeypatch.setattr("streamlink.webbrowser.cdp.connection.connect_websocket_url", fake_connect_websocket_url)
+        with pytest.raises(ConnectionTimeout):
+            async with CDPConnection.create("ws://localhost:1234/fake"):
+                pass
+
+    @pytest.mark.trio()
+    @pytest.mark.parametrize(("timeout", "expected"), [
+        pytest.param(None, 2, id="Default value of 2 seconds"),
+        pytest.param(0, 2, id="No timeout uses default value"),
+        pytest.param(3, 3, id="Custom timeout value"),
+    ])
+    async def test_timeout(self, monkeypatch: pytest.MonkeyPatch, websocket_connection, timeout, expected):
+        async with CDPConnection.create("ws://localhost:1234/fake", timeout=timeout) as cdp_connection:
+            pass
+        assert cdp_connection.cmd_timeout == expected
+
+
+class TestReaderError:
+    @pytest.mark.trio()
+    async def test_invalid_json(self, caplog: pytest.LogCaptureFixture, websocket_connection: FakeWebsocketConnection):
+        with pytest.raises(CDPError) as cm:  # noqa: PT012
+            async with CDPConnection.create("ws://localhost:1234/fake"):
+                assert not websocket_connection.closed
+                await websocket_connection.sender.send("INVALID JSON")
+                await wait_all_tasks_blocked()
+
+        assert str(cm.value) == "Received invalid CDP JSON data: Expecting value: line 1 column 1 (char 0)"
+        assert caplog.records == []
+
+    @pytest.mark.trio()
+    async def test_unknown_session_id(self, caplog: pytest.LogCaptureFixture, websocket_connection: FakeWebsocketConnection):
+        with pytest.raises(CDPError) as cm:  # noqa: PT012
+            async with CDPConnection.create("ws://localhost:1234/fake"):
+                assert not websocket_connection.closed
+                await websocket_connection.sender.send("""{"sessionId":"unknown"}""")
+                await wait_all_tasks_blocked()
+
+        assert str(cm.value) == "Unknown CDP session ID: SessionID('unknown')"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            ("streamlink.webbrowser.cdp.connection", "all", """Received message: {"sessionId":"unknown"}"""),
+        ]
+
+
+class TestSend:
+    @pytest.mark.trio()
+    @pytest.mark.parametrize(("timeout", "jump", "raises"), [
+        pytest.param(
+            None,
+            2 - EPSILON,
+            nullcontext(),
+            id="Default timeout, response in time",
+        ),
+        pytest.param(
+            None,
+            2,
+            pytest.raises(CDPError, match="^Sending CDP message and receiving its response timed out$"),
+            id="Default timeout, response not in time",
+        ),
+        pytest.param(
+            3,
+            3 - EPSILON,
+            nullcontext(),
+            id="Custom timeout, response in time",
+        ),
+        pytest.param(
+            3,
+            3,
+            pytest.raises(CDPError, match="^Sending CDP message and receiving its response timed out$"),
+            id="Custom timeout, response not in time",
+        ),
+    ])
+    async def test_timeout(
+        self,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+        autojump_clock: MockClock,
+        timeout: Optional[float],
+        jump: float,
+        raises: nullcontext,
+    ):
+        assert cdp_connection.cmd_timeout == 2
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        async def response():
+            await trio.sleep(jump)
+            await websocket_connection.sender.send("""{"id":0,"result":{"value":"foo"}}""")
+
+        with raises:
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(partial(cdp_connection.send, fake_command(FakeCommand("foo")), timeout=timeout))
+                nursery.start_soon(response)
+
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == ["""{"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}"""]
+
+    @pytest.mark.trio()
+    async def test_closed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        # noinspection PyTypeChecker
+        fake_send_message = AsyncMock(side_effect=ConnectionClosed(CloseReason(1000, None)))
+        monkeypatch.setattr(FakeWebsocketConnection, "send_message", fake_send_message)
+
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        with pytest.raises(CDPError) as cm:
+            await cdp_connection.send(fake_command(FakeCommand("foo")))
+
+        assert str(cm.value) == "CloseReason<code=1000, name=NORMAL_CLOSURE, reason=None>"
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_bad_command(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        with pytest.raises(CDPError) as cm:  # noqa: PT012
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(cdp_connection.send, bad_command())
+                nursery.start_soon(websocket_connection.sender.send, """{"id":0,"result":{}}""")
+
+        assert str(cm.value) == "Generator of CDP command ID 0 did not exit when expected!"
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == ["""{"id":0,"method":"Fake.badCommand","params":{}}"""]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.badCommand","params":{}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"result":{}}""",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_result_exception(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        with pytest.raises(CDPError) as cm:  # noqa: PT012
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(cdp_connection.send, fake_command(FakeCommand("foo")))
+                nursery.start_soon(websocket_connection.sender.send, """{"id":0,"result":{}}""")
+
+        assert str(cm.value) == "Generator of CDP command ID 0 raised KeyError: 'value'"
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == ["""{"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}"""]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"result":{}}""",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_result_success(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        results = {}
+
+        async def send(key):
+            results[key] = await cdp_connection.send(fake_command(FakeCommand(key)))
+
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        async with trio.open_nursery() as nursery:
+            # ensure that we start the tasks in the correct order
+            nursery.start_soon(send, "foo")
+            await wait_all_tasks_blocked()
+            nursery.start_soon(send, "bar")
+            await wait_all_tasks_blocked()
+
+            assert list(cdp_connection.cmd_buffers.keys()) == [0, 1]
+            assert all(buf.response is None for buf in cdp_connection.cmd_buffers.values())
+            assert all(buf.event.is_set() is False for buf in cdp_connection.cmd_buffers.values())
+
+            # send result of second command first
+            nursery.start_soon(websocket_connection.sender.send, """{"id":1,"result":{"value":"BAR"}}""")
+            await wait_all_tasks_blocked()
+            nursery.start_soon(websocket_connection.sender.send, """{"id":0,"result":{"value":"FOO"}}""")
+
+        assert list(results.keys()) == ["bar", "foo"]
+        assert all(isinstance(result, FakeCommand) for result in results.values())
+        assert results["foo"].value == "FOO"
+        assert results["bar"].value == "BAR"
+
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == [
+            """{"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            """{"id":1,"method":"Fake.fakeCommand","params":{"value":"bar"}}""",
+        ]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":1,"method":"Fake.fakeCommand","params":{"value":"bar"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":1,"result":{"value":"BAR"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"result":{"value":"FOO"}}""",
+            ),
+        ]
+
+
+class TestHandleCmdResponse:
+    @pytest.mark.trio()
+    async def test_unknown_id(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert cdp_connection.cmd_buffers == {}
+
+        await websocket_connection.sender.send("""{"id":123}""")
+        await wait_all_tasks_blocked()
+
+        assert cdp_connection.cmd_buffers == {}
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":123}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "warning",
+                "Got a CDP command response with an unknown ID: 123",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_response_error(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        with pytest.raises(CDPError) as cm:  # noqa: PT012
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(cdp_connection.send, fake_command(FakeCommand("foo")))
+                nursery.start_soon(websocket_connection.sender.send, """{"id":0,"error":"Some error message"}""")
+
+        assert str(cm.value) == "Error in CDP command response 0: Some error message"
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == ["""{"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}"""]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"error":"Some error message"}""",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_response_no_result(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        with pytest.raises(CDPError) as cm:  # noqa: PT012
+            async with trio.open_nursery() as nursery:
+                nursery.start_soon(cdp_connection.send, fake_command(FakeCommand("foo")))
+                nursery.start_soon(websocket_connection.sender.send, """{"id":0}""")
+
+        assert str(cm.value) == "No result in CDP command response 0"
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == ["""{"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}"""]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0}""",
+            ),
+        ]
+
+
+class TestSession:
+    @pytest.fixture()
+    async def cdp_session(self, cdp_connection: CDPConnection):
+        target_id = TargetID("01234")
+        session_id = SessionID("56789")
+        session = cdp_connection.sessions[session_id] = CDPSession(
+            cdp_connection.websocket,
+            target_id=target_id,
+            session_id=session_id,
+            cmd_timeout=cdp_connection.cmd_timeout,
+        )
+        return session
+
+    @pytest.mark.trio()
+    async def test_new_target(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert cdp_connection.sessions == {}
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        session = None
+
+        async def send():
+            nonlocal session
+            session = await cdp_connection.new_target("http://localhost")
+
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(send)
+            await wait_all_tasks_blocked()
+            nursery.start_soon(websocket_connection.sender.send, """{"id":0,"result":{"targetId":"01234"}}""")
+            await wait_all_tasks_blocked()
+            nursery.start_soon(websocket_connection.sender.send, """{"id":1,"result":{"sessionId":"56789"}}""")
+
+        assert isinstance(session, CDPSession)
+        assert session.target_id == TargetID("01234")
+        assert session.session_id == SessionID("56789")
+        assert cdp_connection.sessions[SessionID("56789")] is session
+
+        assert cdp_connection.cmd_buffers == {}
+        assert websocket_connection.sent == [
+            """{"id":0,"method":"Target.createTarget","params":{"url":"http://localhost"}}""",
+            """{"id":1,"method":"Target.attachToTarget","params":{"flatten":true,"targetId":"01234"}}""",
+        ]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Target.createTarget","params":{"url":"http://localhost"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"result":{"targetId":"01234"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":1,"method":"Target.attachToTarget","params":{"flatten":true,"targetId":"01234"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":1,"result":{"sessionId":"56789"}}""",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_session_command(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        cdp_session: CDPSession,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        results = {}
+
+        async def send(obj, key):
+            results[key] = await obj.send(fake_command(FakeCommand(key)))
+
+        assert cdp_connection.cmd_buffers == {}
+        assert cdp_session.cmd_buffers == {}
+        assert websocket_connection.sent == []
+
+        async with trio.open_nursery() as nursery:
+            # ensure that we start the tasks in the correct order
+            nursery.start_soon(send, cdp_connection, "foo")
+            await wait_all_tasks_blocked()
+            nursery.start_soon(send, cdp_session, "bar")
+            await wait_all_tasks_blocked()
+
+            assert list(cdp_connection.cmd_buffers.keys()) == [0]
+            assert list(cdp_session.cmd_buffers.keys()) == [0]
+
+            # send result of second command first
+            nursery.start_soon(websocket_connection.sender.send, """{"id":0,"result":{"value":"BAR"},"sessionId":"56789"}""")
+            await wait_all_tasks_blocked()
+            nursery.start_soon(websocket_connection.sender.send, """{"id":0,"result":{"value":"FOO"}}""")
+
+        assert list(results.keys()) == ["bar", "foo"]
+        assert all(isinstance(result, FakeCommand) for result in results.values())
+        assert results["foo"].value == "FOO"
+        assert results["bar"].value == "BAR"
+
+        assert cdp_connection.cmd_buffers == {}
+        assert cdp_session.cmd_buffers == {}
+        assert websocket_connection.sent == [
+            """{"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            """{"id":0,"method":"Fake.fakeCommand","params":{"value":"bar"},"sessionId":"56789"}""",
+        ]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Sending message: {"id":0,"method":"Fake.fakeCommand","params":{"value":"bar"},"sessionId":"56789"}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"result":{"value":"BAR"},"sessionId":"56789"}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"id":0,"result":{"value":"FOO"}}""",
+            ),
+        ]
+
+
+class TestHandleEvent:
+    @pytest.fixture(autouse=True)
+    def event_parsers(self, monkeypatch: pytest.MonkeyPatch):
+        event_parsers: Dict[str, Type] = {
+            "Fake.fakeEvent": FakeEvent,
+        }
+        monkeypatch.setattr("streamlink.webbrowser.cdp.devtools.util._event_parsers", event_parsers)
+        return event_parsers
+
+    @pytest.mark.trio()
+    @pytest.mark.parametrize("message", [
+        pytest.param("""{"foo":"bar"}""", id="Missing method and params"),
+        pytest.param("""{"method":"method"}""", id="Missing params"),
+        pytest.param("""{"params":{}}""", id="Missing method"),
+    ])
+    async def test_invalid_event(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+        message: str,
+    ):
+        await websocket_connection.sender.send(message)
+        await wait_all_tasks_blocked()
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                f"Received message: {message}",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "warning",
+                "Invalid CDP event message received without method or params",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_unknown_event(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        await websocket_connection.sender.send("""{"method":"unknown","params":{}}""")
+        await wait_all_tasks_blocked()
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"method":"unknown","params":{}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "warning",
+                "Unknown CDP event message received: unknown",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_eventlistener(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert FakeEvent not in cdp_connection.event_channels
+        listener1 = cdp_connection.listen(FakeEvent)
+        listener2 = cdp_connection.listen(FakeEvent)
+        listener3 = cdp_connection.listen(FakeEvent)
+        listeners = listener1, listener2, listener3
+        assert FakeEvent in cdp_connection.event_channels
+        assert len(cdp_connection.event_channels[FakeEvent]) == 3
+
+        results = []
+
+        async def listen_once(listener: CDPEventListener):
+            async with listener as result:
+                results.append(result)
+
+        async def listen_twice(listener: CDPEventListener):
+            async with listener as result:
+                results.append(result)
+                results.append(await listener.receive())
+
+        async def listen_forever(listener: CDPEventListener):
+            async for result in listener:
+                results.append(result)
+
+        async with trio.open_nursery() as nursery:
+            nursery.start_soon(listen_once, listener1)
+            await wait_all_tasks_blocked()
+            nursery.start_soon(listen_twice, listener2)
+            await wait_all_tasks_blocked()
+            nursery.start_soon(listen_forever, listener3)
+            await wait_all_tasks_blocked()
+
+            await websocket_connection.sender.send("""{"method":"Fake.fakeEvent","params":{"value":"foo"}}""")
+            await wait_all_tasks_blocked()
+            assert len(cdp_connection.event_channels[FakeEvent]) == 3
+
+            await websocket_connection.sender.send("""{"method":"Fake.fakeEvent","params":{"value":"bar"}}""")
+            await wait_all_tasks_blocked()
+            assert len(cdp_connection.event_channels[FakeEvent]) == 2
+
+            await websocket_connection.sender.send("""{"method":"Fake.fakeEvent","params":{"value":"baz"}}""")
+            await wait_all_tasks_blocked()
+            assert len(cdp_connection.event_channels[FakeEvent]) == 1
+
+            await cdp_connection.aclose()
+
+        assert results == [
+            FakeEvent(value="foo"),
+            FakeEvent(value="foo"),
+            FakeEvent(value="foo"),
+            FakeEvent(value="bar"),
+            FakeEvent(value="bar"),
+            FakeEvent(value="baz"),
+        ]
+        assert FakeEvent not in cdp_connection.event_channels
+        assert all(listener._sender._closed for listener in listeners)  # type: ignore[attr-defined]
+        assert all(listener._receiver._closed for listener in listeners)  # type: ignore[attr-defined]
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"method":"Fake.fakeEvent","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                "Received event: FakeEvent(value='foo')",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"method":"Fake.fakeEvent","params":{"value":"bar"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                "Received event: FakeEvent(value='bar')",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"method":"Fake.fakeEvent","params":{"value":"baz"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                "Received event: FakeEvent(value='baz')",
+            ),
+        ]
+
+    @pytest.mark.trio()
+    async def test_would_block(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        cdp_connection: CDPConnection,
+        websocket_connection: FakeWebsocketConnection,
+    ):
+        assert FakeEvent not in cdp_connection.event_channels
+        listener = cdp_connection.listen(FakeEvent, max_buffer_size=1)
+        assert FakeEvent in cdp_connection.event_channels
+        assert len(cdp_connection.event_channels[FakeEvent]) == 1
+
+        assert listener._sender.statistics().current_buffer_used == 0
+        assert listener._sender.statistics().max_buffer_size == 1
+
+        await websocket_connection.sender.send("""{"method":"Fake.fakeEvent","params":{"value":"foo"}}""")
+        await wait_all_tasks_blocked()
+        assert listener._sender.statistics().current_buffer_used == 1
+        assert listener._sender.statistics().max_buffer_size == 1
+
+        await websocket_connection.sender.send("""{"method":"Fake.fakeEvent","params":{"value":"bar"}}""")
+        await wait_all_tasks_blocked()
+        assert listener._sender.statistics().current_buffer_used == 1
+        assert listener._sender.statistics().max_buffer_size == 1
+
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"method":"Fake.fakeEvent","params":{"value":"foo"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                "Received event: FakeEvent(value='foo')",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                """Received message: {"method":"Fake.fakeEvent","params":{"value":"bar"}}""",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "all",
+                "Received event: FakeEvent(value='bar')",
+            ),
+            (
+                "streamlink.webbrowser.cdp.connection",
+                "error",
+                """Unable to propagate CDP event FakeEvent(value='bar') due to full channel""",
+            ),
+        ]


### PR DESCRIPTION
Part 3/4 of #5380

This currently includes the commits of #5381 (part 1) and #5386 (part 2), because this code is needed for the CDP connection stuff. Once those PRs have been merged into master, I will rebase this branch.

So the only relevant commits of this PR are the ones after the merge commit. See the check marks of the HEAD commits of those other branches.

----

This
1. Adds the `trio-websocket` and `typing-extensions` runtime dependencies.
   - A bit unfortunate that we have to add another dependency for websockets, but it is what it is... Async I/O via trio is a requirement for a proper implementation.
   - `typing-extensions` is required, because I needed `TypeAlias` for making the `CDPEventListener`'s typing work. This conveniently also adds `Self` and other things.
2. Implements the CDP connection and session management.
   - As mentioned in #5380, the basic design is borrowed from the `trio-chrome-devtools-protocol` project, which uses the MIT license. This is properly annotated with the included license text. I applied several improvements and fixes to the code. This is all fully tested with full coverage.
   - Trio 0.22 currently requires the `from __future__ import annotations` workaround so the memory channels can have proper typing information, which is important. This will be resolved in their next release (they are waiting for the EOL of py37), but I don't think it's worth removing the import and bumping the version requirement once it's released.