### PR TITLE
build: add support for versioningit >=3.0.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # setup
 pip >=21.0.0
 setuptools >=64.0.0  # required for being able to run editable installs
-versioningit >=2.0.0,<3  # required for being able to run editable installs
+versioningit >=2.0.0,<4  # required for being able to run editable installs
 
 # tests
 pytest >=6.0.0

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,6 +1,6 @@
 # setup
 setuptools >=64.0.0  # required for reading the version string when building from git
-versioningit >=2.0.0,<3  # required for reading the version string when building from git
+versioningit >=2.0.0,<4  # required for reading the version string when building from git
 
 # build
 sphinx >=6.0.0,<8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
   "wheel",
   # The versioningit build-requirement gets removed from the source distribution,
   # as the version string is already built into it (see the onbuild versioningit hook):
-  "versioningit >=2.0.0, <3",  # disabled in sdist
+  "versioningit >=2.0.0,<4",  # disabled in sdist
 ]
 # setuptools build-backend override
 # https://setuptools.pypa.io/en/stable/build_meta.html


### PR DESCRIPTION
Keep backward compatibility for `versioningit <3.0.0`

----

https://versioningit.readthedocs.io/en/stable/changelog.html#v3-0-0-2023-12-13

> Breaking: The `build_dir` argument passed to [`Versioningit.do_onbuild()`](https://versioningit.readthedocs.io/en/stable/api.html#versioningit.Versioningit.do_onbuild) and `onbuild` method callables has been changed to an [`OnbuildFileProvider`](https://versioningit.readthedocs.io/en/stable/writing-methods.html#versioningit.OnbuildFileProvider) ABC

----

:heavy_check_mark: `versioningit <3.0.0`

```
$ pip install -U 'versioningit<3.0.0' >/dev/null

$ pytest -q -s build_backend/
.......
7 passed in 0.10s

$ rm -f dist/streamlink-*; python -m build --sdist --wheel >/dev/null 2>&1

$ bsdtar -xzOf dist/streamlink-*.whl streamlink/_version.py
__version__ = "6.4.2+13.gb8b905bc"

$ bsdtar -xzOf dist/streamlink*.tar.gz streamlink-\*/src/streamlink/_version.py
__version__ = "6.4.2+13.gb8b905bc"

$ bsdtar -xzOf dist/streamlink*.tar.gz streamlink-\*/pyproject.toml | head -n8
[build-system]
requires = [
  "setuptools >=64",
  "wheel",
  # The versioningit build-requirement gets removed from the source distribution,
  # as the version string is already built into it (see the onbuild versioningit hook):
  # "versioningit >=2.0.0,<4",
]

$ bsdtar -xzOf dist/streamlink*.tar.gz streamlink-\*/setup.py | tail -n6
    setup(
        cmdclass=get_cmdclasses(),
        entry_points=entry_points,
        data_files=data_files,
        version="6.4.2+13.gb8b905bc",
    )
```

----

:heavy_check_mark: `versioningit >=3.0.0`

```
$ pip install -U 'versioningit>=3.0.0' >/dev/null

$ pytest -q -s build_backend/
.......
7 passed in 0.09s

$ rm -f dist/streamlink-*; python -m build --sdist --wheel >/dev/null 2>&1

$ bsdtar -xzOf dist/streamlink-*.whl streamlink/_version.py
__version__ = "6.4.2+13.gb8b905bc"

$ bsdtar -xzOf dist/streamlink*.tar.gz streamlink-\*/src/streamlink/_version.py
__version__ = "6.4.2+13.gb8b905bc"

$ bsdtar -xzOf dist/streamlink*.tar.gz streamlink-\*/pyproject.toml | head -n8
[build-system]
requires = [
  "setuptools >=64",
  "wheel",
  # The versioningit build-requirement gets removed from the source distribution,
  # as the version string is already built into it (see the onbuild versioningit hook):
  # "versioningit >=2.0.0,<4",
]

$ bsdtar -xzOf dist/streamlink*.tar.gz streamlink-\*/setup.py | tail -n6
    setup(
        cmdclass=get_cmdclasses(),
        entry_points=entry_points,
        data_files=data_files,
        version="6.4.2+13.gb8b905bc",
    )
```