### PR TITLE
session: fix missing plugin override log message

### DIFF
--- a/src/streamlink/session/plugins.py
+++ b/src/streamlink/session/plugins.py
@@ -179,7 +179,7 @@ class StreamlinkPlugins:
             if lookup is None:
                 continue
             mod, plugin = lookup
-            if name in self._plugins:
+            if name in self._plugins or name in self._matchers:
                 log.info(f"Plugin {name} is being overridden by {mod.__file__}")
             plugins[name] = plugin
 

--- a/tests/session/test_plugins.py
+++ b/tests/session/test_plugins.py
@@ -131,6 +131,11 @@ class TestLoad:
         assert session.plugins["testplugin"].__module__ == "streamlink.plugins.testplugin"
         assert caplog.record_tuples == []
 
+    def test_load_path_testplugins_override(self, caplog: pytest.LogCaptureFixture, session: Streamlink):
+        assert session.plugins.load_path(PATH_TESTPLUGINS)
+        assert "testplugin" in session.plugins
+        assert caplog.record_tuples == []
+
         assert session.plugins.load_path(PATH_TESTPLUGINS_OVERRIDE)
         assert "testplugin" in session.plugins
         assert session.plugins.get_names() == ["testplugin"]
@@ -141,6 +146,26 @@ class TestLoad:
                 "streamlink.session",
                 "info",
                 f"Plugin testplugin is being overridden by {PATH_TESTPLUGINS_OVERRIDE / 'testplugin.py'}",
+            ),
+        ]
+
+    def test_load_path_testplugins_override_matchers(self, caplog: pytest.LogCaptureFixture, session: Streamlink):
+        assert _TestPlugin.matchers
+        session.plugins._matchers.update({"testplugin": _TestPlugin.matchers})
+
+        assert "testplugin" not in session.plugins
+        assert session.plugins.get_names() == ["testplugin"]
+        assert caplog.record_tuples == []
+
+        assert session.plugins.load_path(PATH_TESTPLUGINS)
+        assert session.plugins.get_names() == ["testplugin"]
+        assert session.plugins["testplugin"].__name__ == "TestPlugin"
+        assert session.plugins["testplugin"].__module__ == "streamlink.plugins.testplugin"
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.session",
+                "info",
+                f"Plugin testplugin is being overridden by {PATH_TESTPLUGINS / 'testplugin.py'}",
             ),
         ]
 


### PR DESCRIPTION
Fixes #5843 

I didn't notice the missing log message because apparently I only checked this in a live environment from an editable install where all plugins get loaded at once like before, unlike in non-editable installs.

This bugfix justifies another patch release after merging. Will publish 6.6.2 later today...

----

```
$ pip install -q .
$ streamlink -V
streamlink 6.6.1+3.g21ef70bc
$ streamlink twitch.tv/smoke
[session][info] Plugin twitch is being overridden by /home/basti/.local/share/streamlink/plugins/twitch.py
[cli][info] Found matching plugin twitch for URL twitch.tv/smoke
Available streams: audio_only, 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
```