### PR TITLE
tools: pinpoint latest mypy version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,7 @@ coverage[toml]
 ruff ==0.1.5
 
 # typing
-mypy
+mypy ==1.7.0
 lxml-stubs
 trio-typing
 types-freezegun


### PR DESCRIPTION
Similar to ruff, mypy's version should be pinpointed, in case new releases introduce linting issues (which has been the case a couple of times already, requiring all open PRs to be rebased, which can be annoying for first time or inexperienced contributors).

1.7.0 changelog
https://github.com/python/mypy/blob/93e65e443eeac1e0f25a88b33851bb5239bab1a9/CHANGELOG.md#mypy-17