### PR TITLE
stream.hls: add --hls-segment-queue-threshold 

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -241,6 +241,7 @@ class Streamlink:
             "hls-duration": None,
             "hls-playlist-reload-attempts": 3,
             "hls-playlist-reload-time": "default",
+            "hls-segment-queue-threshold": 2,
             "hls-segment-stream-data": False,
             "hls-segment-ignore-names": [],
             "hls-segment-key-uri": None,
@@ -405,6 +406,10 @@ class Streamlink:
                 - ``segment``: duration of the last segment
                 - ``live-edge``: sum of segment durations of the ``hls-live-edge`` value minus one
                 - ``default``: the playlist's target duration
+            * - hls-segment-queue-threshold
+              - ``float``
+              - ``2``
+              - Factor of the playlist's targetduration which sets the threshold for stopping early on missing segments
             * - hls-segment-stream-data
               - ``bool``
               - ``False``

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -241,7 +241,7 @@ class Streamlink:
             "hls-duration": None,
             "hls-playlist-reload-attempts": 3,
             "hls-playlist-reload-time": "default",
-            "hls-segment-queue-threshold": 2,
+            "hls-segment-queue-threshold": 3,
             "hls-segment-stream-data": False,
             "hls-segment-ignore-names": [],
             "hls-segment-key-uri": None,
@@ -408,7 +408,7 @@ class Streamlink:
                 - ``default``: the playlist's target duration
             * - hls-segment-queue-threshold
               - ``float``
-              - ``2``
+              - ``3``
               - Factor of the playlist's targetduration which sets the threshold for stopping early on missing segments
             * - hls-segment-stream-data
               - ``bool``

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -151,7 +151,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
 
         return request_params
 
-    def put(self, sequence: Sequence):
+    def put(self, sequence: Optional[Sequence]):
         if self.closed:
             return
 
@@ -289,8 +289,6 @@ class HLSStreamWorker(SegmentedStreamWorker):
     writer: "HLSStreamWriter"
     stream: "HLSStream"
 
-    SEGMENT_QUEUE_TIMING_THRESHOLD_FACTOR = 2
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -304,6 +302,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
         self.playlist_reload_time: float = 6
         self.playlist_reload_time_override = self.session.options.get("hls-playlist-reload-time")
         self.playlist_reload_retries = self.session.options.get("hls-playlist-reload-attempts")
+        self.segment_queue_timing_threshold_factor = self.session.options.get("hls-segment-queue-threshold")
         self.live_edge = self.session.options.get("hls-live-edge")
         self.duration_offset_start = int(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0))
         self.duration_limit = self.stream.duration or (
@@ -401,7 +400,10 @@ class HLSStreamWorker(SegmentedStreamWorker):
         return sequence.num >= self.playlist_sequence
 
     def _segment_queue_timing_threshold_reached(self) -> bool:
-        threshold = self.playlist_targetduration * self.SEGMENT_QUEUE_TIMING_THRESHOLD_FACTOR
+        if self.segment_queue_timing_threshold_factor <= 0:
+            return False
+
+        threshold = self.playlist_targetduration * self.segment_queue_timing_threshold_factor
         if now() <= self.playlist_sequences_last + timedelta(seconds=threshold):
             return False
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -289,6 +289,8 @@ class HLSStreamWorker(SegmentedStreamWorker):
     writer: "HLSStreamWriter"
     stream: "HLSStream"
 
+    SEGMENT_QUEUE_TIMING_THRESHOLD_MIN = 5.0
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -403,7 +405,10 @@ class HLSStreamWorker(SegmentedStreamWorker):
         if self.segment_queue_timing_threshold_factor <= 0:
             return False
 
-        threshold = self.playlist_targetduration * self.segment_queue_timing_threshold_factor
+        threshold = max(
+            self.SEGMENT_QUEUE_TIMING_THRESHOLD_MIN,
+            self.playlist_targetduration * self.segment_queue_timing_threshold_factor,
+        )
         if now() <= self.playlist_sequences_last + timedelta(seconds=threshold):
             return False
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -954,6 +954,24 @@ def build_parser():
         """,
     )
     transport_hls.add_argument(
+        "--hls-segment-queue-threshold",
+        metavar="FACTOR",
+        type=num(float, ge=0),
+        help="""
+        The multiplication factor of the HLS playlist's target duration after which the stream will be stopped early
+        if no new segments were queued after refreshing the playlist (multiple times). The target duration defines the
+        maximum duration a single segment can have, meaning new segments must be available during this time frame,
+        otherwise playback issues can occur.
+
+        The intention of this queue threshold is to be able to stop early when the end of a stream doesn't get
+        announced by the server, so Streamlink doesn't have to wait until a read-timeout occurs. See --stream-timeout.
+
+        Set to ``0`` to disable.
+
+        Default is 2.
+        """,
+    )
+    transport_hls.add_argument(
         "--hls-segment-ignore-names",
         metavar="NAMES",
         type=comma_list,
@@ -1376,6 +1394,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("hls_duration", "hls-duration", None),
     ("hls_playlist_reload_attempts", "hls-playlist-reload-attempts", None),
     ("hls_playlist_reload_time", "hls-playlist-reload-time", None),
+    ("hls_segment_queue_threshold", "hls-segment-queue-threshold", None),
     ("hls_segment_stream_data", "hls-segment-stream-data", None),
     ("hls_segment_ignore_names", "hls-segment-ignore-names", None),
     ("hls_segment_key_uri", "hls-segment-key-uri", None),

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -968,7 +968,7 @@ def build_parser():
 
         Set to ``0`` to disable.
 
-        Default is 2.
+        Default is 3.
         """,
     )
     transport_hls.add_argument(


### PR DESCRIPTION
Resolves #5476 

Descriptions in the commit messages.

Second commit increases the value from 2 to 3, which is a bit more lenient, so unstable live streams don't cause unnecessary interruptions. This comes at the cost of stable live streams without an endlist tag being stopped a bit later.

Not sure if the name of the CLI-argument and session-option makes sense and if there's a better one that's easier to understand.

----

As a reminder:
https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.1

> The EXT-X-TARGETDURATION tag specifies the **maximum Media Segment duration**. The EXTINF duration of each Media Segment in the Playlist file, when rounded to the nearest integer, **MUST be less than or equal to the target duration**; longer segments can trigger playback stalls or other errors.  It applies to the entire Playlist file.