### PR TITLE
options: refactor Argument/pluginargument

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -12,7 +12,9 @@ from typing import (
     Callable,
     ClassVar,
     Dict,
+    Iterable,
     List,
+    Literal,
     Match,
     NamedTuple,
     Optional,
@@ -34,6 +36,9 @@ from streamlink.user_input import UserInputRequester
 
 if TYPE_CHECKING:  # pragma: no cover
     from streamlink.session import Streamlink
+
+
+_T = TypeVar("_T")
 
 
 log = logging.getLogger(__name__)
@@ -649,15 +654,23 @@ def pluginmatcher(
     return decorator
 
 
+# noinspection GrazieInspection,PyShadowingBuiltins
 def pluginargument(
     name: str,
+    action: Optional[str] = None,
+    nargs: Optional[Union[int, Literal["?", "*", "+"]]] = None,
+    const: Any = None,
+    default: Any = None,
+    type: Optional[Callable[[Any], _T]] = None,  # noqa: A002
+    choices: Optional[Iterable[_T]] = None,
     required: bool = False,
+    help: Optional[str] = None,  # noqa: A002
+    metavar: Optional[Union[str, Sequence[str]]] = None,
+    dest: Optional[str] = None,
     requires: Optional[Union[str, Sequence[str]]] = None,
     prompt: Optional[str] = None,
     sensitive: bool = False,
     argument_name: Optional[str] = None,
-    dest: Optional[str] = None,
-    **options,
 ) -> Callable[[Type[Plugin]], Type[Plugin]]:
     """
     Decorator for plugin arguments. Takes the same arguments as :class:`Argument <streamlink.options.Argument>`.
@@ -687,14 +700,21 @@ def pluginargument(
     """
 
     arg = Argument(
-        name,
+        name=name,
+        action=action,
+        nargs=nargs,
+        const=const,
+        default=default,
+        type=type,
+        choices=choices,
         required=required,
+        help=help,
+        metavar=metavar,
+        dest=dest,
         requires=requires,
         prompt=prompt,
         sensitive=sensitive,
         argument_name=argument_name,
-        dest=dest,
-        **options,
     )
 
     def decorator(cls: Type[Plugin]) -> Type[Plugin]:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -744,7 +744,7 @@ def setup_plugin_options(pluginname: str, pluginclass: Type[Plugin]) -> Options:
     for parg in pluginclass.arguments:
         defaults[parg.dest] = parg.default
 
-        if parg.options.get("help") == argparse.SUPPRESS:
+        if parg.help == argparse.SUPPRESS:
             continue
 
         value = getattr(args, parg.namespace_dest(pluginname))

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,3 +1,5 @@
+import argparse
+
 import pytest
 
 from streamlink.options import Argument, Arguments, Options
@@ -138,6 +140,44 @@ class TestArgument:
         with pytest.raises(AttributeError):
             # noinspection PyPropertyAccess
             arg.default = 456
+
+    def test_options(self):
+        arg = Argument(
+            "test",
+            action="append",
+            nargs=2,
+            default=(0, 0),
+            type=int,
+            choices=[1, 2, 3],
+            required=True,
+            help=argparse.SUPPRESS,
+            metavar=("ONE", "TWO"),
+            dest="dest",
+            requires=["other"],
+            prompt="Test!",
+            sensitive=False,
+            argument_name=None,
+        )
+        assert arg.options == {
+            "action": "append",
+            "nargs": 2,
+            "default": (0, 0),
+            "type": int,
+            "choices": [1, 2, 3],
+            "help": argparse.SUPPRESS,
+            "metavar": ("ONE", "TWO"),
+            "dest": "dest",
+        }
+
+        arg = Argument(
+            "test",
+            action="store_const",
+            const=123,
+        )
+        assert arg.options == {
+            "action": "store_const",
+            "const": 123,
+        }
 
 
 class TestArguments:


### PR DESCRIPTION
This explicitly adds all keywords which are passed to `argparse.ArgumentParser.add_argument()` to the `pluginargument` decorator (`Argument` class). ~~It also turns all options except for `name` into mandatory keywords (which is technically a breaking change, but I don't think anyone with common sense has defined custom plugin arguments using positional args).~~

The intention here is simplifying the parsing of the plugin module AST when building a plugins JSON file with all matchers and arguments (#4741), so Streamlink doesn't have to load all plugins at once. This is what I've been working on again in the past couple of days. It also improves type checking of all plugin arguments.

----

Opening this as a draft for now, because I don't want these changes to be included in the next release yet.

Unrelated to this PR, there's also one issue left with these changes which I will have to think about, namely the argument's `type` option.

The `type` option is currently defined as `Callable[[Any], Any] | None`, but this makes it impossible to serialize when building the plugins JSON data.

The data serializer needs to implement an import path lookup, so the `type` option can reference the actual callable again, e.g. `streamlink.utils.args.keyvalue` or `streamlink.utils.times.hours_minutes_seconds`. These are currently the two functions being used by Streamlink's plugins, but other callables like builtin ones need to be supported as well, like `int` for example. It will however restrict any custom functions defined in plugin modules, should this ever be required. Third party plugins won't be affected by the pluginargument serialization/deserialization, because those have to be loaded all at once beforehand anyway.