### PR TITLE
cli: add --plugin-dir, deprecate --plugin-dirs

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,17 @@
 Deprecations
 ============
 
+streamlink 6.7.0
+----------------
+
+--plugin-dirs
+^^^^^^^^^^^^^
+
+The ``--plugin-dirs`` CLI argument for sideloading plugins from one or more custom directories, separated by commas,
+has been deprecated in favor of the newly added :option:`--plugin-dir` CLI argument, which only takes a single path,
+but can be set multiple times for loading plugins from more than one path.
+
+
 streamlink 6.6.0
 ----------------
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -219,13 +219,23 @@ def build_parser():
         """,
     )
     general.add_argument(
+        "--plugin-dir",
+        dest="plugin_dirs",
+        metavar="DIRECTORY",
+        action="append",
+        help="""
+        Load plugins from this directory.
+
+        Can be set multiple times to load plugins from multiple directories.
+        """,
+    )
+    general.add_argument(
         "--plugin-dirs",
         metavar="DIRECTORY",
         type=comma_list,
+        action="extend",
         help="""
-        Attempts to load plugins from these directories.
-
-        Multiple directories can be used by separating them with a comma.
+        Load plugins from a list of comma-separated directories. (deprecated)
         """,
     )
     general.add_argument(


### PR DESCRIPTION
See #5865

`--plugin-dirs` is a `comma_list` argument, which isn't ideal for path values. This therefore adds the `--plugin-dir` argument, which can be set multiple times with only one single path as argument value. Both argument values are merged into the `plugin_dirs` attribute on the arguments namespace object, so no changes are needed. But this also means that there's no deprecation warning when using the old argument.

```
$ streamlink -l debug --plugin-dir /tmp/foo --plugin-dir /tmp/bar --plugin-dirs /tmp/baz,/tmp/qux
[cli][warning] Plugin path /tmp/foo does not exist or is not a directory!
[cli][warning] Plugin path /tmp/bar does not exist or is not a directory!
[cli][warning] Plugin path /tmp/baz does not exist or is not a directory!
[cli][warning] Plugin path /tmp/qux does not exist or is not a directory!
[cli][debug] OS:         Linux-6.7.6-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.2
[cli][debug] OpenSSL:    OpenSSL 3.2.1 30 Jan 2024
[cli][debug] Streamlink: 6.6.2+6.geef44a16
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.2.2
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.1.0
[cli][debug]  pycountry: 23.12.11
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.24.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.9.0
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  --plugin-dir=['/tmp/foo', '/tmp/bar', '/tmp/baz', '/tmp/qux']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io
```