### PR TITLE
build: fix setuptools in {dev,docs}-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 # setup
 pip >=21.0.0
+setuptools >=64.0.0  # required for being able to run editable installs
 versioningit >=2.0.0,<3  # required for being able to run editable installs
 
 # tests

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,5 @@
 # setup
+setuptools >=64.0.0  # required for reading the version string when building from git
 versioningit >=2.0.0,<3  # required for reading the version string when building from git
 
 # build


### PR DESCRIPTION
With the addition of our custom build-backend hooks in #5558 and #5632 which override setuptools' wheel-build logic, and versioningit itself having moved from setuptools to hatch recently, setuptools no longer gets installed automatically, so we need to add it as an explicit build requirement, or it will be missing in the python environment. It has been working until a few days ago because of other dependencies which also pulled setuptools, but this is no longer the case on py312. ~~Not sure which dependency made this change, but it's not important.~~ (it was pycountry, which is finally available as a wheel after several years of only the sdist being available, hence the automatic setuptools install in the env)

Current test CI failures on master:
https://github.com/streamlink/streamlink/actions/runs/7135638629

Updating `dev-requirements.txt` will fix the `test` and `lint` workflows, and `docs-requirements.txt` will fix the `docs` and `release` workflows.