### PR TITLE
release: 6.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## streamlink 6.4.2 (2023-11-28)
+
+Patch release:
+
+- Fixed: HLS segment maps being written to the output multiple times ([#5689](https://github.com/streamlink/streamlink/pull/5689))
+- Fixed plugins:
+  - bilibili: rewritten plugin ([#5693](https://github.com/streamlink/streamlink/pull/5693))
+  - piczel: updated HLS URLs ([#5690](https://github.com/streamlink/streamlink/pull/5690))
+  - ssh101: fixed stream URL retrieval ([#5686](https://github.com/streamlink/streamlink/pull/5686))
+- Docs: added missing `Cache` API docs ([#5688](https://github.com/streamlink/streamlink/pull/5688))
+
+[Full changelog](https://github.com/streamlink/streamlink/compare/6.4.1...6.4.2)
+
+
 ## streamlink 6.4.1 (2023-11-22)
 
 Patch release:


### PR DESCRIPTION
The HLS segment map fix (#5689) needs to be published in a new release, because all releases prior are broken with FFmpeg 6.1. Outputs of HLS streams with segment maps (which is a requirement for fragmented mp4 HLS streams) from those older Streamlink releases are all faulty, meaning muxing of currently downloaded video/audio streams fails, as well as demuxing of previously created recordings (affecting playback / file-thumbnail generation / etc), which is bad.

----

Old recordings with the faulty output which FFmpeg 6.1 now rejects need to be remuxed using an older FFmpeg version.

```sh
#!/usr/bin/env bash
for file in $(find . -type f -name "*.mp4" -print); do
  ffprobe -v quiet "${file}" && continue  # ffprobe >=6.1 returns status code >0 for those faulty mp4 containers
  echo "Remuxing ${file}"
  /path/to/older/ffmpeg -v error -i "${file}" -c copy -f mp4 "${file}.new" \
    && touch -c -r "${file}" "${file}.new" \
    && rm "${file}" \
    && mv "${file}.new" "${file}"
done
```