### PR TITLE
utils.processoutput: reorder asyncio tasks

### DIFF
--- a/src/streamlink/utils/processoutput.py
+++ b/src/streamlink/utils/processoutput.py
@@ -48,9 +48,9 @@ class ProcessOutput:
 
         tasks = (
             loop.create_task(ontimeout()),
-            loop.create_task(onexit()),
             loop.create_task(onoutput(self.onstdout, process.stdout)),
             loop.create_task(onoutput(self.onstderr, process.stderr)),
+            loop.create_task(onexit()),
         )
 
         try:

--- a/tests/utils/test_processoutput.py
+++ b/tests/utils/test_processoutput.py
@@ -217,3 +217,23 @@ async def test_onoutput_exception(event_loop: asyncio.BaseEventLoop, processoutp
     assert processoutput.onstdout.call_args_list == [call(0, "foo")]
     assert processoutput.onstderr.call_args_list == []
     assert mock_process.kill.called
+
+
+@pytest.mark.asyncio()
+async def test_exit_before_onoutput(event_loop: asyncio.BaseEventLoop, processoutput: FakeProcessOutput, mock_process: Mock):
+    # resolve process.wait() in the onexit task immediately
+    mock_process.wait = AsyncMock(return_value=0)
+
+    # add some data to stdout, but don't actually interpret it in onstdout
+    mock_process.stdout.append(b"foo")
+    processoutput.onstdout.return_value = True
+
+    # the result of the `done` future should have already been set by the onoutput task
+    processoutput.onexit.return_value = False
+
+    result = await processoutput._run()
+
+    assert result is True
+    assert processoutput.onexit.called
+    assert processoutput.onstdout.called
+    assert mock_process.kill.called


### PR DESCRIPTION
Try to drain the stdout/stderr streams first before handling the onexit task, so the overall result can be processed correctly

----

Fixes #5461 

The issue is caused by `process.wait()` resolving first in the `onexit` task, so the result of the `done` future gets set without the async interator(s) of the stdout/stderr stream(s) being drained in the `onoutput` task(s) first.

In my eyes, this looks like an issue in asyncio's subprocess implementation... No idea if this actually fixes #5461, but reordering the tasks at least made the added test pass while not reordering them made it fail.