### PR TITLE
utils.parse: fix import path

### DIFF
--- a/src/streamlink/utils/parse.py
+++ b/src/streamlink/utils/parse.py
@@ -5,7 +5,7 @@ from urllib.parse import parse_qsl
 from lxml.etree import HTML, XML
 
 from streamlink.compat import detect_encoding
-from streamlink.plugin import PluginError
+from streamlink.exceptions import PluginError
 
 
 def _parse(parser, data, name, exception, schema, *args, **kwargs):


### PR DESCRIPTION
This avoids a circular import