### PR TITLE
session: add options argument to streams()

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -603,18 +603,19 @@ class Streamlink:
 
         return self.resolve_url(url, follow_redirect=False)
 
-    def streams(self, url: str, **params):
+    def streams(self, url: str, options: Optional[Options] = None, **params):
         """
         Attempts to find a plugin and extracts streams from the *url* if a plugin was found.
 
         :param url: a URL to match against loaded plugins
+        :param options: Optional options instance passed to the resolved plugin
         :param params: Additional keyword arguments passed to :meth:`Plugin.streams() <streamlink.plugin.Plugin.streams>`
         :raises NoPluginError: on plugin resolve failure
         :return: A :class:`dict` of stream names and :class:`Stream <streamlink.stream.Stream>` instances
         """
 
         pluginname, pluginclass, resolved_url = self.resolve_url(url)
-        plugin = pluginclass(self, resolved_url)
+        plugin = pluginclass(self, resolved_url, options)
 
         return plugin.streams(**params)
 

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -2,7 +2,6 @@ import re
 from io import BytesIO
 
 from streamlink import NoStreamsError
-from streamlink.options import Options
 from streamlink.plugin import pluginargument, pluginmatcher
 from streamlink.plugins import Plugin
 from streamlink.stream.hls import HLSStream
@@ -30,10 +29,6 @@ class TestStream(Stream):
     metavar="PASSWORD",
 )
 class TestPlugin(Plugin):
-    options = Options({
-        "a_option": "default",
-    })
-
     id = "test-id-1234-5678"
     author = "Tѥst Āuƭhǿr"
     category = None
@@ -52,6 +47,9 @@ class TestPlugin(Plugin):
 
         if "NoStreamsError" in self.url:
             raise NoStreamsError
+
+        if "fromoptions" in self.url:
+            return {"fromoptions": HTTPStream(self.session, self.options.get("streamurl"))}
 
         streams = {}
         streams["test"] = TestStream(self.session)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ from requests.adapters import HTTPAdapter
 
 import tests.plugin
 from streamlink.exceptions import NoPluginError, StreamlinkDeprecationWarning
+from streamlink.options import Options
 from streamlink.plugin import HIGH_PRIORITY, LOW_PRIORITY, NO_PRIORITY, NORMAL_PRIORITY, Plugin, pluginmatcher
 from streamlink.plugin.api.http_session import TLSNoDHAdapter
 from streamlink.session import Streamlink
@@ -253,6 +254,13 @@ class TestStreams:
         assert streams["worst"] is streams["350k"]
         assert isinstance(streams["http"], HTTPStream)
         assert isinstance(streams["hls"], HLSStream)
+
+    def test_streams_options(self, session: Streamlink):
+        streams = session.streams("http://test.se/fromoptions", Options({"streamurl": "http://foo/"}))
+
+        assert sorted(streams.keys()) == ["best", "fromoptions", "worst"]
+        assert isinstance(streams["fromoptions"], HTTPStream)
+        assert streams["fromoptions"].url == "http://foo/"
 
     def test_stream_types(self, session: Streamlink):
         streams = session.streams("http://test.se/channel", stream_types=["http", "hls"])


### PR DESCRIPTION
Ref https://github.com/streamlink/streamlink/issues/5468#issuecomment-1657212207

This also removes the unnecessary `TestPlugin.options` override which was missed in #5033 