### PR TITLE
docs: add Alpine Linux to install docs

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -136,6 +136,12 @@ Linux and BSD
       - See the `Linux AppImages`_ section below
     * - :octicon:`verified` Python pip
       - See the `PyPI package and source code`_ section below
+    * - :octicon:`package-dependents` `Alpine Linux (edge, testing)`_
+      - .. code-block:: bash
+
+            sudo apk add streamlink
+
+        `Enabling the edge/testing repository`_
     * - :octicon:`package-dependents` `Arch Linux`_
       - .. code-block:: bash
 
@@ -205,6 +211,7 @@ Linux and BSD
 
             sudo xbps-install streamlink
 
+.. _Alpine Linux (edge, testing): https://pkgs.alpinelinux.org/packages?name=streamlink
 .. _Arch Linux: https://archlinux.org/packages/extra/any/streamlink/
 .. _Arch Linux (aur, git): https://aur.archlinux.org/packages/streamlink-git/
 .. _Debian (sid, testing): https://packages.debian.org/sid/streamlink
@@ -219,6 +226,7 @@ Linux and BSD
 .. _Solus: https://github.com/getsolus/packages/tree/main/packages/s/streamlink
 .. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
 
+.. _Enabling the edge/testing repository: https://wiki.alpinelinux.org/wiki/Repositories#Edge
 .. _Installing AUR packages: https://wiki.archlinux.org/index.php/Arch_User_Repository
 .. _Installing Debian backported packages: https://wiki.debian.org/Backports
 .. _NixOS channel: https://search.nixos.org/packages?show=streamlink&query=streamlink
@@ -233,6 +241,8 @@ Package maintainers
 
     * - Distribution / Platform
       - Maintainer
+    * - Alpine Linux
+      - Robert Sacks <robert at sacks.email>
     * - Arch
       - Giancarlo Razzolini <grazzolini at archlinux.org>
     * - Arch (aur, git)


### PR DESCRIPTION
Unlike Debian backports, no instructions on how to add/enable the required `edge/testing` package repo, for reasons noted in the linked wiki.