### PR TITLE
cli.argparser: allow disabling session options

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1329,7 +1329,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
 def setup_session_options(session: Streamlink, args: argparse.Namespace):
     for arg, option, mapper in _ARGUMENT_TO_SESSIONOPTION:
         value = getattr(args, arg)
-        if value:
+        if value is not None:
             if mapper is not None:
                 value = mapper(value)
             session.set_option(option, value)

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -59,6 +59,23 @@ def test_setup_session_options(parser: ArgumentParser, session: Streamlink, argv
     assert session.get_option(option) == expected
 
 
+@pytest.mark.parametrize(("default", "new", "expected"), [
+    pytest.param(False, None, False, id="Default False, unset"),
+    pytest.param(True, None, True, id="Default True, unset"),
+    pytest.param(False, False, False, id="Default False, set to False"),
+    pytest.param(False, True, True, id="Default False, set to True"),
+    pytest.param(True, False, False, id="Default True, set to False"),
+    pytest.param(True, True, True, id="Default True, set to True"),
+])
+def test_setup_session_options_override(monkeypatch: pytest.MonkeyPatch, session: Streamlink, default, new, expected):
+    arg = "NON_EXISTING_ARGPARSER_ARGUMENT"
+    key = "NON-EXISTING-SESSION-OPTION-KEY"
+    monkeypatch.setattr("streamlink_cli.argparser._ARGUMENT_TO_SESSIONOPTION", [(arg, key, None)])
+    session.set_option(key, default)
+    setup_session_options(session, Namespace(**{arg: new}))
+    assert session.get_option(key) == expected
+
+
 def test_cli_main_setup_session_options(monkeypatch: pytest.MonkeyPatch, parser: ArgumentParser, session: Streamlink):
     class StopTest(Exception):
         pass


### PR DESCRIPTION
`streamlink_cli.argparser` should be able to set session options which default to `True` to `False`. Fix that by checking whether the argument dest on the argparse namespace is not `None` (aka set).

Currently, there are no session options which default to `True`.

----

Required for being able to add `--webbrowser=false` with respective default value of `True` on the Streamlink session.