### PR TITLE
plugins.hiplayer: fix base64 data, drop rotana.net

### DIFF
--- a/src/streamlink/plugins/hiplayer.py
+++ b/src/streamlink/plugins/hiplayer.py
@@ -2,7 +2,6 @@
 $description United Arab Emirates CDN hosting live content for various websites in The Middle East.
 $url alwasat.ly
 $url media.gov.kw
-$url rotana.net
 $type live
 $region various
 """
@@ -19,16 +18,8 @@ from streamlink.stream.hls import HLSStream
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(re.compile(r"""
-    https?://(?:www\.)?
-    (
-        alwasat\.ly
-    |
-        media\.gov\.kw
-    |
-        rotana\.net
-    )
-""", re.VERBOSE))
+@pluginmatcher(name="alwasatly", pattern=re.compile(r"https?://(?:www\.)?alwasat\.ly"))
+@pluginmatcher(name="mediagovkw", pattern=re.compile(r"https?://(?:www\.)?media\.gov\.kw"))
 class HiPlayer(Plugin):
     DAI_URL = "https://pubads.g.doubleclick.net/ssai/event/{0}/streams"
 
@@ -56,7 +47,7 @@ class HiPlayer(Plugin):
         data = self.session.http.get(
             js_url,
             schema=validate.Schema(
-                re.compile(r"var \w+\s*=\s*\[(?P<data>.+)]\.join\([\"']{2}\)"),
+                re.compile(r"\[(?P<data>[^]]+)]\.join\([\"']{2}\)"),
                 validate.none_or_all(
                     validate.get("data"),
                     validate.transform(lambda s: re.sub(r"['\", ]", "", s)),

--- a/tests/plugins/test_hiplayer.py
+++ b/tests/plugins/test_hiplayer.py
@@ -6,10 +6,7 @@ class TestPluginCanHandleUrlHiPlayer(PluginCanHandleUrl):
     __plugin__ = HiPlayer
 
     should_match = [
-        "https://www.alwasat.ly/any",
-        "https://www.alwasat.ly/any/path",
-        "https://www.media.gov.kw/any",
-        "https://www.media.gov.kw/any/path",
-        "https://rotana.net/any",
-        "https://rotana.net/any/path",
+        ("alwasatly", "https://alwasat.ly/live"),
+        ("mediagovkw", "https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTV1"),
+        ("mediagovkw", "https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTVSports"),
     ]


### PR DESCRIPTION
Fixes #5524

```
$ ./script/test-plugin-urls.py hiplayer
:: Finding streams for URL: https://alwasat.ly/live
:: Found streams: 240p, 360p, 480p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTV1
:: Found streams: 240p, 360p, 480p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.media.gov.kw/LiveTV.aspx?PanChannel=KTVSports
:: Found streams: 240p, 360p, 480p, 720p, 1080p, worst, best
```

----

This also drops rotana.net from the plugin because the site appears to be completely different now:
https://rotana.net/ar/channels#/live/rotana_CinemaKSA

The site had a dedicated plugin in the past and then got merged into the hiplayer plugin:
- #4512
- #4507