### PR TITLE
cli: only log args with the same dest once

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -824,9 +824,11 @@ def log_current_arguments(session: Streamlink, parser: argparse.ArgumentParser):
                 sensitive.add(parg.argument_name(pname))
 
     log.debug("Arguments:")
+    seen = set()
     for action in parser._actions:
-        if not hasattr(args, action.dest):
+        if not hasattr(args, action.dest) or action.dest in seen:
             continue
+        seen.add(action.dest)
         value = getattr(args, action.dest)
         if action.default != value:
             name = next(  # pragma: no branch


### PR DESCRIPTION
This prevents args from being logged in the debug output twice if two or more args share the same `dest`.

For example, I want to add `--plugin-dir` (`action="append"`) in addition to `--plugin-dirs` (`type=comma_list, action="expand"`). `--plugin-dir` will have the same `dest="plugin_dirs"`, so both arguments can be merged into the same attribute on the arguments namespace object `args.plugin_dirs`. Without this change, it'll log both args.

No tests, because the current test setup is still `unittest.TestCase` based and needs a rewrite first. I don't want to touch any of this code anymore.