### PR TITLE
plugins.huya: fix stream URLs

### DIFF
--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -12,21 +12,27 @@ import logging
 import re
 from html import unescape as html_unescape
 from typing import Dict
+from urllib.parse import parse_qsl
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.http import HTTPStream
-from streamlink.utils.url import update_scheme
+from streamlink.utils.url import update_qsd, update_scheme
 
 
 log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https?://(?:www\.)?huya\.com/(?P<channel>[^/]+)",
+    r"https?://(?:www\.)?huya\.com/(?P<channel>[^/?]+)",
 ))
 class Huya(Plugin):
     QUALITY_WEIGHTS: Dict[str, int] = {}
+
+    _QUALITY_WEIGHTS_OVERRIDE = {
+        "source_hy": -1000,  # SSLCertVerificationError
+    }
+    _STREAM_URL_QUERYSTRING_PARAMS = "wsSecret", "wsTime"
 
     @classmethod
     def stream_weight(cls, key):
@@ -97,13 +103,18 @@ class Huya(Plugin):
 
         self.id, self.author, self.title, streamdata = data
 
+        self.session.http.headers.update({
+            "Origin": "https://www.huya.com",
+            "Referer": "https://www.huya.com/",
+        })
+
         for cdntype, priority, streamname, flvurl, suffix, anticode in streamdata:
-            url = update_scheme("https://", f"{flvurl}/{streamname}.{suffix}?{anticode}")
-            if self.session.http.head(url, raise_for_status=False).status_code >= 400:
-                continue
+            qs = {k: v for k, v in dict(parse_qsl(anticode)).items() if k in self._STREAM_URL_QUERYSTRING_PARAMS}
+            url = update_scheme("https://", f"{flvurl}/{streamname}.{suffix}")
+            url = update_qsd(url, qs)
 
             name = f"source_{cdntype.lower()}"
-            self.QUALITY_WEIGHTS[name] = priority
+            self.QUALITY_WEIGHTS[name] = self._QUALITY_WEIGHTS_OVERRIDE.get(name, priority)
             yield name, HTTPStream(self.session, url)
 
         log.debug(f"QUALITY_WEIGHTS: {self.QUALITY_WEIGHTS!r}")

--- a/tests/plugins/test_huya.py
+++ b/tests/plugins/test_huya.py
@@ -5,14 +5,10 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlHuya(PluginCanHandleUrl):
     __plugin__ = Huya
 
-    should_match = [
-        "http://www.huya.com/123123123",
-        "http://www.huya.com/name",
-        "https://www.huya.com/123123123",
-        "https://www.huya.com/name",
+    should_match_groups = [
+        ("https://www.huya.com/CHANNEL", {"channel": "CHANNEL"}),
     ]
 
     should_not_match = [
-        "http://www.huya.com",
         "https://www.huya.com",
     ]


### PR DESCRIPTION
Set Referer and Origin headers, keep only necessary query string params in the stream URLs, and remove stream URL HEAD request.

----

Fixes #5784 

No idea if this is valid for all channels.

Random channel test:

```bash
for cdn in $(streamlink --json huya.com/shege | jq -r '.streams | keys[] | select(contains("source_"))'); do
    timeout 20 streamlink -o /dev/null huya.com/shege $cdn
    echo
done
```
```
[cli][info] Found matching plugin huya for URL huya.com/shege
[cli][info] Available streams: source_hs (worst), source_al, source_hw, source_tx (best)
[cli][info] Opening stream: source_al (http)
[cli][info] Writing output to
/dev/null
[download] Written 6.42 MiB to /dev/null (16s @ 411.13 KiB/s)                                                                                   
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...

[cli][info] Found matching plugin huya for URL huya.com/shege
[cli][info] Available streams: source_hs (worst), source_al, source_hw, source_tx (best)
[cli][info] Opening stream: source_hs (http)
[cli][info] Writing output to
/dev/null
[download] Written 8.28 MiB to /dev/null (15s @ 555.56 KiB/s)                                                                                   
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...

[cli][info] Found matching plugin huya for URL huya.com/shege
[cli][info] Available streams: source_hs (worst), source_al, source_hw, source_tx (best)
[cli][info] Opening stream: source_hw (http)
[cli][info] Writing output to
/dev/null
[download] Written 6.49 MiB to /dev/null (15s @ 435.55 KiB/s)                                                                                   
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...

[cli][info] Found matching plugin huya for URL huya.com/shege
[cli][info] Available streams: source_hs (worst), source_al, source_hw, source_tx (best)
[cli][info] Opening stream: source_tx (http)
[cli][info] Writing output to
/dev/null
[download] Written 10.32 MiB to /dev/null (16s @ 670.37 KiB/s)                                                                                  
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```