### PR TITLE
plugins.twitch: remove is-live API check

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -838,7 +838,6 @@ class Twitch(Plugin):
             # TODO: fix the "err" attribute set by HTTPSession.request()
             orig = getattr(err, "err", None)
             if isinstance(orig, HTTPError) and orig.response.status_code >= 400:
-                error = None
                 with suppress(PluginError):
                     error = validate.Schema(
                         validate.parse_json(),
@@ -848,7 +847,7 @@ class Twitch(Plugin):
                         }],
                         validate.get((0, "error")),
                     ).validate(orig.response.text)
-                log.error(error or "Could not access HLS playlist")
+                    log.error(error or "Could not access HLS playlist")
                 return
             raise PluginError(err) from err
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -629,7 +629,7 @@ class TestTwitchHLSMultivariantResponse:
             },
             nullcontext(),
             None,
-            [("streamlink.plugins.twitch", "error", "Could not access HLS playlist")],
+            [],
             id="non-json error response",
         ),
     ], indirect=["plugin"])


### PR DESCRIPTION
Resolves #5707

Let's remove the is-live API check again, for the sake of being able to start streams just after they've gone live. Twitch's GQL API has delayed data (up to a minute or so), so having this check implemented isn't ideal. It does prevent the empty metadata issue though, but I don't think it's important.

The second commit which is included here removes an unnecessary error message for offline channels, but only in those cases where no JSON data was returned by the multivariant playlist error response. I will have a look later at checking the API for offline channels after the playlist has returned 4xx. No idea about geo-blocked content yet though, which was the reason for parsing the JSON data.

----

Online channel (listing streams now takes a bit longer due to `check_streams=True`)
```
$ streamlink twitch.tv/shroud
[cli][info] Found matching plugin twitch for URL twitch.tv/shroud
Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
```

Offline channel with bad data on Twitch's end is now actually offline (due to `check_streams=True`)
```
$ streamlink twitch.tv/paymoneywubby
[cli][info] Found matching plugin twitch for URL twitch.tv/paymoneywubby
error: No playable streams found on this URL: twitch.tv/paymoneywubby
```

Offline channel with JSON data in HLS multivariant playlist response (still garbage error log message)
```
$ streamlink twitch.tv/eslcs
[cli][info] Found matching plugin twitch for URL twitch.tv/eslcs
[plugins.twitch][error] twirp error not_found: transcode does not exist
error: No playable streams found on this URL: twitch.tv/eslcs
```

Offline channel without JSON data in HLS multivariant playlist response (no more unnecessary error log message)
```
$ streamlink twitch.tv/dota2ti_4
[cli][info] Found matching plugin twitch for URL twitch.tv/dota2ti_4
error: No playable streams found on this URL: twitch.tv/dota2ti_4
```