### PR TITLE
docs: fix header and sections in api/stream

### DIFF
--- a/docs/api/stream.rst
+++ b/docs/api/stream.rst
@@ -1,36 +1,18 @@
-Streams
--------
+Stream
+------
 
 .. module:: streamlink.stream
 
-All streams inherit from the :class:`Stream` class.
-
-Stream
-^^^^^^
+All streams inherit from the :class:`Stream` base class.
 
 .. autoclass:: Stream
 
-MuxedStream
-^^^^^^^^^^^
-
 .. autoclass:: MuxedStream
-
-HTTPStream
-^^^^^^^^^^
 
 .. autoclass:: HTTPStream
 
-HLSStream
-^^^^^^^^^
-
 .. autoclass:: HLSStream
 
-MuxedHLSStream
-^^^^^^^^^^^^^^
-
 .. autoclass:: MuxedHLSStream
-
-DASHStream
-^^^^^^^^^^
 
 .. autoclass:: DASHStream

--- a/docs/api_guide.rst
+++ b/docs/api_guide.rst
@@ -58,7 +58,7 @@ Inspecting streams
 ------------------
 
 It's also possible to inspect the stream's internal parameters. Go to
-:ref:`Stream subclasses <api/stream:Streams>` to see which attributes are available
+:ref:`Stream subclasses <api/stream:Stream>` to see which attributes are available
 for inspection for each stream type.
 
 For example, this is a :py:class:`HLSStream <streamlink.stream.HLSStream>` object which


### PR DESCRIPTION
This removes unnecessary sections on the api/stream docs page and fixes the incorrect header.