### PR TITLE
build: add Python 3.12 to package classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Multimedia :: Sound/Audio",
   "Topic :: Multimedia :: Video",

--- a/script/install-dependencies.sh
+++ b/script/install-dependencies.sh
@@ -6,11 +6,6 @@ set -ex
 
 python -m pip install --disable-pip-version-check --upgrade pip setuptools
 
-# temporary dependency workarounds
-[[ "$(python -V)" =~ 3.12. && "$(uname)" != Linux ]] \
-  && python -m pip install --upgrade --force-reinstall \
-    'https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download/cffi-20230923-1/cffi-1.15.1-cp312-cp312-win_amd64.whl'
-
 python -m pip install --upgrade -r dev-requirements.txt
 # https://github.com/streamlink/streamlink/issues/4021
 python -m pip install brotli


### PR DESCRIPTION
Resolves #5544

This adds official support for the upcoming Python 3.12 release in a couple of days to the metadata of Streamlink's sdists/bdists.
https://peps.python.org/pep-0693/

cffi 1.16.0 has finally been released yesterday with support for py312, which means we can finally label Streamlink as py312 compatible and remove the custom-built wheel:
https://github.com/python-cffi/cffi/releases/tag/v1.16.0

cffi is a transitive dependency on Windows via trio, and it's optionally required (without declaring it as a dependency) by pycryptodome:
- https://github.com/python-trio/trio/blob/v0.22.2/setup.py#L93
- https://github.com/Legrandin/pycryptodome/blob/v3.19.0/lib/Crypto/Util/_raw_api.py#L85