### PR TITLE
webbrowser: improve resolve error message

### DIFF
--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -13,6 +13,8 @@ from streamlink.webbrowser.webbrowser import Webbrowser
 
 
 class ChromiumWebbrowser(Webbrowser):
+    ERROR_RESOLVE = "Could not find Chromium-based web browser executable"
+
     @classmethod
     def names(cls) -> List[str]:
         return [

--- a/src/streamlink/webbrowser/webbrowser.py
+++ b/src/streamlink/webbrowser/webbrowser.py
@@ -17,6 +17,8 @@ log = logging.getLogger(__name__)
 
 
 class Webbrowser:
+    ERROR_RESOLVE = "Could not find web browser executable"
+
     TIMEOUT = 10
 
     @classmethod
@@ -34,7 +36,11 @@ class Webbrowser:
     def __init__(self, executable: Optional[str] = None):
         resolved = resolve_executable(executable, self.names(), self.fallback_paths())
         if not resolved:
-            raise WebbrowserError(f"Could not resolve web browser executable{f': {executable}' if executable else ''}")
+            raise WebbrowserError(
+                f"Invalid web browser executable: {executable}"
+                if executable else
+                f"{self.ERROR_RESOLVE}: Please set the path to a supported web browser using --webbrowser-executable",
+            )
 
         self.executable: Union[str, Path] = resolved
         self.arguments: List[str] = self.launch_args().copy()

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -1,7 +1,7 @@
 from contextlib import nullcontext
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from signal import SIGTERM
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import pytest
 import requests_mock as rm
@@ -12,6 +12,39 @@ from streamlink.compat import is_win32
 from streamlink.exceptions import PluginError
 from streamlink.session import Streamlink
 from streamlink.webbrowser.chromium import ChromiumWebbrowser
+from streamlink.webbrowser.exceptions import WebbrowserError
+
+
+class TestInit:
+    @pytest.mark.parametrize(("executable", "resolve_executable", "raises"), [
+        pytest.param(
+            None,
+            None,
+            pytest.raises(WebbrowserError, match="^Could not find Chromium-based web browser executable: Please set the path "),
+            id="Failure with unset path",
+        ),
+        pytest.param(
+            "custom",
+            None,
+            pytest.raises(WebbrowserError, match="^Invalid web browser executable: custom$"),
+            id="Failure with custom path",
+        ),
+        pytest.param(
+            None,
+            "default",
+            nullcontext(),
+            id="Success with default path",
+        ),
+        pytest.param(
+            "custom",
+            "custom",
+            nullcontext(),
+            id="Success with custom path",
+        ),
+    ], indirect=["resolve_executable"])
+    def test_resolve_executable(self, resolve_executable, executable: Optional[str], raises: nullcontext):
+        with raises:
+            ChromiumWebbrowser(executable=executable)
 
 
 class TestFallbacks:

--- a/tests/webbrowser/test_webbrowser.py
+++ b/tests/webbrowser/test_webbrowser.py
@@ -24,13 +24,13 @@ class TestInit:
         pytest.param(
             None,
             None,
-            pytest.raises(WebbrowserError, match="Could not resolve web browser executable"),
-            id="Failure with default path",
+            pytest.raises(WebbrowserError, match="^Could not find web browser executable: Please set the path "),
+            id="Failure with unset path",
         ),
         pytest.param(
             "custom",
             None,
-            pytest.raises(WebbrowserError, match="Could not resolve web browser executable: custom"),
+            pytest.raises(WebbrowserError, match="^Invalid web browser executable: custom$"),
             id="Failure with custom path",
         ),
         pytest.param(


### PR DESCRIPTION
This replaces

> Could not resolve web browser executable
>
> Could not resolve web browser executable: /custom/path/...

with

> Could not find Chromium-based web browser executable: Please set the path to a supported web browser using --webbrowser-executable
>
> Invalid web browser executable: /custom/path/...

if none of the supported executable names or fallback paths could be resolved, e.g. when Chromium and others are not installed.