### PR TITLE
script: don't upload PGP signatures to PyPI

### DIFF
--- a/script/deploy-pypi.sh
+++ b/script/deploy-pypi.sh
@@ -9,7 +9,7 @@ dist_dir=${STREAMLINK_DIST_DIR:-dist}
 
 if [[ "${1}" = "-n" ]] || [[ "${1}" = "--dry-run" ]]; then
     echo >&2 "deploy: dry-run (${version})"
-    for file in "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}; do
+    for file in "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}; do
         echo >&2 "${file}"
     done
 
@@ -28,5 +28,5 @@ else
     twine upload \
         --username "${PYPI_USER}" \
         --password "${PYPI_PASSWORD}" \
-        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}{,.asc}
+        "${dist_dir}"/streamlink-"${version}"{.tar.gz,-*.whl}
 fi


### PR DESCRIPTION
PyPI has removed support for this and discards release signatures:
https://blog.pypi.org/posts/2023-05-23-removing-pgp/

----

2FA will also be a requirement starting in 2024 for each PyPI user.
This will affect the current release process using `twine` and the `streamlink` PyPI user (currently user+pass authenticated - #5129)

I'll have a look at the suggested alternatives by then. It's possible that this requires rewriting the release workflow here.

- https://docs.pypi.org/trusted-publishers/
- https://github.com/pypa/gh-action-pypi-publish
