### PR TITLE
plugins.vimeo: fix missing HLS/DASH API results

### DIFF
--- a/src/streamlink/plugins/vimeo.py
+++ b/src/streamlink/plugins/vimeo.py
@@ -171,10 +171,12 @@ class Vimeo(Plugin):
 
         streams = []
 
+        hls = hls or {}
         for url in hls.values():
             streams.extend(HLSStream.parse_variant_playlist(self.session, url).items())
             break
 
+        dash = dash or {}
         for url in dash.values():
             p = urlparse(url)
             if p.path.endswith("dash.mpd"):


### PR DESCRIPTION
Fixes #5702

HLS and DASH stream data is set to optional in the API response validation schema:
https://github.com/streamlink/streamlink/blob/6.6.2/src/streamlink/plugins/vimeo.py#L56-L57

If the data is missing from the API response, then its value will be `None`, hence the `AttributeError` when trying to call `.values()` for iterating over the data.

Didn't check this on actual live event streams, because I don't know how to find them on Vimeo. This PR fixes the `AttributeError`, but I don't know if live events are actually working.

@WolfganP @Sparticuz
Please see if there are any other issues while trying to watch live event streams, thanks.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback