### PR TITLE
utils.parse: fix libxml2 2.12.0 compatibility

### DIFF
--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -2,11 +2,22 @@ import os
 import sys
 
 
+# compatibility import of charset_normalizer/chardet via requests<3.0
+try:
+    from requests.compat import chardet as charset_normalizer  # type: ignore
+except ImportError:  # pragma: no cover
+    import charset_normalizer
+
+
 is_darwin = sys.platform == "darwin"
 is_win32 = os.name == "nt"
+
+
+detect_encoding = charset_normalizer.detect
 
 
 __all__ = [
     "is_darwin",
     "is_win32",
+    "detect_encoding",
 ]


### PR DESCRIPTION
Resolves #5681 

```
$ python -c 'import lxml.etree;print(lxml.etree.LIBXML_VERSION)'
(2, 12, 0)

$ pytest >/dev/null; echo $?
0
```

```
$ python -c 'import lxml.etree;print(lxml.etree.LIBXML_VERSION)'
(2, 10, 3)

$ pytest >/dev/null; echo $?
0
```