### PR TITLE
stream.dash: warn about skipped segments

### DIFF
--- a/tests/resources/dash/test_dynamic_segment_list_p4.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p4.mpd
@@ -13,18 +13,18 @@
 <Period id="0" start="PT0S">
     <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
         <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
-            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="15">
+            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="30">
                 <Initialization sourceURL="init.m4s"/>
-                <SegmentURL media="15.m4s"/>
-                <SegmentURL media="16.m4s"/>
-                <SegmentURL media="17.m4s"/>
-                <SegmentURL media="18.m4s"/>
-                <SegmentURL media="19.m4s"/>
-                <SegmentURL media="20.m4s"/>
-                <SegmentURL media="21.m4s"/>
-                <SegmentURL media="22.m4s"/>
-                <SegmentURL media="23.m4s"/>
-                <SegmentURL media="24.m4s"/>
+                <SegmentURL media="30.m4s"/>
+                <SegmentURL media="31.m4s"/>
+                <SegmentURL media="32.m4s"/>
+                <SegmentURL media="33.m4s"/>
+                <SegmentURL media="34.m4s"/>
+                <SegmentURL media="35.m4s"/>
+                <SegmentURL media="36.m4s"/>
+                <SegmentURL media="37.m4s"/>
+                <SegmentURL media="38.m4s"/>
+                <SegmentURL media="39.m4s"/>
             </SegmentList>
         </Representation>
     </AdaptationSet>

--- a/tests/resources/dash/test_dynamic_segment_list_p5.mpd
+++ b/tests/resources/dash/test_dynamic_segment_list_p5.mpd
@@ -13,18 +13,18 @@
 <Period id="0" start="PT0S">
     <AdaptationSet id="0" group="1" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25" segmentAlignment="true" startWithSAP="1" subsegmentAlignment="true" subsegmentStartsWithSAP="1">
         <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="4332748">
-            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="15">
+            <SegmentList presentationTimeOffset="0" timescale="1000" duration="4000" startNumber="41">
                 <Initialization sourceURL="init.m4s"/>
-                <SegmentURL media="15.m4s"/>
-                <SegmentURL media="16.m4s"/>
-                <SegmentURL media="17.m4s"/>
-                <SegmentURL media="18.m4s"/>
-                <SegmentURL media="19.m4s"/>
-                <SegmentURL media="20.m4s"/>
-                <SegmentURL media="21.m4s"/>
-                <SegmentURL media="22.m4s"/>
-                <SegmentURL media="23.m4s"/>
-                <SegmentURL media="24.m4s"/>
+                <SegmentURL media="41.m4s"/>
+                <SegmentURL media="42.m4s"/>
+                <SegmentURL media="43.m4s"/>
+                <SegmentURL media="44.m4s"/>
+                <SegmentURL media="45.m4s"/>
+                <SegmentURL media="46.m4s"/>
+                <SegmentURL media="47.m4s"/>
+                <SegmentURL media="48.m4s"/>
+                <SegmentURL media="49.m4s"/>
+                <SegmentURL media="50.m4s"/>
             </SegmentList>
         </Representation>
     </AdaptationSet>

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -276,36 +276,104 @@ class TestMPDParser:
             ("http://test/chunk_ctvideo_ridp0va0br4332748_cn3_mpd.m4s", expected_availability),
         ]
 
-    def test_dynamic_segment_list_continued(self):
+    def test_dynamic_segment_list_continued(self, caplog: pytest.LogCaptureFixture):
+        caplog.set_level("WARNING", "streamlink.stream.dash")
+
+        # init manifest
         with xml("dash/test_dynamic_segment_list_p1.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd")
-
         segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=True)
-        assert [segment.uri for segment in segments_iterator] == [
-            "http://test/init.m4s",
-            "http://test/13.m4s",
-            "http://test/14.m4s",
-            "http://test/15.m4s",
-        ]
 
+        assert [(segment.uri, segment.num) for segment in segments_iterator] == [
+            ("http://test/init.m4s", -1),
+            ("http://test/13.m4s", 13),
+            ("http://test/14.m4s", 14),
+            ("http://test/15.m4s", 15),
+        ], "Queues the init segment and the correct number of segments from the live-edge"
+        assert mpd.timelines[("0", "0", "0")] == 16, "Remembers the next segment number"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == []
+
+        # regular continuation
         with xml("dash/test_dynamic_segment_list_p2.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd", timelines=mpd.timelines)
-
         segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=False)
-        assert [segment.uri for segment in segments_iterator] == [
-            "http://test/16.m4s",
-            "http://test/17.m4s",
-            "http://test/18.m4s",
-        ]
 
+        assert [(segment.uri, segment.num) for segment in segments_iterator] == [
+            ("http://test/16.m4s", 16),
+            ("http://test/17.m4s", 17),
+            ("http://test/18.m4s", 18),
+        ], "All segments from the remembered segment number were queued"
+        assert mpd.timelines[("0", "0", "0")] == 19, "Remembers the next segment number"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == []
+
+        # regular continuation with a different offset
         with xml("dash/test_dynamic_segment_list_p3.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd", timelines=mpd.timelines)
-
         segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=False)
-        assert [segment.uri for segment in segments_iterator] == [
-            "http://test/19.m4s",
-            "http://test/20.m4s",
-            "http://test/21.m4s",
+
+        assert [(segment.uri, segment.num) for segment in segments_iterator] == [
+            ("http://test/19.m4s", 19),
+            ("http://test/20.m4s", 20),
+            ("http://test/21.m4s", 21),
+            ("http://test/22.m4s", 22),
+            ("http://test/23.m4s", 23),
+            ("http://test/24.m4s", 24),
+        ], "All segments from the remembered segment number were queued"
+        assert mpd.timelines[("0", "0", "0")] == 25, "Remembers the next segment number"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == []
+
+        # skipped multiple segments
+        with xml("dash/test_dynamic_segment_list_p4.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd", timelines=mpd.timelines)
+        segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=False)
+
+        assert [(segment.uri, segment.num) for segment in segments_iterator] == [
+            ("http://test/30.m4s", 30),
+            ("http://test/31.m4s", 31),
+            ("http://test/32.m4s", 32),
+            ("http://test/33.m4s", 33),
+            ("http://test/34.m4s", 34),
+            ("http://test/35.m4s", 35),
+            ("http://test/36.m4s", 36),
+            ("http://test/37.m4s", 37),
+            ("http://test/38.m4s", 38),
+            ("http://test/39.m4s", 39),
+        ], "All segments from the remembered segment number were queued"
+        assert mpd.timelines[("0", "0", "0")] == 40, "Remembers the next segment number"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.stream.dash.manifest",
+                "warning",
+                "Skipped segments 25-29 after manifest reload. This is unsupported and will result in incoherent output data.",
+            ),
+        ]
+
+        caplog.records.clear()
+
+        # skipped single segment
+        with xml("dash/test_dynamic_segment_list_p5.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test/", url="http://test/manifest.mpd", timelines=mpd.timelines)
+        segments_iterator = mpd.periods[0].adaptationSets[0].representations[0].segments(init=False)
+
+        assert [(segment.uri, segment.num) for segment in segments_iterator] == [
+            ("http://test/41.m4s", 41),
+            ("http://test/42.m4s", 42),
+            ("http://test/43.m4s", 43),
+            ("http://test/44.m4s", 44),
+            ("http://test/45.m4s", 45),
+            ("http://test/46.m4s", 46),
+            ("http://test/47.m4s", 47),
+            ("http://test/48.m4s", 48),
+            ("http://test/49.m4s", 49),
+            ("http://test/50.m4s", 50),
+        ], "All segments from the remembered segment number were queued"
+        assert mpd.timelines[("0", "0", "0")] == 51, "Remembers the next segment number"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.stream.dash.manifest",
+                "warning",
+                "Skipped segment 40 after manifest reload. This is unsupported and will result in incoherent output data.",
+            ),
         ]
 
     def test_dynamic_segment_list_no_duration(self):


### PR DESCRIPTION
Refactor `SegmentList.segments()` and warn about skipped segments when reloading the manifest and queuing new segments with a sequence number offset that's greater than one.

----

Follow-up of: #5654, #5657 
Related: #5607

/cc @michaelarnauts 