### PR TITLE
tools: bump ruff to 0.1.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.0.291
+ruff ==0.1.0
 
 # typing
 mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,13 +195,6 @@ select = [
   "Q",
   # flake8-tidy-imports
   "TID",
-  # explicitly select rules under the nursery-flag introduced in ruff 0.0.269
-  # remove once enabled via the "E" selector
-  "E111", "E112", "E113", "E114", "E115", "E116", "E117",
-  "E201", "E202", "E203", "E211", "E221", "E222", "E223",
-  "E224", "E225", "E226", "E227", "E228", "E231", "E251",
-  "E252", "E261", "E262", "E265", "E266", "E271", "E272",
-  "E273", "E274", "E275",
 ]
 extend-ignore = [
   "A003",  # builtin-attribute-shadowing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,8 @@ select = [
   "Q",
   # flake8-tidy-imports
   "TID",
+  # Ruff-specific rules
+  "RUF",
 ]
 extend-ignore = [
   "A003",  # builtin-attribute-shadowing
@@ -211,11 +213,14 @@ extend-exclude = [
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
+"docs/**" = ["RUF012"]
 "src/streamlink/__init__.py" = ["I"]
 "src/streamlink/_version.py" = ["I"]
 "src/streamlink/plugin/api/useragents.py" = ["E501"]
-"src/streamlink/webbrowser/cdp/devtools/*" = ["E501"]
+"src/streamlink/plugins/*" = ["RUF012"]
+"src/streamlink/webbrowser/cdp/devtools/*" = ["E501", "F401"]
 "src/streamlink_cli/main.py" = ["PLW0603"]
+"tests/**" = ["RUF012"]
 
 [tool.ruff.isort]
 known-first-party = ["streamlink", "streamlink_cli"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,8 @@ select = [
   "INP",
   # flake8-pie
   "PIE",
+  # flake8-print
+  "T20",
   # flake8-pytest-style
   "PT",
   # flake8-quotes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,8 @@ select = [
   "DTZ",
   # flake8-implicit-str-concat
   "ISC",
+  # flake8-no-pep420
+  "INP",
   # flake8-pie
   "PIE",
   # flake8-pytest-style
@@ -213,7 +215,8 @@ extend-exclude = [
 
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
-"docs/**" = ["RUF012"]
+"docs/**" = ["INP", "RUF012"]
+"script/**" = ["INP"]
 "src/streamlink/__init__.py" = ["I"]
 "src/streamlink/_version.py" = ["I"]
 "src/streamlink/plugin/api/useragents.py" = ["E501"]

--- a/script/generate-cdp.py
+++ b/script/generate-cdp.py
@@ -82,9 +82,9 @@ MODULE_HEADER = f"""{SHARED_HEADER}
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 {{imports}}
 
@@ -896,7 +896,7 @@ class CdpDomain:
         """
         dependencies = self.get_imports()
         imports = [f"import {package}.{d} as {d}\n" for d in sorted(dependencies)]
-        imports.append(f"from {package}.util import T_JSON_DICT, event_class  # noqa")
+        imports.append(f"from {package}.util import T_JSON_DICT, event_class")
 
         return "".join(imports)
 

--- a/script/github-release.py
+++ b/script/github-release.py
@@ -110,7 +110,7 @@ class Git:
     @staticmethod
     def _output(*gitargs, **runkwargs) -> str:
         completedprocess = subprocess.run(
-            ["git", "--no-pager"] + list(map(str, gitargs)),
+            ["git", "--no-pager", *map(str, gitargs)],
             capture_output=True,
             check=True,
             **runkwargs,
@@ -345,7 +345,7 @@ class GitHubAPI:
                 authors[email].commits += 1
 
         # sort by commits in descending order and by login name in ascending order
-        return sorted(  # noqa: C414
+        return sorted(
             sorted(
                 authors.values(),
                 key=lambda author: author.name,

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -170,7 +170,7 @@ def capturewarnings(capture=False):
 
     if capture:
         if _showwarning_default is None:
-            _showwarning_default = warnings.showwarning  # noqa: PLW0603
+            _showwarning_default = warnings.showwarning
             warnings.showwarning = _showwarning
     else:
         if _showwarning_default is not None:

--- a/src/streamlink/plugin/api/websocket.py
+++ b/src/streamlink/plugin/api/websocket.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import unquote_plus, urlparse
 
 from certifi import where as certify_where
-from websocket import ABNF, STATUS_NORMAL, WebSocketApp, enableTrace  # type: ignore[import]
+from websocket import ABNF, STATUS_NORMAL, WebSocketApp, enableTrace  # type: ignore[attr-defined,import]
 
 from streamlink.logger import TRACE, root as rootlogger
 from streamlink.session import Streamlink
@@ -48,9 +48,9 @@ class WebsocketClient(Thread):
         if not header:
             header = []
         elif isinstance(header, dict):
-            header = [f"{str(k)}: {str(v)}" for k, v in header.items()]
+            header = [f"{k!s}: {v!s}" for k, v in header.items()]
         if not any(True for h in header if h.startswith("User-Agent: ")):
-            header.append(f"User-Agent: {str(session.http.headers['User-Agent'])}")
+            header.append(f"User-Agent: {session.http.headers['User-Agent']!s}")
 
         proxy_options: Dict[str, Any] = {}
         http_proxy: Optional[str] = session.get_option("http-proxy")

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -696,7 +696,7 @@ def pluginargument(
 
     def decorator(cls: Type[Plugin]) -> Type[Plugin]:
         if not issubclass(cls, Plugin):
-            raise TypeError(f"{repr(cls)} is not a Plugin")
+            raise TypeError(f"{repr(cls)} is not a Plugin")  # noqa: RUF010  # builtins.repr gets monkeypatched in tests
         if cls.arguments is None:
             cls.arguments = Arguments()
         cls.arguments.add(arg)

--- a/src/streamlink/plugins/pandalive.py
+++ b/src/streamlink/plugins/pandalive.py
@@ -96,7 +96,7 @@ class Pandalive(Plugin):
         playlist = json["PlayList"]
         for key in ("hls", "hls2", "hls3"):
             # use the first available HLS stream
-            if key in playlist and playlist[key]:
+            if playlist.get(key):
                 # all stream qualities share the same URL, so just use the first one
                 return HLSStream.parse_variant_playlist(self.session, playlist[key][0]["url"])
 

--- a/src/streamlink/plugins/reuters.py
+++ b/src/streamlink/plugins/reuters.py
@@ -76,7 +76,7 @@ class Reuters(Plugin):
                 validate.parse_json(),
                 {"videohub-by-guid-v1": {str: {"data": {"result": {"videos": list}}}}},
                 validate.get("videohub-by-guid-v1"),
-                validate.transform(lambda obj: obj[list(obj.keys())[0]]),
+                validate.transform(lambda obj: obj[next(iter((obj.keys())))]),
                 validate.get(("data", "result", "videos", 0)),
                 schema_video,
             )

--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -149,7 +149,7 @@ class StreamlinkOptions(Options):
 
     # ----
 
-    _OPTIONS_HTTP_ATTRS = {
+    _OPTIONS_HTTP_ATTRS: ClassVar[Dict[str, str]] = {
         "http-cookies": "cookies",
         "http-headers": "headers",
         "http-query-params": "params",

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
 from shutil import which
-from typing import Any, Dict, Generic, List, Optional, Sequence, TextIO, TypeVar, Union
+from typing import Any, ClassVar, Dict, Generic, List, Optional, Sequence, TextIO, TypeVar, Union
 
 from streamlink import StreamError
 from streamlink.stream.stream import Stream, StreamIO
@@ -80,7 +80,7 @@ class MuxedStream(Stream, Generic[TSubstreams]):
 
 
 class FFMPEGMuxer(StreamIO):
-    __commands__ = ["ffmpeg"]
+    __commands__: ClassVar[List[str]] = ["ffmpeg"]
 
     DEFAULT_OUTPUT_FORMAT = "matroska"
     DEFAULT_VIDEO_CODEC = "copy"

--- a/src/streamlink/webbrowser/cdp/devtools/browser.py
+++ b/src/streamlink/webbrowser/cdp/devtools/browser.py
@@ -8,13 +8,13 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.page as page
 import streamlink.webbrowser.cdp.devtools.target as target
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class BrowserContextID(str):

--- a/src/streamlink/webbrowser/cdp/devtools/debugger.py
+++ b/src/streamlink/webbrowser/cdp/devtools/debugger.py
@@ -8,12 +8,12 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class BreakpointId(str):

--- a/src/streamlink/webbrowser/cdp/devtools/dom.py
+++ b/src/streamlink/webbrowser/cdp/devtools/dom.py
@@ -8,13 +8,13 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.page as page
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class NodeId(int):

--- a/src/streamlink/webbrowser/cdp/devtools/emulation.py
+++ b/src/streamlink/webbrowser/cdp/devtools/emulation.py
@@ -8,14 +8,14 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.dom as dom
 import streamlink.webbrowser.cdp.devtools.network as network
 import streamlink.webbrowser.cdp.devtools.page as page
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 @dataclass

--- a/src/streamlink/webbrowser/cdp/devtools/fetch.py
+++ b/src/streamlink/webbrowser/cdp/devtools/fetch.py
@@ -8,14 +8,14 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.io as io
 import streamlink.webbrowser.cdp.devtools.network as network
 import streamlink.webbrowser.cdp.devtools.page as page
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class RequestId(str):

--- a/src/streamlink/webbrowser/cdp/devtools/input_.py
+++ b/src/streamlink/webbrowser/cdp/devtools/input_.py
@@ -8,11 +8,11 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 @dataclass

--- a/src/streamlink/webbrowser/cdp/devtools/inspector.py
+++ b/src/streamlink/webbrowser/cdp/devtools/inspector.py
@@ -8,11 +8,11 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:

--- a/src/streamlink/webbrowser/cdp/devtools/io.py
+++ b/src/streamlink/webbrowser/cdp/devtools/io.py
@@ -8,12 +8,12 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class StreamHandle(str):

--- a/src/streamlink/webbrowser/cdp/devtools/network.py
+++ b/src/streamlink/webbrowser/cdp/devtools/network.py
@@ -8,9 +8,9 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.debugger as debugger
 import streamlink.webbrowser.cdp.devtools.emulation as emulation
@@ -18,7 +18,7 @@ import streamlink.webbrowser.cdp.devtools.io as io
 import streamlink.webbrowser.cdp.devtools.page as page
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
 import streamlink.webbrowser.cdp.devtools.security as security
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class ResourceType(enum.Enum):

--- a/src/streamlink/webbrowser/cdp/devtools/page.py
+++ b/src/streamlink/webbrowser/cdp/devtools/page.py
@@ -8,9 +8,9 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.debugger as debugger
 import streamlink.webbrowser.cdp.devtools.dom as dom
@@ -18,7 +18,7 @@ import streamlink.webbrowser.cdp.devtools.emulation as emulation
 import streamlink.webbrowser.cdp.devtools.io as io
 import streamlink.webbrowser.cdp.devtools.network as network
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class FrameId(str):

--- a/src/streamlink/webbrowser/cdp/devtools/runtime.py
+++ b/src/streamlink/webbrowser/cdp/devtools/runtime.py
@@ -8,11 +8,11 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class ScriptId(str):

--- a/src/streamlink/webbrowser/cdp/devtools/security.py
+++ b/src/streamlink/webbrowser/cdp/devtools/security.py
@@ -8,12 +8,12 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.network as network
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class CertificateId(int):

--- a/src/streamlink/webbrowser/cdp/devtools/target.py
+++ b/src/streamlink/webbrowser/cdp/devtools/target.py
@@ -8,13 +8,13 @@
 
 from __future__ import annotations
 
-import enum  # noqa
+import enum
 import typing
-from dataclasses import dataclass  # noqa
+from dataclasses import dataclass
 
 import streamlink.webbrowser.cdp.devtools.browser as browser
 import streamlink.webbrowser.cdp.devtools.page as page
-from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class  # noqa
+from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
 class TargetID(str):

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -417,7 +417,7 @@ def handle_stream(plugin: Plugin, streams: Dict[str, Stream], stream_name: str) 
 
         formatter = get_formatter(plugin)
 
-        for name in [stream_name] + alt_streams:
+        for name in [stream_name, *alt_streams]:
             stream = streams[name]
             stream_type = type(stream).shortname()
 

--- a/src/streamlink_cli/output/player.py
+++ b/src/streamlink_cli/output/player.py
@@ -91,7 +91,7 @@ class PlayerArgs:
 
 
 class PlayerArgsVLC(PlayerArgs):
-    EXECUTABLES = [
+    EXECUTABLES: ClassVar[List[re.Pattern]] = [
         re.compile(r"^vlc$", re.IGNORECASE),
     ]
 
@@ -110,7 +110,7 @@ class PlayerArgsVLC(PlayerArgs):
 
 
 class PlayerArgsMPV(PlayerArgs):
-    EXECUTABLES = [
+    EXECUTABLES: ClassVar[List[re.Pattern]] = [
         re.compile(r"^mpv$", re.IGNORECASE),
     ]
 
@@ -125,7 +125,7 @@ class PlayerArgsMPV(PlayerArgs):
 
 
 class PlayerArgsPotplayer(PlayerArgs):
-    EXECUTABLES = [
+    EXECUTABLES: ClassVar[List[re.Pattern]] = [
         re.compile(r"^potplayer(?:mini(?:64)?)?$", re.IGNORECASE),
     ]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,7 +5,7 @@ import pytest
 
 # import streamlink_cli as early as possible to execute its default signal overrides
 # noinspection PyUnresolvedReferences
-import streamlink_cli  # noqa: F401
+import streamlink_cli
 
 
 # immediately restore default signal handlers for the test runner

--- a/tests/cli/utils/test_progress.py
+++ b/tests/cli/utils/test_progress.py
@@ -188,7 +188,7 @@ class TestWidth:
     @pytest.mark.parametrize(("chars", "expected"), [
         ("ABCDEFGHIJ", 10),
         ("A你好世界こんにちは안녕하세요B", 30),
-        ("·「」『』【】-=！@#￥%……&×（）", 30),
+        ("·「」『』【】-=！@#￥%……&×（）", 30),  # noqa: RUF001
     ])
     def test_width(self, chars, expected):
         assert ProgressFormatter.width(chars) == expected

--- a/tests/plugin/override/testplugin.py
+++ b/tests/plugin/override/testplugin.py
@@ -1,3 +1,5 @@
+# ruff: noqa: INP001
+
 from tests.plugin.testplugin import __plugin__ as TestPlugin
 
 

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -83,7 +83,7 @@ class PluginCanHandleUrl:
 
     @classmethod
     def urls_named(cls) -> List[TUrlNamed]:
-        return [item for item in cls.urls_all() if type(item) is tuple]  # noqa: E721
+        return [item for item in cls.urls_all() if type(item) is tuple]
 
     @classmethod
     def urlgroups_unnamed(cls) -> List[Tuple[TUrl, TMatchGroup]]:
@@ -91,7 +91,7 @@ class PluginCanHandleUrl:
 
     @classmethod
     def urlgroups_named(cls) -> List[Tuple[TName, TUrl, TMatchGroup]]:
-        return [(item[0], item[1], groups) for item, groups in cls.should_match_groups if type(item) is tuple]  # noqa: E721
+        return [(item[0], item[1], groups) for item, groups in cls.should_match_groups if type(item) is tuple]
 
     @classmethod
     def urls_negative(cls) -> List[TUrl]:

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -348,15 +348,15 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
             # regular stream data with prefetch segments
             Playlist(0, [Seg(0), Seg(1, duration=0.5), Pre(2), Pre(3)]),
             # three prefetch segments, one regular (2) and two ads (3 and 4)
-            Playlist(1, [Seg(1, duration=0.5), Pre(2)] + ads + [Pre(3), Pre(4)]),
+            Playlist(1, [Seg(1, duration=0.5), Pre(2), *ads, Pre(3), Pre(4)]),
             # all prefetch segments are gone once regular prefetch segments have shifted
-            Playlist(2, [Seg(2, duration=1.5)] + ads + [Seg(3), Seg(4), Seg(5)]),
+            Playlist(2, [Seg(2, duration=1.5), *ads, Seg(3), Seg(4), Seg(5)]),
             # still no prefetch segments while ads are playing
-            Playlist(3, ads + [Seg(3), Seg(4), Seg(5), Seg(6)]),
+            Playlist(3, [*ads, Seg(3), Seg(4), Seg(5), Seg(6)]),
             # new prefetch segments on the first regular segment occurrence
-            Playlist(4, ads + [Seg(4), Seg(5), Seg(6), Seg(7), Pre(8), Pre(9)]),
-            Playlist(5, ads + [Seg(5), Seg(6), Seg(7), Seg(8), Pre(9), Pre(10)]),
-            Playlist(6, ads + [Seg(6), Seg(7), Seg(8), Seg(9), Pre(10), Pre(11)]),
+            Playlist(4, [*ads, Seg(4), Seg(5), Seg(6), Seg(7), Pre(8), Pre(9)]),
+            Playlist(5, [*ads, Seg(5), Seg(6), Seg(7), Seg(8), Pre(9), Pre(10)]),
+            Playlist(6, [*ads, Seg(6), Seg(7), Seg(8), Seg(9), Pre(10), Pre(11)]),
             Playlist(7, [Seg(7), Seg(8), Seg(9), Seg(10), Pre(11), Pre(12)], end=True),
         ], streamoptions={"disable_ads": True, "low_latency": True})
 

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -186,212 +186,263 @@ class TestOpen:
         pytest.param(
             {},
             {},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="default",
         ),
         pytest.param(
             {},
             {"format": "mpegts"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-f", "mpegts"]
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-f", "mpegts",
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="format",
         ),
         pytest.param(
             {"ffmpeg-fout": "avi"},
             {"format": "mpegts"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-f", "avi"]
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-f", "avi",
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="format-user-override",
         ),
         pytest.param(
             {},
             {"copyts": True},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts",
         ),
         pytest.param(
             {"ffmpeg-copyts": True},
             {"copyts": False},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-user-override",
         ),
         pytest.param(
             {"ffmpeg-start-at-zero": False},
             {"copyts": True},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-disable-session-start-at-zero",
         ),
         pytest.param(
             {"ffmpeg-copyts": True, "ffmpeg-start-at-zero": False},
             {"copyts": False},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-disable-session-start-at-zero-user-override",
         ),
         pytest.param(
             {"ffmpeg-start-at-zero": True},
             {"copyts": True},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts", "-start_at_zero"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts", "-start_at_zero",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-enable-session-start-at-zero",
         ),
         pytest.param(
             {"ffmpeg-copyts": True, "ffmpeg-start-at-zero": True},
             {"copyts": False},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts", "-start_at_zero"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts", "-start_at_zero",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-enable-session-start-at-zero-user-override",
         ),
         pytest.param(
             {},
             {"copyts": True, "start_at_zero": False},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-disable-start-at-zero",
         ),
         pytest.param(
             {"ffmpeg-copyts": True},
             {"copyts": False, "start_at_zero": False},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-disable-start-at-zero-user-override",
         ),
         pytest.param(
             {},
             {"copyts": True, "start_at_zero": True},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts", "-start_at_zero"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts", "-start_at_zero",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-enable-start-at-zero",
         ),
         pytest.param(
             {"ffmpeg-copyts": True},
             {"copyts": False, "start_at_zero": True},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-copyts", "-start_at_zero"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-copyts", "-start_at_zero",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="copyts-enable-start-at-zero-user-override",
         ),
         pytest.param(
             {},
             {"vcodec": "avc"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + ["-c:v", "avc", "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-c:v", "avc",
+                "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC,
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="vcodec",
         ),
         pytest.param(
             {"ffmpeg-video-transcode": "divx"},
             {"vcodec": "avc"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + ["-c:v", "divx", "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-c:v", "divx",
+                "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC,
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="vcodec-user-override",
         ),
         pytest.param(
             {},
             {"acodec": "mp3"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + ["-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC, "-c:a", "mp3"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC,
+                "-c:a", "mp3",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="acodec",
         ),
         pytest.param(
             {"ffmpeg-audio-transcode": "ogg"},
             {"acodec": "mp3"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + ["-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC, "-c:a", "ogg"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC,
+                "-c:a", "ogg",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="acodec-user-override",
         ),
         pytest.param(
             {},
             {"vcodec": "avc", "acodec": "mp3"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + ["-c:v", "avc", "-c:a", "mp3"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-c:v", "avc",
+                "-c:a", "mp3",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="vcodec-acodec",
         ),
         pytest.param(
             {"ffmpeg-video-transcode": "divx", "ffmpeg-audio-transcode": "ogg"},
             {"vcodec": "avc", "acodec": "mp3"},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + ["-c:v", "divx", "-c:a", "ogg"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-c:v", "divx",
+                "-c:a", "ogg",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="vcodec-acodec-user-override",
         ),
         pytest.param(
             {},
             {"maps": ["test", "test2"]},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-map", "test", "-map", "test2"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-map", "test",
+                "-map", "test2",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="maps",
         ),
         pytest.param(
             {},
             {"metadata": {"s:a:0": ["language=eng"]}},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-metadata:s:a:0", "language=eng"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-metadata:s:a:0", "language=eng",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="metadata-stream-audio",
         ),
         pytest.param(
             {},
             {"metadata": {None: ["title=test"]}},
-            FFMPEG_ARGS_DEFAULT_BASE
-            + FFMPEG_ARGS_DEFAULT_CODECS
-            + ["-metadata", "title=test"]
-            + FFMPEG_ARGS_DEFAULT_FORMAT
-            + FFMPEG_ARGS_DEFAULT_OUTPUT,
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                "-metadata", "title=test",
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
             id="metadata-title",
         ),
     ])
@@ -408,7 +459,7 @@ class TestOpen:
 
         streamio.open()
         assert popen.call_args_list == [call(
-            ["ffmpeg"] + expected,
+            ["ffmpeg", *expected],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,

--- a/tests/test_api_http_session.py
+++ b/tests/test_api_http_session.py
@@ -64,7 +64,7 @@ class TestHTTPSession:
 
     @pytest.mark.parametrize("encoding", ["UTF-32BE", "UTF-32LE", "UTF-16BE", "UTF-16LE", "UTF-8"])
     def test_determine_json_encoding(self, recwarn: pytest.WarningsRecorder, encoding: str):
-        data = "Hello world, Γειά σου Κόσμε, こんにちは世界".encode(encoding)
+        data = "Hello world, Γειά σου Κόσμε, こんにちは世界".encode(encoding)  # noqa: RUF001
         assert HTTPSession.determine_json_encoding(data) == encoding
         assert [(record.category, str(record.message)) for record in recwarn.list] == [
             (StreamlinkDeprecationWarning, "Deprecated HTTPSession.determine_json_encoding() call"),
@@ -85,10 +85,10 @@ class TestHTTPSession:
         ("cp949", "cp949"),
     ])
     def test_json(self, monkeypatch: pytest.MonkeyPatch, encoding: str, override: Optional[str]):
-        mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode(encoding))
+        mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode(encoding))  # noqa: RUF001
         monkeypatch.setattr("requests.Response.content", mock_content)
 
         res = requests.Response()
         res.encoding = override
 
-        assert HTTPSession.json(res) == {"test": "Α and Ω"}
+        assert HTTPSession.json(res) == {"test": "Α and Ω"}  # noqa: RUF001

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -189,10 +189,10 @@ class TestLogging:
 
     def test_logfile(self, logfile: str, log: logging.Logger, output: StringIO):
         log.setLevel("info")
-        log.info("Hello world, Γειά σου Κόσμε, こんにちは世界")
+        log.info("Hello world, Γειά σου Κόσμε, こんにちは世界")  # noqa: RUF001
         log.handlers[0].flush()
         with open(logfile, "r", encoding="utf-8") as fh:
-            assert fh.read() == "[test][info] Hello world, Γειά σου Κόσμε, こんにちは世界\n"
+            assert fh.read() == "[test][info] Hello world, Γειά σου Κόσμε, こんにちは世界\n"  # noqa: RUF001
 
 
 class TestCaptureWarnings:

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -123,7 +123,7 @@ async def test_launch(monkeypatch: pytest.MonkeyPatch, mock_clock, webbrowser_la
 
     nursery: trio.Nursery
     process: trio.Process
-    async with webbrowser_launch(webbrowser=webbrowser, timeout=999) as (nursery, process):  # noqa: F841
+    async with webbrowser_launch(webbrowser=webbrowser, timeout=999) as (nursery, process):
         assert process.poll() is None, "process is still running"
         assert f"--remote-debugging-host={host}" in process.args
         assert "--remote-debugging-port=1234" in process.args

--- a/tests/webbrowser/test_webbrowser.py
+++ b/tests/webbrowser/test_webbrowser.py
@@ -62,7 +62,7 @@ class TestLaunch:
     async def test_terminate_on_nursery_exit(self, caplog: pytest.LogCaptureFixture, webbrowser_launch):
         nursery: trio.Nursery
         process: trio.Process
-        async with webbrowser_launch() as (nursery, process):  # noqa: F841
+        async with webbrowser_launch() as (nursery, process):
             assert process.poll() is None, "process is still running"
 
         assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
@@ -87,7 +87,7 @@ class TestLaunch:
     async def test_terminate_on_nursery_timeout(self, caplog: pytest.LogCaptureFixture, mock_clock, webbrowser_launch):
         nursery: trio.Nursery
         process: trio.Process
-        async with webbrowser_launch(timeout=10) as (nursery, process):  # noqa: F841
+        async with webbrowser_launch(timeout=10) as (nursery, process):
             assert process.poll() is None, "process is still running"
             mock_clock.jump(20)
             await trio.sleep(0)
@@ -106,7 +106,7 @@ class TestLaunch:
         nursery: trio.Nursery
         process: trio.Process
         with pytest.raises(FakeBaseException):  # noqa: PT012
-            async with webbrowser_launch() as (nursery, process):  # noqa: F841
+            async with webbrowser_launch() as (nursery, process):
                 assert process.poll() is None, "process is still running"
                 raise FakeBaseException()
 
@@ -123,7 +123,7 @@ class TestLaunch:
     async def test_process_ended_early(self, caplog: pytest.LogCaptureFixture, webbrowser_launch, exit_code):
         nursery: trio.Nursery
         process: trio.Process
-        async with webbrowser_launch(timeout=10) as (nursery, process):  # noqa: F841
+        async with webbrowser_launch(timeout=10) as (nursery, process):
             assert process.poll() is None, "process is still running"
             assert process.stdin
             await process.stdin.send_all(str(exit_code).encode() + b"\r\n")


### PR DESCRIPTION
Simple version bump
https://github.com/astral-sh/ruff/releases/tag/v0.1.0

And three new rule-sets:
1. [`RUF`](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf)
2. [`INP`](https://docs.astral.sh/ruff/rules/#flake8-no-pep420-inp) (no implicit namespace packages)
3. [`T20`](https://docs.astral.sh/ruff/rules/#flake8-print-t20) (no `print()` calls)

There are a couple more rule-sets which could be added, but those currently require lots of code changes.