### PR TITLE
build: fix onbuild test in sdist

### DIFF
--- a/build_backend/test_onbuild.py
+++ b/build_backend/test_onbuild.py
@@ -44,7 +44,10 @@ def test_sdist(build: Path):
         re.MULTILINE,
     ), "versioningit is not a build-requirement"
     assert re.search(
-        r"^(\s*)(version=\"1\.2\.3\+fake\",).*$",
+        # Check for any version string, and not just the fake one,
+        # because tests can be run from the sdist where the version string was already set.
+        # The onbuild hook does only replace the template in `setup.py`.
+        r"^(\s*)(version=\"[^\"]+\",).*$",
         (build / "setup.py").read_text(encoding="utf-8"),
         re.MULTILINE,
     ), "setup() call defines a static version string"


### PR DESCRIPTION
Fixes #5635 

```bash
$ python -m build --sdist
...

$ python -m venv /tmp/venv
$ source /tmp/venv/bin/activate
$ bsdtar -xz -C /tmp/venv -f dist/streamlink-6.3.0+1.g6bc7ebd2.tar.gz

$ cd /tmp/venv/streamlink-6.3.0+1.g6bc7ebd2
$ pip install . -r dev-requirements.txt
...
$ pytest
...
$ echo $?
0
```