### PR TITLE
plugins.nicolive: add metadata

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -2,6 +2,9 @@
 $description Japanese live-streaming and video hosting social platform.
 $url live.nicovideo.jp
 $type live, vod
+$metadata id
+$metadata author
+$metadata title
 $account Required by some streams
 $notes Timeshift is supported
 """
@@ -11,7 +14,7 @@ import re
 from threading import Event
 from urllib.parse import urljoin
 
-from streamlink.plugin import Plugin, PluginError, pluginargument, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.websocket import WebsocketClient
 from streamlink.stream.hls import HLSStream, HLSStreamReader
@@ -181,13 +184,17 @@ class NicoLive(Plugin):
 
         self.niconico_web_login()
 
-        wss_api_url = self.get_wss_api_url()
+        data = self.get_data()
+
+        wss_api_url = self.find_wss_api_url(data)
         if not wss_api_url:
             log.error(
                 "Failed to get wss_api_url. "
                 + "Please check if the URL is correct, and make sure your account has access to the video.",
             )
             return
+
+        self.id, self.author, self.title = self.find_metadata(data)
 
         self.wsclient = NicoLiveWsClient(self.session, wss_api_url)
         self.wsclient.start()
@@ -213,26 +220,56 @@ class NicoLive(Plugin):
 
         return self.wsclient.hls_stream_url
 
-    def get_wss_api_url(self):
-        try:
-            data = self.session.http.get(self.url, schema=validate.Schema(
-                validate.parse_html(),
-                validate.xml_find(".//script[@id='embedded-data'][@data-props]"),
-                validate.get("data-props"),
-                validate.parse_json(),
-                {"site": {
+    def get_data(self):
+        return self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_find(".//script[@id='embedded-data'][@data-props]"),
+            validate.get("data-props"),
+            validate.parse_json(),
+        ))
+
+    @staticmethod
+    def find_metadata(data):
+        schema = validate.Schema(
+            {
+                "program": {
+                    "nicoliveProgramId": str,
+                    "supplier": {"name": str},
+                    "title": str,
+                },
+            },
+            validate.get("program"),
+            validate.union_get(
+                "nicoliveProgramId",
+                ("supplier", "name"),
+                "title",
+            ),
+        )
+
+        return schema.validate(data)
+
+    @staticmethod
+    def find_wss_api_url(data):
+        schema = validate.Schema(
+            {
+                "site": {
                     "relive": {
-                        "webSocketUrl": validate.url(scheme="wss"),
+                        "webSocketUrl": validate.any(
+                            validate.url(scheme="wss"),
+                            "",
+                        ),
                     },
                     validate.optional("frontendId"): int,
-                }},
-                validate.get("site"),
-                validate.union_get(("relive", "webSocketUrl"), "frontendId"),
-            ))
-        except PluginError:
+                },
+            },
+            validate.get("site"),
+            validate.union_get(("relive", "webSocketUrl"), "frontendId"),
+        )
+
+        wss_api_url, frontend_id = schema.validate(data)
+        if not wss_api_url:
             return
 
-        wss_api_url, frontend_id = data
         if frontend_id is not None:
             wss_api_url = update_qsd(wss_api_url, {"frontend_id": frontend_id})
 


### PR DESCRIPTION
Resolves #5515 

I am not sure though if this could break some streams, because metadata is not treated optionally, so if it's missing, then the validation schema could fail.

@SecondaryH could you please check some more streams (preferrably with a login - which I don't have) and verify these changes? Thanks!
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

----

Some streams I've checked:

1\. From the tests file:

```bash
streamlink --json https://live.nicovideo.jp/watch/co2619719 best | jq .metadata
```
```json
{
  "id": "lv342666086",
  "author": "novoll(千葉県民)",
  "category": null,
  "title": "【SFC】魔法騎士レイアース 初見プレイ【13枠目】"
}
```

2\. Picked randomly from their site

```bash
streamlink --json https://live.nicovideo.jp/watch/lv342666014 best | jq .metadata
```
```json
{
  "id": "lv342666014",
  "author": "ノンケのねねし",
  "category": null,
  "title": "【スト６】9月16日、17日に仙台で大規模大会があります（ラウンジ）【ノンケ配信記】"
}
```