### PR TITLE
docs: clean up players page

### DIFF
--- a/docs/players.rst
+++ b/docs/players.rst
@@ -8,15 +8,26 @@ There are three different modes of transporting the stream to the player.
 
 .. list-table::
     :header-rows: 1
+    :class: sd-w-100
 
     * - Name
       - Description
     * - Standard input pipe
-      - This is the default behaviour when there are no other options specified.
+      - This is the default behavior when there are no other options specified.
     * - Named pipe (FIFO)
-      - Use the :option:`--player-fifo` option to enable.
+      - See the :option:`--player-fifo` option.
     * - HTTP
-      - Use the :option:`--player-http` or :option:`--player-continuous-http` options to enable.
+      - See the :option:`--player-http` and :option:`--player-continuous-http` options.
+
+.. note::
+
+    Streamlink also allows passing the resolved stream URL through to the player as its first launch argument
+    when using the :option:`--player-passthrough` option.
+
+    This does only work if the player has support the specific streaming protocol built in. The player will then do
+    all the data fetching on its own while Streamlink will just wait for the player process to end.
+
+    Some streaming protocols like DASH can't be passed through to the player.
 
 
 Player compatibility
@@ -27,88 +38,56 @@ modes.
 
 .. list-table::
     :header-rows: 1
+    :class: sd-w-100
 
     * - Name
+      - OS
+      - License
       - stdin pipe
       - named pipe
       - HTTP
-    * - `Daum Pot Player`_
-      - Yes
-      - No
-      - Yes [1]_
-    * - `MPC-HC`_
-      - Yes [2]_
-      - No
-      - Yes [1]_
-    * - `MPlayer`_
-      - Yes
-      - Yes
-      - Yes
-    * - `mpv`_
-      - Yes
-      - Yes
-      - Yes
-    * - `OMXPlayer`_
-      - No
-      - Yes
-      - Yes [4]_
-    * - `QuickTime`_
-      - No
-      - No
-      - No
     * - `VLC media player`_
-      - Yes [3]_
-      - Yes
-      - Yes
+      - :fab:`windows;fa-xl` :fab:`apple;fa-xl` :fab:`linux;fa-xl`
+      - GPL2 / LGPL2.1
+      - :octicon:`thumbsup;1em;sd-text-success` [1]_
+      - :octicon:`thumbsup;1em;sd-text-success`
+      - :octicon:`thumbsup;1em;sd-text-success`
+    * - `mpv`_
+      - :fab:`windows;fa-xl` :fab:`apple;fa-xl` :fab:`linux;fa-xl`
+      - GPL2 / LGPL2.1
+      - :octicon:`thumbsup;1em;sd-text-success`
+      - :octicon:`thumbsup;1em;sd-text-success`
+      - :octicon:`thumbsup;1em;sd-text-success`
+    * - `MPlayer`_
+      - :fab:`windows;fa-xl` :fab:`apple;fa-xl` :fab:`linux;fa-xl`
+      - GPL2
+      - :octicon:`thumbsup;1em;sd-text-success`
+      - :octicon:`thumbsup;1em;sd-text-success`
+      - :octicon:`thumbsup;1em;sd-text-success`
+    * - `IINA`_
+      - :fab:`apple;fa-xl`
+      - GPL3
+      - :octicon:`thumbsup;1em;sd-text-success` [2]_
+      - :octicon:`thumbsdown;1em;sd-text-danger`
+      - :octicon:`thumbsdown;1em;sd-text-danger`
 
-.. [1] :option:`--player-continuous-http` must be used.
-       Using HTTP with players that rely on Windows' codecs to access HTTP
-       streams may have a long startup time since Windows tend to do multiple
-       HTTP requests and Streamlink will attempt to open the stream for each
-       request.
-.. [2] Stdin requires MPC-HC 1.7 or newer.
-
-.. [3] Some versions of VLC might be unable to use the stdin pipe and
+.. [1] Some versions of VLC might be unable to use the stdin pipe and
        prints the error message
 
        VLC is unable to open the MRL 'fd://0'
 
        Use one of the other transport methods instead to work around this.
 
-.. [4] :option:`--player-continuous-http` has been reported to work for HLS
-       streams when also using the timeout option for omxplayer
-       (see `When using OMXPlayer the stream stops unexpectedly`_.)
-       Other stream types may not work as expected, it is recommended that
-       :option:`--player-fifo` be used.
+.. [2] Requires the ``--stdin`` player argument (:option:`--player-args`)
 
-.. _Daum Pot Player: https://potplayer.daum.net
-.. _MPC-HC: https://mpc-hc.org/
-.. _MPlayer: https://mplayerhq.hu
-.. _mpv: https://mpv.io
-.. _OMXPlayer: https://www.raspberrypi.org/documentation/raspbian/applications/omxplayer.md
-.. _QuickTime: https://apple.com/quicktime
-.. _VLC media player: https://videolan.org
+.. _VLC media player: https://videolan.org/
+.. _mpv: https://mpv.io/
+.. _MPlayer: https://mplayerhq.hu/
+.. _IINA: https://iina.io/
 
 
 Known issues and workarounds
 ----------------------------
-
-MPC-HC reports "File not found"
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Upgrading to version 1.7 or newer will solve this issue since reading data
-from standard input is not supported in version 1.6.x of MPC-HC.
-
-MPC-HC only plays sound on Twitch streams
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Twitch sometimes returns badly muxed streams which may confuse players. The
-following workaround was contributed by MPC-HC developer @kasper93:
-
-    *To fix this problem go to options -> internal filters -> open splitter
-    settings and increase "Stream Analysis Duration" this will let ffmpeg to
-    properly detect all streams.*
-
-Using :option:`--player-passthrough hls <--player-passthrough>` has also been
-reported to work.
 
 MPlayer tries to play Twitch streams at the wrong FPS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -130,9 +109,3 @@ Some versions of Mplayer cannot play Youtube Live streams. And errors like:
     Seek failed
 
 Switching to a recent fork such as mpv resolves the issue.
-
-When using OMXPlayer the stream stops unexpectedly
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When reading from a fifo pipe OMXPlayer will quit when there is no data, to fix
-this you can supply the timeout option to OMXPlayer using :option:`--player "omxplayer --timeout 20" <--player>`.
-For live streams it might be beneficial to also add the omxplayer parameter ``--live``.


### PR DESCRIPTION
- Remove unmaintained/obsolete and proprietary players
  - Daum PotPlayer
  - MPC-HC
  - OMXPlayer
  - QuickTime
- Add new players
  - IINA
- Change player order
- Add OS and license columns
- Add colored icons for supported transport methods
- Fix footnotes and known issues section

----

Closes #5677
This here uses color-coded icons from the `sphinx-design` dependency instead of "yes" and "no"...

----

Dead players like MPC-HC and OMXPlayer should be removed. And while we're at it, let's also remove proprietary players. There isn't even much info about PotPlayer available, and Quicktime doesn't work anyway...

No idea if my data about IINA is correct. The `--stdin` requirement definitely is, I even checked it just now in my macOS VM. I couldn't manage to get the other methods working though, so I assume it's correct.
