### PR TITLE
plugins.ltv_lsm_lv: fix plugin, rm LTVHLSStream

### DIFF
--- a/src/streamlink/plugins/ltv_lsm_lv.py
+++ b/src/streamlink/plugins/ltv_lsm_lv.py
@@ -1,73 +1,42 @@
 """
 $description Live TV channels from LTV, a Latvian public, state-owned broadcaster.
 $url ltv.lsm.lv
-$type live
+$url replay.lsm.lv
+$type live, vod
 $region Latvia
 """
 
 import logging
 import re
-from urllib.parse import urlsplit, urlunsplit
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker
+from streamlink.stream.hls import HLSStream
 
 
 log = logging.getLogger(__name__)
 
 
-def copy_query_url(to, from_):
-    """
-    Replace the query string in one URL with the query string from another URL
-    """
-    return urlunsplit(urlsplit(to)._replace(query=urlsplit(from_).query))
-
-
-class LTVHLSStreamWorker(HLSStreamWorker):
-    def process_segments(self, playlist, segments):
-        super().process_segments(playlist, segments)
-        # update the segment URLs with the query string from the playlist URL
-        for sequence in segments:
-            sequence.uri = copy_query_url(sequence.uri, self.stream.url)
-
-
-class LTVHLSStreamReader(HLSStreamReader):
-    __worker__ = LTVHLSStreamWorker
-
-
-class LTVHLSStream(HLSStream):
-    __reader__ = LTVHLSStreamReader
-
-    @classmethod
-    def parse_variant_playlist(cls, *args, **kwargs):
-        streams = super().parse_variant_playlist(*args, **kwargs)
-
-        for stream in streams.values():
-            stream.args["url"] = copy_query_url(stream.args["url"], stream.multivariant.uri)
-
-        return streams
-
-
 @pluginmatcher(re.compile(
-    r"https://ltv\.lsm\.lv/lv/tiesraide",
+    r"https://(?:ltv|replay)\.lsm\.lv/(?:lv/tiesraide|ru/efir)/",
 ))
 class LtvLsmLv(Plugin):
-    URL_IFRAME = "https://ltv.lsm.lv/embed/live?c={embed_id}"
     URL_API = "https://player.cloudycdn.services/player/ltvlive/channel/{channel_id}/"
 
     def _get_streams(self):
         self.session.http.headers.update({"Referer": self.url})
 
-        embed_id = self.session.http.get(self.url, schema=validate.Schema(
-            re.compile(r"""embed_id\s*:\s*(?P<q>")(?P<embed_id>\w+)(?P=q)"""),
-            validate.any(None, validate.get("embed_id")),
+        iframe_url = self.session.http.get(self.url, schema=validate.Schema(
+            re.compile(r"""(?P<q>")https:\\u002F\\u002Fltv\.lsm\.lv\\u002Fembed\\u002Flive\?\S+?(?P=q)"""),
+            validate.none_or_all(
+                validate.get(0),
+                validate.parse_json(),
+            ),
         ))
-        if not embed_id:
+        if not iframe_url:
+            log.error("Could not find video player iframe")
             return
-        log.debug(f"Found embed ID: {embed_id}")
 
-        iframe_url = self.URL_IFRAME.format(embed_id=embed_id)
         starts_at, channel_id = self.session.http.get(iframe_url, schema=validate.Schema(
             validate.parse_html(),
             validate.xml_xpath_string(".//live[1]/@*[name()=':embed-data']"),
@@ -112,7 +81,7 @@ class LtvLsmLv(Plugin):
             ),
         )
         for surl in stream_sources:
-            yield from LTVHLSStream.parse_variant_playlist(self.session, surl).items()
+            yield from HLSStream.parse_variant_playlist(self.session, surl).items()
 
 
 __plugin__ = LtvLsmLv

--- a/tests/plugins/test_ltv_lsm_lv.py
+++ b/tests/plugins/test_ltv_lsm_lv.py
@@ -6,20 +6,15 @@ class TestPluginCanHandleUrlLtvLsmLv(PluginCanHandleUrl):
     __plugin__ = LtvLsmLv
 
     should_match = [
-        "https://ltv.lsm.lv/lv/tiesraide/example/",
-        "https://ltv.lsm.lv/lv/tiesraide/example/",
-        "https://ltv.lsm.lv/lv/tiesraide/example/live.123/",
-        "https://ltv.lsm.lv/lv/tiesraide/example/live.123/",
-    ]
-
-    should_not_match = [
-        "https://ltv.lsm.lv",
-        "http://ltv.lsm.lv",
-        "https://ltv.lsm.lv/lv",
-        "http://ltv.lsm.lv/lv",
-        "https://ltv.lsm.lv/other-site/",
-        "http://ltv.lsm.lv/other-site/",
-        "https://ltv.lsm.lv/lv/other-site/",
-        "http://ltv.lsm.lv/lv/other-site/",
-        "https://ltv.lsm.lv/lv/tieshraide/example/",
+        "https://ltv.lsm.lv/lv/tiesraide/ltv1",
+        "https://ltv.lsm.lv/lv/tiesraide/ltv7",
+        "https://ltv.lsm.lv/lv/tiesraide/visiem",
+        "https://ltv.lsm.lv/lv/tiesraide/lr1",
+        "https://ltv.lsm.lv/lv/tiesraide/lr2",
+        "https://ltv.lsm.lv/lv/tiesraide/lr3",
+        "https://ltv.lsm.lv/lv/tiesraide/lr4",
+        "https://ltv.lsm.lv/lv/tiesraide/lr5",
+        "https://ltv.lsm.lv/lv/tiesraide/lr6",
+        "https://replay.lsm.lv/lv/tiesraide/ltv7/sporta-studija-aizkulises",
+        "https://replay.lsm.lv/ru/efir/ltv7/sporta-studija-aizkulises",
     ]


### PR DESCRIPTION
Fixes #5857 

Two issues:
1. The site has changed and the embedded player ID can't be extracted separately anymore, so the whole embedded player URL needs to be found instead
2. The plugin's custom `HLSStreamWorker` subclass was not updated after some changes were made in the base class, resulting in an incompatible signature of `LTVHLSStreamWorker.process_segments()` (probably the reason why @karlis-vagalis was using the `--stream-url` parameter)

@karlis-vagalis please check and verify these plugin fixes using a couple of different stream URLs, as the live content is geo-blocked for me and it's only listing replays/VODs on their site. Please include a short debug log (without `--stream-url`), thanks.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

I also have no idea if the custom HLSStream implementation is even necessary anymore. The streams apparently are working fine without it, but I can't say that this is the case for every stream on their site. `--stream-url` completely bypasses Streamlink's HLS implementation, including the plugin's custom subclass of course, so if the streams have been working previously using that CLI parameter, then that would suggest that the custom HLS implementation with the playlist+segment URL query string overrides is indeed unnecessary.

```
$ streamlink -l debug 'https://ltv.lsm.lv/lv/tiesraide/ltv1' best
[cli][debug] OS:         Linux-6.7.6-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.2
[cli][debug] OpenSSL:    OpenSSL 3.2.1 30 Jan 2024
[cli][debug] Streamlink: 6.6.2+1.g6f09f947
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.2.2
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.1.0
[cli][debug]  pycountry: 23.12.11
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.24.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.9.0
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  url=https://ltv.lsm.lv/lv/tiesraide/ltv1
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin ltv_lsm_lv for URL https://ltv.lsm.lv/lv/tiesraide/ltv1
[plugins.ltv_lsm_lv][debug] Found channel ID: x44_ltv06-ltv1-g
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 360p (worst), 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 77130; Last Sequence: 77134
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 77132; End Sequence: None
[stream.hls][debug] Adding segment 77132 to queue
[stream.hls][debug] Adding segment 77133 to queue
[stream.hls][debug] Adding segment 77134 to queue
[stream.hls][debug] Writing segment 77132 to output
[stream.hls][debug] Segment 77132 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://ltv.lsm.lv/lv/tiesraide/ltv1', '-']
[stream.hls][debug] Writing segment 77133 to output
[stream.hls][debug] Segment 77133 complete
[stream.hls][debug] Writing segment 77134 to output
[stream.hls][debug] Segment 77134 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 77135 to queue
[stream.hls][debug] Writing segment 77135 to output
[stream.hls][debug] Segment 77135 complete
[stream.hls][debug] Reloading playlist
...
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```