### PR TITLE
ci.github: add py312-dev test runner on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,9 @@ jobs:
           - python: "3.12-dev"
             os: ubuntu-latest
             continue: true
-#          - python: "3.12-dev"
-#            os: windows-latest
-#            continue: true
+          - python: "3.12-dev"
+            os: windows-latest
+            continue: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -5,8 +5,13 @@
 set -ex
 
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
-python -m pip install --upgrade -r dev-requirements.txt
 
+# temporary dependency workarounds
+[[ "$(python -V)" =~ 3.12. && "$(uname)" != Linux ]] \
+  && python -m pip install --upgrade --force-reinstall \
+    'https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download/cffi-20230923-1/cffi-1.15.1-cp312-cp312-win_amd64.whl'
+
+python -m pip install --upgrade -r dev-requirements.txt
 # https://github.com/streamlink/streamlink/issues/4021
 python -m pip install brotli
 python -m pip install -e .


### PR DESCRIPTION
Ref #5544 

- Enable Python `3.12-dev` test runner on Windows
- Install custom-built cffi wheel on py312/Windows
  - https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/blob/7418285a9f0eb4b186873d681a77e1c49b6af811/.github/workflows/cffi.yml
  - https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/tag/cffi-20230923-1