### PR TITLE
plugins.nasaplus: new plugin

### DIFF
--- a/src/streamlink/plugins/nasaplus.py
+++ b/src/streamlink/plugins/nasaplus.py
@@ -1,0 +1,39 @@
+"""
+$description Live and on-demand streaming platform run by NASA
+$url plus.nasa.gov
+$type live, vod
+$metadata title
+"""
+
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+
+@pluginmatcher(re.compile(
+    r"https?://plus\.nasa\.gov/"),
+)
+class NASAPlus(Plugin):
+    def _get_streams(self):
+        data = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath(".//video[@id='main-video'][1]"),
+            validate.none_or_all(
+                validate.get(0),
+                validate.union((
+                    validate.xml_xpath_string("./source[@src][@type='application/x-mpegURL'][1]/@src"),
+                    validate.get("title"),
+                )),
+            ),
+        ))
+        if not data:
+            return None
+
+        hls_url, self.title = data
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+
+__plugin__ = NASAPlus

--- a/tests/plugins/test_nasaplus.py
+++ b/tests/plugins/test_nasaplus.py
@@ -1,0 +1,14 @@
+from streamlink.plugins.nasaplus import NASAPlus
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlNASAPlus(PluginCanHandleUrl):
+    __plugin__ = NASAPlus
+
+    should_match = [
+        # live / rebroadcast
+        "https://plus.nasa.gov/scheduled-video/iss-expedition-70-in-flight-educational-event-with-the-creative-learning-academy-in-pensacola-florida-and-nasa-flight-engineer-jasmin-moghbeli/",
+
+        # VOD
+        "https://plus.nasa.gov/video/moon-101-introduction-to-the-moon/",
+    ]


### PR DESCRIPTION
Opening this as a draft since there's currently no live stream running, only one scheduled stream in 3 days... No idea if live streams will have a different site layout.

```
$ ./script/test-plugin-urls.py nasaplus
:: Finding streams for URL: https://plus.nasa.gov/scheduled-video/iss-expedition-70-in-flight-educational-event-with-the-creative-learning-academy-in-pensacola-florida-and-nasa-flight-engineer-jasmin-moghbeli/
:: Found streams: 720p_alt2, 720p_alt, 720p, worst, best
:: Finding streams for URL: https://plus.nasa.gov/video/moon-101-introduction-to-the-moon/
:: Found streams: 79k, 234p, 270p, 360p_alt, 360p, 540p, 720p_alt, 720p, 1080p, worst, best
```

```
$ streamlink -j 'https://plus.nasa.gov/scheduled-video/iss-expedition-70-in-flight-educational-event-with-the-creative-learning-academy-in-pensacola-florida-and-nasa-flight-engineer-jasmin-moghbeli/' best | jq .metadata
{
  "id": null,
  "author": null,
  "category": null,
  "title": "ISS Expedition 70 In-Flight Educational Event"
}
```