### PR TITLE
plugins.goodgame: rewrite using API

### DIFF
--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -10,9 +10,9 @@ $metadata title
 
 import logging
 import re
-import sys
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import parse_qsl, urlparse
 
+from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
@@ -21,69 +21,125 @@ from streamlink.stream.hls import HLSStream
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(re.compile(
-    r"https?://(?:www\.)?goodgame\.ru/(?:channel/)?(?P<user>[^/]+)",
+@pluginmatcher(name="default", pattern=re.compile(
+    r"https?://(?:www\.)?goodgame\.ru/(?P<name>(?!channel|player)[^/?]+)",
+))
+@pluginmatcher(name="channel", pattern=re.compile(
+    r"https?://(?:www\.)?goodgame\.ru/channel/(?P<channel>[^/?]+)",
+))
+@pluginmatcher(name="player", pattern=re.compile(
+    r"https?://(?:www\.)?goodgame\.ru/player\?(?P<id>\d+)$",
 ))
 class GoodGame(Plugin):
-    @classmethod
-    def stream_weight(cls, stream):
-        if stream == "source":
-            return sys.maxsize, stream
-        return super().stream_weight(stream)
+    _API_STREAMS_ID = "https://goodgame.ru/api/4/streams/2/id/{id}"
+    _API_STREAMS_CHANNEL = "https://goodgame.ru/api/4/streams/2/channel/{channel}"
+    _URL_HLS = "https://hls.goodgame.ru/manifest/{id}_master.m3u8"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def _get_channel_key(self):
+        return self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"api:(?P<json>{.+?}),\n"),
+            validate.none_or_all(
+                validate.get("json"),
+                validate.parse_json(),
+                {"channel_key": str},
+                validate.get("channel_key"),
+            ),
+        ))
 
-        # `/channel/user` returns different JSON data with less useful information
-        url = urlparse(self.url)
-        self.url = urlunparse(url._replace(path=re.sub(r"^/channel/", "/", url.path)))
+    def _get_api_url(self):
+        if self.matches["default"]:
+            channel = self._get_channel_key()
+            log.debug(f"{channel=}")
+            if not channel:
+                raise NoStreamsError
+            return self._API_STREAMS_CHANNEL.format(channel=channel)
 
-    def _get_streams(self):
-        data = self.session.http.get(
-            self.url,
-            schema=validate.Schema(
-                validate.parse_html(),
-                validate.xml_xpath_string(".//script[contains(text(),'channel:{')][1]/text()"),
-                re.compile(r"channel:(?P<json>{.+?}),?\n"),
-                validate.none_or_all(
-                    validate.get("json"),
-                    validate.parse_json(),
+        elif self.matches["channel"]:
+            return self._API_STREAMS_CHANNEL.format(channel=self.match["channel"])
+
+        elif self.matches["player"]:
+            return self._API_STREAMS_ID.format(id=self.match["id"])
+
+        raise PluginError("Invalid matcher")
+
+    def _api_stream(self, url):
+        return self.session.http.get(url, schema=validate.Schema(
+            validate.parse_json(),
+            validate.any(
+                validate.all(
                     {
-                        "status": bool,
+                        "error": str,
+                    },
+                    validate.get("error"),
+                    validate.transform(lambda data: ("error", data)),
+                ),
+                validate.all(
+                    {
+                        "online": bool,
                         "id": int,
-                        "streamer": {"username": str},
-                        "game": str,
-                        "title": str,
-                        "sources": validate.all(
-                            {str: validate.url()},
-                            validate.filter(lambda k, v: ".m3u8" in v),
-                        ),
+                        "streamer": {
+                            "username": str,
+                        },
+                        "game": {
+                            "title": validate.none_or_all(str),
+                        },
+                        "title": validate.none_or_all(str),
+                        "players": [
+                            validate.all(
+                                {
+                                    "title": str,
+                                    "online": bool,
+                                    "content": validate.all(
+                                        str,
+                                        validate.parse_html(),
+                                        validate.xml_find(".//iframe"),
+                                        validate.get("src"),
+                                        validate.transform(urlparse),
+                                    ),
+                                },
+                                validate.union_get(
+                                    "title",
+                                    "online",
+                                    "content",
+                                ),
+                            ),
+                        ],
                     },
                     validate.union_get(
-                        "status",
+                        "online",
                         "id",
                         ("streamer", "username"),
-                        "game",
+                        ("game", "title"),
                         "title",
-                        "sources",
+                        "players",
                     ),
+                    validate.transform(lambda data: ("data", *data)),
                 ),
             ),
-        )
+        ))
 
-        if not data:
-            log.error("Could not find channel info")
+    def _get_streams(self):
+        api_url = self._get_api_url()
+        log.debug(f"{api_url=}")
+
+        result, *data = self._api_stream(api_url)
+        if result == "error":
+            log.error(data[0] or "Unknown error")
             return
 
-        status, self.id, self.author, self.category, self.title, sources = data
+        online, self.id, self.author, self.category, self.title, players = data
+        hls_url = self._URL_HLS.format(id=self.id)
 
-        if not status:
-            log.debug("Channel appears to be offline")
-            return
+        if online and self.session.http.get(hls_url, raise_for_status=False).status_code < 400:
+            return HLSStream.parse_variant_playlist(self.session, hls_url)
 
-        for name, url in sources.items():
-            name = f"{name}{'p' if name.isnumeric() else ''}"
-            yield name, HLSStream(self.session, url)
+        log.debug("Channel is offline, checking for embedded players...")
+        for p_title, p_online, p_url in players:
+            if p_title == "Twitch" and p_online:
+                channel = dict(parse_qsl(p_url.query)).get("channel")
+                if channel:
+                    log.debug(f"Redirecting to Twitch: {channel=}")
+                    return self.session.streams(f"twitch.tv/{channel}")
 
 
 __plugin__ = GoodGame

--- a/tests/plugins/test_goodgame.py
+++ b/tests/plugins/test_goodgame.py
@@ -1,7 +1,4 @@
-import pytest
-
 from streamlink.plugins.goodgame import GoodGame
-from streamlink.session import Streamlink
 from tests.plugins import PluginCanHandleUrl
 
 
@@ -9,15 +6,21 @@ class TestPluginCanHandleUrlGoodGame(PluginCanHandleUrl):
     __plugin__ = GoodGame
 
     should_match_groups = [
-        ("https://goodgame.ru/CHANNELNAME", {"user": "CHANNELNAME"}),
-        ("https://goodgame.ru/channel/CHANNELNAME", {"user": "CHANNELNAME"}),
+        (("default", "https://goodgame.ru/CHANNELNAME"), {"name": "CHANNELNAME"}),
+        (("default", "https://goodgame.ru/CHANNELNAME/"), {"name": "CHANNELNAME"}),
+        (("default", "https://goodgame.ru/CHANNELNAME?foo=bar"), {"name": "CHANNELNAME"}),
+        (("default", "https://www.goodgame.ru/CHANNELNAME"), {"name": "CHANNELNAME"}),
+
+        (("channel", "https://goodgame.ru/channel/CHANNELNAME"), {"channel": "CHANNELNAME"}),
+        (("channel", "https://goodgame.ru/channel/CHANNELNAME/"), {"channel": "CHANNELNAME"}),
+        (("channel", "https://goodgame.ru/channel/CHANNELNAME?foo=bar"), {"channel": "CHANNELNAME"}),
+        (("channel", "https://www.goodgame.ru/channel/CHANNELNAME"), {"channel": "CHANNELNAME"}),
+
+        (("player", "https://goodgame.ru/player?1234"), {"id": "1234"}),
+        (("player", "https://www.goodgame.ru/player?1234"), {"id": "1234"}),
     ]
 
-
-@pytest.mark.parametrize(("url", "expected"), [
-    ("https://goodgame.ru/CHANNELNAME", "https://goodgame.ru/CHANNELNAME"),
-    ("https://goodgame.ru/channel/CHANNELNAME", "https://goodgame.ru/CHANNELNAME"),
-])
-def test_url_translation(session: Streamlink, url: str, expected: str):
-    plugin = GoodGame(session, url)
-    assert plugin.url == expected
+    should_not_match = [
+        "https://goodgame.ru/channel",
+        "https://goodgame.ru/player",
+    ]


### PR DESCRIPTION
Fixes #5581
Fixes #5585
Fixes #5584
Fixes #5583 

@IosifShmidt
Please check and verify.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

----

1. This now queries their API instead of finding the data in the page's embedded JSON.

    However, URLs using the plugin's default matcher without the `/channel/` prefix appear to not have an API endpoint for querying the channel key, so it still needs to be acquired from the embedded JSON.
    https://goodgame.ru/html/api4docs/index.html

    That should work fine though:
    ```
    $ streamlink -l debug goodgame.ru/Penta | grep plugins.goodgame
    [plugins.goodgame][debug] channel='Mashinasmert'
    [plugins.goodgame][debug] Channel appears to be offline
    ```

    ```
    $ streamlink goodgame.ru/doesnotexist
    [cli][info] Found matching plugin goodgame for URL goodgame.ru/doesnotexist
    error: Unable to open URL: https://goodgame.ru/doesnotexist (404 Client Error: not found for url: https://goodgame.ru/doesnotexist)
    ```

2. Game metadata can either be a string or `null`. This wasn't obvious in the recent plugin changes. Both the game metadata and stream title metadata are now treated as optional.

    The game title metadata now however is nested in another `game` object, so it's possible that the entire `game` object can become `null` instead of `game.title`. This needs to be verified first, otherwise we'll have another `ValidationError`.

3. The player URL is now supported.

    ```
    $ streamlink 'goodgame.ru/player?46071'
    [cli][info] Found matching plugin goodgame for URL goodgame.ru/player?46071
    Available streams: 360p (worst), 540p, 720p, 1080p (best)

    $ streamlink --json 'goodgame.ru/player?46071' | jq .metadata
    {
      "id": "46071",
      "author": "AlMahom",
      "category": "Crusader Kings III",
      "title": "Мультиплеерные Династии"
    }
    ```

4. Twitch redirection should now be supported unless I'm mistaken about the `status` and `online` flags in the API response. Both need to be true for the plugin to redirect to Twitch instead of trying to access the goodgame HLS URL. The `online` field is self-explanatory and to my understanding, `status` is true if the user has activated the Twitch player on their goodgame channel. Is that right?

    I couldn't find any live channels with a Twitch player.

5.  The old stream quality weights have been removed, since the player page revealed the URL of the HLS multivariant playlist. The quality weights were needed because of the individual media playlist URLs which were embedded in the JSON data previously.