### PR TITLE
tests: fix session init

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -494,7 +494,8 @@ class _TestCLIMainLogging(unittest.TestCase):
 
     @classmethod
     def subject(cls, argv, **kwargs):
-        session = Streamlink()
+        with patch("streamlink.session.Streamlink.load_builtin_plugins"):
+            session = Streamlink()
         session.load_plugins(str(Path(tests.__path__[0]) / "plugin"))
 
         with patch("streamlink_cli.main.os.geteuid", create=True, new=Mock(return_value=kwargs.get("euid", 1000))), \
@@ -504,7 +505,6 @@ class _TestCLIMainLogging(unittest.TestCase):
              patch("streamlink_cli.main.setup_streamlink"), \
              patch("streamlink_cli.main.setup_plugins"), \
              patch("streamlink_cli.argparser.find_default_player"), \
-             patch("streamlink.session.Streamlink.load_builtin_plugins"), \
              patch("sys.argv") as mock_argv:
             mock_argv.__getitem__.side_effect = lambda x: argv[x]
             try:

--- a/tests/cli/test_plugin_args_and_options.py
+++ b/tests/cli/test_plugin_args_and_options.py
@@ -52,9 +52,7 @@ def plugin():
 
 
 @pytest.fixture(autouse=True)
-def session(monkeypatch: pytest.MonkeyPatch, parser: ArgumentParser, plugin: Type[Plugin]):
-    monkeypatch.setattr("streamlink.session.Streamlink.load_builtin_plugins", Mock())
-    session = Streamlink()
+def session(session: Streamlink, parser: ArgumentParser, plugin: Type[Plugin]):
     session.plugins["mock"] = plugin
 
     setup_plugin_args(session, parser)

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -280,7 +280,8 @@ class TestMixinStreamHLS(unittest.TestCase):
         return data
 
     def get_session(self, options=None, *args, **kwargs):
-        return Streamlink(options)
+        with patch("streamlink.session.Streamlink.load_builtin_plugins"):
+            return Streamlink(options)
 
     # set up HLS responses, create the session and read thread and start it
     def subject(self, playlists, options=None, streamoptions=None, threadoptions=None, start=True, *args, **kwargs):

--- a/tests/plugins/test_filmon.py
+++ b/tests/plugins/test_filmon.py
@@ -41,10 +41,9 @@ class TestPluginCanHandleUrlFilmon(PluginCanHandleUrl):
 
 
 @pytest.fixture()
-def filmonhls():
+def filmonhls(session: Streamlink):
     with freezegun.freeze_time("2000-01-01T00:00:00Z"), \
          patch("streamlink.plugins.filmon.FilmOnHLS._get_stream_data", return_value=[]):
-        session = Streamlink()
         api = FilmOnAPI(session)
         yield FilmOnHLS(session, "http://fake/one.m3u8", api=api, channel="test")
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -101,8 +101,7 @@ class _TwitchHLSStream(TwitchHLSStream):
     __reader__ = _TwitchHLSStreamReader
 
 
-def test_stream_weight(requests_mock: rm.Mocker):
-    session = Streamlink()
+def test_stream_weight(requests_mock: rm.Mocker, session: Streamlink):
     plugin = Twitch(session, "http://twitch.tv/foo")
 
     with text("hls/test_master_twitch_vod.m3u8") as fh:
@@ -404,8 +403,7 @@ class TestTwitchAPIAccessToken:
         monkeypatch.setattr(Twitch, "_client_integrity_token", mock_client_integrity_token)
 
     @pytest.fixture()
-    def plugin(self, request: pytest.FixtureRequest):
-        session = Streamlink()
+    def plugin(self, request: pytest.FixtureRequest, session: Streamlink):
         options = Options()
         for param in getattr(request, "param", {}):
             options.set(*param)

--- a/tests/plugins/test_ustreamtv.py
+++ b/tests/plugins/test_ustreamtv.py
@@ -53,10 +53,9 @@ class TestPluginCanHandleUrlUStreamTV(PluginCanHandleUrl):
 
 
 class TestPluginUStreamTV:
-    def test_arguments(self):
+    def test_arguments(self, session: Streamlink):
         from streamlink_cli.main import setup_plugin_args  # noqa: PLC0415
 
-        session = Streamlink()
         parser = MagicMock()
         plugins = parser.add_argument_group("Plugin Options")
         group = parser.add_argument_group("UStreamTV", parent=plugins)

--- a/tests/plugins/test_vk.py
+++ b/tests/plugins/test_vk.py
@@ -82,8 +82,7 @@ class TestPluginCanHandleUrlVK(PluginCanHandleUrl):
         pytest.raises(NoStreamsError),
     ),
 ])
-def test_url_redirect(url: str, newurl: str, raises: nullcontext, requests_mock: rm.Mocker):
-    session = Streamlink()
+def test_url_redirect(requests_mock: rm.Mocker, session: Streamlink, url: str, newurl: str, raises: nullcontext):
     # noinspection PyTypeChecker
     plugin: VK = VK(session, url)
     requests_mock.get(url, text=f"""<!DOCTYPE html><html><head><meta property="og:url" content="{newurl}"/></head></html>""")


### PR DESCRIPTION
In preparation for the session initialization rewrite using the plugins JSON data...

Despite there being the `session` pytest fixture for initializing a Streamlink session object without loading any plugins, lots of tests are currently still manually initializing the session, which leads to all plugins being loaded every time. This slows down the tests significantly. On my local system, these changes improve the run time from ~15s to ~10s.

The upcoming plugins JSON data implementation will make lots of changes to the Streamlink class, so patching the `load_builtin_plugins()` method won't be necessary anymore in the tests afterwards.