### PR TITLE
tools: bump ruff to 0.1.13 and fix issues

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.1.9
+ruff ==0.1.13
 
 # typing
 mypy ==1.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,9 @@ extend-ignore = [
   "C408",  # unnecessary-collection-call
   "ISC003",  # explicit-string-concatenation
   "PLC1901",  # compare-to-empty-string
+  "PLC2801",  # unnecessary-dunder-call
   "PLW2901",  # redefined-loop-name
+  "RUF021",  # parenthesize-chained-operators
 ]
 extend-exclude = [
   "docs/conf.py",

--- a/src/streamlink/plugins/crunchyroll.py
+++ b/src/streamlink/plugins/crunchyroll.py
@@ -84,7 +84,7 @@ class CrunchyrollAPIError(Exception):
     """Exception thrown by the Crunchyroll API when an error occurs"""
 
     def __init__(self, msg, code):
-        Exception.__init__(self, msg)
+        super().__init__(msg)
         self.msg = msg
         self.code = code
 

--- a/src/streamlink/stream/wrappers.py
+++ b/src/streamlink/stream/wrappers.py
@@ -51,7 +51,7 @@ class StreamIOThreadWrapper(io.IOBase):
 
     class Filler(Thread):
         def __init__(self, fd, buffer):
-            Thread.__init__(self)
+            super().__init__()
 
             self.error = None
             self.fd = fd


### PR DESCRIPTION
`RUF021` was added to the ignore list, because this rule wants useless parenthesis to be added to boolean expressions, despite everyone being aware of the operator precedence.

`PLC2801` has a faulty implementation in ruff 0.1.13, and it doesn't allow explicit dunder method calls (`__foo__()`), despite this being intentionally done in lots of cases. Some issues have already been fixed on their master branch, but others have not. I fixed those lines of code which made sense, but everything remained untouched with the rule being ignored. Otherwise, an annotation would need to be added, which doesn't make sense.