### PR TITLE
build: set scripts/gui-scripts fields to dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ classifiers = [
 dynamic = [
   "version",
   "entry-points",
+  "scripts",
+  "gui-scripts",
 ]
 
 requires-python = ">=3.8"


### PR DESCRIPTION
There have been some changes in regards to the `scripts`/`gui-scripts` entry-points in setuptools `68.1.0` which now raise warnings:
https://setuptools.pypa.io/en/stable/history.html#v68-1-0

> Detects (and complain about) `scripts` and `gui-scripts` set via `setup.py` when `pyproject.toml` does not include them in `dynamic`.

Apparently, setting `entry-points` in `dynamic` is not enough, or wrong, don't know.

It looks like setuptools translates its `entry-points` config into the `scripts`/`gui-scripts` format expected by PEP 621, hence the requirement for the `dynamic` config.

- https://github.com/streamlink/streamlink/blob/5c7cf4cdc49572ccb2520f017f456d5a61844740/setup.py#L49-L54
- https://github.com/streamlink/streamlink/blob/5c7cf4cdc49572ccb2520f017f456d5a61844740/pyproject.toml#L43-L46

PEP 621:
- https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
- https://packaging.python.org/en/latest/specifications/declaring-project-metadata/#entry-points

----

This fixes the following warnings:

`scripts`

```
/tmp/build-env-88y_mzr8/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:73: _WouldIgnoreField: `scripts` defined outside of `pyproject.toml` would be ignored.
!!

        ********************************************************************************
        ##########################################################################
        # configuration would be ignored/result in error due to `pyproject.toml` #
        ##########################################################################

        The following seems to be defined outside of `pyproject.toml`:

        `scripts = ['streamlink=streamlink_cli.main:main']`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `scripts` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

        For the time being, `setuptools` will still consider the given value (as a
        **transitional** measure), but please note that future releases of setuptools will
        follow strictly the standard.

        To prevent this warning, you can list `scripts` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
  _handle_missing_dynamic(dist, project_table)
```

`gui-scripts`

```
/tmp/build-env-88y_mzr8/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:73: _WouldIgnoreField: `gui-scripts` defined outside of `pyproject.toml` would be ignored.
!!

        ********************************************************************************
        ##########################################################################
        # configuration would be ignored/result in error due to `pyproject.toml` #
        ##########################################################################

        The following seems to be defined outside of `pyproject.toml`:

        `gui-scripts = ['streamlinkw=streamlink_cli.main:main']`

        According to the spec (see the link below), however, setuptools CANNOT
        consider this value unless `gui-scripts` is listed as `dynamic`.

        https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

        For the time being, `setuptools` will still consider the given value (as a
        **transitional** measure), but please note that future releases of setuptools will
        follow strictly the standard.

        To prevent this warning, you can list `gui-scripts` under `dynamic` or alternatively
        remove the `[project]` table from your file and rely entirely on other means of
        configuration.

        By 2023-Oct-30, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        ********************************************************************************

!!
  _handle_missing_dynamic(dist, project_table)
```