### PR TITLE
utils.args: rewrite module

### DIFF
--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -11,7 +11,7 @@ _FILESIZE_UNITS = {
     "m": 2**20,
 }
 
-_KEYVALUE_RE = re.compile(r"(?P<key>[^=]+)\s*=\s*(?P<value>.*)")
+_KEYVALUE_RE = re.compile(r"^(?P<key>[^=\s]+)\s*=\s*(?P<value>.*)$")
 
 
 def boolean(value: str) -> bool:
@@ -44,7 +44,7 @@ def filesize(value: str) -> int:
 
 
 def keyvalue(value: str) -> Tuple[str, str]:
-    match = _KEYVALUE_RE.match(value)
+    match = _KEYVALUE_RE.match(value.lstrip())
     if not match:
         raise ValueError("Invalid key=value format")
 

--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, List, Optional, Tuple, Type, overload
 _BOOLEAN_TRUE = "yes", "1", "true", "on"
 _BOOLEAN_FALSE = "no", "0", "false", "off"
 
-_FILESIZE_RE = re.compile(r"(?P<size>\d+(\.\d+)?)(?P<modifier>[km])?b?", re.IGNORECASE)
+_FILESIZE_RE = re.compile(r"^(?P<size>\d+(\.\d+)?)(?P<modifier>[km])?b?$", re.IGNORECASE)
 _FILESIZE_UNITS = {
     "k": 2**10,
     "m": 2**20,
@@ -33,7 +33,7 @@ def comma_list_filter(acceptable: List[str]) -> Callable[[str], List[str]]:
 
 
 def filesize(value: str) -> int:
-    match = _FILESIZE_RE.match(value)
+    match = _FILESIZE_RE.match(value.strip())
     if not match:
         raise ValueError("Invalid file size format")
 

--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -1,62 +1,74 @@
-import argparse
 import re
-from typing import Optional, Type
+from typing import Any, Callable, List, Optional, Tuple, Type, overload
 
 
-_filesize_re = re.compile(r"""
-    (?P<size>\d+(\.\d+)?)
-    (?P<modifier>[Kk]|[Mm])?
-    (?:[Bb])?
-""", re.VERBOSE)
-_keyvalue_re = re.compile(r"(?P<key>[^=]+)\s*=\s*(?P<value>.*)")
+_BOOLEAN_TRUE = "yes", "1", "true", "on"
+_BOOLEAN_FALSE = "no", "0", "false", "off"
+
+_FILESIZE_RE = re.compile(r"(?P<size>\d+(\.\d+)?)(?P<modifier>[km])?b?", re.IGNORECASE)
+_FILESIZE_UNITS = {
+    "k": 2**10,
+    "m": 2**20,
+}
+
+_KEYVALUE_RE = re.compile(r"(?P<key>[^=]+)\s*=\s*(?P<value>.*)")
 
 
-def boolean(value):
-    truths = ["yes", "1", "true", "on"]
-    falses = ["no", "0", "false", "off"]
-    if value.lower() not in truths + falses:
-        raise argparse.ArgumentTypeError("{0} was not one of {{{1}}}".format(
-            value, ", ".join(truths + falses)))
+def boolean(value: str) -> bool:
+    if value.lower() not in _BOOLEAN_TRUE + _BOOLEAN_FALSE:
+        raise ValueError(f"{value} is not one of {{{', '.join(_BOOLEAN_TRUE + _BOOLEAN_FALSE)}}}")
 
-    return value.lower() in truths
+    return value.lower() in _BOOLEAN_TRUE
 
 
-def comma_list(values):
+def comma_list(values: str) -> List[str]:
     return [val.strip() for val in values.split(",")]
 
 
-def comma_list_filter(acceptable):
-    def func(p):
-        values = comma_list(p)
-        return list(filter(lambda v: v in acceptable, values))
+def comma_list_filter(acceptable: List[str]) -> Callable[[str], List[str]]:
+    def func(values: str) -> List[str]:
+        return [item for item in comma_list(values) if item in acceptable]
 
     return func
 
 
-def filesize(value):
-    match = _filesize_re.match(value)
+def filesize(value: str) -> int:
+    match = _FILESIZE_RE.match(value)
     if not match:
-        raise ValueError
+        raise ValueError("Invalid file size format")
 
-    size = float(match.group("size"))
-    if not size:
-        raise ValueError
-
-    modifier = match.group("modifier")
-    if modifier in ("M", "m"):
-        size *= 1024 * 1024
-    elif modifier in ("K", "k"):
-        size *= 1024
+    size = float(match["size"])
+    size *= _FILESIZE_UNITS.get((match["modifier"] or "").lower(), 1)
 
     return num(int, ge=1)(size)
 
 
-def keyvalue(value):
-    match = _keyvalue_re.match(value)
+def keyvalue(value: str) -> Tuple[str, str]:
+    match = _KEYVALUE_RE.match(value)
     if not match:
-        raise ValueError
+        raise ValueError("Invalid key=value format")
 
-    return match.group("key", "value")
+    return match["key"], match["value"]
+
+
+@overload
+def num(
+    numtype: Type[int],
+    ge: Optional[int] = None,
+    gt: Optional[int] = None,
+    le: Optional[int] = None,
+    lt: Optional[int] = None,
+) -> Callable[[Any], int]: pass  # pragma: no cover
+
+
+@overload
+def num(
+    numtype: Type[float],
+    ge: Optional[float] = None,
+    gt: Optional[float] = None,
+    le: Optional[float] = None,
+    lt: Optional[float] = None,
+) -> Callable[[Any], float]: pass  # pragma: no cover
 
 
 def num(
@@ -65,18 +77,18 @@ def num(
     gt: Optional[float] = None,
     le: Optional[float] = None,
     lt: Optional[float] = None,
-):
-    def func(value):
+) -> Callable[[Any], float]:
+    def func(value: Any) -> float:
         value = numtype(value)
 
         if ge is not None and value < ge:
-            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be >={ge}, but is {value}")
+            raise ValueError(f"{numtype.__name__} value must be >={ge}, but is {value}")
         if gt is not None and value <= gt:
-            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be >{gt}, but is {value}")
+            raise ValueError(f"{numtype.__name__} value must be >{gt}, but is {value}")
         if le is not None and value > le:
-            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be <={le}, but is {value}")
+            raise ValueError(f"{numtype.__name__} value must be <={le}, but is {value}")
         if lt is not None and value >= lt:
-            raise argparse.ArgumentTypeError(f"{numtype.__name__} value must be <{lt}, but is {value}")
+            raise ValueError(f"{numtype.__name__} value must be <{lt}, but is {value}")
 
         return value
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -833,7 +833,9 @@ def build_parser():
         metavar="SIZE",
         type=filesize,
         help="""
-        The maximum size of the ringbuffer. Mega- or kilobytes can be specified via the M or K suffix respectively.
+        The maximum size of the ringbuffer.
+
+        Mebibytes or kibibytes (base 2) can be specified via the M or K suffix respectively.
 
         The ringbuffer is used as a temporary storage between the stream and the player.
         This allows Streamlink to download the stream faster than the player which reads the data from the ringbuffer.
@@ -846,9 +848,6 @@ def build_parser():
         background as long as the ringbuffer doesn't get full.
 
         Default is "16M".
-
-        Note: A smaller size is recommended on lower end systems (such as Raspberry Pi) when playing stream types that require
-        some extra processing to avoid unnecessary background processing.
         """,
     )
     transport.add_argument(

--- a/tests/utils/test_args.py
+++ b/tests/utils/test_args.py
@@ -86,10 +86,10 @@ def test_filesize(value: str, expected: int, raises: nullcontext):
         id="missing value",
     ),
     pytest.param(
-        "Referer  =  https://foo.bar",
-        ("Referer  ", "https://foo.bar"),
+        "  foo  =  bar  ",
+        ("foo", "bar  "),
         does_not_raise,
-        id="whitespace around separator",
+        id="whitespace",
     ),
     pytest.param(
         "User-Agent=Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",

--- a/tests/utils/test_args.py
+++ b/tests/utils/test_args.py
@@ -1,6 +1,5 @@
-from argparse import ArgumentTypeError
 from contextlib import nullcontext
-from typing import Type
+from typing import List, Sequence, Type
 
 import pytest
 
@@ -10,87 +9,110 @@ from streamlink.utils.args import boolean, comma_list, comma_list_filter, filesi
 does_not_raise = nullcontext()
 
 
-class TestUtilsArgs:
-    def test_boolean_true(self):
-        assert boolean("1") is True
-        assert boolean("on") is True
-        assert boolean("true") is True
-        assert boolean("yes") is True
-        assert boolean("Yes") is True
+@pytest.mark.parametrize(("value", "expected", "raises"), [
+    ("1", True, does_not_raise),
+    ("on", True, does_not_raise),
+    ("true", True, does_not_raise),
+    ("yes", True, does_not_raise),
+    ("YES", True, does_not_raise),
+    ("0", False, does_not_raise),
+    ("off", False, does_not_raise),
+    ("false", False, does_not_raise),
+    ("no", False, does_not_raise),
+    ("NO", False, does_not_raise),
+    ("invalid", None, pytest.raises(ValueError, match=r"invalid is not one of .+")),
+    ("2", None, pytest.raises(ValueError, match=r"2 is not one of .+")),
+])
+def test_boolean(value: str, expected: bool, raises: nullcontext):
+    with raises:
+        assert boolean(value) is expected
 
-    def test_boolean_false(self):
-        assert boolean("0") is False
-        assert boolean("false") is False
-        assert boolean("no") is False
-        assert boolean("No") is False
-        assert boolean("off") is False
 
-    def test_boolean_error(self):
-        with pytest.raises(ArgumentTypeError):
-            boolean("yesno")
-        with pytest.raises(ArgumentTypeError):
-            boolean("FOO")
-        with pytest.raises(ArgumentTypeError):
-            boolean("2")
+@pytest.mark.parametrize(("value", "expected"), [
+    pytest.param("foo", ["foo"], id="single item"),
+    pytest.param("foo.bar,example.com", ["foo.bar", "example.com"], id="separator"),
+    pytest.param("/var/run/foo,/var/run/bar", ["/var/run/foo", "/var/run/bar"], id="paths"),
+    pytest.param("foo bar,baz", ["foo bar", "baz"], id="whitespace"),
+])
+def test_comma_list(value: str, expected: List[str]):
+    assert comma_list(value) == expected
 
-    def test_comma_list(self):
-        # (values, result)
-        test_data = [
-            ("foo.bar,example.com", ["foo.bar", "example.com"]),
-            ("/var/run/foo,/var/run/bar", ["/var/run/foo", "/var/run/bar"]),
-            ("foo bar,24", ["foo bar", "24"]),
-            ("hls", ["hls"]),
-        ]
 
-        for _v, _r in test_data:
-            assert comma_list(_v) == _r
+@pytest.mark.parametrize(("acceptable", "value", "expected"), [
+    pytest.param(["foo", "bar"], "foo,bar,baz,qux", ["foo", "bar"], id="superset"),
+    pytest.param(["foo", "bar", "baz"], "foo,bar", ["foo", "bar"], id="subset"),
+])
+def test_comma_list_filter(acceptable: List[str], value: str, expected: List[str]):
+    func = comma_list_filter(acceptable)
+    assert func(value) == expected
 
-    def test_comma_list_filter(self):
-        # (acceptable, values, result)
-        test_data = [
-            (["foo", "bar", "com"], "foo,bar,example.com", ["foo", "bar"]),
-            (["/var/run/foo", "FO"], "/var/run/foo,/var/run/bar",
-             ["/var/run/foo"]),
-            (["hls", "hls5", "dash"], "hls,hls5", ["hls", "hls5"]),
-            (["EU", "RU"], "DE,FR,RU,US", ["RU"]),
-        ]
 
-        for _a, _v, _r in test_data:
-            func = comma_list_filter(_a)
-            assert func(_v) == _r
+@pytest.mark.parametrize(("value", "expected", "raises"), [
+    ("12345", 12345, does_not_raise),
+    ("123.45", int(123.45), does_not_raise),
+    ("1KB", 1 * 2**10, does_not_raise),
+    ("123kB", 123 * 2**10, does_not_raise),
+    ("123.45kB", int(123.45 * 2**10), does_not_raise),
+    ("1mb", 1 * 2**20, does_not_raise),
+    ("123k", 123 * 2**10, does_not_raise),
+    ("123M", 123 * 2**20, does_not_raise),
+    ("123.45M", int(123.45 * 2**20), does_not_raise),
+    ("FOO", None, pytest.raises(ValueError, match=r"^Invalid file size format$")),
+    ("0", None, pytest.raises(ValueError, match=r"^int value must be >=1, but is 0$")),
+    ("0.00000", None, pytest.raises(ValueError, match=r"^int value must be >=1, but is 0$")),
+])
+def test_filesize(value: str, expected: int, raises: nullcontext):
+    with raises:
+        assert filesize(value) == expected
 
-    def test_filesize(self):
-        assert filesize("2000") == 2000
-        assert filesize("11KB") == 1024 * 11
-        assert filesize("12MB") == 1024 * 1024 * 12
-        assert filesize("1KB") == 1024
-        assert filesize("1MB") == 1024 * 1024
-        assert filesize("2KB") == 1024 * 2
 
-    def test_filesize_error(self):
-        with pytest.raises(ValueError):  # noqa: PT011
-            filesize("FOO")
-        with pytest.raises(ValueError):  # noqa: PT011
-            filesize("0.00000")
-
-    def test_keyvalue(self):
-        # (value, result)
-        test_data = [
-            ("X-Forwarded-For=127.0.0.1", ("X-Forwarded-For", "127.0.0.1")),
-            ("Referer=https://foo.bar", ("Referer", "https://foo.bar")),
-            (
-                "User-Agent=Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
-                ("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0"),
-            ),
-            ("domain=example.com", ("domain", "example.com")),
-        ]
-
-        for _v, _r in test_data:
-            assert keyvalue(_v) == _r
-
-    def test_keyvalue_error(self):
-        with pytest.raises(ValueError):  # noqa: PT011
-            keyvalue("127.0.0.1")
+@pytest.mark.parametrize(("value", "expected", "raises"), [
+    pytest.param(
+        "X-Forwarded-For=127.0.0.1",
+        ("X-Forwarded-For", "127.0.0.1"),
+        does_not_raise,
+        id="separator",
+    ),
+    pytest.param(
+        "foo=bar=baz",
+        ("foo", "bar=baz"),
+        does_not_raise,
+        id="value with separator",
+    ),
+    pytest.param(
+        "foo=",
+        ("foo", ""),
+        does_not_raise,
+        id="missing value",
+    ),
+    pytest.param(
+        "Referer  =  https://foo.bar",
+        ("Referer  ", "https://foo.bar"),
+        does_not_raise,
+        id="whitespace around separator",
+    ),
+    pytest.param(
+        "User-Agent=Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0",
+        ("User-Agent", "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/60.0"),
+        does_not_raise,
+        id="user-agent",
+    ),
+    pytest.param(
+        "127.0.0.1",
+        None,
+        pytest.raises(ValueError, match=r"^Invalid key=value format$"),
+        id="invalid format",
+    ),
+    pytest.param(
+        "=value",
+        None,
+        pytest.raises(ValueError, match=r"^Invalid key=value format$"),
+        id="missing key",
+    ),
+])
+def test_keyvalue(value: str, expected: Sequence[str], raises: nullcontext):
+    with raises:
+        assert keyvalue(value) == expected
 
 
 class TestNum:
@@ -127,11 +149,11 @@ class TestNum:
         ({"le": 2}, 1, does_not_raise),
         ({"lt": 2}, 1, does_not_raise),
         ({"ge": 1, "gt": 0, "le": 1, "lt": 2}, 1, does_not_raise),
-        ({"ge": 2}, 1, pytest.raises(ArgumentTypeError, match=r"^int value must be >=2, but is 1$")),
-        ({"gt": 1}, 1, pytest.raises(ArgumentTypeError, match=r"^int value must be >1, but is 1$")),
-        ({"le": 0}, 1, pytest.raises(ArgumentTypeError, match=r"^int value must be <=0, but is 1$")),
-        ({"lt": 1}, 1, pytest.raises(ArgumentTypeError, match=r"^int value must be <1, but is 1$")),
-        ({"ge": 1, "gt": 0, "le": 0, "lt": 2}, 1, pytest.raises(ArgumentTypeError, match=r"^int value must be <=0, but is 1$")),
+        ({"ge": 2}, 1, pytest.raises(ValueError, match=r"^int value must be >=2, but is 1$")),
+        ({"gt": 1}, 1, pytest.raises(ValueError, match=r"^int value must be >1, but is 1$")),
+        ({"le": 0}, 1, pytest.raises(ValueError, match=r"^int value must be <=0, but is 1$")),
+        ({"lt": 1}, 1, pytest.raises(ValueError, match=r"^int value must be <1, but is 1$")),
+        ({"ge": 1, "gt": 0, "le": 0, "lt": 2}, 1, pytest.raises(ValueError, match=r"^int value must be <=0, but is 1$")),
     ])
     def test_operator(self, operators: dict, value: float, raises: nullcontext):
         with raises:

--- a/tests/utils/test_args.py
+++ b/tests/utils/test_args.py
@@ -57,6 +57,7 @@ def test_comma_list_filter(acceptable: List[str], value: str, expected: List[str
     ("123k", 123 * 2**10, does_not_raise),
     ("123M", 123 * 2**20, does_not_raise),
     ("123.45M", int(123.45 * 2**20), does_not_raise),
+    ("  123.45MB  ", int(123.45 * 2**20), does_not_raise),
     ("FOO", None, pytest.raises(ValueError, match=r"^Invalid file size format$")),
     ("0", None, pytest.raises(ValueError, match=r"^int value must be >=1, but is 0$")),
     ("0.00000", None, pytest.raises(ValueError, match=r"^int value must be >=1, but is 0$")),


### PR DESCRIPTION
This updates and fixes the `streamlink.utils.args` module, in preparation for #5715 (which I will rebase and modify after this got merged - after the next release).

----

The first commit keeps the same functionality as the current implementation, apart from different exceptions being raised. The tests have been fully rewritten, but the old tests also pass (ignoring the exception class changes).

The second and third commits fix some issues with the inputs of `filesize()` and `keyvalue()`. This will affect the `--ringbuffer-size` argument, as well as `--http-header`, `--http-cookie`, `--http-query-param`, `--player-env`, `--twitch-api-header` and `--twitch-access-token-param`. This is mainly just whitespace character related but it fixes the missing regex anchors.

The last commit fixes the incorrect `--ringbuffer-size` help text and removes an old and probably unnecessary note.