### PR TITLE
tests: ignore dateutil DeprecationWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ testpaths = [
 ]
 filterwarnings = [
   "always",
+  "ignore:datetime\\.datetime\\.utcfromtimestamp\\(\\):DeprecationWarning:dateutil",
 ]
 
 


### PR DESCRIPTION
This ignores the "timezone-unaware" `datetime` `DeprecationWarning` which `dateutil` raises on Python 3.12.
`dateutil` is a transitive test dependency, required by `freezegun`.

https://github.com/streamlink/streamlink/actions/runs/7367193017/job/20050194304#step:6:284
```
../../../../../opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/dateutil/tz/tz.py:37
  /opt/hostedtoolcache/Python/3.12.1/x64/lib/python3.12/site-packages/dateutil/tz/tz.py:37: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    EPOCH = datetime.datetime.utcfromtimestamp(0)
```

`dateutil` has fixed this in June, but they still haven't published a new release:
https://github.com/dateutil/dateutil/issues/1284