### PR TITLE
ci.github: bump setup-python action to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 300
       - name: Fetch tags
         run: git fetch --depth=300 origin +refs/tags/*:refs/tags/*
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install Python dependencies


### PR DESCRIPTION
789e89a already bumped the setup-python actions on the master branch, but the `test_build` job was merged in a later commit (authored earlier) with the old action version in use.

----

Fixes the deprecated NodeJS 16 CI runners