### PR TITLE
stream.dash: fix SegmentList in dynamic manifests

### DIFF
--- a/tests/resources/dash/test_dynamic_segment_list_p1.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p1.mpd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+  type="dynamic"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  publishTime="2000-01-01T00:00:00Z"
+  maxSegmentDuration="PT10S"
+  minBufferTime="PT10S"
+>
+<Period id="0" start="PT0S">
+    <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+        <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
+            <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="5">
+                <Initialization sourceURL="init.m4s"/>
+                <SegmentURL media="5.m4s"/>
+                <SegmentURL media="6.m4s"/>
+                <SegmentURL media="7.m4s"/>
+                <SegmentURL media="8.m4s"/>
+                <SegmentURL media="9.m4s"/>
+                <SegmentURL media="10.m4s"/>
+                <SegmentURL media="11.m4s"/>
+                <SegmentURL media="12.m4s"/>
+                <SegmentURL media="13.m4s"/>
+                <SegmentURL media="14.m4s"/>
+                <SegmentURL media="15.m4s"/>
+            </SegmentList>
+        </Representation>
+    </AdaptationSet>
+</Period>
+</MPD>

--- a/tests/resources/dash/test_dynamic_segment_list_p2.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p2.mpd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+  type="dynamic"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  publishTime="2000-01-01T00:00:00Z"
+  maxSegmentDuration="PT10S"
+  minBufferTime="PT10S"
+>
+<Period id="0" start="PT0S">
+    <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+        <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
+            <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="9">
+                <Initialization sourceURL="init.m4s"/>
+                <SegmentURL media="9.m4s"/>
+                <SegmentURL media="10.m4s"/>
+                <SegmentURL media="11.m4s"/>
+                <SegmentURL media="12.m4s"/>
+                <SegmentURL media="13.m4s"/>
+                <SegmentURL media="14.m4s"/>
+                <SegmentURL media="15.m4s"/>
+                <SegmentURL media="16.m4s"/>
+                <SegmentURL media="17.m4s"/>
+                <SegmentURL media="18.m4s"/>
+            </SegmentList>
+        </Representation>
+    </AdaptationSet>
+</Period>
+</MPD>

--- a/tests/resources/dash/test_dynamic_segment_list_p3.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p3.mpd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+  type="dynamic"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  publishTime="2000-01-01T00:00:00Z"
+  maxSegmentDuration="PT10S"
+  minBufferTime="PT10S"
+>
+<Period id="0" start="PT0S">
+    <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+        <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
+            <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="12">
+                <Initialization sourceURL="init.m4s"/>
+                <SegmentURL media="12.m4s"/>
+                <SegmentURL media="13.m4s"/>
+                <SegmentURL media="14.m4s"/>
+                <SegmentURL media="15.m4s"/>
+                <SegmentURL media="16.m4s"/>
+                <SegmentURL media="17.m4s"/>
+                <SegmentURL media="18.m4s"/>
+                <SegmentURL media="19.m4s"/>
+                <SegmentURL media="20.m4s"/>
+                <SegmentURL media="21.m4s"/>
+            </SegmentList>
+        </Representation>
+    </AdaptationSet>
+</Period>
+</MPD>

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -276,6 +276,46 @@ class TestMPDParser:
             ("http://test/chunk_ctvideo_ridp0va0br4332748_cn3_mpd.m4s", expected_availability),
         ]
 
+    def test_dynamic_segment_list_continued(self):
+        with xml("dash/test_dynamic_segment_list_p1.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd")
+
+        segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=True)
+        assert [segment.uri for segment in segments_iterator] == [
+            "http://test/init.m4s",
+            "http://test/5.m4s",
+            "http://test/6.m4s",
+            "http://test/7.m4s",
+            "http://test/8.m4s",
+            "http://test/9.m4s",
+            "http://test/10.m4s",
+            "http://test/11.m4s",
+            "http://test/12.m4s",
+            "http://test/13.m4s",
+            "http://test/14.m4s",
+            "http://test/15.m4s",
+        ]
+
+        with xml("dash/test_dynamic_segment_list_p2.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd", timelines=mpd.timelines)
+
+        segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=False)
+        assert [segment.uri for segment in segments_iterator] == [
+            "http://test/16.m4s",
+            "http://test/17.m4s",
+            "http://test/18.m4s",
+        ]
+
+        with xml("dash/test_dynamic_segment_list_p3.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd", timelines=mpd.timelines)
+
+        segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=False)
+        assert [segment.uri for segment in segments_iterator] == [
+            "http://test/19.m4s",
+            "http://test/20.m4s",
+            "http://test/21.m4s",
+        ]
+
     def test_dynamic_timeline_continued(self):
         with xml("dash/test_dynamic_timeline_continued_p1.mpd") as mpd_xml_p1:
             mpd_p1 = MPD(mpd_xml_p1, base_url="http://test/", url="http://test/manifest.mpd")


### PR DESCRIPTION
This PR adds support to keep track of the last yielded segment when using SegmentLists. This actually makes SegmentLists with a dynamic manifest work.

I also check for `init` to avoid yielding the init segment after every refresh.

Fixes #5582

~I have also hardcoded a "live edge" of 3, when we don't have a current_segment yet. This should also be done prettier (and configurable).~

~Note that this PR is still very much WIP. It works, but it isn't pretty. I would like to get some feedback on how to keep track of the last yielded segment correctly. I'm currently storing the last yielded segment in a static dict CURRENT_SEGMENT (key is the representation id) on the Representation (since I need to keep track of them both on audio and video).~

~One of the problems I encounter is that when a manifest reload happens, all classes are re-initialised again, and all my local variables are lost.~
