### PR TITLE
docs: add docs page for Options class

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,7 @@ This is an incomplete reference of the relevant Streamlink APIs.
 .. toctree::
 
     api/streamlink
+    api/options
     api/session
     api/plugin
     api/stream

--- a/docs/api/options.rst
+++ b/docs/api/options.rst
@@ -1,0 +1,11 @@
+Options
+-------
+
+.. module:: streamlink.options
+
+.. autoclass:: Options
+    :private-members:
+
+.. autoclass:: Argument
+
+.. autoclass:: Arguments

--- a/docs/api/plugin.rst
+++ b/docs/api/plugin.rst
@@ -13,12 +13,3 @@ Plugin decorators
 .. autodecorator:: pluginmatcher
 
 .. autodecorator:: pluginargument
-
-Plugin arguments
-^^^^^^^^^^^^^^^^
-
-.. module:: streamlink.options
-
-.. autoclass:: Argument
-
-.. autoclass:: Arguments

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -10,7 +10,10 @@ class Options:
     """
 
     _MAP_GETTERS: ClassVar[Mapping[str, Callable[[Any, str], Any]]] = {}
+    """Optional getter mapping for :class:`Options` subclasses"""
+
     _MAP_SETTERS: ClassVar[Mapping[str, Callable[[Any, str, Any], None]]] = {}
+    """Optional setter mapping for :class:`Options` subclasses"""
 
     def __init__(self, defaults: Optional[Mapping[str, Any]] = None):
         if not defaults:
@@ -29,10 +32,14 @@ class Options:
         return {normalize_key(key): value for key, value in src.items()}
 
     def clear(self) -> None:
+        """Restore default options"""
+
         self.options.clear()
         self.options.update(self.defaults.copy())
 
     def get(self, key: str) -> Any:
+        """Get the stored value of a specific key"""
+
         normalized = self._normalize_key(key)
         method = self._MAP_GETTERS.get(normalized)
         if method is not None:
@@ -41,10 +48,14 @@ class Options:
             return self.options.get(normalized)
 
     def get_explicit(self, key: str) -> Any:
+        """Get the stored value of a specific key and ignore any get-mappings"""
+
         normalized = self._normalize_key(key)
         return self.options.get(normalized)
 
     def set(self, key: str, value: Any) -> None:
+        """Set the value for a specific key"""
+
         normalized = self._normalize_key(key)
         method = self._MAP_SETTERS.get(normalized)
         if method is not None:
@@ -53,10 +64,14 @@ class Options:
             self.options[normalized] = value
 
     def set_explicit(self, key: str, value: Any) -> None:
+        """Set the value for a specific key and ignore any set-mappings"""
+
         normalized = self._normalize_key(key)
         self.options[normalized] = value
 
     def update(self, options: Mapping[str, Any]) -> None:
+        """Merge options"""
+
         for key, value in options.items():
             self.set(key, value)
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -248,6 +248,9 @@ class Plugin:
     match: Optional[Match] = None
     """A reference to the :class:`re.Match` result of the first matching matcher"""
 
+    options: Options
+    """Plugin options, initialized with the user-set values of the plugin's arguments"""
+
     # plugin metadata attributes
     id: Optional[str] = None
     """Metadata 'id' attribute: unique stream ID, etc."""

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -208,6 +208,12 @@ class Streamlink:
     Used for any kind of HTTP request made by plugin and stream implementations.
     """
 
+    options: Options
+    """
+    Session options, which is a subclass of :class:`Options <streamlink.options.Options>`
+    with additional getter/setter mappings for special options.
+    """
+
     def __init__(
         self,
         options: Optional[Dict[str, Any]] = None,


### PR DESCRIPTION
- Add `api/options` page and document `Options` class
- Move `Argument` and `Arguments` from plugin page to options page
- Add docstrings for `Streamlink.options` and `Plugin.options`

----

https://github.com/streamlink/streamlink/pull/5033#issuecomment-1640105400