### PR TITLE
ci.github: update py312 runners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 8
+    after_n_builds: 10
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,13 +29,14 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-        include:
-          - python: "3.12-dev"
-            os: ubuntu-latest
-            continue: true
-          - python: "3.12-dev"
-            os: windows-latest
-            continue: true
+          - "3.12"
+#        include:
+#          - python: "3.13-dev"
+#            os: ubuntu-latest
+#            continue: true
+#          - python: "3.13-dev"
+#            os: windows-latest
+#            continue: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Apparently, the runner images have removed py312 again 4 days ago in
https://github.com/actions/runner-images/commit/929931f61727947eb60ba4ecae57fe82202728ed
so `actions/setup-python` will download the binaries every time, but that doesn't matter apart from slightly longer setup times