### PR TITLE
ci.github: bump actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         env:
           SIGNING_KEY_ID: 1AEB6400EDA27DA9
           SIGNING_KEY_PASSPHRASE: ${{ secrets.SIGNING_KEY_PASSPHRASE }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -66,7 +66,7 @@ jobs:
           python -m pip install -U
           jinja2
           requests
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,11 @@ jobs:
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           name: os:${{ matrix.runs-on }} py:${{ matrix.python-version }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   documentation:
     name: Test docs


### PR DESCRIPTION
Bump remaining actions being based on the deprecated NodeJS 16 runners.

1. `upload/download-artifact`:
   https://github.com/actions/upload-artifact/blob/v4.3.1/docs/MIGRATION.md
   No changes here, since it's a trivial 1:1 artifact name mapping
2. `codecov/codecov-action`:
   https://github.com/codecov/codecov-action/blob/v4.0.1/README.md#v4-release
   No more token-less uploads. I've added the `CODECOV_TOKEN` secret env var to the repo.