### PR TITLE
build: set trio dependency to <0.25 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   "pycryptodome >=3.4.3,<4",
   "PySocks >=1.5.6,!=1.5.7",
   "requests >=2.26.0,<3",
-  "trio >=0.22.0,<1",
+  "trio >=0.22.0,<0.25",
   "trio-websocket >=0.9.0,<1",
   "typing-extensions >=4.0.0",
   "urllib3 >=1.26.0,<3",


### PR DESCRIPTION
Breaking changes, which need to be resolved soon:
https://github.com/python-trio/trio/releases/tag/v0.25.0

Limiting to `<0.25` ensures that the tests pass for now...