### PR TITLE
options: compare equality of Argument objects

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -55,9 +55,6 @@ _PLUGINARGUMENT_TYPE_REGISTRY: Dict[str, Callable[[Any], Any]] = {
 }
 
 
-_T = TypeVar("_T")
-
-
 log = logging.getLogger(__name__)
 
 # FIXME: This is a crude attempt at making a bitrate's
@@ -671,6 +668,9 @@ def pluginmatcher(
     return decorator
 
 
+_TChoices = TypeVar("_TChoices", bound=Iterable)
+
+
 # noinspection GrazieInspection,PyShadowingBuiltins
 def pluginargument(
     name: str,
@@ -678,10 +678,10 @@ def pluginargument(
     nargs: Optional[Union[int, Literal["?", "*", "+"]]] = None,
     const: Any = None,
     default: Any = None,
-    type: Optional[Union[str, Callable[[Any], _T]]] = None,  # noqa: A002
+    type: Optional[Union[str, Callable[[Any], Union[_TChoices, Any]]]] = None,  # noqa: A002
     type_args: Optional[Sequence[Any]] = None,
     type_kwargs: Optional[Dict[str, Any]] = None,
-    choices: Optional[Iterable[_T]] = None,
+    choices: Optional[_TChoices] = None,
     required: bool = False,
     help: Optional[str] = None,  # noqa: A002
     metavar: Optional[Union[str, Sequence[str]]] = None,
@@ -726,7 +726,7 @@ def pluginargument(
     assuming the plugin's module name is ``myplugin``.
     """
 
-    _type: Optional[Callable[[Any], _T]]
+    _type: Optional[Callable[[Any], _TChoices]]
     if not isinstance(type, str):
         _type = type
     else:

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,6 +3,7 @@ import argparse
 import pytest
 
 from streamlink.options import Argument, Arguments, Options
+from streamlink.utils.args import comma_list_filter
 
 
 class TestOptions:
@@ -163,7 +164,7 @@ class TestArgument:
             "nargs": 2,
             "default": (0, 0),
             "type": int,
-            "choices": [1, 2, 3],
+            "choices": (1, 2, 3),
             "help": argparse.SUPPRESS,
             "metavar": ("ONE", "TWO"),
             "dest": "dest",
@@ -178,6 +179,42 @@ class TestArgument:
             "action": "store_const",
             "const": 123,
         }
+
+    def test_equality(self):
+        a1 = Argument(
+            "test",
+            action="append",
+            nargs=2,
+            default=("0", "0"),
+            type=comma_list_filter(["1", "2", "3"], unique=True),
+            choices=["1", "2", "3"],
+            required=True,
+            help=argparse.SUPPRESS,
+            metavar=("ONE", "TWO"),
+            dest="dest",
+            requires=["other"],
+            prompt="Test!",
+            sensitive=False,
+            argument_name="custom-name",
+        )
+        a2 = Argument(
+            "test",
+            action="append",
+            nargs=2,
+            default=("0", "0"),
+            type=comma_list_filter(["1", "2", "3"], unique=True),
+            choices=["1", "2", "3"],
+            required=True,
+            help=argparse.SUPPRESS,
+            metavar=("ONE", "TWO"),
+            dest="dest",
+            requires=["other"],
+            prompt="Test!",
+            sensitive=False,
+            argument_name="custom-name",
+        )
+        assert a1 is not a2
+        assert a1 == a2
 
 
 class TestArguments:

--- a/tests/utils/test_args.py
+++ b/tests/utils/test_args.py
@@ -63,6 +63,12 @@ def test_comma_list_filter(options: dict, value: str, expected: List[str]):
     assert func(value) == expected
 
 
+def test_comma_list_filter_hashable():
+    assert hash(comma_list_filter(["1", "2"])) != hash(comma_list_filter(["1", "2", "3"]))
+    assert hash(comma_list_filter(["1", "2"], unique=True)) == hash(comma_list_filter(["1", "2"], unique=True))
+    assert hash(comma_list_filter(["1", "2"], unique=True)) != hash(comma_list_filter(["1", "2"], unique=False))
+
+
 @pytest.mark.parametrize(("value", "expected", "raises"), [
     ("12345", 12345, does_not_raise),
     ("123.45", int(123.45), does_not_raise),
@@ -175,3 +181,11 @@ class TestNum:
     def test_operator(self, operators: dict, value: float, raises: nullcontext):
         with raises:
             assert num(int, **operators)(value) == value
+
+    def test_hashable(self):
+        assert hash(num(int, ge=1)) == hash(num(int, ge=1))
+        assert hash(num(float, ge=1.0)) == hash(num(float, ge=1.0))
+        assert hash(num(int, ge=1)) != hash(num(int, gt=1))
+        assert hash(num(int, ge=1)) != hash(num(int, le=1))
+        assert hash(num(int, ge=1)) != hash(num(int, lt=1))
+        assert hash(num(int, ge=1)) != hash(num(float, ge=1.0))

--- a/tests/utils/test_times.py
+++ b/tests/utils/test_times.py
@@ -181,6 +181,9 @@ class TestHoursMinutesSeconds:
         assert "error: argument hms: invalid hours_minutes_seconds value: 'invalid'\n" in stderr, \
             "has the correct method name, so argparse errors are useful"
 
+    def test_hours_minutes_seconds_hashable(self):
+        assert hash(hours_minutes_seconds) != hash(hours_minutes_seconds_float)
+
     def test_seconds_to_hhmmss(self):
         assert seconds_to_hhmmss(0) == "00:00:00"
         assert seconds_to_hhmmss(1) == "00:00:01"


### PR DESCRIPTION
Necessary for being able to compare the `Argument` objects built from JSON in the lazy-plugins loader tests for equality.

Opening a separate PR, so these unrelated changes don't bloat up the lazy-plugins stuff (still WIP).

First commits allows hashing the `Argument.type` attribute.