### PR TITLE
plugins.twitch: webbrowser-based client-integrity

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -8,23 +8,27 @@ $notes :ref:`Low latency streaming <cli/plugins/twitch:Low latency streaming>` i
 """
 
 import argparse
+import base64
 import logging
 import re
 import sys
 from datetime import datetime, timedelta
+from json import dumps as json_dumps
 from random import random
-from typing import List, NamedTuple, Optional
+from typing import List, Mapping, NamedTuple, Optional, Tuple
 from urllib.parse import urlparse
 
 from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
+from streamlink.session import Streamlink
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker, HLSStreamWriter
 from streamlink.stream.hls_playlist import M3U8, ByteRange, DateRange, ExtInf, Key, M3U8Parser, Map, load as load_hls_playlist
 from streamlink.stream.http import HTTPStream
 from streamlink.utils.args import keyvalue
 from streamlink.utils.parse import parse_json, parse_qsd
-from streamlink.utils.times import hours_minutes_seconds
+from streamlink.utils.random import CHOICES_ALPHA_NUM, random_token
+from streamlink.utils.times import fromtimestamp, hours_minutes_seconds
 from streamlink.utils.url import update_qsd
 
 
@@ -406,7 +410,7 @@ class TwitchAPI:
             ),
         ))
 
-    def access_token(self, is_live, channel_or_vod):
+    def access_token(self, is_live, channel_or_vod, client_integrity: Optional[Tuple[str, str]] = None):
         query = self._gql_persisted_query(
             "PlaybackAccessToken",
             "0828119ded1c13477966434e15800ff57ddacf13ba1911c129dc2200705b0712",
@@ -424,7 +428,11 @@ class TwitchAPI:
             validate.union_get("signature", "value"),
         )
 
-        return self.call(query, acceptable_status=(200, 400, 401, 403), schema=validate.Schema(
+        headers = {}
+        if client_integrity:
+            headers["Device-Id"], headers["Client-Integrity"] = client_integrity
+
+        return self.call(query, acceptable_status=(200, 400, 401, 403), headers=headers, schema=validate.Schema(
             validate.any(
                 validate.all(
                     {"errors": [{"message": str}]},
@@ -450,7 +458,7 @@ class TwitchAPI:
                         ),
                     },
                     validate.get("data"),
-                    validate.transform(lambda data: ("token", *data)),
+                    validate.transform(lambda data: ("token", *data) if data is not None else ("token", None, None)),
                 ),
             ),
         ))
@@ -499,6 +507,117 @@ class TwitchAPI:
             {"data": {"user": {"stream": {"type": str}}}},
             validate.get(("data", "user", "stream")),
         ))
+
+
+class TwitchClientIntegrity:
+    URL_P_SCRIPT = "https://k.twitchcdn.net/149e9513-01fa-4fb0-aad4-566afd725d1b/2d206a39-8ed7-437e-a3be-862e0f06eea3/p.js"
+
+    # language=javascript
+    JS_INTEGRITY_TOKEN = """
+    // noinspection JSIgnoredPromiseFromCall
+    new Promise((resolve, reject) => {
+        function configureKPSDK() {
+            // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+            window.KPSDK.configure([{
+                "protocol": "https:",
+                "method": "POST",
+                "domain": "gql.twitch.tv",
+                "path": "/integrity"
+            }]);
+        }
+
+        async function fetchIntegrity() {
+            // noinspection JSUnresolvedReference
+            const headers = Object.assign(HEADERS, {"x-device-id": "DEVICE_ID"});
+            // window.fetch gets overridden and the patched function needs to be used
+            const resp = await window.fetch("https://gql.twitch.tv/integrity", {
+                "headers": headers,
+                "body": null,
+                "method": "POST",
+                "mode": "cors",
+                "credentials": "omit"
+            });
+
+            if (resp.status !== 200) {
+                throw new Error(`Unexpected integrity response status code ${resp.status}`);
+            }
+
+            return JSON.stringify(await resp.json());
+        }
+
+        document.addEventListener("kpsdk-load", configureKPSDK, {once: true});
+        document.addEventListener("kpsdk-ready", () => fetchIntegrity().then(resolve, reject), {once: true});
+
+        const script = document.createElement("script");
+        script.addEventListener("error", reject);
+        script.src = "SCRIPT_SOURCE";
+        document.body.appendChild(script);
+    });
+    """
+
+    @classmethod
+    def acquire(
+        cls,
+        session: Streamlink,
+        channel: str,
+        headers: Mapping[str, str],
+        device_id: str,
+    ) -> Optional[Tuple[str, int]]:
+        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools
+        from streamlink.webbrowser.exceptions import WebbrowserError
+
+        url = f"https://www.twitch.tv/{channel}"
+        js_get_integrity_token = cls.JS_INTEGRITY_TOKEN \
+            .replace("SCRIPT_SOURCE", cls.URL_P_SCRIPT) \
+            .replace("HEADERS", json_dumps(headers)) \
+            .replace("DEVICE_ID", device_id)
+        eval_timeout = session.get_option("webbrowser-timeout")
+
+        async def on_main(client_session: CDPClientSession, request: devtools.fetch.RequestPaused):
+            async with client_session.alter_request(request) as cm:
+                cm.body = "<!doctype html>"
+
+        async def acquire_client_integrity_token(client: CDPClient):
+            client_session: CDPClientSession
+            async with client.session() as client_session:
+                client_session.add_request_handler(on_main, url_pattern=url, on_request=True)
+                async with client_session.navigate(url) as frame_id:
+                    await client_session.loaded(frame_id)
+                    return await client_session.evaluate(js_get_integrity_token, timeout=eval_timeout)
+
+        try:
+            client_integrity: Optional[str] = CDPClient.launch(session, acquire_client_integrity_token)
+        except WebbrowserError as err:
+            log.error(f"{type(err).__name__}: {err}")
+            return None
+        if not client_integrity:
+            return None
+
+        token, expiration = parse_json(client_integrity, schema=validate.Schema(
+            {"token": str, "expiration": int},
+            validate.union_get("token", "expiration"),
+        ))
+        is_bad_bot = cls.decode_client_integrity_token(token, schema=validate.Schema(
+            {"is_bad_bot": str},
+            validate.get("is_bad_bot"),
+            validate.transform(lambda val: val.lower() != "false"),
+        ))
+        log.info(f"Is bad bot? {is_bad_bot}")
+        if is_bad_bot:
+            return None
+
+        return token, expiration / 1000
+
+    @staticmethod
+    def decode_client_integrity_token(data: str, schema: Optional[validate.Schema] = None):
+        if not data.startswith("v4.public."):
+            raise PluginError("Invalid client-integrity token format")
+        token = data[len("v4.public."):].replace("-", "+").replace("_", "/")
+        token += "=" * ((4 - (len(token) % 4)) % 4)
+        token = base64.b64decode(token.encode())[:-64].decode()
+        log.debug(f"Client-Integrity token: {token}")
+
+        return parse_json(token, exception=PluginError, schema=schema)
 
 
 @pluginmatcher(re.compile(r"""
@@ -573,7 +692,14 @@ class TwitchAPI:
         Can be repeated to add multiple parameters.
     """,
 )
+@pluginargument(
+    "purge-client-integrity",
+    action="store_true",
+    help="Purge cached Twitch client-integrity token and acquire a new one.",
+)
 class Twitch(Plugin):
+    _CACHE_KEY_CLIENT_INTEGRITY = "client-integrity"
+
     @classmethod
     def stream_weight(cls, stream):
         if stream == "source":
@@ -638,17 +764,52 @@ class Twitch(Plugin):
         except (PluginError, TypeError):
             pass
 
+    def _client_integrity_token(self, channel: str) -> Optional[Tuple[str, str]]:
+        if self.options.get("purge-client-integrity"):
+            log.info("Removing cached client-integrity token...")
+            self.cache.set(self._CACHE_KEY_CLIENT_INTEGRITY, None, 0)
+
+        client_integrity = self.cache.get(self._CACHE_KEY_CLIENT_INTEGRITY)
+        if client_integrity and isinstance(client_integrity, list) and len(client_integrity) == 2:
+            log.info("Using cached client-integrity token")
+            device_id, token = client_integrity
+        else:
+            log.info("Acquiring new client-integrity token...")
+            device_id = random_token(32, CHOICES_ALPHA_NUM)
+            client_integrity = TwitchClientIntegrity.acquire(
+                self.session,
+                channel,
+                self.api.headers,
+                device_id,
+            )
+            if not client_integrity:
+                log.warning("No client-integrity token acquired")
+                return None
+
+            token, expiration = client_integrity
+            self.cache.set(self._CACHE_KEY_CLIENT_INTEGRITY, [device_id, token], expires_at=fromtimestamp(expiration))
+
+        return device_id, token
+
     def _access_token(self, is_live, channel_or_vod):
-        try:
-            response, *data = self.api.access_token(is_live, channel_or_vod)
+        # try without a client-integrity token first (the web player did the same on 2023-05-31)
+        response, *data = self.api.access_token(is_live, channel_or_vod)
+
+        # try again with a client-integrity token if the API response was erroneous
+        if response != "token":
+            client_integrity = self._client_integrity_token(channel_or_vod) if is_live else None
+            response, *data = self.api.access_token(is_live, channel_or_vod, client_integrity)
+
+            # unknown API response error: abort
             if response != "token":
                 error, message = data
-                log.error(f"{error or 'Error'}: {message or 'Unknown error'}")
-                raise PluginError
-            sig, token = data
-        except (PluginError, TypeError):
-            raise NoStreamsError  # noqa: B904
+                raise PluginError(f"{error or 'Error'}: {message or 'Unknown error'}")
 
+        # access token response was empty: stream is offline or channel doesn't exist
+        if response == "token" and data[0] is None:
+            raise NoStreamsError
+
+        sig, token = data
         try:
             restricted_bitrates = self.api.parse_token(token)
         except PluginError:

--- a/src/streamlink/utils/random.py
+++ b/src/streamlink/utils/random.py
@@ -1,0 +1,14 @@
+from random import choice
+
+
+CHOICES_NUM = "0123456789"
+CHOICES_ALPHA_LOWER = "abcdefghijklmnopqrstuvwxyz"
+CHOICES_ALPHA_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+CHOICES_ALPHA = f"{CHOICES_ALPHA_LOWER}{CHOICES_ALPHA_UPPER}"
+CHOICES_ALPHA_NUM = f"{CHOICES_NUM}{CHOICES_ALPHA}"
+CHOICES_HEX_LOWER = f"{CHOICES_NUM}{CHOICES_ALPHA_LOWER[:6]}"
+CHOICES_HEX_UPPER = f"{CHOICES_NUM}{CHOICES_ALPHA_UPPER[:6]}"
+
+
+def random_token(length: int = 32, choices: str = CHOICES_ALPHA_NUM) -> str:
+    return "".join(choice(choices) for _ in range(length))

--- a/tests/utils/test_random.py
+++ b/tests/utils/test_random.py
@@ -1,0 +1,69 @@
+from collections import defaultdict
+from itertools import count
+from typing import Dict, Iterator, Sequence
+
+import pytest
+
+from streamlink.utils.random import (
+    CHOICES_ALPHA,
+    CHOICES_ALPHA_LOWER,
+    CHOICES_ALPHA_NUM,
+    CHOICES_ALPHA_UPPER,
+    CHOICES_HEX_LOWER,
+    CHOICES_HEX_UPPER,
+    CHOICES_NUM,
+    random_token,
+)
+
+
+@pytest.fixture()
+def _iterated_choice(monkeypatch: pytest.MonkeyPatch):
+    choices: Dict[Sequence, Iterator[int]] = defaultdict(lambda: count())
+
+    def fake_choice(seq):
+        return seq[next(choices[seq]) % len(seq)]
+
+    monkeypatch.setattr("streamlink.utils.random.choice", fake_choice)
+
+
+@pytest.mark.usefixtures("_iterated_choice")
+@pytest.mark.parametrize(("args", "expected"), [
+    (
+        dict(),
+        "0123456789abcdefghijklmnopqrstuv",
+    ),
+    (
+        dict(length=62),
+        "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    ),
+    (
+        dict(length=20, choices=CHOICES_NUM),
+        "01234567890123456789",
+    ),
+    (
+        dict(length=52, choices=CHOICES_ALPHA_LOWER),
+        "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz",
+    ),
+    (
+        dict(length=52, choices=CHOICES_ALPHA_UPPER),
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    ),
+    (
+        dict(length=104, choices=CHOICES_ALPHA),
+        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    ),
+    (
+        dict(length=100, choices=CHOICES_ALPHA_NUM),
+        "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzAB",
+    ),
+    (
+        dict(length=32, choices=CHOICES_HEX_LOWER),
+        "0123456789abcdef0123456789abcdef",
+    ),
+    (
+        dict(length=32, choices=CHOICES_HEX_UPPER),
+        "0123456789ABCDEF0123456789ABCDEF",
+    ),
+])
+def test_random_token(args, expected):
+    assert random_token(**args) == expected


### PR DESCRIPTION
Resolves #5370
Also see #5380 

This PR implements the client-integrity token acquirement for the Twitch access token API endpoint, based on Streamlink's newly added webbrowser API (#5380).

Not fully ready yet, hence why I'm opening this as a draft. I am primarily looking for early feedback from users.
Before I'm going to properly open this, I'll have to update the commit message body and add some tests.

----

## Overview

- It adds the `--twitch-purge-client-identity` plugin argument
- If available, it uses the device-id and client-integrity token from the plugin cache (client-integrity tokens expire after 16 hours)
- If no cached device-id + client-integrity token were found or if they expired, then it generates a new device-id and then imports and calls the webbrowser API
- In order to acquire the CI token, it accesses and intercepts `https://www.twitch.tv/CHANNEL` with an empty HTML document, and then executes JS code that implements the CI token acquirement
- The acquired token is then decoded and checked for the `is_bad_bot` key.
- If `is_bad_bot` is `"false"`, then it caches the newly generated device-id and acquired client-integrity token
- On any error or timeout along the way, or if `is_bad_bot` is not `"false"`, then it returns `None` and nothing will be cached. Errors get logged.
- When getting the access token and the results were not `None`, then the device-id and client-integrity HTTP headers get set, which should result in a valid access token

## Currently not implemented

- ~~Initial attempt of getting the access token without a client-integrity token (so no web browser has to be launched while Twitch has disabled the restrictions, like right now)~~
- ~~Authentication data and other API headers set by the user currently don't get passed to the webbrowser implementation~~
- Tests
  I don't think it's worth testing the CI token acquirement and mocking all the API calls. I've updated the important tests though.

## Notes

- ~~It doesn't check whether the chosen channel is currently live, so it'll always acquire a client-integrity token if it's not cached. The live check is done by getting an access token. We'd have to check the live status via the GQL API, but that is delayed and thus not ideal (see the empty stream metadata issues that have popped up over the past months)~~
- I have no idea about VODs and clips. The CI token currently only gets acquired for live channels, which might be incorrect

And as a reminder:
**a Chromium-based web browser is required** in order for the webbrowser API to work. See the available options:
https://streamlink.github.io/latest/cli.html#web-browser-options

## How to test

Install Streamlink from the branch of this PR (and re-install once changes are pushed).
Be aware that there are breaking changes on this and Streamlink's master branch for the upcoming 6.0.0 release.

Guide:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

Via pip:
```
$ python -m pip install git+https://github.com/bastimeyer/streamlink.git@plugins/twitch/client-integrity
```

----

## Example

Note: `--twitch-force-client-integrity` is added temporarily and needs to be added to get the CI token. See my comment below why.

```
$ streamlink --twitch-force-client-integrity --twitch-purge-client-integrity twitch.tv/CHANNEL
[cli][info] Found matching plugin twitch for URL twitch.tv/CHANNEL
[plugins.twitch][info] Removing cached client-integrity token...
[plugins.twitch][info] Acquiring new client-integrity token...
[webbrowser.webbrowser][info] Launching web browser: /usr/bin/chromium
[plugins.twitch][info] Is bad bot? False
Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
```

edit:
**`--twitch-force-client-integrity` removed again**