### PR TITLE
docs: fix scrollbars in sidebars

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -109,6 +109,10 @@ a[href^="https://"]:not(.no-external-link-icon):not(.muted-link):not(.sd-badge):
   Sidebar/Menubar and related
 */
 
+.sidebar-scroll, .toc-scroll {
+  overflow: hidden auto;
+}
+
 .toc-scroll:not(:hover) {
   scrollbar-color: transparent !important;
 }


### PR DESCRIPTION
This fixes horizontal scrollbars appearing in sidebars when there's a vertical non-overlay scrollbar (overlay scrollbars depend on the web browser and its settings).

Alternatively, `scrollbar-gutter: stable` could be set, but this would always claim space for the scrollbar, even if it's not visible, and that doesn't make sense for the left sidebar at least.

![image](https://github.com/streamlink/streamlink/assets/467294/242a87ab-410d-4bd5-b618-9e5e15fbae28)

This also fixes the scrollbar being visible at all times in the TOC sidebar

![image](https://github.com/streamlink/streamlink/assets/467294/401ed9b0-dfef-4a4f-8957-f8528bf0e6ca)
