### PR TITLE
plugins.mitele: fix missing CDN token

### DIFF
--- a/src/streamlink/plugins/mitele.py
+++ b/src/streamlink/plugins/mitele.py
@@ -109,6 +109,8 @@ class Mitele(Plugin):
                 log.warning("Stream may be protected by DRM")
                 continue
             cdn_token = tokens.get(stream["lid"], {}).get("cdn", "")
+            if not cdn_token:
+                continue
             qsd = parse_qsd(cdn_token)
             urls.add(update_qsd(stream["stream"], qsd, quote_via=lambda string, *_, **__: string))
 


### PR DESCRIPTION
Fixes #5435 

One of the items of the CDN-token API response was empty which led to the 403 HTTP response (since the plugin yields all possible streams). This simply skips items with empty CDN-tokens.

@ROBGagn please check and verify
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

```
$ streamlink -l debug --http-proxy=... https://www.mitele.es/directo/boing
[cli][debug] OS:         Linux-6.3.12-1-git-x86_64-with-glibc2.37
[cli][debug] Python:     3.11.3
[cli][debug] Streamlink: 5.5.1+106.g31d038d2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2023.5.7
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.3
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.18.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.22.1
[cli][debug]  trio-websocket: 0.10.3
[cli][debug]  typing-extensions: 4.7.1
[cli][debug]  urllib3: 2.0.3
[cli][debug]  websocket-client: 1.6.1
[cli][debug] Arguments:
[cli][debug]  url=https://www.mitele.es/directo/boing
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --http-proxy=...
[cli][info] Found matching plugin mitele for URL https://www.mitele.es/directo/boing
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
[utils.l10n][debug] Language code: en_US
Available streams: none_150k, 360p_620k_alt2 (worst), 360p_620k_alt, 360p_620k, 360p_1100k_alt2, 360p_1100k_alt, 360p_1100k, 576p_1900k_alt2, 576p_1900k_alt, 576p_1900k, 720p_3400k_alt2, 720p_3400k_alt, 720p_3400k, 720p_4800k_alt2, 720p_4800k_alt, 720p_4800k (best)
```