### PR TITLE
plugins.pandalive: fix live/play API call

### DIFF
--- a/src/streamlink/plugins/pandalive.py
+++ b/src/streamlink/plugins/pandalive.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?pandalive\.co\.kr/",
+    r"https?://(?:www\.)?pandalive\.co\.kr/live/play/[^/]+",
 ))
 class Pandalive(Plugin):
     def _get_streams(self):
@@ -34,10 +34,14 @@ class Pandalive(Plugin):
 
         json = self.session.http.post(
             "https://api.pandalive.co.kr/v1/live/play",
+            headers={
+                "Referer": self.url,
+            },
             data={
                 "action": "watch",
                 "userId": media_code,
             },
+            acceptable_status=(200, 400),
             schema=validate.Schema(
                 validate.parse_json(),
                 validate.any(

--- a/tests/plugins/test_pandalive.py
+++ b/tests/plugins/test_pandalive.py
@@ -6,12 +6,6 @@ class TestPluginCanHandleUrlPandalive(PluginCanHandleUrl):
     __plugin__ = Pandalive
 
     should_match = [
-        "http://pandalive.co.kr/",
-        "http://pandalive.co.kr/any/path",
-        "http://www.pandalive.co.kr/",
-        "http://www.pandalive.co.kr/any/path",
-        "https://pandalive.co.kr/",
-        "https://pandalive.co.kr/any/path",
-        "https://www.pandalive.co.kr/",
-        "https://www.pandalive.co.kr/any/path",
+        "https://www.pandalive.co.kr/live/play/pocet00",
+        "https://www.pandalive.co.kr/live/play/rladbfl1208",
     ]


### PR DESCRIPTION
Fixes #5568

This also changes the pluginmatcher URL regex, so that it only accepts `/live/play/CHANNELNAME` URLs.

@feisao please check
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

----

```
$ ./script/test-plugin-urls.py pandalive
:: Finding streams for URL: https://www.pandalive.co.kr/live/play/pocet00
:::: 종료된 방송입니다.
!! No streams found
:: Finding streams for URL: https://www.pandalive.co.kr/live/play/rladbfl1208
:::: Broadcast type: live
:: Found streams: 160p, 360p, 480p, 720p60, worst, best
```