### PR TITLE
docs: bump furo theme to 2023.07.26

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,10 +2,10 @@
 versioningit >=2.0.0,<3  # required for reading the version string when building from git
 
 # build
-sphinx >=5.0.0,<8
+sphinx >=6.0.0,<8
 
 # themes and extensions
-furo ==2023.03.27
+furo ==2023.07.26
 myst-parser >=1.0.0,<3
 sphinx-design ==0.5.0
 


### PR DESCRIPTION
- Bump furo sphinx theme to latest version
- Require sphinx >=6.0.0

----

- https://github.com/pradyunsg/furo/blob/main/docs/changelog.md
- https://www.sphinx-doc.org/en/master/changes.html