### PR TITLE
utils.crypto: move Crypto imports to utils module

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -15,7 +15,6 @@ import uuid
 from base64 import urlsafe_b64encode
 from binascii import unhexlify
 
-from Crypto.Cipher import AES
 from requests import Response
 from requests.adapters import BaseAdapter
 
@@ -23,6 +22,7 @@ from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWriter
+from streamlink.utils.crypto import AES
 from streamlink.utils.url import update_qsd
 
 

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -10,12 +10,10 @@ import logging
 import re
 from urllib.parse import urljoin
 
-from Crypto.Cipher import AES
-from Crypto.Util.Padding import unpad
-
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.crypto import AES, unpad
 from streamlink.utils.parse import parse_json
 
 

--- a/src/streamlink/plugins/steam.py
+++ b/src/streamlink/plugins/steam.py
@@ -11,13 +11,11 @@ import logging
 import re
 import time
 
-from Crypto.Cipher import PKCS1_v1_5
-from Crypto.PublicKey import RSA
-
 from streamlink.exceptions import FatalPluginError
 from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
+from streamlink.utils.crypto import RSA, PKCS1_v1_5
 
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/ustvnow.py
+++ b/src/streamlink/plugins/ustvnow.py
@@ -12,12 +12,9 @@ import re
 from urllib.parse import urljoin, urlparse
 from uuid import uuid4
 
-from Crypto.Cipher import AES
-from Crypto.Hash import SHA256
-from Crypto.Util.Padding import pad, unpad
-
 from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.crypto import AES, SHA256, pad, unpad
 
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/plugins/webtv.py
+++ b/src/streamlink/plugins/webtv.py
@@ -9,12 +9,10 @@ import binascii
 import logging
 import re
 
-from Crypto.Cipher import AES
-
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
-from streamlink.utils.crypto import unpad_pkcs5
+from streamlink.utils.crypto import AES, unpad_pkcs5
 from streamlink.utils.parse import parse_json
 from streamlink.utils.url import update_scheme
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -6,11 +6,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Mapping, NamedTuple, Optional, Tuple, Union
 from urllib.parse import urlparse
 
-# noinspection PyPackageRequirements
-from Crypto.Cipher import AES
-
-# noinspection PyPackageRequirements
-from Crypto.Util.Padding import unpad
 from requests import Response
 from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDecodingError, InvalidSchema
 
@@ -23,6 +18,7 @@ from streamlink.stream.hls_playlist import M3U8, ByteRange, Key, Map, Media, Seg
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
 from streamlink.utils.cache import LRUCache
+from streamlink.utils.crypto import AES, unpad
 from streamlink.utils.formatter import Formatter
 from streamlink.utils.times import now
 

--- a/src/streamlink/utils/crypto.py
+++ b/src/streamlink/utils/crypto.py
@@ -1,6 +1,21 @@
+# ruff: noqa: F401
 import hashlib
 
-from Crypto.Cipher import AES
+
+# re-export pycryptodome / pycryptodomex stuff in a single place
+# so packagers don't have to maintain dozens of patches
+try:
+    # pycryptodome (drop-in replacement for the old PyCrypto library)
+    from Crypto.Cipher import AES, PKCS1_v1_5
+    from Crypto.Hash import SHA256
+    from Crypto.PublicKey import RSA
+    from Crypto.Util.Padding import pad, unpad
+except ImportError:  # pragma: no cover
+    # pycryptodomex (independent of the old PyCrypto library)
+    from Cryptodome.Cipher import AES, PKCS1_v1_5  # type: ignore
+    from Cryptodome.Hash import SHA256  # type: ignore
+    from Cryptodome.PublicKey import RSA  # type: ignore
+    from Cryptodome.Util.Padding import pad, unpad  # type: ignore
 
 
 def evp_bytestokey(password, salt, key_len, iv_len):

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -9,13 +9,12 @@ from unittest.mock import Mock, call, patch
 import freezegun
 import pytest
 import requests_mock as rm
-from Crypto.Cipher import AES
-from Crypto.Util.Padding import pad
 from requests.exceptions import InvalidSchema
 
 from streamlink.session import Streamlink
 from streamlink.stream.hls import HLSStream, HLSStreamReader, MuxedHLSStream
 from streamlink.stream.hls_playlist import M3U8Parser
+from streamlink.utils.crypto import AES, pad
 from tests.mixins.stream_hls import EventedHLSStreamWorker, EventedHLSStreamWriter, Playlist, Segment, Tag, TestMixinStreamHLS
 from tests.resources import text
 


### PR DESCRIPTION
Had this on the to-do list for a while:
Re-export pycryptodome / pycryptodomex stuff in a single place, so packagers don't have to maintain dozens of patches.

- https://github.com/Legrandin/pycryptodome#pycryptodome
- https://src.fedoraproject.org/rpms/python-streamlink/blob/712c7a9a95dbd63d68314b0e4e55a51fe7cff8f5/f/python-streamlink-5.5.1-pycryptodomex.patch

Drawback of this approach is that this imports all the stuff at once, but we do that anyway since the Streamlink session is loading all plugins at once, too. And the stream implementations which import crypto stuff get loaded as well.