### PR TITLE
stream: fix signatures of Stream classes & methods 

### DIFF
--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -45,11 +45,11 @@ class FilmOnHLS(HLSStream):
     __shortname__ = "hls-filmon"
     __reader__ = FilmOnHLSStreamReader
 
-    def __init__(self, session_, url: str, api: "FilmOnAPI", channel=None, vod_id=None, quality="high", **args):
+    def __init__(self, session, url: str, api: "FilmOnAPI", channel=None, vod_id=None, quality="high", **args):
         if channel is None and vod_id is None:
             raise PluginError("Channel or vod_id must be set")
 
-        super().__init__(session_, url, **args)
+        super().__init__(session, url, **args)
         self.api = api
         self.channel = channel
         self.vod_id = vod_id

--- a/src/streamlink/plugins/mildom.py
+++ b/src/streamlink/plugins/mildom.py
@@ -22,8 +22,8 @@ class MildomHLSStream(HLSStream):
     __shortname__ = "hls-mildom"
     expiry_time = 60 * 120
 
-    def __init__(self, session_, api, server, token, quality, **args):
-        self.session = session_
+    def __init__(self, session, api, server, token, quality, **args):
+        self.session = session
         self.api = api
         self.server = server
         self.token = token

--- a/src/streamlink/plugins/oneplusone.py
+++ b/src/streamlink/plugins/oneplusone.py
@@ -23,15 +23,15 @@ log = logging.getLogger(__name__)
 class OnePlusOneHLS(HLSStream):
     __shortname__ = "hls-oneplusone"
 
-    def __init__(self, session_, url, self_url=None, **args):
-        super().__init__(session_, url, None, **args)
+    def __init__(self, session, url, self_url=None, **args):
+        super().__init__(session, url, None, **args)
         self._url = url
 
         first_parsed = urlparse(self._url)
         self._first_netloc = first_parsed.netloc
         self._first_path_chunklist = first_parsed.path.split("/")[-1]
         self.watch_timeout = int(first_parsed.path.split("/")[2]) - 15
-        self.api = OnePlusOneAPI(session_, self_url)
+        self.api = OnePlusOneAPI(session, self_url)
 
     def _next_watch_timeout(self):
         _next = fromlocaltimestamp(self.watch_timeout).isoformat(" ")

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -706,10 +706,8 @@ class Twitch(Plugin):
                 self.session,
                 url,
                 start_offset=time_offset,
-                keywords={
-                    "disable_ads": self.get_option("disable-ads"),
-                    "low_latency": self.get_option("low-latency"),
-                },
+                disable_ads=self.get_option("disable-ads"),
+                low_latency=self.get_option("low-latency"),
                 **extra_params,
             )
         except OSError as err:

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -197,21 +197,21 @@ class DASHStream(Stream):
         mpd: MPD,
         video_representation: Optional[Representation] = None,
         audio_representation: Optional[Representation] = None,
-        **args,
+        **kwargs,
     ):
         """
         :param session: Streamlink session instance
         :param mpd: Parsed MPD manifest
         :param video_representation: Video representation
         :param audio_representation: Audio representation
-        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
+        :param kwargs: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
         super().__init__(session)
         self.mpd = mpd
         self.video_representation = video_representation
         self.audio_representation = audio_representation
-        self.args = session.http.valid_request_args(**args)
+        self.args = session.http.valid_request_args(**kwargs)
 
     def __json__(self):
         json = dict(type=self.shortname())
@@ -266,7 +266,7 @@ class DASHStream(Stream):
         period: int = 0,
         with_video_only: bool = False,
         with_audio_only: bool = False,
-        **args,
+        **kwargs,
     ) -> Dict[str, "DASHStream"]:
         """
         Parse a DASH manifest file and return its streams.
@@ -276,10 +276,10 @@ class DASHStream(Stream):
         :param period: Which MPD period to use (index number) for finding representations
         :param with_video_only: Also return video-only streams, otherwise only return muxed streams
         :param with_audio_only: Also return audio-only streams, otherwise only return muxed streams
-        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
+        :param kwargs: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
-        manifest, mpd_params = cls.fetch_manifest(session, url_or_manifest, **args)
+        manifest, mpd_params = cls.fetch_manifest(session, url_or_manifest, **kwargs)
 
         try:
             mpd = cls.parse_mpd(manifest, mpd_params)
@@ -337,7 +337,7 @@ class DASHStream(Stream):
             if not vid and not aud:
                 continue
 
-            stream = DASHStream(session, mpd, vid, aud, **args)
+            stream = DASHStream(session, mpd, vid, aud, **kwargs)
             stream_name = []
 
             if vid:

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -20,17 +20,18 @@ class HTTPStream(Stream):
         session_,
         url: str,
         buffered: bool = True,
-        **args,
+        **kwargs,
     ):
         """
         :param streamlink.session.Streamlink session_: Streamlink session instance
         :param url: The URL of the HTTP stream
         :param buffered: Wrap stream output in an additional reader-thread
-        :param args: Additional keyword arguments passed to :meth:`requests.Session.request`
+        :param kwargs: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
         super().__init__(session_)
-        self.args = dict(url=url, **args)
+        self.args = self.session.http.valid_request_args(**kwargs)
+        self.args["url"] = url
         self.buffered = buffered
 
     def __json__(self):

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from streamlink.exceptions import StreamError
+from streamlink.session import Streamlink
 from streamlink.stream.stream import Stream
 from streamlink.stream.wrappers import StreamIOIterWrapper, StreamIOThreadWrapper
 
@@ -17,19 +18,19 @@ class HTTPStream(Stream):
 
     def __init__(
         self,
-        session_,
+        session: Streamlink,
         url: str,
         buffered: bool = True,
         **kwargs,
     ):
         """
-        :param streamlink.session.Streamlink session_: Streamlink session instance
+        :param session: Streamlink session instance
         :param url: The URL of the HTTP stream
         :param buffered: Wrap stream output in an additional reader-thread
         :param kwargs: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
-        super().__init__(session_)
+        super().__init__(session)
         self.args = self.session.http.valid_request_args(**kwargs)
         self.args["url"] = url
         self.buffered = buffered


### PR DESCRIPTION
Two commits:

1. A correction of d314c5b which shouldn't go into a stable release like this. The parameter removal is not a breaking change since it was only added to `master` so far.

   Any keywords arguments now get passed to `HLSStream` and `MuxedHLSStream` using the already existing variable keyword arguments (`**kwargs`) which then get filtered when making HTTP session calls.

   This also cleans up the API documentation a bit by having consistent names.

2. A "light" breaking change:

   The `session_` argument was named that way during the Livestreamer project because `session` was supposed to be included in the variable keyword arguments (`**kwargs`) because of (an old version of) `requests` (see 0308347 and 39008e9).

   Positional-only / keyword-only arguments have only become available with the drop of py37, so technically, all these classes/methods could've been called/initialized using the `session_` keyword instead of just setting a positional argument, but that's very unlikely for 3rd party implementors to do that. I've decided against defining the arguments as positional-only / keyword-only now, because it's not really important.

   I'm going to add the name change to the list of breaking changes, even though it's a really minor change and basically just a fix for something annoying that should've been changed a long time ago.
   #5401 