### PR TITLE
plugins.afreeca: fix broadcast number regex

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -50,7 +50,7 @@ class AfreecaHLSStream(HLSStream):
     help="Purge cached AfreecaTV credentials to initiate a new session and reauthenticate.",
 )
 class AfreecaTV(Plugin):
-    _re_bno = re.compile(r"var nBroadNo = (?P<bno>\d+);")
+    _re_bno = re.compile(r"window.nBroadNo = (?P<bno>\d+);")
 
     CHANNEL_API_URL = "http://live.afreecatv.com/afreeca/player_live_api.php"
     CHANNEL_RESULT_OK = 1

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -52,7 +52,7 @@ class AfreecaHLSStream(HLSStream):
 class AfreecaTV(Plugin):
     _re_bno = re.compile(r"window\.nBroadNo\s*=\s*(?P<bno>\d+);")
 
-    CHANNEL_API_URL = "http://live.afreecatv.com/afreeca/player_live_api.php"
+    CHANNEL_API_URL = "https://live.afreecatv.com/afreeca/player_live_api.php"
     CHANNEL_RESULT_OK = 1
     QUALITYS = ["original", "hd", "sd"]
     QUALITY_WEIGHTS = {
@@ -77,7 +77,7 @@ class AfreecaTV(Plugin):
     _schema_stream = validate.Schema(
         {
             validate.optional("view_url"): validate.url(
-                scheme=validate.any("rtmp", "http"),
+                scheme=validate.any("rtmp", "https"),
             ),
             "stream_status": str,
         },

--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -50,7 +50,7 @@ class AfreecaHLSStream(HLSStream):
     help="Purge cached AfreecaTV credentials to initiate a new session and reauthenticate.",
 )
 class AfreecaTV(Plugin):
-    _re_bno = re.compile(r"window.nBroadNo = (?P<bno>\d+);")
+    _re_bno = re.compile(r"window\.nBroadNo\s*=\s*(?P<bno>\d+);")
 
     CHANNEL_API_URL = "http://live.afreecatv.com/afreeca/player_live_api.php"
     CHANNEL_RESULT_OK = 1


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
Resolves: #5845 

I found a changes for the `https://play.afreecatv.com/{username}`.
By modifying the regex, streamlink can get the stream URL correctly.

```
[session][debug] Plugin afreeca is being overridden by /home/b4tt3ry/.local/share/streamlink/plugins/afreeca.py
[cli][debug] OS:         Linux-6.5.11-8-pve-x86_64-with-glibc2.38
[cli][debug] Python:     3.11.6
[cli][debug] OpenSSL:    OpenSSL 3.2.1 30 Jan 2024
[cli][debug] Streamlink: 6.5.1
[cli][debug] Dependencies:
[cli][debug]  certifi: 2023.11.17
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.2
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.24.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.9.0
[cli][debug]  urllib3: 1.26.18
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  url=https://play.afreecatv.com/ecvhao/
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin afreeca for URL https://play.afreecatv.com/ecvhao/
Available streams: sd (worst), hd, original (best)
```