### PR TITLE
plugins.nos: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -2,6 +2,7 @@
 $description Live TV channels and video on-demand service from NOS, a Dutch public, state-owned broadcaster.
 $url nos.nl
 $type live, vod
+$metadata id
 $metadata title
 $region Netherlands
 """
@@ -9,7 +10,7 @@ $region Netherlands
 import logging
 import re
 
-from streamlink.plugin import Plugin, PluginError, pluginmatcher
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 
@@ -18,86 +19,43 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:\w+\.)?nos\.nl/(?:livestream|collectie|video|uitzendingen)",
+    r"https?://(?:\w+\.)?nos\.nl/(?:live|video|collectie)",
 ))
 class NOS(Plugin):
-    _msg_live_offline = "This livestream is offline."
-    vod_keys = {
-        "pages/Collection/Video/Video": "item",
-        "pages/Video/Video": "video",
-    }
-
     def _get_streams(self):
-        try:
-            scripts = self.session.http.get(self.url, schema=validate.Schema(
+        data = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
                 validate.parse_html(),
-                validate.xml_findall(".//script[@type='application/json'][@data-ssr-name]"),
-                [
-                    validate.union((
-                        validate.get("data-ssr-name"),
-                        validate.all(
-                            validate.getattr("text"),
-                            validate.parse_json(),
-                        ),
-                    )),
-                ],
-            ))
-        except PluginError:
-            log.error("Could not find any stream data")
+                validate.xml_xpath_string(".//script[@type='application/ld+json'][1]/text()"),
+                validate.none_or_all(
+                    validate.parse_json(),
+                    {
+                        "@type": "VideoObject",
+                        "encodingFormat": "application/vnd.apple.mpegurl",
+                        "contentUrl": validate.url(),
+                        "identifier": validate.any(int, str),
+                        "name": str,
+                    },
+                    validate.union_get(
+                        "contentUrl",
+                        "identifier",
+                        "name",
+                    ),
+                ),
+            ),
+        )
+        if not data:
             return
 
-        for _data_ssr_name, _data_json in scripts:
-            video_url = None
-            log.trace(f"Found _data_ssr_name={_data_ssr_name}")
+        hls_url, self.id, self.title = data
 
-            if _data_ssr_name == "pages/Broadcasts/Broadcasts":
-                self.title, video_url, is_live = validate.Schema(
-                    {"currentLivestream": {
-                        "is_live": bool,
-                        "title": str,
-                        "stream": validate.url(),
-                    }},
-                    validate.get("currentLivestream"),
-                    validate.union_get("title", "stream", "is_live"),
-                ).validate(_data_json)
-                if not is_live:
-                    log.error(self._msg_live_offline)
-                    continue
+        res = self.session.http.get(hls_url, raise_for_status=False)
+        if res.status_code >= 400:
+            log.error("Content is inaccessible or may have expired")
+            return
 
-            elif _data_ssr_name == "pages/Livestream/Livestream":
-                self.title, video_url, is_live = validate.Schema(
-                    {
-                        "streamIsLive": bool,
-                        "title": str,
-                        "stream": validate.url(),
-                    },
-                    validate.union_get("title", "stream", "streamIsLive"),
-                ).validate(_data_json)
-                if not is_live:
-                    log.error(self._msg_live_offline)
-                    continue
-
-            elif _data_ssr_name in self.vod_keys.keys():
-                _key = self.vod_keys[_data_ssr_name]
-                self.title, video_url = validate.Schema(
-                    {_key: {
-                        "title": str,
-                        "aspect_ratios": {
-                            "profiles": validate.all(
-                                [{
-                                    "name": str,
-                                    "url": validate.url(),
-                                }],
-                                validate.filter(lambda p: p["name"] == "hls_unencrypted"),
-                            ),
-                        },
-                    }},
-                    validate.get(_key),
-                    validate.union_get("title", ("aspect_ratios", "profiles", 0, "url")),
-                ).validate(_data_json)
-
-            if video_url is not None:
-                return HLSStream.parse_variant_playlist(self.session, video_url)
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
 
 
 __plugin__ = NOS

--- a/tests/plugins/test_nos.py
+++ b/tests/plugins/test_nos.py
@@ -6,15 +6,17 @@ class TestPluginCanHandleUrlNOS(PluginCanHandleUrl):
     __plugin__ = NOS
 
     should_match = [
-        "https://nos.nl/livestream/2220100-wk-sprint-schaatsen-1-000-meter-mannen.html",
+        "https://nos.nl/live",
         "https://nos.nl/collectie/13781/livestream/2385081-ek-voetbal-engeland-schotland",
-        "https://nos.nl/collectie/13781/livestream/2385461-ek-voetbal-voorbeschouwing-italie-wales-18-00-uur",
-        "https://nos.nl/collectie/13781/video/2385846-ek-in-2-21-gosens-show-tegen-portugal-en-weer-volle-bak-in-boedapest",
-        "https://nos.nl/video/2385779-dronebeelden-tonen-spoor-van-vernieling-bij-leersum",
-        "https://nos.nl/uitzendingen",
-        "https://nos.nl/uitzendingen/livestream/2385462",
+        "https://nos.nl/collectie/13951/video/2491092-dit-was-prinsjesdag",
+        "https://nos.nl/video/2490788-meteoor-gespot-boven-noord-nederland",
     ]
 
     should_not_match = [
         "https://nos.nl/artikel/2385784-explosieve-situatie-leidde-tot-verwoeste-huizen-en-omgewaaide-bomen-leersum",
+        "https://nos.nl/sport",
+        "https://nos.nl/sport/videos",
+        "https://nos.nl/programmas",
+        "https://nos.nl/uitzendingen",
+        "https://nos.nl/uitzendingen/livestream/2385462",
     ]


### PR DESCRIPTION
Fixes #5555

@ltguillaume could you please check and verify?
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

URLs of the type `https://nos.nl/artikel/...` are explicitly not supported, because adding a validation schema for getting the HLS URLs is a bit ridiculous (different JSON payload, nested objects, multiple kinds of video schemas).

----

```
$ ./script/test-plugin-urls.py nos
:: Finding streams for URL: https://nos.nl/collectie/13781/livestream/2385081-ek-voetbal-engeland-schotland
:::: Content is inaccessible or may have expired
!! No streams found
:: Finding streams for URL: https://nos.nl/collectie/13951/video/2491092-dit-was-prinsjesdag
:: Found streams: 360p, 480p, 720p, 1080p, worst, best
:: Finding streams for URL: https://nos.nl/live
:: Found streams: 360p, 480p, 720p, 1080p, worst, best
:: Finding streams for URL: https://nos.nl/video/2490788-meteoor-gespot-boven-noord-nederland
:: Found streams: 360p, 480p, 720p, 1080p, worst, best
```