### PR TITLE
build: bump setuptools to >=65.6

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -429,7 +429,7 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
       - At least version **3.8**
     * - build
       - `setuptools`_
-      - At least version **64.0.0** |br|
+      - At least version **65.6.0** |br|
         Used as build backend
     * - build
       - `wheel`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >=64",
+  "setuptools >=65.6",
   "wheel",
   # The versioningit build-requirement gets removed from the source distribution,
   # as the version string is already built into it (see the onbuild versioningit hook):


### PR DESCRIPTION
Resolves #5841 

----

bad

```sh
docker run --rm -i --mount type=bind,source=./dist,target=/dist python:3.11 bash <<"EOF"
cd "$(mktemp -d)"
tar -xzf /dist/streamlink-6.6.1+2.g47cebc73.tar.gz --strip-components=1
python -m pip install build
python -m build --no-isolation --wheel
EOF
```
```
ERROR Missing dependencies:
        setuptools>=65.6
```

----

good

```sh
docker run --rm -i --mount type=bind,source=./dist,target=/dist python:3.11 bash <<"EOF"
cd "$(mktemp -d)"
tar -xzf /dist/streamlink-6.6.1+2.g47cebc73.tar.gz --strip-components=1
python -m pip install build setuptools==65.6 versioningit
python -m build --no-isolation --wheel
EOF
```
```
Successfully built streamlink-6.6.1+2.g47cebc73-py3-none-any.whl
```