### PR TITLE
plugins.vidio: fix stream token

### DIFF
--- a/src/streamlink/plugins/vidio.py
+++ b/src/streamlink/plugins/vidio.py
@@ -6,6 +6,7 @@ $type live, vod
 import logging
 import re
 from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -17,7 +18,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?vidio\.com/",
+    r"https?://(?:www\.)?vidio\.com/.+",
 ))
 class Vidio(Plugin):
     tokens_url = "https://www.vidio.com/live/{id}/tokens"
@@ -28,6 +29,10 @@ class Vidio(Plugin):
             self.tokens_url.format(id=stream_id),
             params={"type": stream_type},
             headers={"Referer": self.url},
+            cookies={
+                "ahoy_visit": str(uuid4()),
+                "ahoy_visitor": str(uuid4()),
+            },
             schema=validate.Schema(
                 validate.parse_json(),
                 {"token": str},

--- a/tests/plugins/test_vidio.py
+++ b/tests/plugins/test_vidio.py
@@ -12,6 +12,5 @@ class TestPluginCanHandleUrlVidio(PluginCanHandleUrl):
     ]
 
     should_not_match = [
-        "http://www.vidio.com",
-        "https://www.vidio.com",
+        "https://www.vidio.com/",
     ]


### PR DESCRIPTION
Fixes #5761

```
$ ./script/test-plugin-urls.py vidio
:: Finding streams for URL: https://www.vidio.com/live/204-sctv-tv-stream
:: Found streams: 240p_alt, 240p, 360p_alt, 360p, 480p_alt, 480p, 720p_alt, 720p, worst, best
:: Finding streams for URL: https://www.vidio.com/live/5075-dw-tv-stream
:: Found streams: 240p, 360p, 480p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.vidio.com/watch/766861-5-rekor-fantastis-zidane-bersama-real-madrid
:: Found streams: 270p, 360p, 720p, worst, best
```