### PR TITLE
plugin: add str to pluginargument type argument

### DIFF
--- a/docs/api/plugin.rst
+++ b/docs/api/plugin.rst
@@ -13,3 +13,5 @@ Plugin decorators
 .. autodecorator:: pluginmatcher
 
 .. autodecorator:: pluginargument
+
+.. autodata:: streamlink.plugin.plugin._PLUGINARGUMENT_TYPE_REGISTRY

--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -19,7 +19,6 @@ from streamlink.plugin.api import useragents, validate
 from streamlink.plugin.api.websocket import WebsocketClient
 from streamlink.stream.hls import HLSStream, HLSStreamReader
 from streamlink.utils.parse import parse_json
-from streamlink.utils.times import hours_minutes_seconds
 from streamlink.utils.url import update_qsd
 
 
@@ -153,7 +152,7 @@ class NicoLiveHLSStream(HLSStream):
 )
 @pluginargument(
     "timeshift-offset",
-    type=hours_minutes_seconds,
+    type="hours_minutes_seconds",
     argument_name="niconico-timeshift-offset",
     metavar="[[XX:]XX:]XX | [XXh][XXm][XXs]",
     help="""

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -45,7 +45,6 @@ log = logging.getLogger(__name__)
 @pluginargument(
     "url",
     metavar="URL",
-    type=str,
     help="Source URL where the iframe is located, only required for direct URLs of ott.streann.com",
 )
 class Streann(Plugin):

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -44,7 +44,6 @@ from streamlink.stream.hls import (
     parse_tag,
 )
 from streamlink.stream.http import HTTPStream
-from streamlink.utils.args import keyvalue
 from streamlink.utils.parse import parse_json, parse_qsd
 from streamlink.utils.random import CHOICES_ALPHA_NUM, random_token
 from streamlink.utils.times import fromtimestamp, hours_minutes_seconds_float
@@ -655,7 +654,7 @@ class TwitchClientIntegrity:
 @pluginargument(
     "api-header",
     metavar="KEY=VALUE",
-    type=keyvalue,
+    type="keyvalue",
     action="append",
     help="""
         A header to add to each Twitch API HTTP request.
@@ -668,7 +667,7 @@ class TwitchClientIntegrity:
 @pluginargument(
     "access-token-param",
     metavar="KEY=VALUE",
-    type=keyvalue,
+    type="keyvalue",
     action="append",
     help="""
         A parameter to add to the API request for acquiring the streaming access token.

--- a/src/streamlink/plugins/zattoo.py
+++ b/src/streamlink/plugins/zattoo.py
@@ -26,12 +26,9 @@ from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.hls import HLSStream
-from streamlink.utils.args import comma_list_filter
 
 
 log = logging.getLogger(__name__)
-
-STREAMS_ZATTOO = ["dash", "hls7"]
 
 
 @pluginmatcher(re.compile(r"""
@@ -86,12 +83,13 @@ STREAMS_ZATTOO = ["dash", "hls7"]
 @pluginargument(
     "stream-types",
     metavar="TYPES",
-    type=comma_list_filter(STREAMS_ZATTOO),
+    type="comma_list_filter",
+    type_kwargs={"acceptable": ["dash", "hls7"]},
     default=["dash"],
-    help=f"""
+    help="""
         A comma-delimited list of stream types which should be used.
 
-        The following types are allowed: {','.join(STREAMS_ZATTOO)}
+        The following types are allowed: dash, hls7
 
         Default is "dash".
     """,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,8 +1,10 @@
+import argparse
 import logging
 import re
 import time
+from contextlib import nullcontext
 from operator import eq, gt, lt
-from typing import Type
+from typing import Any, Type
 from unittest.mock import Mock, call, patch
 
 import freezegun
@@ -21,7 +23,7 @@ from streamlink.plugin import (
 )
 
 # noinspection PyProtectedMember
-from streamlink.plugin.plugin import _COOKIE_KEYS, Matcher, parse_params, stream_weight
+from streamlink.plugin.plugin import _COOKIE_KEYS, _PLUGINARGUMENT_TYPE_REGISTRY, Matcher, parse_params, stream_weight
 from streamlink.session import Streamlink
 
 
@@ -203,6 +205,10 @@ class TestPluginArguments:
             PluginArgument("baz", dest="_baz", help="BAZ"),
         )
 
+    def test_pluginargument_type_registry(self):
+        assert _PLUGINARGUMENT_TYPE_REGISTRY
+        assert all(callable(value) for value in _PLUGINARGUMENT_TYPE_REGISTRY.values())
+
     @pytest.mark.parametrize("pluginclass", [DecoratedPlugin, ClassAttrPlugin])
     def test_arguments(self, pluginclass):
         assert pluginclass.arguments is not None
@@ -217,7 +223,66 @@ class TestPluginArguments:
 
         assert tuple(arg.name for arg in MixedPlugin.arguments) == ("qux", "foo", "bar", "baz")
 
-    def test_decorator_typerror(self):
+    @pytest.mark.parametrize(("options", "args", "expected", "raises"), [
+        pytest.param(
+            {"type": "boolean"},
+            ["--myplugin-foo", "yes"],
+            True,
+            nullcontext(),
+            id="boolean",
+        ),
+        pytest.param(
+            {"type": "keyvalue"},
+            ["--myplugin-foo", "key=value"],
+            ("key", "value"),
+            nullcontext(),
+            id="keyvalue",
+        ),
+        pytest.param(
+            {"type": "comma_list_filter", "type_args": (["one", "two", "four"], )},
+            ["--myplugin-foo", "one,two,three,four"],
+            ["one", "two", "four"],
+            nullcontext(),
+            id="comma_list_filter - args",
+        ),
+        pytest.param(
+            {"type": "comma_list_filter", "type_kwargs": {"acceptable": ["one", "two", "four"]}},
+            ["--myplugin-foo", "one,two,three,four"],
+            ["one", "two", "four"],
+            nullcontext(),
+            id="comma_list_filter - kwargs",
+        ),
+        pytest.param(
+            {"type": "hours_minutes_seconds"},
+            ["--myplugin-foo", "1h2m3s"],
+            3723,
+            nullcontext(),
+            id="hours_minutes_seconds",
+        ),
+        pytest.param(
+            {"type": "UNKNOWN"},
+            None,
+            None,
+            pytest.raises(TypeError),
+            id="UNKNOWN",
+        ),
+    ])
+    def test_type_argument_map(self, options: dict, args: list, expected: Any, raises: nullcontext):
+        class MyPlugin(FakePlugin):
+            pass
+
+        with raises:
+            pluginargument("foo", **options)(MyPlugin)
+            assert MyPlugin.arguments is not None
+            pluginarg = MyPlugin.arguments.get("foo")
+            assert pluginarg
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument(pluginarg.argument_name("myplugin"), **pluginarg.options)
+            namespace = parser.parse_args(args)
+            assert namespace.myplugin_foo == expected
+
+    def test_decorator_typeerror(self):
         with patch("builtins.repr", Mock(side_effect=lambda obj: obj.__name__)):
             with pytest.raises(TypeError) as cm:
                 # noinspection PyUnusedLocal


### PR DESCRIPTION
Follow-up of #5715

This adds a `@pluginargument()` `type` function registry, so the `@pluginargument()` data can be fully JSON-serialized.

Built-in plugins now must always reference the `type` argument of each `@pluginargument()` (if set) via the registered function name. This is optional for third-party plugins.