### PR TITLE
docs: unlist outdated/unmaintained packages

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -187,11 +187,6 @@ Linux and BSD
       - .. code-block:: bash
 
             sudo emerge net-misc/streamlink
-    * - :octicon:`package-dependents` `NetBSD (pkgsrc)`_
-      - .. code-block:: bash
-
-            cd /usr/pkgsrc/multimedia/streamlink
-            sudo make install clean
     * - :octicon:`package-dependents` `NixOS`_
       - .. code-block:: bash
 
@@ -220,7 +215,6 @@ Linux and BSD
 .. _FreeBSD (pkg): https://ports.freebsd.org/cgi/ports.cgi?query=streamlink&stype=name
 .. _FreeBSD (ports): https://www.freshports.org/multimedia/streamlink
 .. _Gentoo Linux: https://packages.gentoo.org/package/net-misc/streamlink
-.. _NetBSD (pkgsrc): https://pkgsrc.se/multimedia/streamlink
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
 .. _openSUSE: https://build.opensuse.org/package/show/multimedia:apps/streamlink
 .. _Solus: https://github.com/getsolus/packages/tree/main/packages/s/streamlink
@@ -257,8 +251,6 @@ Package maintainers
       - Takefu <takefu at airport.fm>
     * - Gentoo
       - soredake <fdsfgs at krutt.org>
-    * - NetBSD
-      - Maya Rashish <maya at netbsd.org>
     * - NixOS
       - Tuomas Tynkkynen <tuomas.tynkkynen at iki.fi>
     * - openSUSE

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -201,10 +201,6 @@ Linux and BSD
       - .. code-block:: bash
 
             sudo eopkg install streamlink
-    * - :octicon:`package-dependents` `Void`_
-      - .. code-block:: bash
-
-            sudo xbps-install streamlink
 
 .. _Alpine Linux (edge, testing): https://pkgs.alpinelinux.org/packages?name=streamlink
 .. _Arch Linux: https://archlinux.org/packages/extra/any/streamlink/
@@ -218,7 +214,6 @@ Linux and BSD
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
 .. _openSUSE: https://build.opensuse.org/package/show/multimedia:apps/streamlink
 .. _Solus: https://github.com/getsolus/packages/tree/main/packages/s/streamlink
-.. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
 
 .. _Enabling the edge/testing repository: https://wiki.alpinelinux.org/wiki/Repositories#Edge
 .. _Installing AUR packages: https://wiki.archlinux.org/index.php/Arch_User_Repository
@@ -257,8 +252,6 @@ Package maintainers
       - Simon Puchert <simonpuchert at alice.de>
     * - Solus
       - Joey Riches <josephriches at gmail.com>
-    * - Void
-      - Michal Vasilek <michal at vasilek.cz>
     * - Windows binaries
       - Sebastian Meyer <mail at bastimeyer.de>
     * - Linux AppImages


### PR DESCRIPTION
Both packages appear to be unmaintained, with the latest packaged version being `5.5.1`.

- https://pkgsrc.se/multimedia/streamlink
- https://github.com/void-linux/void-packages/commits/559ab36d2914e685efcc7bf1a4433a73ffcd96cf/srcpkgs/streamlink
- https://github.com/void-linux/void-packages/pulls?q=streamlink
