### PR TITLE
build: include build-shell-completions.sh in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,5 +13,7 @@ recursive-include tests *
 prune docs/_build
 include docs/_build/man/*
 
+include script/build-shell-completions.sh
+
 prune */__pycache__
 global-exclude *.pyc *~ *.bak *.swp *.pyo


### PR DESCRIPTION
Some packagers are currently patching the versioningit fallback version string, which isn't meant for setting the right version. It's a fallback for when not using the dist tarball or a git repo with at least one tag.

The packagers need to do that because they incorrectly use the tarball generated by GitHub as package source instead of our signed sdist tarball which has the right version string already built in.

- https://git.alpinelinux.org/aports/tree/testing/streamlink/APKBUILD?id=083eb89bb9af1e5570429a2580c0c2d5d136be4c#n47
- https://src.fedoraproject.org/rpms/python-streamlink/blob/f8680363a554b0b49c447de73304013644f48575/f/python-streamlink.spec#_75

```sh
# signed Streamlink sdist tarball
$ curl -sSL https://github.com/streamlink/streamlink/releases/download/6.2.1/streamlink-6.2.1.tar.gz \
  | bsdtar -xOf- streamlink-6.2.1/src/streamlink/_version.py \
  | grep __version__
__version__ = "6.2.1"

# tarball built by GitHub from the git tag
$ curl -sSL https://github.com/streamlink/streamlink/archive/refs/tags/6.2.1.tar.gz \
  | bsdtar -xOf- streamlink-6.2.1/src/streamlink/_version.py \
  | grep __version__
__version__ = _get_version()
```

----

The second commit therefore adds and updates the version string comments accordingly, while the first one adds the missing shell completions build-script to the sdist, despite the sdist including pre-built shell completions in the `completions` directory, so that there's no need to ever use the GH tarball, even when building the completions manually.