### PR TITLE
cli: ignore coverage in _parser util module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ omit = [
   "src/streamlink/packages/*",
   "src/streamlink/webbrowser/cdp/devtools/*",
   "src/streamlink_cli/packages/*",
+  "src/streamlink_cli/_parser.py",
 ]
 exclude_lines = [
   "pragma: no cover",


### PR DESCRIPTION
Should've been included in #5819