### PR TITLE
stream.hls: remove Sequence named tuple wrapper

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 
 class AbemaTVHLSStreamWriter(HLSStreamWriter):
     def should_filter_sequence(self, sequence):
-        return "/tsad/" in sequence.segment.uri or super().should_filter_sequence(sequence)
+        return "/tsad/" in sequence.uri or super().should_filter_sequence(sequence)
 
 
 class AbemaTVHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -30,8 +30,8 @@ log = logging.getLogger(__name__)
 
 
 class AbemaTVHLSStreamWriter(HLSStreamWriter):
-    def should_filter_sequence(self, sequence):
-        return "/tsad/" in sequence.uri or super().should_filter_sequence(sequence)
+    def should_filter_segment(self, segment):
+        return "/tsad/" in segment.uri or super().should_filter_segment(segment)
 
 
 class AbemaTVHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -16,8 +16,8 @@ log = logging.getLogger(__name__)
 
 
 class AfreecaHLSStreamWriter(HLSStreamWriter):
-    def should_filter_sequence(self, sequence):
-        return "preloading" in sequence.uri or super().should_filter_sequence(sequence)
+    def should_filter_segment(self, segment):
+        return "preloading" in segment.uri or super().should_filter_segment(segment)
 
 
 class AfreecaHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 class AfreecaHLSStreamWriter(HLSStreamWriter):
     def should_filter_sequence(self, sequence):
-        return "preloading" in sequence.segment.uri or super().should_filter_sequence(sequence)
+        return "preloading" in sequence.uri or super().should_filter_sequence(sequence)
 
 
 class AfreecaHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -28,14 +28,8 @@ class LTVHLSStreamWorker(HLSStreamWorker):
     def process_sequences(self, playlist, sequences):
         super().process_sequences(playlist, sequences)
         # update the segment URLs with the query string from the playlist URL
-        self.playlist_sequences = [
-            sequence._replace(
-                segment=sequence.segment._replace(
-                    uri=copy_query_url(sequence.segment.uri, self.stream.url),
-                ),
-            )
-            for sequence in self.playlist_sequences
-        ]
+        for sequence in sequences:
+            sequence.segment.uri = copy_query_url(sequence.segment.uri, self.stream.url)
 
 
 class LTVHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -25,10 +25,10 @@ def copy_query_url(to, from_):
 
 
 class LTVHLSStreamWorker(HLSStreamWorker):
-    def process_sequences(self, playlist, sequences):
-        super().process_sequences(playlist, sequences)
+    def process_segments(self, playlist, segments):
+        super().process_segments(playlist, segments)
         # update the segment URLs with the query string from the playlist URL
-        for sequence in sequences:
+        for sequence in segments:
             sequence.uri = copy_query_url(sequence.uri, self.stream.url)
 
 

--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -29,7 +29,7 @@ class LTVHLSStreamWorker(HLSStreamWorker):
         super().process_sequences(playlist, sequences)
         # update the segment URLs with the query string from the playlist URL
         for sequence in sequences:
-            sequence.segment.uri = copy_query_url(sequence.segment.uri, self.stream.url)
+            sequence.uri = copy_query_url(sequence.uri, self.stream.url)
 
 
 class LTVHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -26,7 +26,7 @@ class PlutoHLSStreamWriter(HLSStreamWriter):
     ad_re = re.compile(r"_ad/creative/|dai\.google\.com|Pluto_TV_OandO/.*(Bumper|plutotv_filler)")
 
     def should_filter_sequence(self, sequence):
-        return self.ad_re.search(sequence.segment.uri) is not None or super().should_filter_sequence(sequence)
+        return self.ad_re.search(sequence.uri) is not None or super().should_filter_sequence(sequence)
 
 
 class PlutoHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -25,8 +25,8 @@ log = logging.getLogger(__name__)
 class PlutoHLSStreamWriter(HLSStreamWriter):
     ad_re = re.compile(r"_ad/creative/|dai\.google\.com|Pluto_TV_OandO/.*(Bumper|plutotv_filler)")
 
-    def should_filter_sequence(self, sequence):
-        return self.ad_re.search(sequence.uri) is not None or super().should_filter_sequence(sequence)
+    def should_filter_segment(self, segment):
+        return self.ad_re.search(segment.uri) is not None or super().should_filter_segment(segment)
 
 
 class PlutoHLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -19,7 +19,7 @@ class TV8HLSStreamWriter(HLSStreamWriter):
     ad_re = re.compile(r"/ad/|/crea/")
 
     def should_filter_sequence(self, sequence):
-        return self.ad_re.search(sequence.segment.uri) is not None or super().should_filter_sequence(sequence)
+        return self.ad_re.search(sequence.uri) is not None or super().should_filter_sequence(sequence)
 
 
 class TV8HLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/tv8.py
+++ b/src/streamlink/plugins/tv8.py
@@ -18,8 +18,8 @@ log = logging.getLogger(__name__)
 class TV8HLSStreamWriter(HLSStreamWriter):
     ad_re = re.compile(r"/ad/|/crea/")
 
-    def should_filter_sequence(self, sequence):
-        return self.ad_re.search(sequence.uri) is not None or super().should_filter_sequence(sequence)
+    def should_filter_segment(self, segment):
+        return self.ad_re.search(segment.uri) is not None or super().should_filter_segment(segment)
 
 
 class TV8HLSStreamReader(HLSStreamReader):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -18,6 +18,7 @@ import logging
 import re
 import sys
 from contextlib import suppress
+from dataclasses import asdict as dataclass_asdict, dataclass, replace as dataclass_replace
 from datetime import datetime, timedelta
 from json import dumps as json_dumps
 from random import random
@@ -31,17 +32,7 @@ from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.session import Streamlink
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker, HLSStreamWriter
-from streamlink.stream.hls_playlist import (
-    M3U8,
-    ByteRange,
-    DateRange,
-    ExtInf,
-    Key,
-    M3U8Parser,
-    Map,
-    load as load_hls_playlist,
-    parse_tag,
-)
+from streamlink.stream.hls_playlist import M3U8, DateRange, M3U8Parser, Segment, load as load_hls_playlist, parse_tag
 from streamlink.stream.http import HTTPStream
 from streamlink.utils.args import keyvalue
 from streamlink.utils.parse import parse_json, parse_qsd
@@ -55,15 +46,8 @@ log = logging.getLogger(__name__)
 LOW_LATENCY_MAX_LIVE_EDGE = 2
 
 
-class TwitchSegment(NamedTuple):
-    uri: str
-    duration: float
-    title: Optional[str]
-    key: Optional[Key]
-    discontinuity: bool
-    byterange: Optional[ByteRange]
-    date: Optional[datetime]
-    map: Optional[Map]
+@dataclass
+class TwitchSegment(Segment):
     ad: bool
     prefetch: bool
 
@@ -98,15 +82,13 @@ class TwitchM3U8Parser(M3U8Parser):
         # Use the last duration for extrapolating the start time of the prefetch segment, which is needed for checking
         # whether it is an ad segment and matches the parsed date ranges or not
         date = last.date + timedelta(seconds=last.duration)
-        # Don't reset the discontinuity state in prefetch segments (at the bottom of the playlist)
-        discontinuity = self._discontinuity
         # Always treat prefetch segments after a discontinuity as ad segments
-        ad = discontinuity or self._is_segment_ad(date)
-        segment = last._replace(
+        ad = self._discontinuity or self._is_segment_ad(date)
+        segment = dataclass_replace(
+            last,
             uri=self.uri(value),
             duration=duration,
             title=None,
-            discontinuity=discontinuity,
             date=date,
             ad=ad,
             prefetch=True,
@@ -120,34 +102,13 @@ class TwitchM3U8Parser(M3U8Parser):
         if self._is_daterange_ad(daterange):
             self.m3u8.dateranges_ads.append(daterange)
 
-    # TODO: fix this mess by switching to segment dataclasses with inheritance
-    def get_segment(self, uri: str) -> TwitchSegment:  # type: ignore[override]
-        extinf: ExtInf = self._extinf or ExtInf(0, None)
-        self._extinf = None
+    # TODO: avoid having to copy the segment data
+    def get_segment(self, uri: str) -> TwitchSegment:
+        segment = super().get_segment(uri)
+        data = dataclass_asdict(segment)
+        ad = self._is_segment_ad(segment.date, segment.title)
 
-        discontinuity = self._discontinuity
-        self._discontinuity = False
-
-        byterange = self._byterange
-        self._byterange = None
-
-        date = self._date
-        self._date = None
-
-        ad = self._is_segment_ad(date, extinf.title)
-
-        return TwitchSegment(
-            uri=uri,
-            duration=extinf.duration,
-            title=extinf.title,
-            key=self._key,
-            discontinuity=discontinuity,
-            byterange=byterange,
-            date=date,
-            map=self._map,
-            ad=ad,
-            prefetch=False,
-        )
+        return TwitchSegment(**data, ad=ad, prefetch=False)
 
     def _is_segment_ad(self, date: Optional[datetime], title: Optional[str] = None) -> bool:
         return (

--- a/src/streamlink/stream/hls.py
+++ b/src/streamlink/stream/hls.py
@@ -146,50 +146,50 @@ class HLSStreamWriter(SegmentedStreamWriter[Segment, Response]):
 
         return request_params
 
-    def put(self, sequence: Optional[Segment]):
+    def put(self, segment: Optional[Segment]):
         if self.closed:
             return
 
-        if sequence is None:
+        if segment is None:
             self.queue(None, None)
             return
 
         # always queue the segment's map first if it exists
-        if sequence.map is not None:
-            cached_map_future = self.map_cache.get(sequence.map.uri)
+        if segment.map is not None:
+            cached_map_future = self.map_cache.get(segment.map.uri)
             # use cached map request if not a stream discontinuity
             # don't fetch multiple times when map request of previous segment is still pending
-            if cached_map_future is not None and not sequence.discontinuity:
+            if cached_map_future is not None and not segment.discontinuity:
                 future = cached_map_future
             else:
-                future = self.executor.submit(self.fetch_map, sequence)
-                self.map_cache.set(sequence.map.uri, future)
-            self.queue(sequence, future, True)
+                future = self.executor.submit(self.fetch_map, segment)
+                self.map_cache.set(segment.map.uri, future)
+            self.queue(segment, future, True)
 
         # regular segment request
-        future = self.executor.submit(self.fetch, sequence)
-        self.queue(sequence, future, False)
+        future = self.executor.submit(self.fetch, segment)
+        self.queue(segment, future, False)
 
-    def fetch(self, sequence: Segment) -> Optional[Response]:
+    def fetch(self, segment: Segment) -> Optional[Response]:
         try:
             return self._fetch(
-                sequence.uri,
+                segment.uri,
                 stream=self.stream_data,
-                **self.create_request_params(sequence.num, sequence, False),
+                **self.create_request_params(segment.num, segment, False),
             )
         except StreamError as err:
-            log.error(f"Failed to fetch segment {sequence.num}: {err}")
+            log.error(f"Failed to fetch segment {segment.num}: {err}")
 
-    def fetch_map(self, sequence: Segment) -> Optional[Response]:
-        _map: Map = sequence.map  # type: ignore[assignment]  # map is not None
+    def fetch_map(self, segment: Segment) -> Optional[Response]:
+        _map: Map = segment.map  # type: ignore[assignment]  # map is not None
         try:
             return self._fetch(
                 _map.uri,
                 stream=False,
-                **self.create_request_params(sequence.num, _map, True),
+                **self.create_request_params(segment.num, _map, True),
             )
         except StreamError as err:
-            log.error(f"Failed to fetch map for segment {sequence.num}: {err}")
+            log.error(f"Failed to fetch map for segment {segment.num}: {err}")
 
     def _fetch(self, url: str, **request_params) -> Optional[Response]:
         if self.closed or not self.retries:  # pragma: no cover
@@ -203,22 +203,22 @@ class HLSStreamWriter(SegmentedStreamWriter[Segment, Response]):
             **request_params,
         )
 
-    def should_filter_sequence(self, sequence: Segment) -> bool:
-        return self.ignore_names is not None and self.ignore_names.search(sequence.uri) is not None
+    def should_filter_segment(self, segment: Segment) -> bool:
+        return self.ignore_names is not None and self.ignore_names.search(segment.uri) is not None
 
-    def write(self, sequence: Segment, result: Response, *data):
-        if not self.should_filter_sequence(sequence):
-            log.debug(f"Writing segment {sequence.num} to output")
+    def write(self, segment: Segment, result: Response, *data):
+        if not self.should_filter_segment(segment):
+            log.debug(f"Writing segment {segment.num} to output")
 
             written_once = self.reader.buffer.written_once
             try:
-                return self._write(sequence, result, *data)
+                return self._write(segment, result, *data)
             finally:
                 is_paused = self.reader.is_paused()
 
                 # Depending on the filtering implementation, the segment's discontinuity attribute can be missing.
                 # Also check if the output will be resumed after data has already been written to the buffer before.
-                if sequence.discontinuity or is_paused and written_once:
+                if segment.discontinuity or is_paused and written_once:
                     log.warning(
                         "Encountered a stream discontinuity. This is unsupported and will result in incoherent output data.",
                     )
@@ -229,7 +229,7 @@ class HLSStreamWriter(SegmentedStreamWriter[Segment, Response]):
                     self.reader.resume()
 
         else:
-            log.debug(f"Discarding segment {sequence.num}")
+            log.debug(f"Discarding segment {segment.num}")
 
             # Read and discard any remaining HTTP response data in the response connection.
             # Unread data in the HTTPResponse connection blocks the connection from being released back to the pool.
@@ -240,10 +240,10 @@ class HLSStreamWriter(SegmentedStreamWriter[Segment, Response]):
                 log.info("Filtering out segments and pausing stream output")
                 self.reader.pause()
 
-    def _write(self, sequence: Segment, result: Response, is_map: bool):
-        if sequence.key and sequence.key.method != "NONE":
+    def _write(self, segment: Segment, result: Response, is_map: bool):
+        if segment.key and segment.key.method != "NONE":
             try:
-                decryptor = self.create_decryptor(sequence.key, sequence.num)
+                decryptor = self.create_decryptor(segment.key, segment.num)
             except (StreamError, ValueError) as err:
                 log.error(f"Failed to create decryptor: {err}")
                 self.close()
@@ -259,10 +259,10 @@ class HLSStreamWriter(SegmentedStreamWriter[Segment, Response]):
                 chunk = unpad(decrypted_chunk, AES.block_size, style="pkcs7")
                 self.reader.buffer.write(chunk)
             except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
-                log.error(f"Download of segment {sequence.num} failed: {err}")
+                log.error(f"Download of segment {segment.num} failed: {err}")
                 return
             except ValueError as err:
-                log.error(f"Error while decrypting segment {sequence.num}: {err}")
+                log.error(f"Error while decrypting segment {segment.num}: {err}")
                 return
 
         else:
@@ -270,13 +270,13 @@ class HLSStreamWriter(SegmentedStreamWriter[Segment, Response]):
                 for chunk in result.iter_content(self.WRITE_CHUNK_SIZE):
                     self.reader.buffer.write(chunk)
             except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
-                log.error(f"Download of segment {sequence.num} failed: {err}")
+                log.error(f"Download of segment {segment.num} failed: {err}")
                 return
 
         if is_map:
-            log.debug(f"Segment initialization {sequence.num} complete")
+            log.debug(f"Segment initialization {segment.num} complete")
         else:
-            log.debug(f"Segment {sequence.num} complete")
+            log.debug(f"Segment {segment.num} complete")
 
 
 class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
@@ -293,8 +293,9 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
         self.playlist_end: Optional[int] = None
         self.playlist_targetduration: float = 0
         self.playlist_sequence: int = -1
-        self.playlist_sequences: List[Segment] = []
-        self.playlist_sequences_last: datetime = now()
+        self.playlist_sequence_last: datetime = now()
+        self.playlist_segments: List[Segment] = []
+
         self.playlist_reload_last: datetime = now()
         self.playlist_reload_time: float = 6
         self.playlist_reload_time_override = self.session.options.get("hls-playlist-reload-time")
@@ -350,7 +351,7 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
         self.playlist_reload_time = self._playlist_reload_time(playlist)
 
         if playlist.segments:
-            self.process_sequences(playlist, playlist.segments)
+            self.process_segments(playlist)
 
     def _playlist_reload_time(self, playlist: M3U8) -> float:
         if self.playlist_reload_time_override == "segment" and playlist.segments:
@@ -366,31 +367,32 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
 
         return self.playlist_reload_time
 
-    def process_sequences(self, playlist: M3U8, sequences: List[Segment]) -> None:
-        first_sequence, last_sequence = sequences[0], sequences[-1]
+    def process_segments(self, playlist: M3U8) -> None:
+        segments = playlist.segments
+        first_segment, last_segment = segments[0], segments[-1]
 
-        if first_sequence.key and first_sequence.key.method != "NONE":
+        if first_segment.key and first_segment.key.method != "NONE":
             log.debug("Segments in this playlist are encrypted")
 
-        self.playlist_changed = ([s.num for s in self.playlist_sequences] != [s.num for s in sequences])
-        self.playlist_sequences = sequences
+        self.playlist_changed = ([s.num for s in self.playlist_segments] != [s.num for s in segments])
+        self.playlist_segments = segments
 
         if not self.playlist_changed:
             self.playlist_reload_time = max(self.playlist_reload_time / 2, 1)
 
         if playlist.is_endlist:
-            self.playlist_end = last_sequence.num
+            self.playlist_end = last_segment.num
 
         if self.playlist_sequence < 0:
             if self.playlist_end is None and not self.hls_live_restart:
-                edge_index = -(min(len(sequences), max(int(self.live_edge), 1)))
-                edge_sequence = sequences[edge_index]
-                self.playlist_sequence = edge_sequence.num
+                edge_index = -(min(len(segments), max(int(self.live_edge), 1)))
+                edge_segment = segments[edge_index]
+                self.playlist_sequence = edge_segment.num
             else:
-                self.playlist_sequence = first_sequence.num
+                self.playlist_sequence = first_segment.num
 
-    def valid_sequence(self, sequence: Segment) -> bool:
-        return sequence.num >= self.playlist_sequence
+    def valid_segment(self, segment: Segment) -> bool:
+        return segment.num >= self.playlist_sequence
 
     def _segment_queue_timing_threshold_reached(self) -> bool:
         if self.segment_queue_timing_threshold_factor <= 0:
@@ -400,31 +402,31 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
             self.SEGMENT_QUEUE_TIMING_THRESHOLD_MIN,
             self.playlist_targetduration * self.segment_queue_timing_threshold_factor,
         )
-        if now() <= self.playlist_sequences_last + timedelta(seconds=threshold):
+        if now() <= self.playlist_sequence_last + timedelta(seconds=threshold):
             return False
 
         log.warning(f"No new segments in playlist for more than {threshold:.2f}s. Stopping...")
         return True
 
     @staticmethod
-    def duration_to_sequence(duration: float, sequences: List[Segment]) -> int:
+    def duration_to_sequence(duration: float, segments: List[Segment]) -> int:
         d = 0.0
         default = -1
 
-        sequences_order = sequences if duration >= 0 else reversed(sequences)
+        segments_order = segments if duration >= 0 else reversed(segments)
 
-        for sequence in sequences_order:
+        for segment in segments_order:
             if d >= abs(duration):
-                return sequence.num
-            d += sequence.duration
-            default = sequence.num
+                return segment.num
+            d += segment.duration
+            default = segment.num
 
         # could not skip far enough, so return the default
         return default
 
     def iter_segments(self):
         self.playlist_reload_last \
-            = self.playlist_sequences_last \
+            = self.playlist_sequence_last \
             = now()
 
         try:
@@ -441,12 +443,12 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
             self.duration_offset_start = -self.duration_offset_start
 
         if self.duration_offset_start != 0:
-            self.playlist_sequence = self.duration_to_sequence(self.duration_offset_start, self.playlist_sequences)
+            self.playlist_sequence = self.duration_to_sequence(self.duration_offset_start, self.playlist_segments)
 
-        if self.playlist_sequences:
+        if self.playlist_segments:
             log.debug("; ".join([
-                f"First Sequence: {self.playlist_sequences[0].num}",
-                f"Last Sequence: {self.playlist_sequences[-1].num}",
+                f"First Sequence: {self.playlist_segments[0].num}",
+                f"Last Sequence: {self.playlist_segments[-1].num}",
             ]))
             log.debug("; ".join([
                 f"Start offset: {self.duration_offset_start}",
@@ -458,16 +460,16 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
         total_duration = 0
         while not self.closed:
             queued = False
-            for sequence in self.playlist_sequences:
-                if not self.valid_sequence(sequence):
+            for segment in self.playlist_segments:
+                if not self.valid_segment(segment):
                     continue
 
-                log.debug(f"Adding segment {sequence.num} to queue")
-                yield sequence
+                log.debug(f"Adding segment {segment.num} to queue")
+                yield segment
 
                 queued = True
 
-                total_duration += sequence.duration
+                total_duration += segment.duration
                 if self.duration_limit and total_duration >= self.duration_limit:
                     log.info(f"Stopping stream early after {self.duration_limit}")
                     return
@@ -475,14 +477,14 @@ class HLSStreamWorker(SegmentedStreamWorker[Segment, Response]):
                 if self.closed:  # pragma: no cover
                     return
 
-                self.playlist_sequence = sequence.num + 1
+                self.playlist_sequence = segment.num + 1
 
             # End of stream
             if self.closed or self.playlist_end is not None and (not queued or self.playlist_sequence > self.playlist_end):
                 return
 
             if queued:
-                self.playlist_sequences_last = now()
+                self.playlist_sequence_last = now()
             elif self._segment_queue_timing_threshold_reached():
                 return
 

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -2,6 +2,7 @@ import logging
 import math
 import re
 from binascii import Error as BinasciiError, unhexlify
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Callable, ClassVar, Dict, Iterator, List, Mapping, NamedTuple, Optional, Tuple, Type, Union
 from urllib.parse import urljoin, urlparse
@@ -104,14 +105,16 @@ class IFrameStreamInfo(NamedTuple):
     video: Optional[str]
 
 
-class Playlist(NamedTuple):
+@dataclass
+class Playlist:
     uri: str
     stream_info: Union[StreamInfo, IFrameStreamInfo]
     media: List[Media]
     is_iframe: bool
 
 
-class Segment(NamedTuple):
+@dataclass
+class Segment:
     uri: str
     duration: float
     title: Optional[str]

--- a/src/streamlink/stream/hls_playlist.py
+++ b/src/streamlink/stream/hls_playlist.py
@@ -116,6 +116,7 @@ class Playlist:
 @dataclass
 class Segment:
     uri: str
+    num: int
     duration: float
     title: Optional[str]
     key: Optional[Key]
@@ -665,6 +666,11 @@ class M3U8Parser(metaclass=M3U8ParserMeta):
 
         self.m3u8.is_master = not not self.m3u8.playlists
 
+        # Update segment numbers
+        media_sequence = self.m3u8.media_sequence or 0
+        for i, segment in enumerate(self.m3u8.segments):
+            segment.num = media_sequence + i
+
         return self.m3u8
 
     def uri(self, uri: str) -> str:
@@ -690,6 +696,7 @@ class M3U8Parser(metaclass=M3U8ParserMeta):
 
         return Segment(
             uri=uri,
+            num=-1,
             duration=extinf.duration,
             title=extinf.title,
             key=self._key,

--- a/tests/stream/test_hls.py
+++ b/tests/stream/test_hls.py
@@ -219,7 +219,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_reload.wait_ready(1), "Loads playlist for the first time"
             assert worker.playlist_sequence == -1, "Initial sequence number"
-            assert worker.playlist_sequences_last == EPOCH, "Sets the initial last queue time"
+            assert worker.playlist_sequence_last == EPOCH, "Sets the initial last queue time"
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
@@ -227,7 +227,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #1"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
-            assert worker.playlist_sequences_last == EPOCH + ONE_SECOND, "Updates the last queue time"
+            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Updates the last queue time"
             assert worker.playlist_targetduration == 5.0
 
             # trigger next reload when the target duration has passed
@@ -237,7 +237,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #2"
             assert worker.playlist_sequence == 2, "Updates the sequence number again"
-            assert worker.playlist_sequences_last == EPOCH + ONE_SECOND + targetduration, "Updates the last queue time again"
+            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND + targetduration, "Updates the last queue time again"
             assert worker.playlist_targetduration == 5.0
 
             for num in range(3, 6):
@@ -248,7 +248,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() call #{num}"
                 assert worker.playlist_sequence == 2, "Sequence number is unchanged"
-                assert worker.playlist_sequences_last == EPOCH + ONE_SECOND + targetduration, "Last queue time is unchanged"
+                assert worker.playlist_sequence_last == EPOCH + ONE_SECOND + targetduration, "Last queue time is unchanged"
                 assert worker.playlist_targetduration == 5.0
 
             assert mock_log.warning.call_args_list == []
@@ -280,7 +280,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_reload.wait_ready(1), "Loads playlist for the first time"
             assert worker.playlist_sequence == -1, "Initial sequence number"
-            assert worker.playlist_sequences_last == EPOCH, "Sets the initial last queue time"
+            assert worker.playlist_sequence_last == EPOCH, "Sets the initial last queue time"
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
@@ -288,7 +288,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at first wait() call"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
-            assert worker.playlist_sequences_last == EPOCH + ONE_SECOND, "Updates the last queue time"
+            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Updates the last queue time"
             assert worker.playlist_targetduration == 5.0
             assert self.await_read() == self.content(segments)
 
@@ -300,7 +300,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() #{num + 1}"
                 assert worker.playlist_sequence == 1, "Sequence number is unchanged"
-                assert worker.playlist_sequences_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
+                assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
 
         assert self.thread.data == [], "No new data"
         assert worker.is_alive()
@@ -325,7 +325,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_reload.wait_ready(1), "Loads playlist for the first time"
             assert worker.playlist_sequence == -1, "Initial sequence number"
-            assert worker.playlist_sequences_last == EPOCH, "Sets the initial last queue time"
+            assert worker.playlist_sequence_last == EPOCH, "Sets the initial last queue time"
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
@@ -333,7 +333,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #1"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
-            assert worker.playlist_sequences_last == EPOCH + ONE_SECOND, "Updates the last queue time"
+            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Updates the last queue time"
             assert worker.playlist_targetduration == 1.0
 
             for num in range(2, 7):
@@ -344,7 +344,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() call #{num}"
                 assert worker.playlist_sequence == 1, "Sequence number is unchanged"
-                assert worker.playlist_sequences_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
+                assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
                 assert worker.playlist_targetduration == 1.0
 
             assert mock_log.warning.call_args_list == []

--- a/tests/stream/test_hls_filtered.py
+++ b/tests/stream/test_hls_filtered.py
@@ -31,7 +31,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = _TestSubjectHLSStream
 
     @classmethod
-    def filter_sequence(cls, sequence):
+    def filter_segment(cls, sequence):
         return sequence.title == FILTERED
 
     def get_session(self, options=None, *args, **kwargs):
@@ -57,7 +57,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert data == self.content(segments), "Does not filter by default"
         assert reader.filter_wait(timeout=0)
 
-    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_sequence", new=filter_sequence)
+    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_segment", new=filter_segment)
     @patch("streamlink.stream.hls.log")
     def test_filtered_logging(self, mock_log):
         thread, reader, writer, segments = self.subject([
@@ -113,7 +113,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert data == self.content(segments, cond=lambda s: s.num % 4 > 1), "Correctly filters out segments"
         assert all(self.called(s) for s in segments.values()), "Downloads all segments"
 
-    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_sequence", new=filter_sequence)
+    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_segment", new=filter_segment)
     def test_filtered_timeout(self):
         thread, reader, writer, segments = self.subject([
             Playlist(0, [Segment(0), Segment(1)], end=True),
@@ -128,7 +128,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
         with pytest.raises(OSError, match=r"^Read timeout$"):
             self.await_read()
 
-    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_sequence", new=filter_sequence)
+    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_segment", new=filter_segment)
     def test_filtered_no_timeout(self):
         thread, reader, writer, segments = self.subject([
             Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)]),
@@ -156,7 +156,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
         data = self.await_read()
         assert data == self.content(segments, cond=lambda s: s.num >= 2)
 
-    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_sequence", new=filter_sequence)
+    @patch("streamlink.stream.hls.HLSStreamWriter.should_filter_segment", new=filter_segment)
     def test_filtered_closed(self):
         thread, reader, writer, segments = self.subject(start=False, playlists=[
             Playlist(0, [SegmentFiltered(0), SegmentFiltered(1)], end=True),

--- a/tests/stream/test_hls_filtered.py
+++ b/tests/stream/test_hls_filtered.py
@@ -32,7 +32,7 @@ class TestFilteredHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
     @classmethod
     def filter_sequence(cls, sequence):
-        return sequence.segment.title == FILTERED
+        return sequence.title == FILTERED
 
     def get_session(self, options=None, *args, **kwargs):
         session = super().get_session(options)

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -12,7 +12,7 @@ from streamlink.stream.hls_playlist import (
     Resolution,
     Segment,
     StreamInfo,
-    load,
+    parse_m3u8,
     parse_tag,
 )
 from tests.resources import text
@@ -212,9 +212,9 @@ def test_parse_resolution(string: str, expected: Resolution):
 
 
 class TestHLSPlaylist:
-    def test_load(self):
+    def test_load(self) -> None:
         with text("hls/test_1.m3u8") as m3u8_fh:
-            playlist = load(m3u8_fh.read(), "http://test.se/")
+            playlist = parse_m3u8(m3u8_fh.read(), "http://test.se/", parser=M3U8Parser)
 
         assert playlist.media == [
             Media(
@@ -382,9 +382,9 @@ class TestHLSPlaylist:
             ),
         ]
 
-    def test_parse_date(self):
+    def test_parse_date(self) -> None:
         with text("hls/test_date.m3u8") as m3u8_fh:
-            playlist = load(m3u8_fh.read(), "http://test.se/")
+            playlist = parse_m3u8(m3u8_fh.read(), "http://test.se/", parser=M3U8Parser)
 
         start_date = datetime(year=2000, month=1, day=1, hour=0, minute=0, second=0, microsecond=0, tzinfo=UTC)
         end_date = datetime(year=2000, month=1, day=1, hour=0, minute=1, second=0, microsecond=0, tzinfo=UTC)

--- a/tests/stream/test_hls_playlist.py
+++ b/tests/stream/test_hls_playlist.py
@@ -499,6 +499,7 @@ class TestHLSPlaylist:
         assert list(playlist.segments) == [
             Segment(
                 uri="http://test.se/segment0-15.ts",
+                num=0,
                 duration=15.0,
                 title="live",
                 date=start_date,
@@ -509,6 +510,7 @@ class TestHLSPlaylist:
             ),
             Segment(
                 uri="http://test.se/segment15-30.5.ts",
+                num=1,
                 duration=15.5,
                 title="live",
                 date=start_date + delta_15,
@@ -519,6 +521,7 @@ class TestHLSPlaylist:
             ),
             Segment(
                 uri="http://test.se/segment30.5-60.ts",
+                num=2,
                 duration=29.5,
                 title="live",
                 date=start_date + delta_30,
@@ -529,6 +532,7 @@ class TestHLSPlaylist:
             ),
             Segment(
                 uri="http://test.se/segment60-.ts",
+                num=3,
                 duration=60.0,
                 title="live",
                 date=start_date + delta_60,


### PR DESCRIPTION
Ref #5498 

1. **Turn `Segment` and `Playlist` into dataclasses, so they can be subclassed**
    - Make `TwitchSegment` inherit from `Segment`
    - Update `TwitchM3U8Parser` accordingly
    - Fix `ltv_lsm_lv` plugin (previously cloned the `Segment` named tuple, now simply updates the `uri` attribute)

2. **Remove `Sequence` named tuple wrapper, so `HLSStream{Writer,Worker}` operate on the `Segment` directly**
    - Add `num` attribute to `Segment` and initialize with `-1`
    - Move sequence number logic from `HLSStreamWorker` to `M3U8Parser`
    - Update various `Sequence` references in `HLSStream{Writer,Worker}`
    - Update generic typevar of `HLSStream{Writer,Worker,Reader}`
    - Update HLS subclasses accordingly in various plugins

    I was thinking about adding a `segment` compatibility property with a deprecation warning to `Segment`, so third-party plugin implementations which subclass `HLSStream{Writer,Worker}` don't break when they still implement logic for the `Sequence` wrapper (where the actual segment was accessed via the `segment` attribute), but I decided against it, because (3) changes the names and signatures of some methods anyway. As said in #5498, these are not public interfaces, so I don't care.

3. **Update class attributes and method names/signatures of `HLSStream{Writer,Worker}` after the removal of `Sequence`**
    - Change names from sequence(s) to segment(s)
    - Remove `sequences` arg from `HLSStreamWorker.process_segments()` as it's not needed anymore after the sequence number logic was moved to the parser
    - Keep "Sequence" names and log messages for everything that's about the order of segments in the playlist or the position in the stream
    - Update HLS subclasses accordingly in various plugins

4. **Refactor M3U8 playlist loading and update/fix typing**
    - Rename `stream.hls_playlist.load` to `stream.hls_playlist.parse_m3u8`
    - Replace `HLSStreamWorker._reload_playlist()` and `HLSStream._get_variant_playlist()` with direct `parse_m3u8()` calls, using dependency injection and the `HLSStream.__parser__` reference
    - Turn `M3U8` into a generic class and add covariant type-vars for the `Segment` and `Playlist` dataclasses
    - Turn `M3U8Parser` into a generic class and add covariant type-vars for the `M3U8` class, as well as `Segment` and `Playlist`
    - Update HLS Twitch subclasses accordingly

    There are still some typing issues left, but I didn't manage to fix it (yet). I believe there are currently some restrictions ([PEP 696 - default values for `TypeVar`s](https://peps.python.org/pep-0696/)), so unless the whole design of the parser and stuff gets rewritten, this can't be improved further. But I'm not 100% sure. Should be good enough though.

----

I was also thinking about finally moving the HLS and DASH stuff into their own sub-packages, so we don't have multiple modules lying around in the `stream` package. This would even make more sense with my plans for the `BaseSegment` stuff, so the HLS and DASH parsers don't have to import the segmented stream implementations, as the `BaseSegment` definition would have to go there otherwise. Those changes don't belong in this PR though.

----

Btw, I'm not expecting any reviews here, because it requires knowledge of the details of the HLS classes. I will merge this when I feel ready.