### PR TITLE
plugins: ignore case in protocol-plugin input URLs

### DIFF
--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
     r"(?P<url>\S+\.mpd(?:\?\S*)?)(?:\s(?P<params>.+))?$",
+    re.IGNORECASE,
 ))
 class MPEGDASH(Plugin):
     @classmethod

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
     r"(?P<url>\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?$",
+    re.IGNORECASE,
 ))
 class HLSPlugin(Plugin):
     def _get_streams(self):

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -14,6 +14,7 @@ class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
     should_match_groups = [
         # implicit DASH URLs
         ("example.com/foo.mpd", {"url": "example.com/foo.mpd"}),
+        ("example.com/foo.MPD", {"url": "example.com/foo.MPD"}),
         ("example.com/foo.mpd?bar", {"url": "example.com/foo.mpd?bar"}),
         ("http://example.com/foo.mpd", {"url": "http://example.com/foo.mpd"}),
         ("http://example.com/foo.mpd?bar", {"url": "http://example.com/foo.mpd?bar"}),
@@ -33,6 +34,7 @@ class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
     should_not_match = [
         # implicit DASH URLs must have their path end with ".mpd"
         "example.com/mpd",
+        "example.com/MPD",
         "example.com/mpd abc=def",
         "example.com/foo.mpd,bar",
         "example.com/foo.mpd,bar abc=def",
@@ -44,6 +46,7 @@ class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
 
 @pytest.mark.parametrize(("url", "priority"), [
     ("http://example.com/foo.mpd", LOW_PRIORITY),
+    ("http://example.com/foo.MPD", LOW_PRIORITY),
     ("dash://http://example.com/foo.mpd", NORMAL_PRIORITY),
     ("dash://http://example.com/bar", NORMAL_PRIORITY),
     ("http://example.com/bar", NO_PRIORITY),

--- a/tests/plugins/test_hls.py
+++ b/tests/plugins/test_hls.py
@@ -15,6 +15,7 @@ class TestPluginCanHandleUrlHLSPlugin(PluginCanHandleUrl):
     should_match_groups = [
         # implicit HLS URLs
         ("example.com/foo.m3u8", {"url": "example.com/foo.m3u8"}),
+        ("example.com/foo.M3U8", {"url": "example.com/foo.M3U8"}),
         ("example.com/foo.m3u8?bar", {"url": "example.com/foo.m3u8?bar"}),
         ("http://example.com/foo.m3u8", {"url": "http://example.com/foo.m3u8"}),
         ("http://example.com/foo.m3u8?bar", {"url": "http://example.com/foo.m3u8?bar"}),
@@ -38,6 +39,7 @@ class TestPluginCanHandleUrlHLSPlugin(PluginCanHandleUrl):
     should_not_match = [
         # implicit HLS URLs must have their path end with ".m3u8"
         "example.com/m3u8",
+        "example.com/M3U8",
         "example.com/m3u8 abc=def",
         "example.com/foo.m3u8,bar",
         "example.com/foo.m3u8,bar abc=def",
@@ -50,6 +52,7 @@ class TestPluginCanHandleUrlHLSPlugin(PluginCanHandleUrl):
 
 @pytest.mark.parametrize(("url", "priority"), [
     ("http://example.com/foo.m3u8", LOW_PRIORITY),
+    ("http://example.com/foo.M3U8", LOW_PRIORITY),
     ("hls://http://example.com/foo.m3u8", NORMAL_PRIORITY),
     ("hls://http://example.com/bar", NORMAL_PRIORITY),
     ("hlsvariant://http://example.com/foo.m3u8", NORMAL_PRIORITY),


### PR DESCRIPTION
Allow URL paths ending in `.M3U8` and `.MPD` to be recognized by the HLS and DASH plugins.

----

Fixes #5615 