### PR TITLE
tests: fix positive URLs assertion in plugins test

### DIFF
--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -119,7 +119,7 @@ class PluginCanHandleUrl:
     def test_class_setup(self):
         assert hasattr(self, "__plugin__"), "Test has a __plugin__ attribute"
         assert issubclass(self.__plugin__, Plugin), "Test has a __plugin__ that is a subclass of the Plugin class"
-        assert len(self.should_match) + len(self.should_match_groups) > 0, "Test has at least one positive URL"
+        assert self.should_match or self.should_match_groups, "Test has at least one positive URL"
 
     def test_class_name(self, classnames: Set[str]):
         assert self.__class__.__name__ not in classnames


### PR DESCRIPTION
This makes the error message much more clear when a plugin URL test has missing positive URLs. Happend to me yesterday after rewriting the artetv plugin and accidentally misspelling the `should_match_groups` attribute.