### PR TITLE
docs: bump and reorder docs-requirements

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,7 +1,13 @@
-sphinx >=5.0.0, <7
-furo ==2023.03.27
-myst-parser >=1.0.0, <2
-sphinx-design >=0.4.1, <1
-versioningit >=2.0.0, <3
+# setup
+versioningit >=2.0.0,<3  # required for reading the version string when building from git
 
+# build
+sphinx >=5.0.0,<8
+
+# themes and extensions
+furo ==2023.03.27
+myst-parser >=1.0.0,<3
+sphinx-design ==0.5.0
+
+# typing
 docutils-stubs


### PR DESCRIPTION
- Bump max version of sphinx from <7 to <8
- Bump max version of myst-parser to <3
- Pinpoint sphinx-design to 0.5.0
- Properly group dependencies by type

----

This doesn't bump the version of furo (didn't check for new versions yet), so it's still building with sphinx 6 and not with sphinx 7. The other bumped dependencies only bump their respective dependencies, including support for sphinx 7, with additional minor fixes. myst-parser bumped its major version because it has dropped support for py37 which we already did.

I decided to pinpoint the version of sphinx-design, because similar to the furo theme, it's responsible for the rendered HTML output, and we want that to be stable.

I will have a look at newer furo versions separately.

----

- https://github.com/executablebooks/MyST-Parser/releases/tag/v2.0.0
- https://github.com/executablebooks/sphinx-design/releases/tag/v0.5.0
- https://www.sphinx-doc.org/en/master/changes.html#release-7-0-0-released-apr-29-2023

----

https://github.com/pradyunsg/furo/blob/2023.03.27/pyproject.toml#L20