### PR TITLE
docs: split API docs into multiple documents

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,97 +1,12 @@
 API Reference
 =============
 
-This is a reference of all the available API methods in Streamlink.
+This is an incomplete reference of the relevant Streamlink APIs.
 
+.. toctree::
 
-Streamlink
-------------
-
-.. autofunction:: streamlink.streams
-
-
-Session
--------
-
-.. autoclass:: streamlink.Streamlink
-    :member-order: bysource
-
-
-Plugins
--------
-
-Plugin
-^^^^^^
-
-.. module:: streamlink.plugin
-
-.. autoclass:: Plugin
-    :private-members: _get_streams
-    :member-order: bysource
-
-Plugin decorators
-^^^^^^^^^^^^^^^^^
-
-.. autodecorator:: pluginmatcher
-
-.. autodecorator:: pluginargument
-
-Plugin arguments
-^^^^^^^^^^^^^^^^
-
-.. module:: streamlink.options
-
-.. autoclass:: Argument
-
-.. autoclass:: Arguments
-
-
-Streams
--------
-
-.. module:: streamlink.stream
-
-All streams inherit from the :class:`Stream` class.
-
-Stream
-^^^^^^
-
-.. autoclass:: Stream
-
-MuxedStream
-^^^^^^^^^^^
-
-.. autoclass:: MuxedStream
-
-HTTPStream
-^^^^^^^^^^
-
-.. autoclass:: HTTPStream
-
-HLSStream
-^^^^^^^^^
-
-.. autoclass:: HLSStream
-
-MuxedHLSStream
-^^^^^^^^^^^^^^
-
-.. autoclass:: MuxedHLSStream
-
-DASHStream
-^^^^^^^^^^
-
-.. autoclass:: DASHStream
-
-
-Exceptions
-----------
-
-Streamlink has multiple types of exceptions:
-
-.. autoexception:: streamlink.exceptions.StreamlinkError
-.. autoexception:: streamlink.exceptions.PluginError
-.. autoexception:: streamlink.exceptions.FatalPluginError
-.. autoexception:: streamlink.exceptions.NoPluginError
-.. autoexception:: streamlink.exceptions.NoStreamsError
-.. autoexception:: streamlink.exceptions.StreamError
+    api/streamlink
+    api/session
+    api/plugin
+    api/stream
+    api/exceptions

--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -1,0 +1,9 @@
+Exceptions
+----------
+
+.. autoexception:: streamlink.exceptions.StreamlinkError
+.. autoexception:: streamlink.exceptions.PluginError
+.. autoexception:: streamlink.exceptions.FatalPluginError
+.. autoexception:: streamlink.exceptions.NoPluginError
+.. autoexception:: streamlink.exceptions.NoStreamsError
+.. autoexception:: streamlink.exceptions.StreamError

--- a/docs/api/plugin.rst
+++ b/docs/api/plugin.rst
@@ -1,0 +1,24 @@
+Plugin
+------
+
+.. module:: streamlink.plugin
+
+.. autoclass:: Plugin
+    :private-members: _get_streams
+    :member-order: bysource
+
+Plugin decorators
+^^^^^^^^^^^^^^^^^
+
+.. autodecorator:: pluginmatcher
+
+.. autodecorator:: pluginargument
+
+Plugin arguments
+^^^^^^^^^^^^^^^^
+
+.. module:: streamlink.options
+
+.. autoclass:: Argument
+
+.. autoclass:: Arguments

--- a/docs/api/session.rst
+++ b/docs/api/session.rst
@@ -1,0 +1,5 @@
+Session
+-------
+
+.. autoclass:: streamlink.session.Streamlink
+    :member-order: bysource

--- a/docs/api/stream.rst
+++ b/docs/api/stream.rst
@@ -1,0 +1,36 @@
+Streams
+-------
+
+.. module:: streamlink.stream
+
+All streams inherit from the :class:`Stream` class.
+
+Stream
+^^^^^^
+
+.. autoclass:: Stream
+
+MuxedStream
+^^^^^^^^^^^
+
+.. autoclass:: MuxedStream
+
+HTTPStream
+^^^^^^^^^^
+
+.. autoclass:: HTTPStream
+
+HLSStream
+^^^^^^^^^
+
+.. autoclass:: HLSStream
+
+MuxedHLSStream
+^^^^^^^^^^^^^^
+
+.. autoclass:: MuxedHLSStream
+
+DASHStream
+^^^^^^^^^^
+
+.. autoclass:: DASHStream

--- a/docs/api/streamlink.rst
+++ b/docs/api/streamlink.rst
@@ -1,0 +1,4 @@
+Streamlink
+----------
+
+.. autofunction:: streamlink.streams

--- a/docs/api_guide.rst
+++ b/docs/api_guide.rst
@@ -58,7 +58,7 @@ Inspecting streams
 ------------------
 
 It's also possible to inspect the stream's internal parameters. Go to
-:ref:`Stream subclasses <api:Streams>` to see which attributes are available
+:ref:`Stream subclasses <api/stream:Streams>` to see which attributes are available
 for inspection for each stream type.
 
 For example, this is a :py:class:`HLSStream <streamlink.stream.HLSStream>` object which

--- a/docs/api_guide.rst
+++ b/docs/api_guide.rst
@@ -75,7 +75,7 @@ Session object
 
 The session allows you to set various options and is more efficient
 when extracting streams more than once. You start by creating a
-:py:class:`Streamlink <streamlink.Streamlink>` object:
+:py:class:`Streamlink <streamlink.session.Streamlink>` object:
 
 .. code-block:: python
 
@@ -95,4 +95,4 @@ and extract streams like this:
     >>> streams = session.streams("URL")
 
 
-See :py:meth:`Streamlink.set_option <streamlink.Streamlink.set_option>` to see which options are available.
+See :py:meth:`Streamlink.set_option() <streamlink.session.Streamlink.set_option>` to see which options are available.

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -87,7 +87,7 @@ streamlink 3.0.0
 Removal of separate https-proxy option
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:ref:`HTTPS proxy CLI option <cli:HTTP options>` and the respective :ref:`Session options <api:Session>`
+:ref:`HTTPS proxy CLI option <cli:HTTP options>` and the respective :ref:`Session options <api/session:Session>`
 have been deprecated in favor of a single :option:`--http-proxy` that sets the proxy for all HTTP and
 HTTPS requests, including WebSocket connections.
 
@@ -98,8 +98,9 @@ streamlink 2.4.0
 Stream-type related CLI arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-:ref:`Stream-type related CLI arguments <cli:Stream transport options>` and the respective :ref:`Session options <api:Session>`
-have been deprecated in favor of existing generic arguments/options, to avoid redundancy and potential confusion.
+:ref:`Stream-type related CLI arguments <cli:Stream transport options>` and the respective
+:ref:`Session options <api/session:Session>` have been deprecated in favor of existing generic arguments/options,
+to avoid redundancy and potential confusion.
 
 - use :option:`--stream-segment-attempts` instead of ``--{dash,hds,hls}-segment-attempts``
 - use :option:`--stream-segment-threads` instead of ``--{dash,hds,hls}-segment-threads``

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -52,8 +52,8 @@ Session.resolve_url() return type changes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Due to the changes of the :py:class:`Plugin <streamlink.plugin.Plugin>` class mentioned above, the return value of
-:py:meth:`Streamlink.resolve_url <streamlink.Streamlink.resolve_url>` and
-:py:meth:`Streamlink.resolve_url_no_redirect <streamlink.Streamlink.resolve_url_no_redirect>` had to be changed
+:py:meth:`Streamlink.resolve_url() <streamlink.session.Streamlink.resolve_url>` and
+:py:meth:`Streamlink.resolve_url_no_redirect() <streamlink.session.Streamlink.resolve_url_no_redirect>` had to be changed
 from ``tuple[type[Plugin], str]`` to ``tuple[str, type[Plugin], str]``, and both methods now return the resolved plugin name
 as the first item, in addition to the plugin class and resolved URL.
 
@@ -64,9 +64,10 @@ streamlink 4.2.0
 Deprecation of url_master in HLSStream
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``url_master`` parameter and attribute of the :py:class:`streamlink.stream.HLSStream`
-and :py:class:`streamlink.stream.MuxedHLSStream` classes have been deprecated in favor of the ``multivariant`` parameter
-and attribute. ``multivariant`` is an :py:class:`M3U8` reference of the parsed HLS multivariant playlist.
+The ``url_master`` parameter and attribute of the :py:class:`HLSStream <streamlink.stream.HLSStream>`
+and :py:class:`MuxedHLSStream <streamlink.stream.MuxedHLSStream>` classes have been deprecated in favor of
+the ``multivariant`` parameter and attribute. ``multivariant`` is an :py:class:`M3U8` reference of the parsed
+HLS multivariant playlist.
 
 
 streamlink 4.0.0

--- a/src/streamlink/api.py
+++ b/src/streamlink/api.py
@@ -6,9 +6,9 @@ def streams(url: str, **params):
     Initializes an empty Streamlink session, attempts to find a plugin and extracts streams from the URL if a plugin was found.
 
     :param url: a URL to match against loaded plugins
-    :param params: Additional keyword arguments passed to :meth:`streamlink.Streamlink.streams`
+    :param params: Additional keyword arguments passed to :meth:`Streamlink.streams() <streamlink.session.Streamlink.streams>`
     :raises NoPluginError: on plugin resolve failure
-    :returns: A :class:`dict` of stream names and :class:`streamlink.stream.Stream` instances
+    :returns: A :class:`dict` of stream names and :class:`Stream <streamlink.stream.Stream>` instances
     """
 
     session = Streamlink()

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -90,7 +90,7 @@ class Options:
 
 class Argument:
     """
-    Accepts most of the parameters accepted by :meth:`ArgumentParser.add_argument`,
+    Accepts most of the parameters accepted by :meth:`ArgumentParser.add_argument()`,
     except that ``requires`` is a special case which is only enforced if the plugin is in use.
     In addition, the ``name`` parameter is the name relative to the plugin name, but can be overridden by ``argument_name``.
 
@@ -118,7 +118,7 @@ class Argument:
         :param argument_name: Custom CLI argument name without plugin name prefix
         :param dest: Custom plugin option name
         :param is_global: Whether this plugin argument refers to a global CLI argument (deprecated)
-        :param options: Arguments passed to :meth:`ArgumentParser.add_argument`, excluding ``requires`` and ``dest``
+        :param options: Arguments passed to :meth:`ArgumentParser.add_argument()`, excluding ``requires`` and ``dest``
         """
 
         self.required = required

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -387,7 +387,7 @@ class Plugin:
 
         Returns a :class:`dict` containing the streams, where the key is
         the name of the stream (most commonly the quality name), with the value
-        being a :class:`Stream` instance.
+        being a :class:`Stream <streamlink.stream.Stream>` instance.
 
         The result can contain the synonyms **best** and **worst** which
         point to the streams which are likely to be of highest and
@@ -413,7 +413,7 @@ class Plugin:
 
         :param stream_types: A list of stream types to return
         :param sorting_excludes: Specify which streams to exclude from the best/worst synonyms
-        :returns: A :class:`dict` of stream names and :class:`streamlink.stream.Stream` instances
+        :returns: A :class:`dict` of stream names and :class:`Stream <streamlink.stream.Stream>` instances
         """
 
         try:
@@ -516,8 +516,9 @@ class Plugin:
         """
         Implement the stream and metadata retrieval here.
 
-        Needs to return either a dict of :class:`streamlink.stream.Stream` instances mapped by stream name, or needs to act
-        as a generator which yields tuples of stream names and :class:`streamlink.stream.Stream` instances.
+        Needs to return either a dict of :class:`Stream <streamlink.stream.Stream>` instances mapped by stream name,
+        or needs to act as a generator which yields tuples of stream names and :class:`Stream <streamlink.stream.Stream>`
+        instances.
         """
 
         raise NotImplementedError
@@ -606,7 +607,7 @@ class Plugin:
     def clear_cookies(self, cookie_filter: Optional[Callable] = None) -> List[str]:
         """
         Removes all saved cookies for this plugin. To filter the cookies that are deleted
-        specify the ``cookie_filter`` argument (see :func:`save_cookies`).
+        specify the ``cookie_filter`` argument (see :meth:`save_cookies`).
 
         :param cookie_filter: a function to filter the cookies
         :type cookie_filter: function
@@ -656,7 +657,7 @@ def pluginmatcher(
     A matcher consists of a compiled regular expression pattern for the plugin's input URL,
     a priority value and an optional name.
     The priority value determines which plugin gets chosen by
-    :meth:`Streamlink.resolve_url <streamlink.Streamlink.resolve_url>` if multiple plugins match the input URL.
+    :meth:`Streamlink.resolve_url() <streamlink.session.Streamlink.resolve_url>` if multiple plugins match the input URL.
     The matcher name can be used for accessing it and its matching result when multiple matchers are defined.
 
     Plugins must at least have one matcher. If multiple matchers are defined, then the first matching one
@@ -711,7 +712,7 @@ def pluginargument(
     **options,
 ) -> Callable[[Type[Plugin]], Type[Plugin]]:
     """
-    Decorator for plugin arguments. Takes the same arguments as :class:`streamlink.options.Argument`.
+    Decorator for plugin arguments. Takes the same arguments as :class:`Argument <streamlink.options.Argument>`.
 
     .. code-block:: python
 

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -603,9 +603,9 @@ class Streamlink:
         Attempts to find a plugin and extracts streams from the *url* if a plugin was found.
 
         :param url: a URL to match against loaded plugins
-        :param params: Additional keyword arguments passed to :meth:`streamlink.plugin.Plugin.streams`
+        :param params: Additional keyword arguments passed to :meth:`Plugin.streams() <streamlink.plugin.Plugin.streams>`
         :raises NoPluginError: on plugin resolve failure
-        :return: A :class:`dict` of stream names and :class:`streamlink.stream.Stream` instances
+        :return: A :class:`dict` of stream names and :class:`Stream <streamlink.stream.Stream>` instances
         """
 
         pluginname, pluginclass, resolved_url = self.resolve_url(url)

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -16,6 +16,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDe
 
 from streamlink.buffers import RingBuffer
 from streamlink.exceptions import StreamError
+from streamlink.session import Streamlink
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, MuxedStream
 from streamlink.stream.filtered import FilteredStream
 from streamlink.stream.hls_playlist import M3U8, ByteRange, Key, Map, Media, Segment, load as load_hls_playlist
@@ -534,7 +535,7 @@ class MuxedHLSStream(MuxedStream["HLSStream"]):
 
     def __init__(
         self,
-        session,
+        session: Streamlink,
         video: str,
         audio: Union[str, List[str]],
         url_master: Optional[str] = None,
@@ -544,7 +545,7 @@ class MuxedHLSStream(MuxedStream["HLSStream"]):
         **args,
     ):
         """
-        :param streamlink.Streamlink session: Streamlink session instance
+        :param session: Streamlink session instance
         :param video: Video stream URL
         :param audio: Audio stream URL or list of URLs
         :param url_master: The URL of the HLS playlist's multivariant playlist (deprecated)
@@ -603,7 +604,7 @@ class HLSStream(HTTPStream):
         **args,
     ):
         """
-        :param streamlink.Streamlink session_: Streamlink session instance
+        :param streamlink.session.Streamlink session_: Streamlink session instance
         :param url: The URL of the HLS playlist
         :param url_master: The URL of the HLS playlist's multivariant playlist (deprecated)
         :param multivariant: The parsed multivariant playlist
@@ -684,7 +685,7 @@ class HLSStream(HTTPStream):
         """
         Parse a variant playlist and return its streams.
 
-        :param streamlink.Streamlink session_: Streamlink session instance
+        :param streamlink.session.Streamlink session_: Streamlink session instance
         :param url: The URL of the variant playlist
         :param name_key: Prefer to use this key as stream name, valid keys are: name, pixels, bitrate
         :param name_prefix: Add this prefix to the stream names

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -23,7 +23,7 @@ class HTTPStream(Stream):
         **args,
     ):
         """
-        :param streamlink.Streamlink session_: Streamlink session instance
+        :param streamlink.session.Streamlink session_: Streamlink session instance
         :param url: The URL of the HTTP stream
         :param buffered: Wrap stream output in an additional reader-thread
         :param args: Additional keyword arguments passed to :meth:`requests.Session.request`


### PR DESCRIPTION
The API docs should be split up for better legibility (I intend on adding docs for the webbrowser API). This also removes an unnecessary layer in the sidebar on the right. Some references needed an update, so I checked for the rest as well, but I didn't check thoroughly...

Current mess:
https://streamlink.github.io/api.html

New (mess):
https://deploy-preview-5398--streamlink.netlify.app/api.html