### PR TITLE
webbrowser: minor docs improvements

### DIFF
--- a/src/streamlink/webbrowser/cdp/connection.py
+++ b/src/streamlink/webbrowser/cdp/connection.py
@@ -139,6 +139,8 @@ class CDPBase:
     It provides methods for sending CDP commands and receiving their responses, as well as for listening to CDP events.
 
     Both CDP commands and events can be sent and received in a global context and in a session context.
+
+    The Chrome Devtools Protocol is documented at https://chromedevtools.github.io/devtools-protocol/
     """
 
     def __init__(

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1265,7 +1265,8 @@ def build_parser():
         The web browser is run isolated and in a clean environment without access to regular user data.
 
         Streamlink currently only supports Chromium-based web browsers using the Chrome Devtools Protocol (CDP).
-        This includes Chromium itself, Google Chrome, Brave, Vivaldi, and others.
+        This includes Chromium itself, Google Chrome, Microsoft Edge, Brave, Vivaldi, and others, but full support for
+        third party Chromium forks is not guaranteed. If you encounter any issues, please try Chromium or Google Chrome instead.
 
         Default is true.
         """,


### PR DESCRIPTION
- Update help text of `--webbrowser` CLI argument
- Add CDP docs link to `CDPBase` class docstring
