### PR TITLE
tests: fix webbrowser test coverage

### DIFF
--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -78,7 +78,7 @@ class TestCreateConnection:
         monkeypatch.setattr("streamlink.webbrowser.cdp.connection.connect_websocket_url", fake_connect_websocket_url)
         with pytest.raises(ConnectionTimeout):
             async with CDPConnection.create("ws://localhost:1234/fake"):
-                pass
+                pass  # pragma: no cover
 
     @pytest.mark.trio()
     @pytest.mark.parametrize(("timeout", "expected"), [


### PR DESCRIPTION
This made #5668 fail:
https://app.codecov.io/gh/streamlink/streamlink/pull/5668/blob/tests/webbrowser/cdp/test_connection.py#L80