### PR TITLE
plugins.huya: check stream availability

### DIFF
--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -98,9 +98,13 @@ class Huya(Plugin):
         self.id, self.author, self.title, streamdata = data
 
         for cdntype, priority, streamname, flvurl, suffix, anticode in streamdata:
+            url = update_scheme("https://", f"{flvurl}/{streamname}.{suffix}?{anticode}")
+            if self.session.http.head(url, raise_for_status=False).status_code >= 400:
+                continue
+
             name = f"source_{cdntype.lower()}"
             self.QUALITY_WEIGHTS[name] = priority
-            yield name, HTTPStream(self.session, update_scheme("https://", f"{flvurl}/{streamname}.{suffix}?{anticode}"))
+            yield name, HTTPStream(self.session, url)
 
         log.debug(f"QUALITY_WEIGHTS: {self.QUALITY_WEIGHTS!r}")
 


### PR DESCRIPTION
Resolves #5744 

```
$ streamlink -l debug 'https://www.huya.com/chuhe'
[cli][debug] OS:         Linux-6.6.8-1-git-x86_64-with-glibc2.38
[cli][debug] Python:     3.12.1
[cli][debug] OpenSSL:    OpenSSL 3.2.0 23 Nov 2023
[cli][debug] Streamlink: 6.5.0+6.g3696dc99
[cli][debug] Dependencies:
[cli][debug]  certifi: 2023.11.17
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.3
[cli][debug]  pycountry: 23.12.11
[cli][debug]  pycryptodome: 3.19.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.23.2
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.9.0
[cli][debug]  urllib3: 2.1.0
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.huya.com/chuhe
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin huya for URL https://www.huya.com/chuhe
[plugins.huya][debug] QUALITY_WEIGHTS: {'source_al': -1, 'source_tx': 45, 'source_hw': 50}
Available streams: source_al (worst), source_tx, source_hw (best)
```

```
$ streamlink -l debug 'https://www.huya.com/kpl'
[cli][debug] OS:         Linux-6.6.8-1-git-x86_64-with-glibc2.38
[cli][debug] Python:     3.12.1
[cli][debug] OpenSSL:    OpenSSL 3.2.0 23 Nov 2023
[cli][debug] Streamlink: 6.5.0+6.g3696dc99
[cli][debug] Dependencies:
[cli][debug]  certifi: 2023.11.17
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.3
[cli][debug]  pycountry: 23.12.11
[cli][debug]  pycryptodome: 3.19.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.23.2
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.9.0
[cli][debug]  urllib3: 2.1.0
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.huya.com/kpl
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin huya for URL https://www.huya.com/kpl
[plugins.huya][debug] QUALITY_WEIGHTS: {'source_al': 11, 'source_tx': 25, 'source_hw': 39, 'source_al13': 10, 'source_tx15': 15, 'source_hyzj': -1}
Available streams: source_hyzj (worst), source_al13, source_al, source_tx15, source_tx, source_hw (best)
```