### PR TITLE
script: fix plugin test script

### DIFF
--- a/script/test-plugin-urls.py
+++ b/script/test-plugin-urls.py
@@ -142,10 +142,10 @@ class PluginUrlTester:
 
     def run(self) -> int:
         code = 0
-        session = Streamlink()
         for url in sorted(self.urls):
             self.logger.info(f"Finding streams for URL: {url}")
 
+            session = Streamlink()
             # noinspection PyBroadException
             try:
                 pluginname, Pluginclass, resolved_url = session.resolve_url(url)


### PR DESCRIPTION
Create a new Streamlink and HTTP session on each URL

----

This was a requirement for making the plugin test script work for #5645, otherwise every second request on tvp.pl would be rejected.
