### PR TITLE
plugins.bigo: rewrite and fix plugin

### DIFF
--- a/tests/plugins/test_bigo.py
+++ b/tests/plugins/test_bigo.py
@@ -6,27 +6,5 @@ class TestPluginCanHandleUrlBigo(PluginCanHandleUrl):
     __plugin__ = Bigo
 
     should_match = [
-        "http://bigo.tv/00000000",
-        "https://bigo.tv/00000000",
-        "https://www.bigo.tv/00000000",
-        "http://www.bigo.tv/00000000",
-        "http://www.bigo.tv/fancy1234",
-        "http://www.bigo.tv/abc.123",
-        "http://www.bigo.tv/000000.00",
-    ]
-
-    should_not_match = [
-        # Old URLs don't work anymore
-        "http://live.bigo.tv/00000000",
-        "https://live.bigo.tv/00000000",
-        "http://www.bigoweb.co/show/00000000",
-        "https://www.bigoweb.co/show/00000000",
-        "http://bigoweb.co/show/00000000",
-        "https://bigoweb.co/show/00000000",
-
-        # Wrong URL structure
-        "https://www.bigo.tv/show/00000000",
-        "http://www.bigo.tv/show/00000000",
-        "http://bigo.tv/show/00000000",
-        "https://bigo.tv/show/00000000",
+        "https://www.bigo.tv/SITE_ID",
     ]


### PR DESCRIPTION
Fixes #5753

```
$ ./script/test-plugin-urls.py bigo -r SITE_ID 954321825
:: Finding streams for URL: https://www.bigo.tv/954321825
:: Found streams: live, worst, best
```

```
$ streamlink --json 'https://www.bigo.tv/954321825' | jq .metadata
{
  "id": "7287389864212587887",
  "author": "954321825",
  "category": "League of Legends",
  "title": "Gaming"
}
```

```
$ streamlink 'https://www.bigo.tv/achannelthatdoesnotexist'
[cli][info] Found matching plugin bigo for URL https://www.bigo.tv/achannelthatdoesnotexist
error: No playable streams found on this URL: https://www.bigo.tv/achannelthatdoesnotexist
```

```
$ streamlink 'https://www.bigo.tv/x'
[cli][info] Found matching plugin bigo for URL https://www.bigo.tv/x
[plugins.bigo][info] Channel is offline
error: No playable streams found on this URL: https://www.bigo.tv/x
```