### PR TITLE
logger: fix missing FileHandler encoding

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -193,7 +193,7 @@ def basicConfig(
     with _config_lock:
         handler: logging.StreamHandler
         if filename is not None:
-            handler = logging.FileHandler(filename, filemode)
+            handler = logging.FileHandler(filename, filemode, encoding="utf-8")
         else:
             handler = logging.StreamHandler(stream)
 


### PR DESCRIPTION
- Always set encoding of `logging.FileHandler` to `utf-8`
- Update and add tests

----

Fixes #5531 
