### PR TITLE
plugins: fix URL matchers of HLS and DASH

### DIFF
--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -14,7 +14,8 @@ log = logging.getLogger(__name__)
     r"dash://(?P<url>\S+)(?:\s(?P<params>.+))?$",
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-    r"(?P<url>\S+\.mpd(?:\?\S*)?)(?:\s(?P<params>.+))?$",
+    # URL with explicit scheme, or URL with implicit HTTPS scheme and a path
+    r"(?P<url>[^/]+/\S+\.mpd(?:\?\S*)?)(?:\s(?P<params>.+))?$",
     re.IGNORECASE,
 ))
 class MPEGDASH(Plugin):

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -14,7 +14,8 @@ log = logging.getLogger(__name__)
     r"hls(?:variant)?://(?P<url>\S+)(?:\s(?P<params>.+))?$",
 ))
 @pluginmatcher(priority=LOW_PRIORITY, pattern=re.compile(
-    r"(?P<url>\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?$",
+    # URL with explicit scheme, or URL with implicit HTTPS scheme and a path
+    r"(?P<url>[^/]+/\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?$",
     re.IGNORECASE,
 ))
 class HLSPlugin(Plugin):

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -20,10 +20,14 @@ class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
         ("http://example.com/foo.mpd?bar", {"url": "http://example.com/foo.mpd?bar"}),
         ("https://example.com/foo.mpd", {"url": "https://example.com/foo.mpd"}),
         ("https://example.com/foo.mpd?bar", {"url": "https://example.com/foo.mpd?bar"}),
+        ("file://foo.mpd", {"url": "file://foo.mpd"}),
+        ("file:///foo.mpd", {"url": "file:///foo.mpd"}),
+        ("file://../foo.mpd", {"url": "file://../foo.mpd"}),
         # explicit DASH URLs with protocol prefix
         ("dash://example.com/foo?bar", {"url": "example.com/foo?bar"}),
         ("dash://http://example.com/foo?bar", {"url": "http://example.com/foo?bar"}),
         ("dash://https://example.com/foo?bar", {"url": "https://example.com/foo?bar"}),
+        ("dash://file://foo", {"url": "file://foo"}),
         # optional parameters
         ("example.com/foo.mpd?bar abc=def", {"url": "example.com/foo.mpd?bar", "params": "abc=def"}),
         ("http://example.com/foo.mpd?bar abc=def", {"url": "http://example.com/foo.mpd?bar", "params": "abc=def"}),
@@ -33,6 +37,8 @@ class TestPluginCanHandleUrlMPEGDASH(PluginCanHandleUrl):
 
     should_not_match = [
         # implicit DASH URLs must have their path end with ".mpd"
+        "example.mpd",
+        "/example.mpd",
         "example.com/mpd",
         "example.com/MPD",
         "example.com/mpd abc=def",
@@ -59,6 +65,9 @@ def test_priority(url, priority):
     ("example.com/foo.mpd", "https://example.com/foo.mpd"),
     ("http://example.com/foo.mpd", "http://example.com/foo.mpd"),
     ("https://example.com/foo.mpd", "https://example.com/foo.mpd"),
+    ("file://foo.mpd", "file://foo.mpd"),
+    ("file:///foo.mpd", "file:///foo.mpd"),
+    ("file://../foo.mpd", "file://../foo.mpd"),
     ("dash://example.com/foo", "https://example.com/foo"),
     ("dash://http://example.com/foo", "http://example.com/foo"),
     ("dash://https://example.com/foo", "https://example.com/foo"),

--- a/tests/plugins/test_hls.py
+++ b/tests/plugins/test_hls.py
@@ -21,13 +21,18 @@ class TestPluginCanHandleUrlHLSPlugin(PluginCanHandleUrl):
         ("http://example.com/foo.m3u8?bar", {"url": "http://example.com/foo.m3u8?bar"}),
         ("https://example.com/foo.m3u8", {"url": "https://example.com/foo.m3u8"}),
         ("https://example.com/foo.m3u8?bar", {"url": "https://example.com/foo.m3u8?bar"}),
+        ("file://foo.m3u8", {"url": "file://foo.m3u8"}),
+        ("file:///foo.m3u8", {"url": "file:///foo.m3u8"}),
+        ("file://../foo.m3u8", {"url": "file://../foo.m3u8"}),
         # explicit HLS URLs with protocol prefix
         ("hls://example.com/foo?bar", {"url": "example.com/foo?bar"}),
         ("hls://http://example.com/foo?bar", {"url": "http://example.com/foo?bar"}),
         ("hls://https://example.com/foo?bar", {"url": "https://example.com/foo?bar"}),
+        ("hls://file://foo", {"url": "file://foo"}),
         ("hlsvariant://example.com/foo?bar", {"url": "example.com/foo?bar"}),
         ("hlsvariant://http://example.com/foo?bar", {"url": "http://example.com/foo?bar"}),
         ("hlsvariant://https://example.com/foo?bar", {"url": "https://example.com/foo?bar"}),
+        ("hlsvariant://file://foo", {"url": "file://foo"}),
         # optional parameters
         ("example.com/foo.m3u8?bar abc=def", {"url": "example.com/foo.m3u8?bar", "params": "abc=def"}),
         ("http://example.com/foo.m3u8?bar abc=def", {"url": "http://example.com/foo.m3u8?bar", "params": "abc=def"}),
@@ -38,6 +43,8 @@ class TestPluginCanHandleUrlHLSPlugin(PluginCanHandleUrl):
 
     should_not_match = [
         # implicit HLS URLs must have their path end with ".m3u8"
+        "example.m3u8",
+        "/example.m3u8",
         "example.com/m3u8",
         "example.com/M3U8",
         "example.com/m3u8 abc=def",
@@ -67,6 +74,9 @@ def test_priority(url, priority):
     ("example.com/foo.m3u8", "https://example.com/foo.m3u8"),
     ("http://example.com/foo.m3u8", "http://example.com/foo.m3u8"),
     ("https://example.com/foo.m3u8", "https://example.com/foo.m3u8"),
+    ("file://foo.m3u8", "file://foo.m3u8"),
+    ("file:///foo.m3u8", "file:///foo.m3u8"),
+    ("file://../foo.m3u8", "file://../foo.m3u8"),
     ("hls://example.com/foo", "https://example.com/foo"),
     ("hls://http://example.com/foo", "http://example.com/foo"),
     ("hls://https://example.com/foo", "https://example.com/foo"),


### PR DESCRIPTION
For implicit (scheme-less) HTTPS URLs, the HLS and DASH plugins shouldn't match

1. `/example.m3u8` or `/example.mpd`, as the host part is missing here
2. `example.m3u8` or `example.mpd`, as those would be interpreted as TLDs without a path