### PR TITLE
tests: ignore DeprecationWarning in pycountry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ build-file = "streamlink/_version.py"
 filterwarnings = [
   "always",
   "ignore:::pkg_resources",
+  "ignore::DeprecationWarning:pycountry",
 ]
 
 


### PR DESCRIPTION
The stacklevel of the DeprecationWarning raised by `pkg_resources` got changed in setuptools 68.0.0, so we have to adjust our warnings filter.

`pycountry` is still importing `pkg_resources`.

----

From the last scheduled CI runner on master:
https://github.com/streamlink/streamlink/actions/runs/5328587588/jobs/9653353840#step:5:268

> ```
> ../../../../../opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pycountry/__init__.py:10
>   /opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/pycountry/__init__.py:10: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
>     import pkg_resources
> ```