### PR TITLE
plugins.mangomolo: new plugin

### DIFF
--- a/src/streamlink/plugins/mangomolo.py
+++ b/src/streamlink/plugins/mangomolo.py
@@ -1,0 +1,52 @@
+"""
+$description OTT video platform owned by Alpha Technology Group
+$url media.gov.kw
+$type live
+"""
+
+import logging
+import re
+
+from streamlink.exceptions import NoStreamsError
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream import HLSStream
+from streamlink.utils.url import update_scheme
+
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(
+    name="mangomoloplayer",
+    pattern=re.compile(r"https?://player\.mangomolo\.com/v1/"),
+)
+@pluginmatcher(
+    name="mediagovkw",
+    pattern=re.compile(r"https?://media\.gov\.kw/"),
+)
+class Mangomolo(Plugin):
+    def _get_player_url(self):
+        player_url = self.session.http.get(self.url, schema=validate.Schema(
+            validate.parse_html(),
+            validate.xml_xpath_string(".//iframe[contains(@src,'//player.mangomolo.com/v1/')][1]/@src"),
+        ))
+        if not player_url:
+            log.error("Could not find embedded player")
+            raise NoStreamsError
+
+        self.url = update_scheme("https://", player_url)
+
+    def _get_streams(self):
+        if not self.matches["mangomoloplayer"]:
+            self._get_player_url()
+
+        hls_url = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"src\s*:\s*(?P<q>[\"'])(?P<url>https?://\S+?\.m3u8\S*?)(?P=q)"),
+            validate.none_or_all(validate.get("url")),
+        ))
+        if hls_url:
+            return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+
+__plugin__ = Mangomolo

--- a/tests/plugins/test_mangomolo.py
+++ b/tests/plugins/test_mangomolo.py
@@ -1,0 +1,22 @@
+from streamlink.plugins.mangomolo import Mangomolo
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlMangomolo(PluginCanHandleUrl):
+    __plugin__ = Mangomolo
+
+    should_match = [
+        (
+            "mangomoloplayer",
+            "https://player.mangomolo.com/v1/live?id=MTk1&channelid=MzU1&countries=bnVsbA==&w=100%25&h=100%25"
+            + "&autoplay=true&filter=none&signature=9ea6c8ed03b8de6e339d6df2b0685f25&app_id=43",
+        ),
+        (
+            "mediagovkw",
+            "https://media.gov.kw/LiveTV.aspx?PanChannel=KTV1",
+        ),
+        (
+            "mediagovkw",
+            "https://media.gov.kw/LiveTV.aspx?PanChannel=KTVSports",
+        ),
+    ]


### PR DESCRIPTION
Resolves #5850 
Rel #5848

- https://www.mangomolo.com/about-us
- https://www.mangomolo.com/products
- https://www.google.com/search?q=Alpha+Technology+Group

```
$ ./script/test-plugin-urls.py mangomolo
:: Finding streams for URL: https://media.gov.kw/LiveTV.aspx?PanChannel=KTV1
:: Found streams: 240p, 360p, 720p, 1080p, worst, best
:: Finding streams for URL: https://media.gov.kw/LiveTV.aspx?PanChannel=KTVSports
:: Found streams: 240p, 360p, 720p, 1080p, worst, best
:: Finding streams for URL: https://player.mangomolo.com/v1/live?id=MTk1&channelid=MzU1&countries=bnVsbA==&w=100%25&h=100%25&autoplay=true&filter=none&signature=9ea6c8ed03b8de6e339d6df2b0685f25&app_id=43
:: Found streams: 240p, 360p, 720p, 1080p, worst, best
```

I wish there were a better way for platforms like this where other companies/organizations embed their player into their site. Adding plugin matchers with a low priority that matches everything is surely not the right idea, so embedding sites need to be added explicitly. Maybe it's worth figuring out a solution. That would allow sites which embed YouTube or Vimeo player or what not to be matched. Maybe an `embed://` plugin which tries to find embedded players by making another plugin lookup on the session instance.