### PR TITLE
docs: fix custom ext_argparse Sphinx extension

### DIFF
--- a/docs/_man.rst
+++ b/docs/_man.rst
@@ -31,8 +31,6 @@ Options
 -------
 
 .. argparse::
-    :module: streamlink_cli.main
-    :attr: parser_helper
 
 
 Bugs

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -24,5 +24,3 @@ Command-line usage
 
 
 .. argparse::
-    :module: streamlink_cli.main
-    :attr: parser_helper

--- a/script/build-shell-completions.sh
+++ b/script/build-shell-completions.sh
@@ -23,7 +23,7 @@ for shell in "${!COMPLETIONS[@]}"; do
   python -m shtab \
     "--shell=${shell}" \
     --error-unimportable \
-    streamlink_cli.main.parser_helper \
+    streamlink_cli._parser.get_parser \
     > "${dist}"
   echo "Completions for ${shell} written to ${dist}"
 done

--- a/src/streamlink_cli/_parser.py
+++ b/src/streamlink_cli/_parser.py
@@ -1,0 +1,16 @@
+"""
+Utility module for importing Streamlink's argparse.ArgumentParser instance
+when building the documentation, man page or command-line shell completions.
+"""
+
+from streamlink.session import Streamlink
+from streamlink_cli.argparser import build_parser
+from streamlink_cli.main import setup_plugin_args
+
+
+def get_parser():
+    session = Streamlink(plugins_builtin=True)
+    parser = build_parser()
+    setup_plugin_args(session, parser)
+
+    return parser

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -952,10 +952,3 @@ def main():
         )
 
     sys.exit(error_code)
-
-
-def parser_helper():
-    session = Streamlink(plugins_builtin=True)
-    parser = build_parser()
-    setup_plugin_args(session, parser)
-    return parser


### PR DESCRIPTION
- Move the `parser_helper()` function from `streamlink_cli.main` into the `streamlink_cli._parser` module
- Refactor `ext_argparse` and set default import paths
- Update import path in `build-shell-completions.sh`

Unfortunately, the `streamlink_cli._parser` module can't be excluded from the sdist/wheel distributions, as packagers might build shell completions from the installed `streamlink_cli` package instead of using the pre-built shell completions included in the sdist or building them from an editable install.

----

This helper function was added in #1638 and serves no purpose in the CLI's main module itself. It should therefore not be a part of it.