### PR TITLE
plugins.bilibili: add back HTTPStream from v1 API

### DIFF
--- a/tests/plugins/test_bilibili.py
+++ b/tests/plugins/test_bilibili.py
@@ -6,5 +6,5 @@ class TestPluginCanHandleUrlBilibili(PluginCanHandleUrl):
     __plugin__ = Bilibili
 
     should_match_groups = [
-        ("https://live.bilibili.com/CHANNEL", {"channel": "CHANNEL"}),
+        ("https://live.bilibili.com/CHANNEL?live_from=78001", {"channel": "CHANNEL"}),
     ]


### PR DESCRIPTION
Resolves #5700 

This adds back the v1 API request and the progressive HTTP streams. Those streams have a higher quality compared to their HLS streams for some reason. The plugin therefore treats them with a higher priority, so that `--stream-types=http` doesn't have to be set (its default value is `hls,http,*`). (*This will be cleaned up eventually with the new stream selection stuff though*)

----

Getting some channel IDs from their `/all` page:

```js
>>> Array.from(document.body.querySelectorAll("a#card")).slice(0, 10).map(a=>new URL(a.href).pathname.substring(1)).join(" ")
'26807102 30048568 31602877 31561419 31142202 24660442 31773868 30844372 11484134 27768132'
```

Testing the progressive HTTP streams from the v1 API:

```bash
for channel in 26807102 30048568 31602877 31561419 31142202 24660442 31773868 30844372 11484134 27768132; do
    ./script/test-plugin-urls.py bilibili -r CHANNEL $channel
    streamlink --stdout -l none "https://live.bilibili.com/$channel?live_from=78001" best 2>/dev/null \
      | ffprobe -v error -of json -show_streams - \
      | jq -r '.streams[] | select(.codec_name == "h264") | "\(.width)x\(.height)"'
done
```

```
:: Finding streams for URL: https://live.bilibili.com/26807102?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1920x1080
:: Finding streams for URL: https://live.bilibili.com/30048568?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1280x720
:: Finding streams for URL: https://live.bilibili.com/31602877?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1920x1080
:: Finding streams for URL: https://live.bilibili.com/31561419?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
720x1280
:: Finding streams for URL: https://live.bilibili.com/31142202?live_from=78001
:: Found streams: httpstream_alt, httpstream, worst, best
720x1280
:: Finding streams for URL: https://live.bilibili.com/24660442?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1200x900
:: Finding streams for URL: https://live.bilibili.com/31773868?live_from=78001
:: Found streams: httpstream_alt, httpstream, worst, best
1920x1080
:: Finding streams for URL: https://live.bilibili.com/30844372?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1920x1080
:: Finding streams for URL: https://live.bilibili.com/11484134?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1920x1080
:: Finding streams for URL: https://live.bilibili.com/27768132?live_from=78001
:: Found streams: hls_alt, hls, httpstream_alt, httpstream, worst, best
1918x886
```