### PR TITLE
plugins.huya: force https stream URLs

### DIFF
--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -13,6 +13,7 @@ from typing import Dict
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.http import HTTPStream
+from streamlink.utils.url import update_scheme
 
 
 log = logging.getLogger(__name__)
@@ -96,7 +97,7 @@ class Huya(Plugin):
         for cdntype, priority, streamname, flvurl, suffix, anticode in streamdata:
             name = f"source_{cdntype.lower()}"
             self.QUALITY_WEIGHTS[name] = priority
-            yield name, HTTPStream(self.session, f"{flvurl}/{streamname}.{suffix}?{anticode}")
+            yield name, HTTPStream(self.session, update_scheme("https://", f"{flvurl}/{streamname}.{suffix}?{anticode}"))
 
         log.debug(f"QUALITY_WEIGHTS: {self.QUALITY_WEIGHTS!r}")
 


### PR DESCRIPTION
ref #5466 

Doesn't hurt and don't see any issues. No idea why their API returns non-TLS URLs, but since it's a progressive HTTP stream, I'm not even wondering...

```
$ streamlink -l debug https://www.huya.com/476318 best
[cli][debug] OS:         Linux-6.4.6-1-git-x86_64-with-glibc2.37
[cli][debug] Python:     3.11.3
[cli][debug] Streamlink: 6.0.0+4.gca4ca90c
[cli][debug] Dependencies:
[cli][debug]  certifi: 2023.7.22
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.3
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.18.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.22.2
[cli][debug]  trio-websocket: 0.10.3
[cli][debug]  typing-extensions: 4.7.1
[cli][debug]  urllib3: 2.0.4
[cli][debug]  websocket-client: 1.6.1
[cli][debug] Arguments:
[cli][debug]  url=https://www.huya.com/476318
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin huya for URL https://www.huya.com/476318
[plugins.huya][debug] QUALITY_WEIGHTS: {'source_al': 30, 'source_tx': 20, 'source_hw': 20, 'source_hs': 30}
[cli][info] Available streams: source_tx (worst), source_hw, source_al, source_hs (best)
[cli][info] Opening stream: source_hs (http)
[cli][info] Starting player: mpv
[cli][debug] Pre-buffering 8192 bytes
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://www.huya.com/476318', '-']
[cli][debug] Writing stream to output
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```