### PR TITLE
utils.module: optimize plugin module loading

### DIFF
--- a/src/streamlink/session.py
+++ b/src/streamlink/session.py
@@ -15,7 +15,7 @@ from streamlink.options import Options
 from streamlink.plugin.api.http_session import HTTPSession, TLSNoDHAdapter
 from streamlink.plugin.plugin import NO_PRIORITY, Matcher, Plugin
 from streamlink.utils.l10n import Localization
-from streamlink.utils.module import load_module
+from streamlink.utils.module import exec_module
 from streamlink.utils.url import update_scheme
 
 
@@ -641,12 +641,13 @@ class Streamlink:
         """
 
         success = False
-        for _loader, name, _ispkg in pkgutil.iter_modules([path]):
+        for module_info in pkgutil.iter_modules([path]):
+            name = module_info.name
             # set the full plugin module name
             # use the "streamlink.plugins." prefix even for sideloaded plugins
             module_name = f"streamlink.plugins.{name}"
             try:
-                mod = load_module(module_name, path)
+                mod = exec_module(module_info.module_finder, module_name)  # type: ignore[arg-type]
             except ImportError as err:
                 log.exception(f"Failed to load plugin {name} from {path}", exc_info=err)
                 continue

--- a/src/streamlink/utils/module.py
+++ b/src/streamlink/utils/module.py
@@ -1,15 +1,30 @@
-from importlib.machinery import SOURCE_SUFFIXES, FileFinder, SourceFileLoader
+from importlib.abc import PathEntryFinder
+from importlib.machinery import FileFinder
 from importlib.util import module_from_spec
+from pathlib import Path
+from pkgutil import get_importer
+from types import ModuleType
+from typing import Union
 
 
-_loader_details = [(SourceFileLoader, SOURCE_SUFFIXES)]
+def load_module(name: str, path: Union[Path, str]) -> ModuleType:
+    path = str(path)
+    finder = get_importer(path)
+    if not finder:
+        raise ImportError(f"Not a package path: {path}", path=path)
+
+    return exec_module(finder, name)
 
 
-def load_module(name, path=None):
-    finder = FileFinder(path, *_loader_details)
+def exec_module(finder: PathEntryFinder, name: str) -> ModuleType:
     spec = finder.find_spec(name)
     if not spec or not spec.loader:
-        raise ImportError(f"no module named {name}")
+        raise ImportError(
+            f"No module named '{name}'",
+            name=name,
+            path=finder.path if isinstance(finder, FileFinder) else None,
+        )
     mod = module_from_spec(spec)
     spec.loader.exec_module(mod)
+
     return mod

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -103,7 +103,7 @@ class TestLoadPlugins:
         logs: list,
     ):
         monkeypatch.setattr("streamlink.session.Streamlink.load_builtin_plugins", Mock())
-        monkeypatch.setattr("streamlink.session.load_module", Mock(side_effect=side_effect))
+        monkeypatch.setattr("streamlink.session.exec_module", Mock(side_effect=side_effect))
         session = Streamlink()
         with raises:
             session.load_plugins(str(PATH_TESTPLUGINS))

--- a/tests/utils/test_module.py
+++ b/tests/utils/test_module.py
@@ -1,5 +1,5 @@
-import os.path
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -9,12 +9,40 @@ from streamlink.utils.module import load_module
 # used in the import test to verify that this module was imported
 __test_marker__ = "test_marker"
 
+_here = Path(__file__).parent
 
-class TestUtilsModule:
-    def test_load_module_non_existent(self):
-        with pytest.raises(ImportError):
-            load_module("non_existent_module", os.path.dirname(__file__))
 
-    def test_load_module(self):
-        assert load_module(__name__.split(".")[-1], os.path.dirname(__file__)).__test_marker__ \
-               == sys.modules[__name__].__test_marker__
+@pytest.mark.parametrize(("name", "path", "expected"), [
+    pytest.param(
+        "some_module",
+        _here / "does_not_exist",
+        ImportError(
+            f"Not a package path: {_here / 'does_not_exist'}",
+            path=str(_here / "does_not_exist"),
+        ),
+        id="no-package",
+    ),
+    pytest.param(
+        "does_not_exist",
+        _here,
+        ImportError(
+            "No module named 'does_not_exist'",
+            name="does_not_exist",
+            path=str(_here),
+        ),
+        id="no-module",
+    ),
+])
+def test_load_module_importerror(name: str, path: Path, expected: ImportError):
+    with pytest.raises(ImportError) as cm:
+        load_module(name, path)
+    assert cm.value.msg == expected.msg
+    assert cm.value.name == expected.name
+    assert cm.value.path == expected.path
+
+
+def test_load_module():
+    mod = load_module(__name__.split(".")[-1], Path(__file__).parent)
+    assert "__test_marker__" in mod.__dict__
+    assert mod is not sys.modules[__name__]
+    assert mod.__test_marker__ == sys.modules[__name__].__test_marker__


### PR DESCRIPTION
Minor performance improvement for loading (plugin) modules. This is unrelated to the plugins JSON data loader I've been working on, hence this PR.

----

1. **utils.module: fix load_module(), add exec_module()**
    - Use global finder cache via `pkgutil.get_importer()` instead of always creating a new `FileFinder` object for each module
    - Add `exec_module()` for being able to reuse `PathEntryFinder` objects returned by `pkgutil.iter_modules()`
    - Add support for pathlib path objects
    - Update tests
2. **session: re-use PathEntryFinder in load_plugins()**
3. **tests: re-use PathEntryFinder in test_plugins**