### PR TITLE
Fix tests by resetting the log level

### DIFF
--- a/tests/cli/test_main_logging.py
+++ b/tests/cli/test_main_logging.py
@@ -33,10 +33,13 @@ def _setup(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
     monkeypatch.setattr("streamlink_cli.main.setup_signals", Mock())
     monkeypatch.setattr("streamlink_cli.argparser.find_default_player", Mock())
 
+    level = streamlink_cli.main.logger.root.level
+
     try:
         yield
     finally:
         streamlink_cli.main.logger.root.handlers.clear()
+        streamlink_cli.main.logger.root.setLevel(level)
         streamlink_cli.main.args = None  # type: ignore[assignment]
         streamlink_cli.main.console = None  # type: ignore[assignment]
 


### PR DESCRIPTION
While packing the version, I got tests errors, probably because the order of test execution wasn't the same.

`test_main_logging` tests are changing the log level by calling `streamlink_cli.main.setup(parser)`. We need to reset it to its default value on teardown.
The log level is set by this code in `setup`:
```
# We don't want log output when we are printing JSON or a command-line.
silent_log = any(getattr(args, attr) for attr in QUIET_OPTIONS)
log_level = args.loglevel if not silent_log else "none"
log_file = args.logfile if log_level != "none" else None
setup_logger_and_console(console_out, log_file, log_level, args.json)
```

Here is a test failure caused by this:
```
________________________ TestLogging.test_default_level ________________________

self = <tests.test_logger.TestLogging object at 0x7f9d4174eb90>

    def test_default_level(self):
>       assert logging.getLogger("streamlink").level == logger.WARNING
E       AssertionError: assert 9223372036854775807 == 30
E        +  where 9223372036854775807 = <StreamlinkLogger streamlink (none)>.level
E        +    where <StreamlinkLogger streamlink (none)> = <function getLogger at 0x7f9d46eeaca0>('streamlink')
E        +      where <function getLogger at 0x7f9d46eeaca0> = logging.getLogger
E        +  and   30 = logger.WARNING

tests/test_logger.py:90: AssertionError
```

<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
