### PR TITLE
plugins.twitch: disable headless mode

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -565,7 +565,12 @@ class TwitchClientIntegrity:
                     return await client_session.evaluate(js_get_integrity_token, timeout=eval_timeout)
 
         try:
-            client_integrity: Optional[str] = CDPClient.launch(session, acquire_client_integrity_token)
+            client_integrity: Optional[str] = CDPClient.launch(
+                session,
+                acquire_client_integrity_token,
+                # headless mode gets detected by Twitch, so we have to disable it regardless the user config
+                headless=False,
+            )
         except WebbrowserError as err:
             log.error(f"{type(err).__name__}: {err}")
             return None


### PR DESCRIPTION
Resolves #5600

This ignores the `--webbrowser-headless` config in the Twitch plugin and always forces `headless` to be `False`, because Twitch is able to detect Chromium's headless mode when forcing the acquirement of the client-integrity token. You can check this easily by setting an invalid OAuth token for example (`--twitch-api-header="Authorization=OAuth invalid"`) or by modifying the plugin.

The CI tokens are currently not a requirement, but this can change at any time, and if they do and Streamlink has headless mode enabled by default (which is the case), then users are forced to update their configs or CLI arguments until we publish a new release, which is unnecessary. So let's set `headless` to `False` in the Twitch plugin now.