### PR TITLE
tests: remove pytest downgrade again

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ setuptools >=64.0.0  # required for being able to run editable installs
 versioningit >=2.0.0,<4  # required for being able to run editable installs
 
 # tests
-pytest >=6.0.0,<8
+pytest >=6.0.0
 pytest-asyncio
 pytest-trio
 requests-mock


### PR DESCRIPTION
pytest-asyncio 0.23.4 has been released and now itself limits pytest to <8, so this does not have to be done by us anymore.

As soon as pytest-asyncio will have resolved its incompatibilities with pytest >=8, the latest versions will be picked up by pip automatically.

----

#5802 