### PR TITLE
docs: add support for $metadata plugin metadata

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -25,7 +25,6 @@ _option_line_re = re.compile(r"^(?!\s{2,}%\(prog\)s|\s{2,}--\w[\w-]*\w\b|Example
 _option_re = re.compile(r"(?:^|(?<=\s))(?P<arg>--\w[\w-]*\w)(?P<val>=\w+)?\b")
 _prog_re = re.compile(r"%\(prog\)s")
 _percent_re = re.compile(r"%%")
-_cli_metadata_variables_section_cross_link_re = re.compile(r"the \"Metadata variables\" section")
 _inline_code_block_re = re.compile(r"(?<!`)`([^`]+?)`")
 _example_inline_code_block_re = re.compile(r"(?<=^Example: )(.+)$", re.MULTILINE)
 
@@ -92,9 +91,15 @@ class ArgparseDirective(Directive):
         # fix escaped chars for percent-formatted argparse help strings
         helptext = _percent_re.sub("%", helptext)
 
-        # create cross-link for the "Metadata variables" section
-        helptext = _cli_metadata_variables_section_cross_link_re.sub(
+        # create cross-links for the "Metadata variables" and "Plugins" sections
+        helptext = re.sub(
+            r"the \"Metadata variables\" section",
             "the \":ref:`Metadata variables <cli/metadata:Variables>`\" section",
+            helptext,
+        )
+        helptext = re.sub(
+            r"the \"Plugins\" section",
+            "the \":ref:`Plugins <plugins:Plugins>`\" section",
             helptext,
         )
 

--- a/docs/ext_plugins.py
+++ b/docs/ext_plugins.py
@@ -52,10 +52,24 @@ class MetadataList(IMetadataItem):
     def generate(self) -> Iterator[str]:
         if not self.value:
             return
+        yield f":{self.title}: - {' '.join(self.get_item(0))}"
         indent = " " * len(f":{self.title}:")
-        yield f":{self.title}: - {self.value[0]}"
-        for val in self.value[1:]:
-            yield f"{indent} - {val}"
+        for idx in range(1, len(self.value)):
+            yield f"{indent} - {' '.join(self.get_item(idx))}"
+
+    def get_item(self, idx: int) -> Iterator[str]:
+        yield self.value[idx]
+
+
+class MetadataMetadataList(MetadataList):
+    def __init__(self):
+        super().__init__("Metadata")
+
+    def get_item(self, idx: int) -> Iterator[str]:
+        variable, *data = str(self.value[idx]).split(" ")
+        yield f":ref:`{variable} <cli/metadata:Variables>`"
+        if data:
+            yield " ".join(["-", *data])
 
 
 class PluginOnGithub(IDatalistItem):
@@ -144,6 +158,7 @@ class PluginMetadata:
             description=MetadataItem("Description"),
             url=MetadataList("URL(s)"),
             type=MetadataItem("Type"),
+            metadata=MetadataMetadataList(),
             region=MetadataItem("Region"),
             account=MetadataItem("Account"),
             notes=MetadataList("Notes"),

--- a/src/streamlink/plugins/aloula.py
+++ b/src/streamlink/plugins/aloula.py
@@ -2,6 +2,10 @@
 $description Live TV channels and video on-demand service from the SBA, a Saudi, state-owned broadcaster.
 $url aloula.sa
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/ard_live.py
+++ b/src/streamlink/plugins/ard_live.py
@@ -2,6 +2,7 @@
 $description Live TV channels and video on-demand service from ARD, a German public, independent broadcaster.
 $url daserste.de
 $type live, vod
+$metadata title
 $region Germany
 """
 

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -3,6 +3,7 @@ $description Live TV channels and video on-demand service from ARD, a German pub
 $url ardmediathek.de
 $url mediathek.daserste.de
 $type live, vod
+$metadata title
 $region Germany
 """
 

--- a/src/streamlink/plugins/artetv.py
+++ b/src/streamlink/plugins/artetv.py
@@ -2,6 +2,7 @@
 $description European public service channel promoting culture, including magazine shows, concerts and documentaries.
 $url arte.tv
 $type live, vod
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/blazetv.py
+++ b/src/streamlink/plugins/blazetv.py
@@ -2,6 +2,10 @@
 $description British live TV channel and video on-demand service from Blaze, owned by A&E Networks UK.
 $url blaze.tv
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 $region United Kingdom
 """
 

--- a/src/streamlink/plugins/bloomberg.py
+++ b/src/streamlink/plugins/bloomberg.py
@@ -2,6 +2,7 @@
 $description America-based television network centred towards business and capital market programming.
 $url bloomberg.com
 $type live, vod
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/booyah.py
+++ b/src/streamlink/plugins/booyah.py
@@ -1,7 +1,10 @@
 """
-$description Global live streaming and video hosting community platform designed for gaming enthusiasts.
+$description Global live-streaming and video hosting community platform designed for gaming enthusiasts.
 $url booyah.live
 $type live, vod
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/brightcove.py
+++ b/src/streamlink/plugins/brightcove.py
@@ -2,6 +2,7 @@
 $description Global live-streaming and video on-demand hosting platform.
 $url players.brightcove.net
 $type live, vod
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/cbsnews.py
+++ b/src/streamlink/plugins/cbsnews.py
@@ -2,6 +2,8 @@
 $description 24-hour live-streaming world news channel, based in the United States of America.
 $url cbsnews.com
 $type live
+$metadata id
+$metadata title
 """
 
 import re

--- a/src/streamlink/plugins/ceskatelevize.py
+++ b/src/streamlink/plugins/ceskatelevize.py
@@ -2,6 +2,8 @@
 $description Live TV channels from CT, a Czech public, state-owned broadcaster.
 $url ceskatelevize.cz
 $type live
+$metadata id
+$metadata title
 $region Czechia
 """
 

--- a/src/streamlink/plugins/cmmedia.py
+++ b/src/streamlink/plugins/cmmedia.py
@@ -2,6 +2,10 @@
 $description Live TV channel and video on-demand service from CMM, a Spanish public, state-owned broadcaster.
 $url cmmedia.es
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 $notes Content not licensed for digital distribution is unavailable via the live channel stream.
 """
 

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -2,6 +2,10 @@
 $description Video streaming service focused on anime, manga, and dorama.
 $url crunchyroll.com
 $type vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -2,6 +2,9 @@
 $description Global live-streaming and video on-demand hosting platform.
 $url dailymotion.com
 $type live, vod
+$metadata id
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/deutschewelle.py
+++ b/src/streamlink/plugins/deutschewelle.py
@@ -2,6 +2,9 @@
 $description Live TV channels and video on-demand service from Deutsche Welle, a German public, state-owned broadcaster.
 $url dw.com
 $type live, vod
+$metadata id
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/dlive.py
+++ b/src/streamlink/plugins/dlive.py
@@ -2,6 +2,8 @@
 $description Global live-streaming platform owned by BitTorrent, Inc.
 $url dlive.tv
 $type live, vod
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/earthcam.py
+++ b/src/streamlink/plugins/earthcam.py
@@ -2,6 +2,9 @@
 $description A network of live webcams for tourism and entertainment.
 $url earthcam.com
 $type live, vod
+$metadata author
+$metadata category
+$metadata title
 $notes Only works for the cams hosted on EarthCam
 """
 

--- a/src/streamlink/plugins/facebook.py
+++ b/src/streamlink/plugins/facebook.py
@@ -2,6 +2,7 @@
 $description Global live-streaming and video hosting social platform.
 $url facebook.com
 $type live, vod
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/huajiao.py
+++ b/src/streamlink/plugins/huajiao.py
@@ -2,6 +2,9 @@
 $description Chinese live-streaming platform for live video game broadcasts and individual live streams.
 $url huajiao.com
 $type live
+$metadata author
+$metadata category
+$metadata title
 """
 
 import base64

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -2,6 +2,9 @@
 $description Chinese live-streaming platform for live video game broadcasts and individual live streams.
 $url huya.com
 $type live
+$metadata id
+$metadata author
+$metadata title
 """
 
 import base64

--- a/src/streamlink/plugins/idf1.py
+++ b/src/streamlink/plugins/idf1.py
@@ -2,6 +2,8 @@
 $description French live TV channel and video on-demand service owned by IDF1.
 $url idf1.fr
 $type live, vod
+$metadata id
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/livestream.py
+++ b/src/streamlink/plugins/livestream.py
@@ -2,6 +2,8 @@
 $description Global live-streaming and video on-demand hosting platform.
 $url livestream.com
 $type live
+$metadata id
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/lnk.py
+++ b/src/streamlink/plugins/lnk.py
@@ -2,6 +2,10 @@
 $description Lithuanian live TV channels from LNK Group, including 2TV, BTV, Info TV, LNK and TV1.
 $url lnk.lt
 $type live
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 $region Lithuania
 """
 

--- a/src/streamlink/plugins/mdstrm.py
+++ b/src/streamlink/plugins/mdstrm.py
@@ -4,6 +4,8 @@ $url mdstrm.com
 $url latina.pe/tvenvivo
 $url saltillo.multimedios.com/video
 $type live
+$metadata id
+$metadata title
 """
 import logging
 import re

--- a/src/streamlink/plugins/mixcloud.py
+++ b/src/streamlink/plugins/mixcloud.py
@@ -2,6 +2,9 @@
 $description British music live-streaming platform for radio shows and DJ mixes.
 $url mixcloud.com
 $type live
+$metadata id
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/mjunoon.py
+++ b/src/streamlink/plugins/mjunoon.py
@@ -2,6 +2,9 @@
 $description Pakistani live TV channels and video on-demand service. OTT service from mjunoon.
 $url mjunoon.tv
 $type live, vod
+$metadata author
+$metadata category
+$metadata title
 $region Pakistan
 """
 

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -2,6 +2,9 @@
 $description Chinese, global live-streaming platform run by Huya Live.
 $url nimo.tv
 $type live
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -2,6 +2,7 @@
 $description Live TV channels and video on-demand service from NOS, a Dutch public, state-owned broadcaster.
 $url nos.nl
 $type live, vod
+$metadata title
 $region Netherlands
 """
 

--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -3,6 +3,9 @@ $description Russian live-streaming and video hosting social platform.
 $url ok.ru
 $url mobile.ok.ru
 $type live, vod
+$metadata id
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/onetv.py
+++ b/src/streamlink/plugins/onetv.py
@@ -2,6 +2,7 @@
 $description A state/privately owned Russian live TV channel.
 $url 1tv.ru
 $type live
+$metadata title
 $region Russia
 """
 

--- a/src/streamlink/plugins/pandalive.py
+++ b/src/streamlink/plugins/pandalive.py
@@ -2,6 +2,8 @@
 $description South Korean live-streaming platform for individual live streams.
 $url pandalive.co.kr
 $type live
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/piaulizaportal.py
+++ b/src/streamlink/plugins/piaulizaportal.py
@@ -2,6 +2,8 @@
 $description Japanese live-streaming and video hosting platform owned by PIA Corporation.
 $url ulizaportal.jp
 $type live, vod
+$metadata id
+$metadata title
 $account Purchased tickets are required.
 $notes Tickets purchased at "PIA LIVE STREAM" are used for this platform.
 """

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -1,7 +1,10 @@
 """
-$description Global live streaming and video hosting platform for the creative community.
+$description Global live-streaming and video hosting platform for the creative community.
 $url picarto.tv
 $type live, vod
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/piczel.py
+++ b/src/streamlink/plugins/piczel.py
@@ -2,6 +2,9 @@
 $description Global live-streaming platform for the creative community.
 $url piczel.tv
 $type live
+$metadata id
+$metadata author
+$metadata title
 """
 
 import re

--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -2,6 +2,10 @@
 $description Live TV and video on-demand service owned by Paramount Streaming.
 $url pluto.tv
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/pluzz.py
+++ b/src/streamlink/plugins/pluzz.py
@@ -3,6 +3,7 @@ $description Live TV channels and video on-demand service from france.tv, a Fren
 $url france.tv
 $url francetvinfo.fr
 $type live, vod
+$metadata title
 $region France, Andorra, Monaco
 """
 

--- a/src/streamlink/plugins/qq.py
+++ b/src/streamlink/plugins/qq.py
@@ -2,6 +2,10 @@
 $description Chinese live-streaming platform for live video game broadcasts and live sports game related streams.
 $url live.qq.com
 $type live
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/rtpa.py
+++ b/src/streamlink/plugins/rtpa.py
@@ -2,6 +2,7 @@
 $description Live TV channels and video on-demand service from RTPA, a Spanish public broadcaster.
 $url rtpa.es
 $type live, vod
+$metadata title
 """
 
 import re

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -2,6 +2,7 @@
 $description Live TV channels and video on-demand service from RTVE, a Spanish public, state-owned broadcaster.
 $url rtve.es
 $type live, vod
+$metadata id
 $region Spain
 """
 

--- a/src/streamlink/plugins/sbscokr.py
+++ b/src/streamlink/plugins/sbscokr.py
@@ -2,6 +2,9 @@
 $description Live TV channels from SBS, a South Korean public broadcaster.
 $url www.sbs.co.kr/live
 $type live
+$metadata id
+$metadata author
+$metadata title
 $region South Korea
 """
 

--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -2,6 +2,7 @@
 $description Japanese live-streaming service used primarily by Japanese idols & voice actors and their fans.
 $url showroom-live.com
 $type live
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -1,11 +1,12 @@
 """
-$description Global live streaming and video on-demand hosting platform.
+$description Global live-streaming and video on-demand hosting platform.
 $url ott.streann.com
 $url centroecuador.ec
 $url columnaestilos.com
 $url evtv.online/noticias-de-venezuela
 $url telecuracao.com
 $type live, vod
+$metadata title
 """
 
 import base64

--- a/src/streamlink/plugins/stv.py
+++ b/src/streamlink/plugins/stv.py
@@ -2,6 +2,7 @@
 $description Live TV channels from STV, a Scottish free-to-air broadcaster.
 $url player.stv.tv
 $type live
+$metadata title
 $region United Kingdom
 """
 

--- a/src/streamlink/plugins/svtplay.py
+++ b/src/streamlink/plugins/svtplay.py
@@ -2,6 +2,9 @@
 $description Live TV channels and video on-demand service from SVT, a Swedish public, state-owned broadcaster.
 $url svtplay.se
 $type live, vod
+$metadata author
+$metadata category
+$metadata title
 $region Sweden
 """
 

--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -2,6 +2,7 @@
 $description Video content from Telefe, an Argentine TV station.
 $url mitelefe.com
 $type live
+$metadata title
 $region Argentina
 """
 

--- a/src/streamlink/plugins/trovo.py
+++ b/src/streamlink/plugins/trovo.py
@@ -1,7 +1,11 @@
 """
-$description Global video game live streaming and video hosting platform, owned by Tencent.
+$description Global video game live-streaming and video hosting platform, owned by Tencent.
 $url trovo.live
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/turkuvaz.py
+++ b/src/streamlink/plugins/turkuvaz.py
@@ -11,6 +11,8 @@ $url minikacocuk.com.tr
 $url minikago.com.tr
 $url vavtv.com.tr
 $type live, vod
+$metadata id
+$metadata title
 $region various
 """
 

--- a/src/streamlink/plugins/tv4play.py
+++ b/src/streamlink/plugins/tv4play.py
@@ -3,6 +3,7 @@ $description Live TV channels and video on-demand service from TV4, a Swedish fr
 $url tv4play.se
 $url fotbollskanalen.se
 $type live, vod
+$metadata title
 $region Sweden
 $notes Only non-premium streams are supported
 """

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -3,6 +3,8 @@ $description Live TV channels and VODs from TVP, a Polish public, state-owned br
 $url tvp.info
 $url tvp.pl
 $type live, vod
+$metadata id
+$metadata title
 $notes Some VODs may be geo-restricted. Authentication is not supported.
 """
 

--- a/src/streamlink/plugins/twitcasting.py
+++ b/src/streamlink/plugins/twitcasting.py
@@ -2,6 +2,7 @@
 $description Global live broadcasting and live broadcast archiving social platform.
 $url twitcasting.tv
 $type live
+$metadata id
 """
 
 import hashlib

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -2,6 +2,10 @@
 $description Global live-streaming and video hosting social platform owned by Amazon.
 $url twitch.tv
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 $notes See the :ref:`Authentication <cli/plugins/twitch:Authentication>` docs on how to prevent ads.
 $notes Read more about :ref:`embedded ads <cli/plugins/twitch:Embedded ads>` here.
 $notes :ref:`Low latency streaming <cli/plugins/twitch:Low latency streaming>` is supported.

--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -2,6 +2,9 @@
 $description Global live-streaming and video hosting social platform.
 $url vimeo.com
 $type live, vod
+$metadata id
+$metadata author
+$metadata title
 $notes Password protected streams are not supported
 """
 

--- a/src/streamlink/plugins/vinhlongtv.py
+++ b/src/streamlink/plugins/vinhlongtv.py
@@ -2,6 +2,8 @@
 $description Vietnamese live TV channels from THVL, including THVL1, THVL2, THVL3 and THVL4.
 $url thvli.vn
 $type live
+$metadata id
+$metadata title
 $region Vietnam
 """
 

--- a/src/streamlink/plugins/vk.py
+++ b/src/streamlink/plugins/vk.py
@@ -3,6 +3,9 @@ $description Russian live-streaming and video hosting social platform.
 $url vk.com
 $url vk.ru
 $type live, vod
+$metadata id
+$metadata author
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/vkplay.py
+++ b/src/streamlink/plugins/vkplay.py
@@ -2,6 +2,10 @@
 $description Russian live-streaming platform for gaming and esports, owned by VKontakte.
 $url vkplay.live
 $type live
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
 
 import logging

--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -3,6 +3,10 @@ $description Global live-streaming and video hosting social platform owned by Go
 $url youtube.com
 $url youtu.be
 $type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 $notes Protected videos are not supported
 """
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -553,7 +553,8 @@ def build_parser():
         help=f"""
         Change the title of the video player's window.
 
-        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables,
+        as well as the "Plugins" section for the list of metadata variables defined in each plugin.
 
         This option is only supported for the following players: {', '.join(sorted(PlayerOutput.PLAYERS.keys()))}
 
@@ -585,7 +586,8 @@ def build_parser():
 
         You will be prompted if the file already exists.
 
-        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables,
+        as well as the "Plugins" section for the list of metadata variables defined in each plugin.
 
         Unsupported characters in substituted variables will be replaced with an underscore.
 
@@ -612,7 +614,8 @@ def build_parser():
 
         You will be prompted if the file already exists.
 
-        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables,
+        as well as the "Plugins" section for the list of metadata variables defined in each plugin.
 
         Unsupported characters in substituted variables will be replaced with an underscore.
 
@@ -631,7 +634,8 @@ def build_parser():
 
         You will be prompted if the file already exists.
 
-        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables.
+        Please see the "Metadata variables" section of Streamlink's CLI documentation for all available metadata variables,
+        as well as the "Plugins" section for the list of metadata variables defined in each plugin.
 
         Unsupported characters in substituted variables will be replaced with an underscore.
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -36,6 +36,12 @@ plugintests = [
     if tname.startswith("test_") and tname not in plugintests_ignore
 ]
 
+PLUGIN_TYPES = "live", "vod", "live, vod"
+PLUGIN_METADATA = "id", "author", "category", "title"
+
+re_url = re.compile("^https?://")
+re_metadata = re.compile(rf"^({'|'.join(re.escape(item) for item in PLUGIN_METADATA)})(\s.+)?$")
+
 
 def unique(iterable):
     seen = set()
@@ -102,6 +108,7 @@ class TestPluginMetadata:
             "description",
             "url",
             "type",
+            "metadata",
             "region",
             "account",
             "notes",
@@ -119,6 +126,7 @@ class TestPluginMetadata:
     def metadata_keys_repeat(self):
         return (
             "url",
+            "metadata",
             "notes",
         )
 
@@ -186,9 +194,16 @@ class TestPluginMetadata:
         assert keys == tuple(unique(keys)), "Non-repeatable keys are set at most only once"
 
     def test_key_url(self, metadata_items):
-        assert not any(re.match("^https?://", val) for key, val in metadata_items if key == "url"), \
-            "URL metadata values don't start with http:// or https://"
+        assert not any(re_url.match(val) for key, val in metadata_items if key == "url"), \
+            "$url metadata values don't start with http:// or https://"
 
     def test_key_type(self, metadata_dict):
-        assert metadata_dict.get("type") in ("live", "vod", "live, vod"), \
-            "Type metadata has the correct value"
+        assert metadata_dict.get("type") in PLUGIN_TYPES, \
+            "$type metadata has the correct value"
+
+    def test_key_metadata(self, metadata_items):
+        assert all(re_metadata.match(val) for key, val in metadata_items if key == "metadata"), \
+            "$metadata metadata values have the correct format"
+        indexes = [PLUGIN_METADATA.index(val.split(" ")[0]) for key, val in metadata_items if key == "metadata"]
+        assert [PLUGIN_METADATA[i] for i in indexes] == [PLUGIN_METADATA[i] for i in sorted(indexes)], \
+            "$metadata metadata values are ordered correctly"


### PR DESCRIPTION
This allows plugins to optionally define which stream metadata variables
are available, with an optional comment for each variable.

`$metadata` can be repeated multiple times, once for each supported
variable, and it must be set immediately after the mandatory `$type`.

The supported variables must be defined in the following order:
- id
- author
- category
- title

The optional comment is separated by a simple space character, but it
is rendered differently in the docs.

----

Resolves #5516 

The plugin metadata changes are all based on this simple regex `self\.(id|author|category|title)`, so this data might be wrong and/or incomplete, and optional comments are missing too.

The rendering of the plugins page could be improved later on. I couldn't figure out how to style `:refs:` in rst and my MyST-parser custom syntax attempts failed.