### PR TITLE
plugin.api.validate: drop deprecated text alias

### DIFF
--- a/src/streamlink/plugin/api/validate/__init__.py
+++ b/src/streamlink/plugin/api/validate/__init__.py
@@ -1,5 +1,3 @@
-from typing import TYPE_CHECKING
-
 # noinspection PyPep8Naming,PyShadowingBuiltins
 from streamlink.plugin.api.validate._schemas import (  # noqa: A001
     AllSchema as all,
@@ -42,40 +40,3 @@ from streamlink.plugin.api.validate._validators import (  # noqa: A001
     validator_xml_xpath as xml_xpath,
     validator_xml_xpath_string as xml_xpath_string,
 )
-
-
-if TYPE_CHECKING:  # pragma: no cover
-    from typing import Type
-
-    text: Type[str]
-
-
-def _deprecations():
-    import sys
-
-    deprecations = {
-        "text": (str, f"`{__name__}.text` is deprecated. Use `str` instead."),
-    }
-
-    def __getattr__(_attr: str):
-        if _attr in deprecations:
-            import warnings
-
-            from streamlink.exceptions import StreamlinkDeprecationWarning
-
-            val, msg = deprecations[_attr]
-            warnings.warn(msg, StreamlinkDeprecationWarning, stacklevel=2)
-
-            return val
-
-        raise AttributeError
-
-    __all__ = [k for k in globals().keys() if not k.startswith("_")]
-    __all__.extend(deprecations.keys())
-
-    sys.modules[__name__].__getattr__ = __getattr__
-    sys.modules[__name__].__all__ = __all__
-
-
-_deprecations()
-del _deprecations

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import pytest
 from lxml.etree import Element, tostring as etree_tostring
 
-from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
+from streamlink.exceptions import PluginError
 from streamlink.plugin.api import validate
 
 # noinspection PyProtectedMember
@@ -13,19 +13,6 @@ from streamlink.plugin.api.validate._exception import ValidationError
 
 def assert_validationerror(exception, expected):
     assert str(exception) == dedent(expected).strip("\n")
-
-
-def test_text_is_str(recwarn: pytest.WarningsRecorder):
-    assert "text" not in getattr(validate, "__dict__", {})
-    assert "text" in getattr(validate, "__all__", [])
-    assert validate.text is str, "Exports text as str alias for backwards compatiblity"
-    assert [(record.category, str(record.message), record.filename) for record in recwarn.list] == [
-        (
-            StreamlinkDeprecationWarning,
-            "`streamlink.plugin.api.validate.text` is deprecated. Use `str` instead.",
-            __file__,
-        ),
-    ]
 
 
 class TestSchema:


### PR DESCRIPTION
#5401 

https://streamlink.github.io/deprecations.html#deprecation-of-plugin-api-validate-text