### PR TITLE
revert: cli.argparser: allow disabling session options

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1329,7 +1329,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
 def setup_session_options(session: Streamlink, args: argparse.Namespace):
     for arg, option, mapper in _ARGUMENT_TO_SESSIONOPTION:
         value = getattr(args, arg)
-        if value is not None:
+        if value:
             if mapper is not None:
                 value = mapper(value)
             session.set_option(option, value)

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -59,23 +59,6 @@ def test_setup_session_options(parser: ArgumentParser, session: Streamlink, argv
     assert session.get_option(option) == expected
 
 
-@pytest.mark.parametrize(("default", "new", "expected"), [
-    pytest.param(False, None, False, id="Default False, unset"),
-    pytest.param(True, None, True, id="Default True, unset"),
-    pytest.param(False, False, False, id="Default False, set to False"),
-    pytest.param(False, True, True, id="Default False, set to True"),
-    pytest.param(True, False, False, id="Default True, set to False"),
-    pytest.param(True, True, True, id="Default True, set to True"),
-])
-def test_setup_session_options_override(monkeypatch: pytest.MonkeyPatch, session: Streamlink, default, new, expected):
-    arg = "NON_EXISTING_ARGPARSER_ARGUMENT"
-    key = "NON-EXISTING-SESSION-OPTION-KEY"
-    monkeypatch.setattr("streamlink_cli.argparser._ARGUMENT_TO_SESSIONOPTION", [(arg, key, None)])
-    session.set_option(key, default)
-    setup_session_options(session, Namespace(**{arg: new}))
-    assert session.get_option(key) == expected
-
-
 def test_cli_main_setup_session_options(monkeypatch: pytest.MonkeyPatch, parser: ArgumentParser, session: Streamlink):
     class StopTest(Exception):
         pass


### PR DESCRIPTION
Revert 9c6dd568216da4e20be32e85413551a8cb2219e4

Fixes #5395 

Let's revert this for now. I will have a proper look at this tomorrow.