### PR TITLE
plugin: add missing pluginargument type functions

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -42,7 +42,9 @@ if TYPE_CHECKING:  # pragma: no cover
 
 #: See the :func:`~.pluginargument` decorator
 _PLUGINARGUMENT_TYPE_REGISTRY: Dict[str, Callable[[Any], Any]] = {
-    "boolean": streamlink.utils.args.boolean,
+    "int": int,
+    "float": float,
+    "bool": streamlink.utils.args.boolean,
     "comma_list": streamlink.utils.args.comma_list,
     "comma_list_filter": streamlink.utils.args.comma_list_filter,
     "filesize": streamlink.utils.args.filesize,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -225,11 +225,25 @@ class TestPluginArguments:
 
     @pytest.mark.parametrize(("options", "args", "expected", "raises"), [
         pytest.param(
-            {"type": "boolean"},
+            {"type": "int"},
+            ["--myplugin-foo", "123"],
+            123,
+            nullcontext(),
+            id="int",
+        ),
+        pytest.param(
+            {"type": "float"},
+            ["--myplugin-foo", "123.456"],
+            123.456,
+            nullcontext(),
+            id="float",
+        ),
+        pytest.param(
+            {"type": "bool"},
             ["--myplugin-foo", "yes"],
             True,
             nullcontext(),
-            id="boolean",
+            id="bool",
         ),
         pytest.param(
             {"type": "keyvalue"},


### PR DESCRIPTION
- Add `int` and `float` types to the pluginargument type registry
- Rename `boolean` to `bool`

----

Somehow forgot to add this in #5779. The `bool` name change is fine, because it hasn't been included in a release yat and only affects Streamlink's own plugins anyway.