### PR TITLE
stream.file: fix read mode

### DIFF
--- a/src/streamlink/stream/file.py
+++ b/src/streamlink/stream/file.py
@@ -29,4 +29,4 @@ class FileStream(Stream):
         return self.path
 
     def open(self):
-        return self.fileobj or open(self.path)
+        return self.fileobj or open(self.path, "rb")

--- a/tests/stream/test_file.py
+++ b/tests/stream/test_file.py
@@ -1,18 +1,34 @@
-from unittest.mock import Mock, call, mock_open, patch
+from io import BytesIO
+from unittest.mock import Mock, call
+
+import pytest
 
 from streamlink import Streamlink
 from streamlink.stream.file import FileStream
 
 
 class TestFileStream:
-    def test_open_path(self, session: Streamlink):
-        mock = mock_open()
-        stream = FileStream(session, path="/test/path")
-        with patch("streamlink.stream.file.open", mock, create=True):
-            stream.open()
-        assert mock.call_args_list == [call("/test/path")]
+    @pytest.fixture(autouse=True)
+    def mock_open(self, monkeypatch: pytest.MonkeyPatch) -> Mock:
+        mock_open = Mock(return_value=BytesIO(b"foo"))
+        monkeypatch.setattr("builtins.open", mock_open)
 
-    def test_open_fileobj(self, session: Streamlink):
-        fileobj = Mock()
+        return mock_open
+
+    def test_open_path(self, session: Streamlink, mock_open: Mock):
+        stream = FileStream(session, path="/test/path")
+        streamio = stream.open()
+        assert mock_open.call_args_list == [call("/test/path", "rb")]
+        assert streamio.read() == b"foo"
+
+        streamio.close()
+
+    def test_open_fileobj(self, session: Streamlink, mock_open: Mock):
+        fileobj = BytesIO(b"bar")
         stream = FileStream(session, fileobj=fileobj)
-        assert stream.open() is fileobj
+        streamio = stream.open()
+        assert streamio is fileobj
+        assert mock_open.call_args_list == []
+        assert streamio.read() == b"bar"
+
+        streamio.close()


### PR DESCRIPTION
Most useless PR of the year, because `FileStream` isn't actually used in the entire code base, because `file://` inputs are handled by the `HTTPSession`'s `FileAdapter`. Other use cases are being a `Stream` wrapper for basic stream I/O objects, but that's not the case anywhere here either (it was the case in 4176c99db241ff6fa46ec9a6a0f30fda28a183be).

The `stream.file` module could therefore also be removed, but I feel like this should be done in a major version bump, so let's keep it for now.

Anyway, `FileStream.open()` attempted to open file paths in text mode ever since it was implemented (never used though), which is obviously wrong for the stream implementation:
https://github.com/streamlink/streamlink/blame/6.3.1/src/streamlink/stream/file.py#L32

I only noticed that after bumping ruff to `1.0.3` when it complained about the missing `encoding` keyword.