### PR TITLE
release: 6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## streamlink 6.2.1 (2023-10-03)
+
+Patch release:
+
+- Added: official support for Python 3.12 ([#5576](https://github.com/streamlink/streamlink/pull/5576))
+- Fixed plugins: goodgame ([#5557](https://github.com/streamlink/streamlink/pull/5557)), nos ([#5565](https://github.com/streamlink/streamlink/pull/5565)), pandalive ([#5569](https://github.com/streamlink/streamlink/pull/5569)), wwenetwork ([#5559](https://github.com/streamlink/streamlink/pull/5559))
+- Build: added custom setuptools build-backend override which fixes issues with building Windows-specific wheels ([#5558](https://github.com/streamlink/streamlink/pull/5558))
+
+[Full changelog](https://github.com/streamlink/streamlink/compare/6.2.0...6.2.1)
+
+
 ## streamlink 6.2.0 (2023-09-14)
 
 Release highlights:


### PR DESCRIPTION
Let's publish a new release with official Python 3.12 support.

The planned release for 3.12 is today, but I've set the release date of Streamlink 6.2.1 for tomorrow.
https://peps.python.org/pep-0693/#release-schedule

The recent build-backend changes shouldn't justify bumping the minor version, as there are no changes when building, and it's not a new feature either, so it's just a minor version bump.

----

Btw, I've added the hacktoberfest tag to the repo a week ago in hopes for some more contributions this month. Then I noticed after registering my account that they're not rewarding people with t-shirts anymore and moved towards NFT-like nonsense. No idea if this non-code release-PR will be considered a bad PR now and void my participation (especially when I will merge it myself), but IDGAF about this anymore with those "reward" changes.

I will push the segmented stream changes (#5498) after this release in the next couple of days.