### PR TITLE
chore: update GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_plugin_issue.yml
+++ b/.github/ISSUE_TEMPLATE/1_plugin_issue.yml
@@ -7,21 +7,25 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Thanks for reporting a plugin issue!
+        # Thanks for reporting a plugin issue!
+
+        ## What is a plugin issue?
 
         Plugin issues describe broken functionality within a plugin's code base, e.g. the streaming site has made breaking changes, streams don't get resolved correctly, or authentication has stopped working, etc.
+        [See the list of the available plugins here.](https://streamlink.github.io/plugins.html)
 
-        ----
+        ## DON'T IGNORE this template
 
-        **DON'T IGNORE this template and fill in all the required details.**
-        **Issues that don't adhere to our request will be closed and ignored.**
+        **Please fill in all the required details and don't skip any parts.**
+        **Issues that don't adhere to our request will be closed and ignored immediately.**
+
         This is because analyzing bugs, issues or requests without proper details and log output is harder than necessary.
         Low quality and low effort issues are noise and steal the time of the maintainers and contributors.
   - type: checkboxes
     attributes:
       label: Checklist
       options:
-        - label: This is a plugin issue and not a different kind of issue
+        - label: This is a [plugin issue](https://streamlink.github.io/plugins.html) and not [a different kind of issue](https://github.com/streamlink/streamlink/issues/new/choose)
           required: true
         - label: "[I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)"
           required: true
@@ -29,15 +33,15 @@ body:
           required: true
         - label: "[I have checked the commit log of the master branch](https://github.com/streamlink/streamlink/commits/master)"
           required: true
-  - type: dropdown
+  - type: input
     attributes:
       label: Streamlink version
       description: |
         [Only the **latest stable release** or **latest build from the master branch** will be accepted.](https://streamlink.github.io/install.html)
+        Run [`streamlink --version`](https://streamlink.github.io/cli.html#cmdoption-version) and check the [list of recent releases.](https://streamlink.github.io/changelog.html)
+        Issues without a valid version string will be closed and ignored immediately.
+
         The mandatory debug log down below still needs to include the explicit version string.
-      options:
-        - Latest stable release
-        - Latest build from the master branch
     validations:
       required: true
   - type: textarea
@@ -46,6 +50,8 @@ body:
       description: |
         Explain the plugin issue as thoroughly as you can.
         Please also provide the exact steps for reproducing the issue, e.g. a list of input URLs.
+
+        Remember that it is impossible for the developers and maintainers of this project to be aware of specific details of every site/plugin.
     validations:
       required: true
   - type: textarea
@@ -53,12 +59,14 @@ body:
       label: Debug log
       description: |
         **DEBUG LOG OUTPUT IS REQUIRED for plugin issues!**
-        INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
+
+        INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove sensitive data like usernames, passwords, cookies, etc!**
+        Issues that don't include a **full debug log** will be closed and ignored immediately.
 
         Use the [`--loglevel=debug`](https://streamlink.github.io/latest/cli.html#cmdoption-loglevel) parameter and avoid using parameters which suppress log output.
-        Debug log includes important details about your platform and the version you're using. Don't remove it.
+        Debug log includes important details about the used Python environment. **Don't remove it.**
 
-        If the log output is too long and repetitive parts can't be truncated, or if you have multiple log outputs to share, please post a link to a [GitHub gist](https://gist.github.com/) with the log output instead.
+        If the log output is too long and repetitive parts can't be truncated, or if you have multiple log outputs to share, then please post a link to a [GitHub gist](https://gist.github.com/) with the log output instead.
 
         **DO NOT post screenshots of the log output and instead copy the text from your terminal application.**
       placeholder: |

--- a/.github/ISSUE_TEMPLATE/2_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_bug_report.yml
@@ -7,23 +7,28 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Thanks for reporting a bug!
+        # Thanks for reporting a bug!
+
+        ## What is a bug report?
 
         Bugs are the result of broken functionality within Streamlink's main code base.
+        This can be a bug in the command-line interface, the various streaming protocol implementations, or the core Streamlink APIs, etc.
 
         **Use the [plugin issue template](https://github.com/streamlink/streamlink/issues/new/choose) if your report is about a broken plugin.**
+        [See the list of the available plugins here.](https://streamlink.github.io/plugins.html)
 
-        ----
+        ## DON'T IGNORE this template
 
-        **DON'T IGNORE this template and fill in all the required details.**
-        **Issues that don't adhere to our request will be closed and ignored.**
+        **Please fill in all the required details and don't skip any parts.**
+        **Issues that don't adhere to our request will be closed and ignored immediately.**
+
         This is because analyzing bugs, issues or requests without proper details and log output is harder than necessary.
         Low quality and low effort issues are noise and steal the time of the maintainers and contributors.
   - type: checkboxes
     attributes:
       label: Checklist
       options:
-        - label: This is a bug report and not a different kind of issue
+        - label: This is a bug report and not [a different kind of issue](https://github.com/streamlink/streamlink/issues/new/choose)
           required: true
         - label: "[I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)"
           required: true
@@ -31,15 +36,15 @@ body:
           required: true
         - label: "[I have checked the commit log of the master branch](https://github.com/streamlink/streamlink/commits/master)"
           required: true
-  - type: dropdown
+  - type: input
     attributes:
       label: Streamlink version
       description: |
         [Only the **latest stable release** or **latest build from the master branch** will be accepted.](https://streamlink.github.io/install.html)
+        Run [`streamlink --version`](https://streamlink.github.io/cli.html#cmdoption-version) and check the [list of recent releases.](https://streamlink.github.io/changelog.html)
+        Issues without a valid version string will be closed and ignored immediately.
+
         The mandatory debug log down below still needs to include the explicit version string.
-      options:
-        - Latest stable release
-        - Latest build from the master branch
     validations:
       required: true
   - type: textarea
@@ -57,12 +62,14 @@ body:
       label: Debug log
       description: |
         **DEBUG LOG OUTPUT IS REQUIRED for bug reports!**
-        INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove usernames and passwords**
+
+        INCLUDE THE ENTIRE COMMAND LINE and make sure to **remove sensitive data like usernames, passwords, cookies, etc!**
+        Issues that don't include a **full debug log** will be closed and ignored immediately.
 
         Use the [`--loglevel=debug`](https://streamlink.github.io/latest/cli.html#cmdoption-loglevel) parameter and avoid using parameters which suppress log output.
-        Debug log includes important details about your platform and the version you're using. Don't remove it.
+        Debug log includes important details about the used Python environment. **Don't remove it.**
 
-        If the log output is too long and repetitive parts can't be truncated, or if you have multiple log outputs to share, please post a link to a [GitHub gist](https://gist.github.com/) with the log output instead.
+        If the log output is too long and repetitive parts can't be truncated, or if you have multiple log outputs to share, then please post a link to a [GitHub gist](https://gist.github.com/) with the log output instead.
 
         **DO NOT post screenshots of the log output and instead copy the text from your terminal application.**
       placeholder: |

--- a/.github/ISSUE_TEMPLATE/3_plugin_request.yml
+++ b/.github/ISSUE_TEMPLATE/3_plugin_request.yml
@@ -7,21 +7,27 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Thanks for requesting a plugin!
+        # Thanks for filing a plugin request!
 
-        [READ THE PLUGIN REQUEST REQUIREMENTS IN THE CONTRIBUTION GUIDELINES BEFORE POSTING!](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#plugin-requests)
+        ## What is a plugin request?
 
-        ----
+        The purpose of Streamlink's plugins is to translate input URLs from certain websites to specific stream URLs with optionally required parameters, access tokens, etc.
+        [READ THE PLUGIN REQUEST REQUIREMENTS IN THE CONTRIBUTION GUIDELINES BEFORE REQUESTING A PLUGIN!](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#plugin-requests)
 
-        **DON'T IGNORE this template and fill in all the required details.**
-        **Issues that don't adhere to our request will be closed and ignored.**
+        [See the list of already available plugins here.](https://streamlink.github.io/plugins.html)
+
+        ## DON'T IGNORE this template
+
+        **Please fill in all the required details and don't skip any parts.**
+        **Issues that don't adhere to our request will be closed and ignored immediately.**
+
         This is because analyzing bugs, issues or requests without proper details and log output is harder than necessary.
         Low quality and low effort issues are noise and steal the time of the maintainers and contributors.
   - type: checkboxes
     attributes:
       label: Checklist
       options:
-        - label: This is a plugin request and not a different kind of issue
+        - label: This is a plugin request and not [a different kind of issue](https://github.com/streamlink/streamlink/issues/new/choose)
           required: true
         - label: "[I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)"
           required: true
@@ -31,12 +37,14 @@ body:
     attributes:
       label: Description
       description: |
-        Explain the plugin and site as clearly as you can according to the plugin request guidelines. For example:
+        Explain the plugin and site as clearly as you can [according to the plugin request guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#plugin-requests).
+
+        For example (please provide more details if possible):
 
         - What is the site about?
-        - Who is it run by?
+        - Who is it owned and run by?
         - What kind of content does it provide?
-        - Are there any access restrictions like logins or region checks?
+        - Are there any access restrictions, like logins or region checks?
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/4_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/4_feature_request.yml
@@ -7,31 +7,39 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Thanks for filing a feature request!
+        # Thanks for filing a feature request!
 
-        Use the [plugin request template](https://github.com/streamlink/streamlink/issues/new/choose) if you're requesting a new plugin instead of a new feature.
+        ## What is a feature request?
 
-        ----
+        Feature requests are meant for improvements of the core functionality of Streamlink.
 
-        **DON'T IGNORE this template and fill in all the required details.**
-        **Issues that don't adhere to our request will be closed and ignored.**
+        THEY ARE NOT MEANT FOR PLUGIN REQUESTS!
+        Use the [plugin request template](https://github.com/streamlink/streamlink/issues/new/choose) if you're requesting a new [plugin](https://streamlink.github.io/plugins.html) instead of a new feature.
+
+        ## DON'T IGNORE this template
+
+        **Please fill in all the required details and don't skip any parts.**
+        **Issues that don't adhere to our request will be closed and ignored immediately.**
+
         This is because analyzing bugs, issues or requests without proper details and log output is harder than necessary.
         Low quality and low effort issues are noise and steal the time of the maintainers and contributors.
   - type: checkboxes
     attributes:
       label: Checklist
       options:
-        - label: This is a feature request and not a different kind of issue
+        - label: This is a feature request and not [a different kind of issue](https://github.com/streamlink/streamlink/issues/new/choose)
           required: true
         - label: "[I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)"
           required: true
-        - label: "[I have checked the list of open and recently closed plugin requests](https://github.com/streamlink/streamlink/issues?q=is%3Aissue+label%3A%22feature+request%22)"
+        - label: "[I have checked the list of open and recently closed feature requests](https://github.com/streamlink/streamlink/issues?q=is%3Aissue+label%3A%22feature+request%22)"
           required: true
   - type: textarea
     attributes:
       label: Description
       description: |
-        Explain the feature as clearly as you can. For example:
+        Explain the feature as clearly as you can.
+
+        For example (please provide more details if possible):
 
         - What is it?
         - How would you expect it to work?


### PR DESCRIPTION
1. This makes the header text more clear
2. A specific version string is now required for plugin issues and bug reports instead of the dropdown, so people are asked to actually check their used version
3. Random cleanups and fixes

Checked my test repo for rendering issues. Everything looked fine...