### PR TITLE
stream.dash: use suggestedPresentationDelay to calculate the live edge for dynamic manifests

### DIFF
--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -293,6 +293,7 @@ class MPD(MPDNode):
     timelines: Dict[TTimelineIdent, int]
 
     DEFAULT_MINBUFFERTIME = 3.0
+    DEFAULT_LIVE_EDGE_SEGMENTS = 3
 
     def __init__(self, *args, url: Optional[str] = None, **kwargs) -> None:
         # top level has no parent
@@ -775,7 +776,12 @@ class SegmentList(_MultipleSegmentBaseType):
         """Calculate the optimal segment number to start based on the suggestedPresentationDelay"""
         suggested_delay = self.root.suggestedPresentationDelay
 
-        offset = max(0, math.ceil(suggested_delay.total_seconds() / self.duration_seconds))
+        if self.duration_seconds == 0.0:
+            log.info(f"Unknown segment duration. Falling back to an offset of {MPD.DEFAULT_LIVE_EDGE_SEGMENTS} segments.")
+            offset = MPD.DEFAULT_LIVE_EDGE_SEGMENTS
+        else:
+            offset = max(0, math.ceil(suggested_delay.total_seconds() / self.duration_seconds))
+
         start = self.startNumber + len(self.segmentURLs) - offset
         log.debug(f"Calculated optimal offset is {offset} segments. First segment is {start}.")
 

--- a/tests/resources/dash/test_dynamic_segment_list_no_duration.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_no_duration.mpd
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+  type="dynamic"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  publishTime="2000-01-01T00:00:00Z"
+  maxSegmentDuration="PT10S"
+  minBufferTime="PT10S"
+>
+<Period id="0" start="PT0S">
+    <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
+        <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
+            <SegmentList presentationTimeOffset="0" timescale="1000" startNumber="5">
+                <Initialization sourceURL="init.m4s"/>
+                <SegmentURL media="5.m4s"/>
+                <SegmentURL media="6.m4s"/>
+                <SegmentURL media="7.m4s"/>
+                <SegmentURL media="8.m4s"/>
+                <SegmentURL media="9.m4s"/>
+                <SegmentURL media="10.m4s"/>
+                <SegmentURL media="11.m4s"/>
+                <SegmentURL media="12.m4s"/>
+                <SegmentURL media="13.m4s"/>
+                <SegmentURL media="14.m4s"/>
+                <SegmentURL media="15.m4s"/>
+            </SegmentList>
+        </Representation>
+    </AdaptationSet>
+</Period>
+</MPD>

--- a/tests/resources/dash/test_dynamic_segment_list_p1.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p1.mpd
@@ -13,7 +13,7 @@
 <Period id="0" start="PT0S">
     <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
         <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
-            <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="5">
+            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="5">
                 <Initialization sourceURL="init.m4s"/>
                 <SegmentURL media="5.m4s"/>
                 <SegmentURL media="6.m4s"/>

--- a/tests/resources/dash/test_dynamic_segment_list_p2.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p2.mpd
@@ -13,7 +13,7 @@
 <Period id="0" start="PT0S">
     <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
         <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
-            <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="9">
+            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="9">
                 <Initialization sourceURL="init.m4s"/>
                 <SegmentURL media="9.m4s"/>
                 <SegmentURL media="10.m4s"/>

--- a/tests/resources/dash/test_dynamic_segment_list_p3.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p3.mpd
@@ -13,7 +13,7 @@
 <Period id="0" start="PT0S">
     <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
         <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
-            <SegmentList presentationTimeOffset="0" timescale="90000" duration="900000" startNumber="12">
+            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="12">
                 <Initialization sourceURL="init.m4s"/>
                 <SegmentURL media="12.m4s"/>
                 <SegmentURL media="13.m4s"/>

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -283,14 +283,6 @@ class TestMPDParser:
         segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=True)
         assert [segment.uri for segment in segments_iterator] == [
             "http://test/init.m4s",
-            "http://test/5.m4s",
-            "http://test/6.m4s",
-            "http://test/7.m4s",
-            "http://test/8.m4s",
-            "http://test/9.m4s",
-            "http://test/10.m4s",
-            "http://test/11.m4s",
-            "http://test/12.m4s",
             "http://test/13.m4s",
             "http://test/14.m4s",
             "http://test/15.m4s",

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -308,6 +308,18 @@ class TestMPDParser:
             "http://test/21.m4s",
         ]
 
+    def test_dynamic_segment_list_no_duration(self):
+        with xml("dash/test_dynamic_segment_list_no_duration.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd")
+
+        segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=True)
+        assert [segment.uri for segment in segments_iterator] == [
+            "http://test/init.m4s",
+            "http://test/13.m4s",
+            "http://test/14.m4s",
+            "http://test/15.m4s",
+        ]
+
     def test_dynamic_timeline_continued(self):
         with xml("dash/test_dynamic_timeline_continued_p1.mpd") as mpd_xml_p1:
             mpd_p1 = MPD(mpd_xml_p1, base_url="http://test/", url="http://test/manifest.mpd")


### PR DESCRIPTION
Follow-up for #5654, also mentioned in #5582

Reworked this PR to calculate the live edge based on the `suggestedPresentationDelay`.