### PR TITLE
plugins.vimeo: fix event and player URLs

### DIFF
--- a/tests/plugins/test_vimeo.py
+++ b/tests/plugins/test_vimeo.py
@@ -5,14 +5,16 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlVimeo(PluginCanHandleUrl):
     __plugin__ = Vimeo
 
-    should_match = [
-        ("default", "https://vimeo.com/783455878"),
-        ("default", "https://vimeo.com/channels/music/176894130"),
-        ("default", "https://vimeo.com/album/3706071/video/148903960"),
-        ("default", "https://vimeo.com/ondemand/worldoftomorrow3/467204924"),
-        ("default", "https://vimeo.com/ondemand/100footsurfingdays"),
-        ("default", "https://vimeo.com/771745400/840d05200c"),
-        ("player", "https://player.vimeo.com/video/176894130"),
+    should_match_groups = [
+        (("default", "https://vimeo.com/783455878"), {}),
+        (("default", "https://vimeo.com/channels/music/176894130"), {}),
+        (("default", "https://vimeo.com/ondemand/worldoftomorrow3/467204924"), {}),
+        (("default", "https://vimeo.com/ondemand/100footsurfingdays"), {}),
+
+        (("player", "https://player.vimeo.com/video/176894130"), {}),
+
+        (("event", "https://vimeo.com/event/4154130"), {"event_id": "4154130"}),
+        (("event", "https://vimeo.com/event/4154130/embed"), {"event_id": "4154130"}),
     ]
 
     should_not_match = [


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/pull/5854#issuecomment-2001985675

Some event streams are not accessible directly and the `oembed` API response doesn't include the `uri` attribute in this case. Accessing the embedded player of these events however seems to work and the config URL can be obtained this way. This PR splits up the `_query_api()` method and retrieves the `config_url` from events and non-event streams/videos separately.

The `player.vimeo.com` logic was also broken due to changes on their end, which should be fixed now.

No idea about other kinds of videos/streams. There's a high chance that some content is still not working correctly.

As can be seen in the tests diff, some URLs were removed, because they are not accessible anymore. Not sure if that's just the specific content or if these features were removed (e.g. album views). I don't use vimeo, so if anyone does have URLs of the same kind, please link, so they can be added to the tests.

```
$ ./script/test-plugin-urls.py vimeo
:: Finding streams for URL: https://player.vimeo.com/video/176894130
:: Found streams: 720p_hls, 360p_hls, 540p_hls, 240p_hls, 1080p_hls, 240p, 240p+a52k, 240p+a120k, 240p+a237k, 360p, 360p+a52k, 360p+a120k, 360p+a237k, 540p, 540p+a52k, 540p+a120k, 540p+a237k, 720p, 720p+a52k, 720p+a120k, 720p+a237k, 1080p, 1080p+a52k, 1080p+a120k, 1080p+a237k, worst, best
:: Finding streams for URL: https://vimeo.com/783455878
:: Found streams: 240p, 240p+a66k, 240p+a98k, 240p+a191k, 360p, 360p+a66k, 360p+a98k, 360p+a191k, 540p, 540p+a66k, 540p+a98k, 540p+a191k, 720p, 720p+a66k, 720p+a98k, 720p+a191k, 1080p, 1080p+a66k, 1080p+a98k, 1080p+a191k, worst, best
:: Finding streams for URL: https://vimeo.com/channels/music/176894130
:: Found streams: 720p_hls, 360p_hls, 540p_hls, 240p_hls, 1080p_hls, 240p, 240p+a52k, 240p+a120k, 240p+a237k, 360p, 360p+a52k, 360p+a120k, 360p+a237k, 540p, 540p+a52k, 540p+a120k, 540p+a237k, 720p, 720p+a52k, 720p+a120k, 720p+a237k, 1080p, 1080p+a52k, 1080p+a120k, 1080p+a237k, worst, best
:: Finding streams for URL: https://vimeo.com/event/4154130
:: Found streams: 240p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://vimeo.com/event/4154130/embed
:: Found streams: 240p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://vimeo.com/ondemand/100footsurfingdays
:: Found streams: 720p_hls, 540p_hls, 1080p_hls, 360p_hls, 720p_dash, 360p_dash, 1080p_dash, 540p_dash, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://vimeo.com/ondemand/worldoftomorrow3/467204924
:: Found streams: 540p_hls, 1080p_hls, 720p_hls, 240p_hls, 360p_hls, 240p, 240p+a64k, 240p+a128k, 240p+a255k, 360p, 360p+a64k, 360p+a128k, 360p+a255k, 540p, 540p+a64k, 540p+a128k, 540p+a255k, 720p, 720p+a64k, 720p+a128k, 720p+a255k, 1080p, 1080p+a64k, 1080p+a128k, 1080p+a255k, worst, best
```