### PR TITLE
plugin.api.validate: fix perf of validate_sequence

### DIFF
--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -72,9 +72,10 @@ def _validate_type(schema, value):
 def _validate_sequence(schema, value):
     cls = type(schema)
     validate(cls, value)
+    any_schemas = AnySchema(*schema)
 
     return cls(
-        validate(AnySchema(*schema), v) for v in value
+        validate(any_schemas, v) for v in value
     )
 
 


### PR DESCRIPTION
Small performance fix for the `_validate_sequence()` overload of `validate()` which I've noticed while writing the API docs.