### PR TITLE
docs: replace simple/grid-tables with list-tables

### DIFF
--- a/docs/cli/metadata.rst
+++ b/docs/cli/metadata.rst
@@ -20,25 +20,33 @@ or an empty string (:option:`--output`, :option:`--record`, :option:`--record-an
 
 The :option:`--json` argument always lists the standard plugin metadata: ``id``, ``author``, ``category`` and ``title``.
 
-.. rst-class:: table-custom-layout table-custom-layout-platform-locations
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout table-custom-layout-platform-locations
 
-============================== =================================================
-Variable                       Description
-============================== =================================================
-``id``                         The unique ID of the stream, eg. an internal numeric ID or randomized string.
-``plugin``                     The plugin name. See :ref:`Plugins <plugins:Plugins>` for the name of each built-in plugin.
-``title``                      The stream's title, usually a short descriptive text.
-``author``                     The stream's author, eg. a channel or broadcaster name.
-``category``                   The stream's category, eg. the name of a game being played, a music genre, etc.
-``game``                       Alias for ``category``.
-``url``                        The resolved URL of the stream.
-``time``                       The current timestamp. Can optionally be formatted via ``{time:format}``.
+    * - Variable
+      - Description
+    * - ``id``
+      - The unique ID of the stream, eg. an internal numeric ID or randomized string.
+    * - ``plugin``
+      - The plugin name. See :ref:`Plugins <plugins:Plugins>` for the name of each built-in plugin.
+    * - ``title``
+      - The stream's title, usually a short descriptive text.
+    * - ``author``
+      - The stream's author, eg. a channel or broadcaster name.
+    * - ``category``
+      - The stream's category, eg. the name of a game being played, a music genre, etc.
+    * - ``game``
+      - Alias for ``category``.
+    * - ``url``
+      - The resolved URL of the stream.
+    * - ``time``
+      - The current timestamp. Can optionally be formatted via ``{time:format}``.
 
-                               The format parameter string is passed to Python's `datetime.strftime()`_ method,
-                               so all the usual time directives are available.
+        The format parameter string is passed to Python's `datetime.strftime()`_ method,
+        so all the usual time directives are available.
 
-                               The default format is ``%Y-%m-%d_%H-%M-%S``.
-============================== =================================================
+        The default format is ``%Y-%m-%d_%H-%M-%S``.
 
 
 Examples

--- a/docs/cli/protocols.rst
+++ b/docs/cli/protocols.rst
@@ -29,15 +29,18 @@ The following example shows HLS streams (``.m3u8``) and DASH streams (``.mpd``):
 Supported streaming protocols
 -----------------------------
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-============================== =================================================
-Name                           Explicit prefix
-============================== =================================================
-Apple HTTP Live Streaming      ``hls://``
-MPEG-DASH                      ``dash://``
-Progressive HTTP/HTTPS         ``httpstream://``
-============================== =================================================
+    * - Name
+      - Explicit prefix
+    * - Apple HTTP Live Streaming
+      - ``hls://``
+    * - MPEG-DASH
+      - ``dash://``
+    * - Progressive HTTP/HTTPS
+      - ``httpstream://``
 
 .. note::
 
@@ -75,17 +78,20 @@ Available parameters
 
 Parameters are passed to the following methods of their respective stream implementations:
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-==================== =======================
-Protocol prefix      Method references
-==================== =======================
-``httpstream://``    - :py:meth:`streamlink.stream.HTTPStream`
-                     - :py:meth:`requests.Session.request`
-``hls://``           - :py:meth:`streamlink.stream.HLSStream.parse_variant_playlist`
-                     - :py:meth:`streamlink.stream.HLSStream`
-                     - :py:meth:`streamlink.stream.MuxedHLSStream`
-                     - :py:meth:`requests.Session.request`
-``dash://``          - :py:meth:`streamlink.stream.DASHStream.parse_manifest`
-                     - :py:meth:`requests.Session.request`
-==================== =======================
+    * - Protocol prefix
+      - Method references
+    * - ``httpstream://``
+      - - :py:meth:`streamlink.stream.HTTPStream`
+        - :py:meth:`requests.Session.request`
+    * - ``hls://``
+      - - :py:meth:`streamlink.stream.HLSStream.parse_variant_playlist`
+        - :py:meth:`streamlink.stream.HLSStream`
+        - :py:meth:`streamlink.stream.MuxedHLSStream`
+        - :py:meth:`requests.Session.request`
+    * - ``dash://``
+      - - :py:meth:`streamlink.stream.DASHStream.parse_manifest`
+        - :py:meth:`requests.Session.request`

--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -209,28 +209,34 @@ To resolve this, move the config file(s) to the correct location or copy the con
 
 **Deprecated paths**
 
-.. rst-class:: table-custom-layout table-custom-layout-platform-locations
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout table-custom-layout-platform-locations
 
-========= ========
-Platform  Location
-========= ========
-Linux/BSD - ``${HOME}/.streamlinkrc``
-macOS     - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/config``
-          - ``${HOME}/.streamlinkrc``
-Windows   - ``%APPDATA%\streamlink\streamlinkrc``
-========= ========
+    * - Platform
+      - Location
+    * - Linux/BSD
+      - - ``${HOME}/.streamlinkrc``
+    * - macOS
+      - - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/config``
+        - ``${HOME}/.streamlinkrc``
+    * - Windows
+      - - ``%APPDATA%\streamlink\streamlinkrc``
 
 **Migration**
 
-.. rst-class:: table-custom-layout table-custom-layout-platform-locations
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout table-custom-layout-platform-locations
 
-========= ========
-Platform  Location
-========= ========
-Linux/BSD ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/config``
-macOS     ``${HOME}/Library/Application Support/streamlink/config``
-Windows   ``%APPDATA%\streamlink\config``
-========= ========
+    * - Platform
+      - Location
+    * - Linux/BSD
+      - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/config``
+    * - macOS
+      - ``${HOME}/Library/Application Support/streamlink/config``
+    * - Windows
+      - ``%APPDATA%\streamlink\config``
 
 Custom plugins sideloading paths
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -240,22 +246,26 @@ Old and deprecated paths will be dropped in the future.
 
 **Deprecated paths**
 
-.. rst-class:: table-custom-layout table-custom-layout-platform-locations
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout table-custom-layout-platform-locations
 
-========= ========
-Platform  Location
-========= ========
-Linux/BSD ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/plugins``
-macOS     ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/plugins``
-========= ========
+    * - Platform
+      - Location
+    * - Linux/BSD
+      - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/plugins``
+    * - macOS
+      - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/plugins``
 
 **Migration**
 
-.. rst-class:: table-custom-layout table-custom-layout-platform-locations
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout table-custom-layout-platform-locations
 
-========= ========
-Platform  Location
-========= ========
-Linux/BSD ``${XDG_DATA_HOME:-${HOME}/.local/share}/streamlink/plugins``
-macOS     ``${HOME}/Library/Application Support/streamlink/plugins``
-========= ========
+    * - Platform
+      - Location
+    * - Linux/BSD
+      - ``${XDG_DATA_HOME:-${HOME}/.local/share}/streamlink/plugins``
+    * - macOS
+      - ``${HOME}/Library/Application Support/streamlink/plugins``

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -53,38 +53,39 @@ Installation
 Windows
 -------
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-==================================== ===========================================
-Method                               Installing
-==================================== ===========================================
-Installers                           See the `Windows binaries`_ section below
+    * - Method
+      - Installing
+    * - Installers
+      - See the `Windows binaries`_ section below
+    * - Portable
+      - See the `Windows binaries`_ section below
+    * - Nightly builds
+      - See the `Windows binaries`_ section below
+    * - Python pip
+      - See the `PyPI package and source code`_ section below
+    * - `Chocolatey`_
+      - .. code-block:: bat
 
-Portable                             See the `Windows binaries`_ section below
+            choco install streamlink
 
-Nightly builds                       See the `Windows binaries`_ section below
+        `Installing Chocolatey packages`_
+    * - `Scoop`_
+      - .. code-block::
 
-Python pip                           See the `PyPI package and source code`_ section below
+            scoop bucket add extras
+            scoop install streamlink
 
-`Chocolatey`_                        .. code-block:: bat
+        `Installing Scoop packages`_
+    * - `Windows Package Manager`_
+      - .. code-block:: bat
 
-                                        choco install streamlink
+            winget install streamlink
 
-                                     `Installing Chocolatey packages`_
-
-`Scoop`_                             .. code-block::
-
-                                        scoop bucket add extras
-                                        scoop install streamlink
-
-                                     `Installing Scoop packages`_
-
-`Windows Package Manager`_           .. code-block:: bat
-
-                                        winget install streamlink
-
-                                     `Installing Winget packages`_
-==================================== ===========================================
+        `Installing Winget packages`_
 
 .. _Chocolatey: https://chocolatey.org/packages/streamlink
 .. _Scoop: https://scoop.sh/#/apps?q=streamlink&s=0&d=1&o=true
@@ -99,19 +100,20 @@ Python pip                           See the `PyPI package and source code`_ sec
 macOS
 -----
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-==================================== ===========================================
-Method                               Installing
-==================================== ===========================================
-Python pip                           See the `PyPI package and source code`_ section below
+    * - Method
+      - Installing
+    * - Python pip
+      - See the `PyPI package and source code`_ section below
+    * - `Homebrew`_
+      - .. code-block:: bash
 
-`Homebrew`_                          .. code-block:: bash
+            brew install streamlink
 
-                                        brew install streamlink
-
-                                     `Installing Homebrew packages`_
-==================================== ===========================================
+        `Installing Homebrew packages`_
 
 .. _Homebrew: https://formulae.brew.sh/formula/streamlink
 .. _Installing Homebrew packages: https://brew.sh
@@ -122,75 +124,76 @@ Python pip                           See the `PyPI package and source code`_ sec
 Linux and BSD
 -------------
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-==================================== ===========================================
-Distribution                         Installing
-==================================== ===========================================
-AppImage                             See the `Linux AppImages`_ section below
+    * - Method / Distribution
+      - Installing
+    * - AppImage
+      - See the `Linux AppImages`_ section below
+    * - AppImage nightly builds
+      - See the `Linux AppImages`_ section below
+    * - Python pip
+      - See the `PyPI package and source code`_ section below
+    * - `Arch Linux`_
+      - .. code-block:: bash
 
-AppImage nightly builds              See the `Linux AppImages`_ section below
+            sudo pacman -S streamlink
+    * - `Arch Linux (aur, git)`_
+      - .. code-block:: bash
 
-Python pip                           See the `PyPI package and source code`_ section below
+            git clone https://aur.archlinux.org/streamlink-git.git
+            cd streamlink-git
+            makepkg -si
 
-`Arch Linux`_                        .. code-block:: bash
+        `Installing AUR packages`_
+    * - `Debian (sid, testing)`_
+      - .. code-block:: bash
 
-                                        sudo pacman -S streamlink
+            sudo apt update
+            sudo apt install streamlink
+    * - `Debian (stable)`_
+      - .. code-block:: bash
 
-`Arch Linux (aur, git)`_             .. code-block:: bash
+            # If you don't have Debian backports already (see link below):
+            echo "deb http://deb.debian.org/debian bullseye-backports main" | sudo tee "/etc/apt/sources.list.d/streamlink.list"
 
-                                        git clone https://aur.archlinux.org/streamlink-git.git
-                                        cd streamlink-git
-                                        makepkg -si
+            sudo apt update
+            sudo apt -t bullseye-backports install streamlink
 
-                                     `Installing AUR packages`_
+        `Installing Debian backported packages`_
+    * - `Fedora`_
+      - .. code-block:: bash
 
-`Debian (sid, testing)`_             .. code-block:: bash
+            sudo dnf install streamlink
+    * - `Gentoo Linux`_
+      - .. code-block:: bash
 
-                                        sudo apt update
-                                        sudo apt install streamlink
+            sudo emerge net-misc/streamlink
+    * - `NetBSD (pkgsrc)`_
+      - .. code-block:: bash
 
-`Debian (stable)`_                   .. code-block:: bash
+            cd /usr/pkgsrc/multimedia/streamlink
+            sudo make install clean
+    * - `NixOS`_
+      - .. code-block:: bash
 
-                                        # If you don't have Debian backports already (see link below):
-                                        echo "deb http://deb.debian.org/debian bullseye-backports main" | sudo tee "/etc/apt/sources.list.d/streamlink.list"
+            nix-env -iA nixos.streamlink
 
-                                        sudo apt update
-                                        sudo apt -t bullseye-backports install streamlink
+        `NixOS channel`_
+    * - `openSUSE`_
+      - .. code-block:: bash
 
-                                     `Installing Debian backported packages`_
+            sudo zypper install streamlink
+    * - `Solus`_
+      - .. code-block:: bash
 
-`Fedora`_                            .. code-block:: bash
+            sudo eopkg install streamlink
+    * - `Void`_
+      - .. code-block:: bash
 
-                                        sudo dnf install streamlink
-
-`Gentoo Linux`_                      .. code-block:: bash
-
-                                        sudo emerge net-misc/streamlink
-
-`NetBSD (pkgsrc)`_                   .. code-block:: bash
-
-                                        cd /usr/pkgsrc/multimedia/streamlink
-                                        sudo make install clean
-
-`NixOS`_                             .. code-block:: bash
-
-                                        nix-env -iA nixos.streamlink
-
-                                     `NixOS channel`_
-
-`openSUSE`_                          .. code-block:: bash
-
-                                        sudo zypper install streamlink
-
-`Solus`_                             .. code-block:: bash
-
-                                        sudo eopkg install streamlink
-
-`Void`_                              .. code-block:: bash
-
-                                        sudo xbps-install streamlink
-==================================== ===========================================
+            sudo xbps-install streamlink
 
 .. _Arch Linux: https://archlinux.org/packages/extra/any/streamlink/
 .. _Arch Linux (aur, git): https://aur.archlinux.org/packages/streamlink-git/
@@ -212,25 +215,38 @@ Python pip                           See the `PyPI package and source code`_ sec
 Package maintainers
 -------------------
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-==================================== ===========================================
-Distribution/Platform                Maintainer
-==================================== ===========================================
-Arch                                 Giancarlo Razzolini <grazzolini at archlinux.org>
-Arch (aur, git)                      Josip Ponjavic <josipponjavic at gmail.com>
-Chocolatey                           Scott Walters <me at scowalt.com>
-Debian                               Alexis Murzeau <amubtdx at gmail.com>
-Fedora                               Mohamed El Morabity <melmorabity at fedoraproject.org>
-Gentoo                               soredake <fdsfgs at krutt.org>
-NetBSD                               Maya Rashish <maya at netbsd.org>
-NixOS                                Tuomas Tynkkynen <tuomas.tynkkynen at iki.fi>
-openSUSE                             Simon Puchert <simonpuchert at alice.de>
-Solus                                Joey Riches <josephriches at gmail.com>
-Void                                 Michal Vasilek <michal at vasilek.cz>
-Windows binaries                     Sebastian Meyer <mail at bastimeyer.de>
-Linux AppImages                      Sebastian Meyer <mail at bastimeyer.de>
-==================================== ===========================================
+    * - Distribution / Platform
+      - Maintainer
+    * - Arch
+      - Giancarlo Razzolini <grazzolini at archlinux.org>
+    * - Arch (aur, git)
+      - Josip Ponjavic <josipponjavic at gmail.com>
+    * - Chocolatey
+      - Scott Walters <me at scowalt.com>
+    * - Debian
+      - Alexis Murzeau <amubtdx at gmail.com>
+    * - Fedora
+      - Mohamed El Morabity <melmorabity at fedoraproject.org>
+    * - Gentoo
+      - soredake <fdsfgs at krutt.org>
+    * - NetBSD
+      - Maya Rashish <maya at netbsd.org>
+    * - NixOS
+      - Tuomas Tynkkynen <tuomas.tynkkynen at iki.fi>
+    * - openSUSE
+      - Simon Puchert <simonpuchert at alice.de>
+    * - Solus
+      - Joey Riches <josephriches at gmail.com>
+    * - Void
+      - Michal Vasilek <michal at vasilek.cz>
+    * - Windows binaries
+      - Sebastian Meyer <mail at bastimeyer.de>
+    * - Linux AppImages
+      - Sebastian Meyer <mail at bastimeyer.de>
 
 
 Package availability
@@ -275,28 +291,30 @@ On some systems, this isn't the case by default and an alternative, like :comman
     needs to be extended. This can be done by adding ``export PATH="${HOME}/.local/bin:${PATH}"``
     to ``~/.profile`` or ``~/.bashrc``.
 
-.. rst-class:: table-custom-layout
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout
 
-==================================== ===========================================
-Version                              Installing
-==================================== ===========================================
-`Latest release`_                    .. code-block:: bash
+    * - Version
+      - Installing
+    * - `Latest release`_
+      - .. code-block:: bash
 
-                                         pip install --user -U streamlink
+            pip install --user -U streamlink
+    * - `Master branch`_
+      - .. code-block:: bash
 
-`Master branch`_                     .. code-block:: bash
+            pip install --user -U git+https://github.com/streamlink/streamlink.git
+    * - `Specific tag/branch/commit`_
+      - .. code-block:: bash
 
-                                         pip install --user -U git+https://github.com/streamlink/streamlink.git
-
-`Specific tag/branch/commit`_        .. code-block:: bash
-
-                                         pip install --user -U git+https://github.com/USERNAME/streamlink.git@REVISION
-==================================== ===========================================
+            pip install --user -U git+https://github.com/USERNAME/streamlink.git@REVISION
 
 .. _pip: https://pip.pypa.io/en/stable/
 .. _Latest release: https://pypi.python.org/pypi/streamlink
 .. _Master branch: https://github.com/streamlink/streamlink/commits/master
 .. _Specific tag/branch/commit: https://pip.pypa.io/en/stable/reference/pip_install/#git
+
 
 Virtual environment
 -------------------
@@ -350,6 +368,7 @@ install it first, either with a system package manager, or using ``pip``, as det
 .. _virtualenv: https://virtualenv.readthedocs.io/en/latest/
 .. _pipx: https://pypa.github.io/pipx/
 
+
 Dependencies
 ------------
 
@@ -358,36 +377,69 @@ To install Streamlink from source you will need these dependencies.
 Since :ref:`4.0.0 <changelog:streamlink 4.0.0 (2022-05-01)>`,
 Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ / `PEP-518`_.
 
-.. rst-class:: table-custom-layout table-custom-layout-dependencies
+.. list-table::
+    :header-rows: 1
+    :class: table-custom-layout table-custom-layout-dependencies
 
-========= ========================= ===========================================
-Type      Name                       Notes
-========= ========================= ===========================================
-python    `Python`_                 At least version **3.8**.
+    * - Type
+      - Name
+      - Notes
+    * - python
+      - `Python`_
+      - At least version **3.8**
+    * - build
+      - `setuptools`_
+      - At least version **64.0.0** |br|
+        Used as build backend
+    * - build
+      - `wheel`_
+      - Used by the build frontend for creating Python wheels
+    * - build
+      - `versioningit`_
+      - At least version **2.0.0** |br|
+        Used for generating the version string from git when building, or when running in an editable install
+    * - runtime
+      - `certifi`_
+      - Used for loading the CA bundle extracted from the Mozilla Included CA Certificate List
+    * - runtime
+      - `isodate`_
+      - Used for parsing ISO8601 strings
+    * - runtime
+      - `lxml`_
+      - Used for processing HTML and XML data
+    * - runtime
+      - `pycountry`_
+      - Used for localization settings, provides country and language data
+    * - runtime
+      - `pycryptodome`_
+      - Used for decrypting encrypted streams
+    * - runtime
+      - `PySocks`_
+      - Used for SOCKS Proxies
+    * - runtime
+      - `requests`_
+      - Used for making any kind of HTTP/HTTPS request
+    * - runtime
+      - `trio`_
+      - Used for async concurrency and I/O in some parts of Streamlink
+    * - runtime
+      - `trio-websocket`_
+      - Used for WebSocket connections on top of the async trio framework
+    * - runtime
+      - `typing-extensions`_
+      - Used for backporting runtime support of certain type hints on older Python versions
+    * - runtime
+      - `urllib3`_
+      - Used internally by `requests`_, defined as direct dependency
+    * - runtime
+      - `websocket-client`_
+      - Used for making websocket connections
+    * - optional
+      - `FFmpeg`_
+      - Required for `muxing`_ multiple video/audio/subtitle streams into a single output stream.
 
-build     `setuptools`_             At least version **64.0.0**. |br| Used as build backend.
-build     `wheel`_                  Used by the build frontend for creating Python wheels.
-build     `versioningit`_           At least version **2.0.0**. |br| Used for generating the version string from git
-                                    when building, or when running in an editable install.
-
-runtime   `certifi`_                Used for loading the CA bundle extracted from the Mozilla Included CA Certificate List
-runtime   `isodate`_                Used for parsing ISO8601 strings
-runtime   `lxml`_                   Used for processing HTML and XML data
-runtime   `pycountry`_              Used for localization settings, provides country and language data
-runtime   `pycryptodome`_           Used for decrypting encrypted streams
-runtime   `PySocks`_                Used for SOCKS Proxies
-runtime   `requests`_               Used for making any kind of HTTP/HTTPS request
-runtime   `trio`_                   Used for async concurrency and I/O in some parts of Streamlink
-runtime   `trio-websocket`_         Used for WebSocket connections on top of the async trio framework
-runtime   `typing-extensions`_      Used for backporting runtime support of certain type hints on older Python versions
-runtime   `urllib3`_                Used internally by `requests`_, defined as direct dependency
-runtime   `websocket-client`_       Used for making websocket connections
-
-optional  `FFmpeg`_                 Required for `muxing`_ multiple video/audio/subtitle streams into a single output stream.
-
-                                     - DASH streams with video and audio content always have to get remuxed.
-                                     - HLS streams optionally need to get remuxed depending on the stream selection.
-========= ========================= ===========================================
+        - DASH streams with video and audio content always have to get remuxed.
+        - HLS streams optionally need to get remuxed depending on the stream selection.
 
 .. _pyproject.toml: https://github.com/streamlink/streamlink/blob/master/pyproject.toml
 .. _PEP-517: https://peps.python.org/pep-0517/

--- a/docs/issues.rst
+++ b/docs/issues.rst
@@ -11,18 +11,26 @@ By default most players do not cache the data they receive from Streamlink.
 Caching can reduce the amount of buffering you run into because the player will
 have some breathing room between receiving the data and playing it.
 
-============= ============================== ======================================
-Player        Parameter                      Note
-============= ============================== ======================================
-MPC-HC        --                             Currently no way of configuring the cache
-MPlayer       ``-cache <kbytes>``            Between 1024 and 8192 is recommended
-mpv           ``--cache=yes                  Between 1024 and 8192 is recommended
-              --demuxer-max-bytes=<kbytes>``
-VLC           ``--file-caching <ms>          Between 1000 and 10000 is recommended
-              --network-caching <ms>``
-============= ============================== ======================================
+.. list-table::
+    :header-rows: 1
 
-Use the :option:`--player-args` or :option:`--player` option to pass these options to your player.
+    * - Player
+      - Parameter
+      - Note
+    * - MPC-HC
+      -
+      - Currently no way of configuring the cache
+    * - MPlayer
+      - ``-cache <kbytes>``
+      - Between 1024 and 8192 is recommended
+    * - mpv
+      - ``--cache=yes --demuxer-max-bytes=<kbytes>``
+      - Between 1024 and 8192 is recommended
+    * - VLC
+      - ``--file-caching <ms> --network-caching <ms>``
+      - Between 1000 and 10000 is recommended
+
+Use the :option:`--player-args` option to pass these options to your player.
 
 
 Multi-threaded streaming

--- a/docs/players.rst
+++ b/docs/players.rst
@@ -6,15 +6,17 @@ Transport modes
 
 There are three different modes of transporting the stream to the player.
 
-====================== =========================================================
-Name                   Description
-====================== =========================================================
-Standard input pipe    This is the default behaviour when there are no other
-                       options specified.
-Named pipe (FIFO)      Use the :option:`--player-fifo` option to enable.
-HTTP                   Use the :option:`--player-http` or
-                       :option:`--player-continuous-http` options to enable.
-====================== =========================================================
+.. list-table::
+    :header-rows: 1
+
+    * - Name
+      - Description
+    * - Standard input pipe
+      - This is the default behaviour when there are no other options specified.
+    * - Named pipe (FIFO)
+      - Use the :option:`--player-fifo` option to enable.
+    * - HTTP
+      - Use the :option:`--player-http` or :option:`--player-continuous-http` options to enable.
 
 
 Player compatibility
@@ -23,17 +25,41 @@ Player compatibility
 This is a list of video players and their compatibility with the transport
 modes.
 
-===================================================== ========== ========== ====
-Name                                                  Stdin Pipe Named Pipe HTTP
-===================================================== ========== ========== ====
-`Daum Pot Player`_                                    Yes        No         Yes [1]_
-`MPC-HC`_                                             Yes [2]_   No         Yes [1]_
-`MPlayer`_                                            Yes        Yes        Yes
-`mpv`_                                                Yes        Yes        Yes
-`OMXPlayer`_                                          No         Yes        Yes [4]_
-`QuickTime`_                                          No         No         No
-`VLC media player`_                                   Yes [3]_   Yes        Yes
-===================================================== ========== ========== ====
+.. list-table::
+    :header-rows: 1
+
+    * - Name
+      - stdin pipe
+      - named pipe
+      - HTTP
+    * - `Daum Pot Player`_
+      - Yes
+      - No
+      - Yes [1]_
+    * - `MPC-HC`_
+      - Yes [2]_
+      - No
+      - Yes [1]_
+    * - `MPlayer`_
+      - Yes
+      - Yes
+      - Yes
+    * - `mpv`_
+      - Yes
+      - Yes
+      - Yes
+    * - `OMXPlayer`_
+      - No
+      - Yes
+      - Yes [4]_
+    * - `QuickTime`_
+      - No
+      - No
+      - No
+    * - `VLC media player`_
+      - Yes [3]_
+      - Yes
+      - Yes
 
 .. [1] :option:`--player-continuous-http` must be used.
        Using HTTP with players that rely on Windows' codecs to access HTTP


### PR DESCRIPTION
Unlike "simple" tables, the structure of list-tables is not dependent on the table contents, so it's way less restrictive:
- https://docutils.sourceforge.io/docs/ref/rst/directives.html#table
- https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table

No content changes apart from a single fix in regards to player args on the issues page. Btw, the players and issues pages both haven't been updated in ages and need a rewrite.

----

The intention of these changes is being able to add specific icons to the packages on the install page, to indicate whether they are managed externally or built here, so having list-tables is a requirement.