### PR TITLE
plugins.afreeca: support metadata

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -2,9 +2,9 @@
 $description TV and live video game broadcasts, artist performances and personal daily-life video blogs & shows.
 $url play.afreecatv.com
 $type live
-+$metadata id
-+$metadata author
-+$metadata title
+$metadata id
+$metadata author
+$metadata title
 """
 
 import logging


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Resolves: #5813 

I don't know if it's right to handle it this way.
Nickname and title written in Korean are displayed as Unicode.
I'm not very familiar with python so I don't know how to handle this.

```json
{
  "plugin": "afreeca",
  "metadata": {
    "id": "ecvhao",
    "author": "\uc6b0\uc641\uad73",
    "category": null,
    "title": "\uc774\ub2c8\uc15cD 2\uae30 \ub05d\uae4c\uc9c0 \ubcf4\ub294 \ub0a0"
  },
  ...
}
```