### PR TITLE
plugins.btv: parse HLS multivariant playlist

### DIFF
--- a/src/streamlink/plugins/btv.py
+++ b/src/streamlink/plugins/btv.py
@@ -61,7 +61,7 @@ class BTV(Plugin):
             log.error("The content is not available in your region")
             return
 
-        return {"live": HLSStream(self.session, stream_url)}
+        return HLSStream.parse_variant_playlist(self.session, stream_url)
 
 
 __plugin__ = BTV

--- a/tests/plugins/test_btv.py
+++ b/tests/plugins/test_btv.py
@@ -6,7 +6,7 @@ class TestPluginCanHandleUrlBTV(PluginCanHandleUrl):
     __plugin__ = BTV
 
     should_match = [
-        "http://btvplus.bg/live",
-        "http://btvplus.bg/live/",
-        "http://www.btvplus.bg/live/",
+        "https://btvplus.bg/live",
+        "https://btvplus.bg/live/",
+        "https://www.btvplus.bg/live/",
     ]


### PR DESCRIPTION
Fixes #5697

```
$ ./script/test-plugin-urls.py btv
:: Finding streams for URL: https://btvplus.bg/live
:: Found streams: 720p, 1080p, worst, best
:: Finding streams for URL: https://btvplus.bg/live/
:: Found streams: 720p, 1080p, worst, best
:: Finding streams for URL: https://www.btvplus.bg/live/
:: Found streams: 720p, 1080p, worst, best
```