### PR TITLE
Add colors to HTML docs for player compatibility table

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -344,3 +344,14 @@ section#plugins dl.field-list li {
 .clearfix:after {
   clear: both;
 }
+
+/*
+  Tables
+*/
+.yes {
+    color: green;
+}
+
+.no {
+    color: red;
+}

--- a/docs/players.rst
+++ b/docs/players.rst
@@ -19,6 +19,13 @@ There are three different modes of transporting the stream to the player.
       - Use the :option:`--player-http` or :option:`--player-continuous-http` options to enable.
 
 
+
+.. role:: yes
+   :class: yes
+
+.. role:: no
+   :class: no
+
 Player compatibility
 --------------------
 
@@ -33,33 +40,33 @@ modes.
       - named pipe
       - HTTP
     * - `Daum Pot Player`_
-      - Yes
-      - No
-      - Yes [1]_
+      - :yes:`Yes`
+      - :no:`No`
+      - :yes:`Yes` [1]_
     * - `MPC-HC`_
-      - Yes [2]_
-      - No
-      - Yes [1]_
+      - :yes:`Yes` [2]_
+      - :no:`No`
+      - :yes:`Yes` [1]_
     * - `MPlayer`_
-      - Yes
-      - Yes
-      - Yes
+      - :yes:`Yes`
+      - :yes:`Yes`
+      - :yes:`Yes`
     * - `mpv`_
-      - Yes
-      - Yes
-      - Yes
+      - :yes:`Yes`
+      - :yes:`Yes`
+      - :yes:`Yes`
     * - `OMXPlayer`_
-      - No
-      - Yes
-      - Yes [4]_
+      - :no:`No`
+      - :yes:`Yes`
+      - :yes:`Yes` [4]_
     * - `QuickTime`_
-      - No
-      - No
-      - No
+      - :no:`No`
+      - :no:`No`
+      - :no:`No`
     * - `VLC media player`_
-      - Yes [3]_
-      - Yes
-      - Yes
+      - :yes:`Yes` [3]_
+      - :yes:`Yes`
+      - :yes:`Yes`
 
 .. [1] :option:`--player-continuous-http` must be used.
        Using HTTP with players that rely on Windows' codecs to access HTTP


### PR DESCRIPTION
Changes proposed in this pull request:

- Add custom css for compatibility colors
- Add colors to compatibility table

Looks like this on my system (LibreWolf / Firefox 118.0.2-1):

![2023-11-20_12-23-32](https://github.com/streamlink/streamlink/assets/1139517/91012cb2-103b-4167-9f9d-988a36a0cfc5)


<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
