### PR TITLE
stream.segmented: fix and add more typing

### DIFF
--- a/src/streamlink/plugins/ustreamtv.py
+++ b/src/streamlink/plugins/ustreamtv.py
@@ -337,7 +337,7 @@ class UStreamTVWsClient(WebsocketClient):
     }
 
 
-class UStreamTVStreamWriter(SegmentedStreamWriter):
+class UStreamTVStreamWriter(SegmentedStreamWriter[Segment, Response]):
     reader: "UStreamTVStreamReader"
     stream: "UStreamTVStream"
 
@@ -393,7 +393,7 @@ class UStreamTVStreamWriter(SegmentedStreamWriter):
             log.error(f"Failed to read {self.stream.kind} segment {segment.num}: {err}")
 
 
-class UStreamTVStreamWorker(SegmentedStreamWorker):
+class UStreamTVStreamWorker(SegmentedStreamWorker[Segment, Response]):
     reader: "UStreamTVStreamReader"
     writer: "UStreamTVStreamWriter"
     stream: "UStreamTVStream"
@@ -427,7 +427,7 @@ class UStreamTVStreamWorker(SegmentedStreamWorker):
             self.segment_id = segment.num + 1
 
 
-class UStreamTVStreamReader(SegmentedStreamReader):
+class UStreamTVStreamReader(SegmentedStreamReader[Segment, Response]):
     __worker__ = UStreamTVStreamWorker
     __writer__ = UStreamTVStreamWriter
 

--- a/src/streamlink/stream/dash.py
+++ b/src/streamlink/stream/dash.py
@@ -8,6 +8,8 @@ from time import time
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse
 
+from requests import Response
+
 from streamlink.exceptions import PluginError, StreamError
 from streamlink.session import Streamlink
 from streamlink.stream.dash_manifest import MPD, Representation, Segment, freeze_timeline
@@ -22,7 +24,7 @@ from streamlink.utils.times import now
 log = logging.getLogger(__name__)
 
 
-class DASHStreamWriter(SegmentedStreamWriter):
+class DASHStreamWriter(SegmentedStreamWriter[Segment, Response]):
     reader: "DASHStreamReader"
     stream: "DASHStream"
 
@@ -69,7 +71,7 @@ class DASHStreamWriter(SegmentedStreamWriter):
         log.debug(f"{self.reader.mime_type} segment {segment.name}: completed")
 
 
-class DASHStreamWorker(SegmentedStreamWorker):
+class DASHStreamWorker(SegmentedStreamWorker[Segment, Response]):
     reader: "DASHStreamReader"
     writer: "DASHStreamWriter"
     stream: "DASHStream"
@@ -162,7 +164,7 @@ class DASHStreamWorker(SegmentedStreamWorker):
         return changed
 
 
-class DASHStreamReader(SegmentedStreamReader):
+class DASHStreamReader(SegmentedStreamReader[Segment, Response]):
     __worker__ = DASHStreamWorker
     __writer__ = DASHStreamWriter
 

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -62,7 +62,7 @@ class ByteRangeOffset:
         return bytes_start, self._calc_end(bytes_start, byterange.range)
 
 
-class HLSStreamWriter(SegmentedStreamWriter):
+class HLSStreamWriter(SegmentedStreamWriter[Sequence, Response]):
     WRITE_CHUNK_SIZE = 8192
 
     reader: "HLSStreamReader"
@@ -284,7 +284,7 @@ class HLSStreamWriter(SegmentedStreamWriter):
             log.debug(f"Segment {sequence.num} complete")
 
 
-class HLSStreamWorker(SegmentedStreamWorker):
+class HLSStreamWorker(SegmentedStreamWorker[Sequence, Response]):
     reader: "HLSStreamReader"
     writer: "HLSStreamWriter"
     stream: "HLSStream"
@@ -509,7 +509,7 @@ class HLSStreamWorker(SegmentedStreamWorker):
                     log.warning(f"Failed to reload playlist: {err}")
 
 
-class HLSStreamReader(FilteredStream, SegmentedStreamReader):
+class HLSStreamReader(FilteredStream, SegmentedStreamReader[Sequence, Response]):
     __worker__ = HLSStreamWorker
     __writer__ = HLSStreamWriter
 


### PR DESCRIPTION
- Turn `SegmentedStream{Writer,Worker,Reader}` into generic classes with segment and segment-result types
- Fix typing information of the writer's queue
- Add missing typing information
- Update segmented stream classes accordingly

----

#5498

Next step will be fixing the whole `Segment` mess by adding a common `BaseSegment`. This will require more changes due to how the current segments are implemented and structured.
