### PR TITLE
stream.segmented: add --stream-segmented-duration

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -194,6 +194,7 @@ class StreamlinkOptions(Options):
         "dash-timeout": _factory_set_deprecated("stream-timeout", float),
         "hls-timeout": _factory_set_deprecated("stream-timeout", float),
         "http-stream-timeout": _factory_set_deprecated("stream-timeout", float),
+        "hls-duration": _factory_set_deprecated("stream-segmented-duration", float),
     }
 
 
@@ -234,11 +235,11 @@ class Streamlink:
             "stream-segment-attempts": 3,
             "stream-segment-threads": 1,
             "stream-segment-timeout": 10.0,
+            "stream-segmented-duration": None,
             "stream-timeout": 60.0,
             "hls-live-edge": 3,
             "hls-live-restart": False,
             "hls-start-offset": 0.0,
-            "hls-duration": None,
             "hls-playlist-reload-attempts": 3,
             "hls-playlist-reload-time": "default",
             "hls-segment-queue-threshold": 3,
@@ -373,6 +374,10 @@ class Streamlink:
               - ``float``
               - ``10.0``
               - Segment connect and read timeout
+            * - stream-segmented-duration
+              - ``float | None``
+              - ``None``
+              - Limit the playback duration of segmented streams, rounded to the nearest segment
             * - stream-timeout
               - ``float``
               - ``60.0``
@@ -390,10 +395,10 @@ class Streamlink:
               - ``0.0``
               - Number of seconds to skip from the beginning of the HLS stream,
                 interpreted as a negative offset for livestreams
-            * - hls-duration
+            * - hls-duration *(deprecated)*
               - ``float | None``
               - ``None``
-              - Limit the HLS stream playback duration, rounded to the nearest HLS segment
+              - See ``stream-segmented-duration``
             * - hls-playlist-reload-attempts
               - ``int``
               - ``3``

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -82,6 +82,7 @@ class DASHStreamWorker(SegmentedStreamWorker[DASHSegment, Response]):
         self.mpd = self.stream.mpd
 
         self.manifest_reload_retries = self.session.options.get("dash-manifest-reload-attempts")
+        self.duration = self.stream.duration or self.duration
 
     @contextmanager
     def sleeper(self, duration):
@@ -198,6 +199,7 @@ class DASHStream(Stream):
         mpd: MPD,
         video_representation: Optional[Representation] = None,
         audio_representation: Optional[Representation] = None,
+        duration: Optional[float] = None,
         **kwargs,
     ):
         """
@@ -205,6 +207,7 @@ class DASHStream(Stream):
         :param mpd: Parsed MPD manifest
         :param video_representation: Video representation
         :param audio_representation: Audio representation
+        :param duration: Number of seconds until ending the stream
         :param kwargs: Additional keyword arguments passed to :meth:`requests.Session.request`
         """
 
@@ -212,6 +215,7 @@ class DASHStream(Stream):
         self.mpd = mpd
         self.video_representation = video_representation
         self.audio_representation = audio_representation
+        self.duration = duration
         self.args = session.http.valid_request_args(**kwargs)
 
     def __json__(self):  # noqa: PLW3201

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -303,9 +303,10 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         self.playlist_reload_retries = self.session.options.get("hls-playlist-reload-attempts")
         self.segment_queue_timing_threshold_factor = self.session.options.get("hls-segment-queue-threshold")
         self.live_edge = self.session.options.get("hls-live-edge")
+
         self.duration_offset_start = int(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0))
-        self.duration_limit = self.stream.duration or (
-            int(self.session.options.get("hls-duration")) if self.session.options.get("hls-duration") else None)
+        self.duration = self.stream.duration or self.duration or self.session.options.get("hls-duration")
+
         self.hls_live_restart = self.stream.force_restart or self.session.options.get("hls-live-restart")
 
         if str(self.playlist_reload_time_override).isnumeric() and float(self.playlist_reload_time_override) >= 2:
@@ -449,12 +450,11 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             ]))
             log.debug("; ".join([
                 f"Start offset: {self.duration_offset_start}",
-                f"Duration: {self.duration_limit}",
+                f"Duration: {self.duration}",
                 f"Start Sequence: {self.playlist_sequence}",
                 f"End Sequence: {self.playlist_end}",
             ]))
 
-        total_duration = 0
         while not self.closed:
             queued = False
             for segment in self.playlist_segments:
@@ -465,11 +465,6 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
                 yield segment
 
                 queued = True
-
-                total_duration += segment.duration
-                if self.duration_limit and total_duration >= self.duration_limit:
-                    log.info(f"Stopping stream early after {self.duration_limit}")
-                    return
 
                 if self.closed:  # pragma: no cover
                     return

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -887,6 +887,17 @@ def build_parser():
         Default is 10.0.
         """,
     )
+    transport_hls.add_argument(
+        "--stream-segmented-duration",
+        type=hours_minutes_seconds_float,
+        metavar="[[XX:]XX:]XX[.XX] | [XXh][XXm][XX[.XX]s]",
+        help="""
+        Limit the playback duration of segmented streams, like HLS and DASH.
+        The actual duration may be slightly longer, as it is rounded to the nearest segment.
+
+        Default is unlimited.
+        """,
+    )
     transport.add_argument(
         "--stream-timeout",
         type=num(float, gt=0),
@@ -1051,9 +1062,7 @@ def build_parser():
         type=hours_minutes_seconds_float,
         metavar="[[XX:]XX:]XX[.XX] | [XXh][XXm][XX[.XX]s]",
         help="""
-        Limit the playback duration, useful for watching segments of a stream.
-        The actual duration may be slightly longer, as it is rounded to the
-        nearest HLS segment.
+        Deprecated in favor of --stream-segmented-duration.
 
         Default is unlimited.
         """,
@@ -1386,6 +1395,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("hls_segment_threads", "hls-segment-threads", None),
     ("hls_segment_timeout", "hls-segment-timeout", None),
     ("hls_timeout", "hls-timeout", None),
+    ("hls_duration", "hls-duration", None),
     ("http_stream_timeout", "http-stream-timeout", None),
 
     # stream transport arguments
@@ -1394,11 +1404,11 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("stream_segment_attempts", "stream-segment-attempts", None),
     ("stream_segment_threads", "stream-segment-threads", None),
     ("stream_segment_timeout", "stream-segment-timeout", None),
+    ("stream_segmented_duration", "stream-segmented-duration", None),
     ("stream_timeout", "stream-timeout", None),
     ("hls_live_edge", "hls-live-edge", None),
     ("hls_live_restart", "hls-live-restart", None),
     ("hls_start_offset", "hls-start-offset", None),
-    ("hls_duration", "hls-duration", None),
     ("hls_playlist_reload_attempts", "hls-playlist-reload-attempts", None),
     ("hls_playlist_reload_time", "hls-playlist-reload-time", None),
     ("hls_segment_queue_threshold", "hls-segment-queue-threshold", None),

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -3,7 +3,7 @@ import typing
 import unittest
 from datetime import datetime, timedelta, timezone
 from threading import Event
-from typing import Dict
+from typing import Dict, Optional
 from unittest.mock import Mock, call, patch
 
 import freezegun
@@ -11,6 +11,7 @@ import pytest
 import requests_mock as rm
 from requests.exceptions import InvalidSchema
 
+from streamlink.exceptions import StreamlinkDeprecationWarning
 from streamlink.session import Streamlink
 from streamlink.stream.hls import (
     M3U8,
@@ -18,6 +19,7 @@ from streamlink.stream.hls import (
     HLSSegment,
     HLSStream,
     HLSStreamReader,
+    HLSStreamWorker,
     M3U8Parser,
     MuxedHLSStream,
 )
@@ -167,7 +169,8 @@ class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
         assert self.await_read(read_all=True) == self.content(segments), "Stream ends and read-all handshake doesn't time out"
 
-    def test_offset_and_duration(self):
+    @patch("streamlink.stream.segmented.segmented.log")
+    def test_offset_and_duration(self, mock_log: Mock):
         thread, segments = self.subject([
             Playlist(1234, [Segment(0), Segment(1, duration=0.5), Segment(2, duration=0.5), Segment(3)], end=True),
         ], streamoptions={"start_offset": 1, "duration": 1})
@@ -176,6 +179,7 @@ class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert data == self.content(segments, cond=lambda s: 0 < s.num < 3), "Respects the offset and duration"
         assert all(self.called(s) for s in segments.values() if 0 < s.num < 3), "Downloads second and third segment"
         assert not any(self.called(s) for s in segments.values() if 0 > s.num > 3), "Skips other segments"
+        assert mock_log.info.call_args_list == [call("Stopping stream early after 1.00s")]
 
     def test_map(self):
         discontinuity = Tag("EXT-X-DISCONTINUITY")
@@ -459,6 +463,63 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             assert worker.playlist_end == 4, "Stream has ended"
             assert not worker.handshake_wait.wait_ready(0), "Doesn't wait once ended"
             assert not worker.handshake_reload.wait_ready(0), "Doesn't reload playlist once ended"
+
+
+class TestHLSStreamWorkerOptions:
+    @pytest.mark.parametrize(("options", "session", "expected", "warning"), [
+        pytest.param(
+            {},
+            {},
+            None,
+            [],
+            id="no duration",
+        ),
+        pytest.param(
+            {"duration": 123.45},
+            {},
+            123.45,
+            [],
+            id="duration keyword",
+        ),
+        pytest.param(
+            {},
+            {"stream-segmented-duration": 123.45},
+            123.45,
+            [],
+            id="stream-segmented-duration session option",
+        ),
+        pytest.param(
+            {},
+            {"hls-duration": 123.45},
+            123.45,
+            [(
+                StreamlinkDeprecationWarning,
+                "`hls-duration` has been deprecated in favor of the `stream-segmented-duration` option",
+            )],
+            id="hls-duration session option",
+        ),
+        pytest.param(
+            {"duration": 123.45},
+            {"stream-segmented-duration": 543.21},
+            123.45,
+            [],
+            id="duration keyword priority",
+        ),
+    ], indirect=["session"])
+    def test_duration(
+        self,
+        recwarn: pytest.WarningsRecorder,
+        session: Streamlink,
+        options: dict,
+        expected: Optional[float],
+        warning: list,
+    ):
+        stream = HLSStream(session, "https://foo/", **options)
+        reader = HLSStreamReader(stream)
+        worker = HLSStreamWorker(reader)
+
+        assert worker.duration is expected
+        assert [(record.category, str(record.message)) for record in recwarn.list] == warning
 
 
 @patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))


### PR DESCRIPTION
Closes #5450 
Replaces #5493

This PR implements the max stream duration in the `SegmentedStreamWorker`, as opposed to each worker subclass separately (previously `HLSStreamWorker`), which is now possible with the switch towards a common `Segment` base class added in #5594 and the segmented stream changes prior to that (#5498).

`--hls-duration` has been marked as deprecated, as well as its respective session option.

In the previous attempt (#5493), there were comments about the name of `--stream-segmented-duration`. This option now affects all segmented stream types, so we need a new name-prefix for that. The other `--stream-segment-*` CLI args are about individual segments, not about the segmented stream types, so it doesn't make sense using that prefix here. We can't call the new option `--stream-duration` either, because that would imply that it's possible to limit the duration for all kinds of streams, which is not true.

Also, as mentioned, the related `--hls-start-offset` option needs to be changed as well in the future. This however requires more code refactoring, because of initialization segments which need to be written to the output first and can't be skipped. There's a fundamentally different implementation in the HLS and DASH streams regarding initialization segments which requires a rewrite of the HLS init segments, so the base `SegmentedStreamWorker` can work with init segments while skipping the first segments when using the start-offset option. The HLS init segment implementation is rather weird and also incorrect, at least for fragmented MPEG4 segments, as it combines the content of each segment with its init segment, which is unnecessary (still works though). This was done because of MPEG-TS init segments, and nobody could interpret the HLS spec correctly and knew if the "init" segments were a requirement for each segment.

I will keep this PR as a draft until I have the start offset stuff ready because it doesn't make sense having partial/incomplete changes on the master branch.