### PR TITLE
plugins.bilibili: query API on missing stream data

### DIFF
--- a/tests/plugins/test_bilibili.py
+++ b/tests/plugins/test_bilibili.py
@@ -5,6 +5,6 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlBilibili(PluginCanHandleUrl):
     __plugin__ = Bilibili
 
-    should_match = [
-        "https://live.bilibili.com/123123123",
+    should_match_groups = [
+        ("https://live.bilibili.com/CHANNEL", {"channel": "CHANNEL"}),
     ]


### PR DESCRIPTION
Resolves #5770 

```
$ ./script/test-plugin-urls.py bilibili -l debug -r CHANNEL 519
:: Finding streams for URL: https://live.bilibili.com/519
:: Found streams: live_alt, live, worst, best

$ ./script/test-plugin-urls.py bilibili -l debug -r CHANNEL 27482546
:: Finding streams for URL: https://live.bilibili.com/27482546
:: Found streams: live_alt, live, worst, best

$ ./script/test-plugin-urls.py bilibili -l debug -r CHANNEL 27888667
:: Finding streams for URL: https://live.bilibili.com/27888667
:::: Falling back to _get_api_playinfo()
:: Found streams: live_alt, live, worst, best
```

@TwoQuantumBits please give this a try and see if some channels are still not working
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback