### PR TITLE
plugins.piczel: fix and update HLS URL

### DIFF
--- a/src/streamlink/plugins/piczel.py
+++ b/src/streamlink/plugins/piczel.py
@@ -19,7 +19,7 @@ from streamlink.stream.hls import HLSStream
 ))
 class Piczel(Plugin):
     _URL_STREAMS = "https://piczel.tv/api/streams"
-    _URL_HLS = "https://piczel.tv/hls/{id}/index.m3u8"
+    _URL_HLS = "https://playback.piczel.tv/live/{id}/llhls.m3u8?_HLS_legacy=YES"
 
     def _get_streams(self):
         channel = self.match.group("channel")
@@ -57,7 +57,7 @@ class Piczel(Plugin):
         if not is_live:
             return
 
-        return {"live": HLSStream(self.session, self._URL_HLS.format(id=self.id))}
+        return HLSStream.parse_variant_playlist(self.session, self._URL_HLS.format(id=self.id))
 
 
 __plugin__ = Piczel


### PR DESCRIPTION
Fixes #5684 

Segment initialization gets written to the output only once after merging #5689, so muxing now works fine when using FFmpeg 6.1:

```
$ streamlink -l debug https://piczel.tv/watch/ZeeMBT best
[cli][debug] OS:         Linux-6.6.2-1-git-x86_64-with-glibc2.38
[cli][debug] Python:     3.12.0
[cli][debug] OpenSSL:    OpenSSL 3.1.4 24 Oct 2023
[cli][debug] Streamlink: 6.4.1+6.g5680c7cf
[cli][debug] Dependencies:
[cli][debug]  certifi: 2023.11.17
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.3
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.19.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.23.1
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.8.0
[cli][debug]  urllib3: 2.1.0
[cli][debug]  websocket-client: 1.6.4
[cli][debug] Arguments:
[cli][debug]  url=https://piczel.tv/watch/ZeeMBT
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][info] Found matching plugin piczel for URL https://piczel.tv/watch/ZeeMBT
[utils.l10n][debug] Language code: en_US
[stream.ffmpegmux][debug] ffmpeg version n6.1 Copyright (c) 2000-2023 the FFmpeg developers
[stream.ffmpegmux][debug]  built with gcc 13.2.1 (GCC) 20230801
[stream.ffmpegmux][debug]  configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libfreetype --enable-libfribidi --enable-libgsm --enable-libiec61883 --enable-libjack --enable-libjxl --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librav1e --enable-librsvg --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpl --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-version3 --enable-vulkan
[stream.ffmpegmux][debug]  libavutil      58. 29.100 / 58. 29.100
[stream.ffmpegmux][debug]  libavcodec     60. 31.102 / 60. 31.102
[stream.ffmpegmux][debug]  libavformat    60. 16.100 / 60. 16.100
[stream.ffmpegmux][debug]  libavdevice    60.  3.100 / 60.  3.100
[stream.ffmpegmux][debug]  libavfilter     9. 12.100 /  9. 12.100
[stream.ffmpegmux][debug]  libswscale      7.  5.100 /  7.  5.100
[stream.ffmpegmux][debug]  libswresample   4. 12.100 /  4. 12.100
[stream.ffmpegmux][debug]  libpostproc    57.  3.100 / 57.  3.100
[stream.hls][debug] Using external audio tracks for stream 1080p (language=None, name=Audio_1)
[cli][info] Available streams: 1080p (worst, best)
[cli][info] Opening stream: 1080p (hls-multi)
[cli][info] Starting player: mpv
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[utils.named_pipe][info] Creating pipe streamlinkpipe-107859-1-3094
[utils.named_pipe][info] Creating pipe streamlinkpipe-107859-2-8342
[stream.ffmpegmux][debug] ffmpeg command: /usr/bin/ffmpeg -nostats -y -i /tmp/streamlinkpipe-107859-1-3094 -i /tmp/streamlinkpipe-107859-2-8342 -c:v copy -c:a copy -map 0:v? -map 0:a? -map 1:a -f mpegts pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-107859-1-3094
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-107859-2-8342
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 0; Last Sequence: 473
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 471; End Sequence: None
[stream.hls][debug] Adding segment 471 to queue
[stream.hls][debug] Adding segment 472 to queue
[stream.hls][debug] Adding segment 473 to queue
[stream.hls][debug] Writing segment 471 to output
[stream.hls][debug] Segment initialization 471 complete
[stream.hls][debug] First Sequence: 0; Last Sequence: 473
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 471; End Sequence: None
[stream.hls][debug] Adding segment 471 to queue
[stream.hls][debug] Adding segment 472 to queue
[stream.hls][debug] Adding segment 473 to queue
[stream.hls][debug] Writing segment 471 to output
[stream.hls][debug] Segment initialization 471 complete
[stream.hls][debug] Writing segment 471 to output
[stream.hls][debug] Segment 471 complete
[stream.hls][debug] Writing segment 471 to output
[stream.hls][debug] Segment 471 complete
[stream.hls][debug] Writing segment 472 to output
[stream.hls][debug] Segment 472 complete
[cli.output][debug] Opening subprocess: ['/home/basti/.local/bin/mpv', '--force-media-title=https://piczel.tv/watch/ZeeMBT', '-']
[stream.hls][debug] Writing segment 473 to output
[stream.hls][debug] Segment 473 complete
[stream.hls][debug] Writing segment 472 to output
[stream.hls][debug] Segment 472 complete
[stream.hls][debug] Writing segment 473 to output
[stream.hls][debug] Segment 473 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 474 to queue
[stream.hls][debug] Writing segment 474 to output
[stream.hls][debug] Segment 474 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 474 to queue
[stream.hls][debug] Writing segment 474 to output
[stream.hls][debug] Segment 474 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 475 to queue
[stream.hls][debug] Writing segment 475 to output
[stream.hls][debug] Segment 475 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 475 to queue
[stream.hls][debug] Writing segment 475 to output
[stream.hls][debug] Segment 475 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 476 to queue
[stream.hls][debug] Writing segment 476 to output
[stream.hls][debug] Segment 476 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 476 to queue
[stream.hls][debug] Writing segment 476 to output
[stream.hls][debug] Segment 476 complete
[cli][info] Player closed
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.segmented][debug] Closing worker thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-107859-1-3094
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-107859-2-8342
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```