### PR TITLE
cli: log OpenSSL version in debug log

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -5,6 +5,7 @@ import os
 import platform
 import re
 import signal
+import ssl
 import sys
 import warnings
 from contextlib import closing, suppress
@@ -787,6 +788,7 @@ def log_current_versions():
 
     log.debug(f"OS:         {os_version}")
     log.debug(f"Python:     {platform.python_version()}")
+    log.debug(f"OpenSSL:    {ssl.OPENSSL_VERSION}")
     log.debug(f"Streamlink: {streamlink_version}")
 
     # https://peps.python.org/pep-0508/#names

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -689,6 +689,7 @@ class TestCLIMainLoggingInfos(_TestCLIMainLogging):
     @patch("streamlink_cli.main.importlib.metadata")
     @patch("streamlink_cli.main.log_current_arguments", Mock(side_effect=_TestCLIMainLogging.StopTest))
     @patch("platform.python_version", Mock(return_value="python"))
+    @patch("ssl.OPENSSL_VERSION", "OPENSSL_VERSION")
     def test_log_current_versions(self, mock_importlib_metadata: Mock, mock_log: Mock):
         class FakePackageNotFoundError(Exception):
             pass
@@ -714,6 +715,7 @@ class TestCLIMainLoggingInfos(_TestCLIMainLogging):
             assert mock_log.debug.mock_calls == [
                 call("OS:         linux"),
                 call("Python:     python"),
+                call("OpenSSL:    OPENSSL_VERSION"),
                 call("Streamlink: streamlink"),
                 call("Dependencies:"),
                 call(" foo: 1.2.3"),
@@ -729,6 +731,7 @@ class TestCLIMainLoggingInfos(_TestCLIMainLogging):
             assert mock_log.debug.mock_calls == [
                 call("OS:         macOS 0.0.0"),
                 call("Python:     python"),
+                call("OpenSSL:    OPENSSL_VERSION"),
                 call("Streamlink: streamlink"),
                 call("Dependencies:"),
                 call(" foo: 1.2.3"),
@@ -745,6 +748,7 @@ class TestCLIMainLoggingInfos(_TestCLIMainLogging):
             assert mock_log.debug.mock_calls == [
                 call("OS:         Windows 0.0.0"),
                 call("Python:     python"),
+                call("OpenSSL:    OPENSSL_VERSION"),
                 call("Streamlink: streamlink"),
                 call("Dependencies:"),
                 call(" foo: 1.2.3"),


### PR DESCRIPTION
- https://docs.python.org/3/library/ssl.html
- https://docs.python.org/3/library/ssl.html#ssl.OPENSSL_VERSION
- https://peps.python.org/pep-0644/

Relevant:
- #5425