### PR TITLE
webbrowser.chromium: add MSEdge fallback on win32

### DIFF
--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -26,7 +26,20 @@ class ChromiumWebbrowser(Webbrowser):
     @classmethod
     def fallback_paths(cls) -> List[Union[str, Path]]:
         if is_win32:
-            return [
+            ms_edge: List[Union[str, Path]] = [
+                str(Path(base) / sub / "msedge.exe")
+                for sub in (
+                    "Microsoft\\Edge\\Application",
+                    "Microsoft\\Edge Beta\\Application",
+                    "Microsoft\\Edge Dev\\Application",
+                )
+                for base in [os.getenv(env) for env in (
+                    "PROGRAMFILES",
+                    "PROGRAMFILES(X86)",
+                )]
+                if base is not None
+            ]
+            google_chrome: List[Union[str, Path]] = [
                 str(Path(base) / sub / "chrome.exe")
                 for sub in (
                     "Google\\Chrome\\Application",
@@ -40,6 +53,7 @@ class ChromiumWebbrowser(Webbrowser):
                 )]
                 if base is not None
             ]
+            return ms_edge + google_chrome
 
         if is_darwin:
             return [

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -25,6 +25,12 @@ class TestFallbacks:
             "LOCALAPPDATA": "C:\\Users\\user\\AppData\\Local",
         }.get)
         assert ChromiumWebbrowser.fallback_paths() == [
+            "C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe",
+            "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+            "C:\\Program Files\\Microsoft\\Edge Beta\\Application\\msedge.exe",
+            "C:\\Program Files (x86)\\Microsoft\\Edge Beta\\Application\\msedge.exe",
+            "C:\\Program Files\\Microsoft\\Edge Dev\\Application\\msedge.exe",
+            "C:\\Program Files (x86)\\Microsoft\\Edge Dev\\Application\\msedge.exe",
             "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
             "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe",
             "C:\\Users\\user\\AppData\\Local\\Google\\Chrome\\Application\\chrome.exe",


### PR DESCRIPTION
This adds Microsoft Edge to the Chromium fallback list on win32.

It actually prioritizes MS Edge over Google Chrome, which I think is a better solution because on Windows it's guaranteed that Edge is installed. Both are non-free browsers on a non-free OS, so I don't care one single bit about what people will say about edge vs chrome.

This does only affect the fallback paths, which means `chromium`, etc. is still looked up first in the `PATH` env var, even though this won't work on Windows unless people have special setups.

For those users of Windows who don't want to run Edge, they either won't notice it because it runs headlessly by default, or they can change it via the `--webbrowser-executable` option.