### PR TITLE
webbrowser: fix compatibility with trio 0.25

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -443,6 +443,9 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
       - `certifi`_
       - Used for loading the CA bundle extracted from the Mozilla Included CA Certificate List
     * - runtime
+      - `exceptiongroup`_
+      - Used for ``ExceptionGroup`` handling, to allow writing async trio code on older Python versions.
+    * - runtime
       - `isodate`_
       - Used for parsing ISO8601 strings
     * - runtime
@@ -492,6 +495,7 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
 .. _versioningit: https://versioningit.readthedocs.io/en/stable/
 
 .. _certifi: https://certifiio.readthedocs.io/en/latest/
+.. _exceptiongroup: https://github.com/agronholm/exceptiongroup
 .. _isodate: https://pypi.org/project/isodate/
 .. _lxml: https://lxml.de/
 .. _pycountry: https://pypi.org/project/pycountry/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "pycryptodome >=3.4.3,<4",
   "PySocks >=1.5.6,!=1.5.7",
   "requests >=2.26.0,<3",
-  "trio >=0.22.0,<0.25",
+  "trio >=0.25.0,<1",
   "trio-websocket >=0.9.0,<1",
   "typing-extensions >=4.0.0",
   "urllib3 >=1.26.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dynamic = [
 requires-python = ">=3.8"
 dependencies = [
   "certifi",
+  "exceptiongroup",
   "isodate",
   "lxml >=4.6.4,<6",
   "pycountry",

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -5,6 +5,9 @@ import sys
 import warnings
 from typing import Any, Callable, Dict, Optional, Tuple
 
+# import exceptiongroup, so it can monkeypatch ExceptionGroup logic on <=py311
+import exceptiongroup  # noqa: F401
+
 from streamlink.exceptions import StreamlinkDeprecationWarning
 
 

--- a/src/streamlink/session/session.py
+++ b/src/streamlink/session/session.py
@@ -3,6 +3,7 @@ import warnings
 from functools import lru_cache
 from typing import Any, Dict, Optional, Tuple, Type
 
+import streamlink.compat  # noqa: F401
 from streamlink import __version__
 from streamlink.exceptions import NoPluginError, PluginError, StreamlinkDeprecationWarning
 from streamlink.logger import StreamlinkLogger

--- a/src/streamlink/webbrowser/cdp/connection.py
+++ b/src/streamlink/webbrowser/cdp/connection.py
@@ -1,4 +1,3 @@
-# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
 from __future__ import annotations
 
 import dataclasses

--- a/src/streamlink/webbrowser/webbrowser.py
+++ b/src/streamlink/webbrowser/webbrowser.py
@@ -8,6 +8,7 @@ from subprocess import DEVNULL
 from typing import AsyncContextManager, AsyncGenerator, Generator, List, Optional, Union
 
 import trio
+from exceptiongroup import BaseExceptionGroup, catch
 
 from streamlink.utils.path import resolve_executable
 from streamlink.webbrowser.exceptions import WebbrowserError
@@ -59,7 +60,7 @@ class Webbrowser:
 
         launcher = _WebbrowserLauncher(executable, arguments, timeout)
 
-        # noinspection PyTypeChecker
+        # noinspection PyArgumentList
         return launcher.launch()
 
     @staticmethod
@@ -79,37 +80,39 @@ class _WebbrowserLauncher:
 
     @asynccontextmanager
     async def launch(self) -> AsyncGenerator[trio.Nursery, None]:
-        async with trio.open_nursery() as nursery:
-            log.info(f"Launching web browser: {self.executable}")
-            # the process is run in a separate task
-            run_process = partial(
-                trio.run_process,
-                [self.executable, *self.arguments],
-                check=False,
-                stdout=DEVNULL,
-                stderr=DEVNULL,
-            )
-            # trio ensures that the process gets terminated when the task group gets cancelled
-            process: trio.Process = await nursery.start(run_process)
-            # the process watcher task cancels the entire task group when the user terminates/kills the process
-            nursery.start_soon(self._task_process_watcher, process, nursery)
-            try:
-                # the application logic is run here
-                with trio.move_on_after(self.timeout) as cancel_scope:
-                    yield nursery
-            except BaseException:
-                # handle KeyboardInterrupt and SystemExit
-                raise
-            else:
-                # check if the application logic has timed out
-                if cancel_scope.cancelled_caught:
-                    log.warning("Web browser task group has timed out")
-            finally:
-                # check if the task group hasn't been cancelled yet in the process watcher task
-                if not self._process_ended_early:
-                    log.debug("Waiting for web browser process to terminate")
-                # once the application logic is done, cancel the entire task group and terminate/kill the process
-                nursery.cancel_scope.cancel()
+        def handle_baseexception(exc_grp: BaseExceptionGroup) -> None:
+            raise exc_grp.exceptions[0] from exc_grp.exceptions[0].__context__
+
+        with catch({  # type: ignore[dict-item]  # bug in exceptiongroup==1.2.0
+            (KeyboardInterrupt, SystemExit): handle_baseexception,  # type: ignore[dict-item]  # bug in exceptiongroup==1.2.0
+        }):
+            async with trio.open_nursery() as nursery:
+                log.info(f"Launching web browser: {self.executable}")
+                # the process is run in a separate task
+                run_process = partial(
+                    trio.run_process,
+                    [self.executable, *self.arguments],
+                    check=False,
+                    stdout=DEVNULL,
+                    stderr=DEVNULL,
+                )
+                # trio ensures that the process gets terminated when the task group gets cancelled
+                process: trio.Process = await nursery.start(run_process)
+                # the process watcher task cancels the entire task group when the user terminates/kills the process
+                nursery.start_soon(self._task_process_watcher, process, nursery)
+                try:
+                    # the application logic is run here
+                    with trio.move_on_after(self.timeout) as cancel_scope:
+                        yield nursery
+                    # check if the application logic has timed out
+                    if cancel_scope.cancelled_caught:
+                        log.warning("Web browser task group has timed out")
+                finally:
+                    # check if the task group hasn't been cancelled yet in the process watcher task
+                    if not self._process_ended_early:
+                        log.debug("Waiting for web browser process to terminate")
+                    # once the application logic is done, cancel the entire task group and terminate/kill the process
+                    nursery.cancel_scope.cancel()
 
     async def _task_process_watcher(self, process: trio.Process, nursery: trio.Nursery) -> None:
         """Task for cancelling the launch task group if the user closes the browser or if it exits early on its own"""

--- a/tests/webbrowser/cdp/__init__.py
+++ b/tests/webbrowser/cdp/__init__.py
@@ -1,6 +1,3 @@
-# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
-from __future__ import annotations
-
 from typing import List
 
 import trio


### PR DESCRIPTION
See #5893

Breaking changes in `trio`'s `0.25` release (apparently the last breaking change before their first stable release):
https://github.com/python-trio/trio/releases/tag/v0.25.0

----

1. **build: add exceptiongroup dependency**
    Add the `exceptiongroup` dependency directly to Streamlink, so we can write `ExceptionGroup` handling code on all supported versions of Python without having to rely on `trio`'s conditional dependency.
2. **webbrowser: fix compatibility with trio 0.25**
   - Set min. version requirement of `trio` to `0.25`,
      so we don't have to set `strict_exception_groups` to `True` on older versions (probably not even possible via `pytest-trio`)
   - Fix compatibility with `trio>=0.25`:
      Since `strict_exception_groups` now defaults to `True`, trio nurseries now always raise an `ExceptionGroup` in all cases, so update tests and handle exception groups instead. Don't unwrap exception groups for now, even if only a single exception is included.
      Explicitly handle `KeyboardInterrupt`/`SystemExit` and re-raise by using the `exceptiongroup.catch` utility (<py311 compat)
3. **plugins.twitch: update CI-token error handling**

----

It's a bit annoying having to include the `exceptiongroup` dependency, but there's no other way around this. [Python 3.11's `except*` syntax](https://docs.python.org/3/reference/compound_stmts.html#except-star) can't be used and making Python 3.11 the min requirement of the whole project because of this doesn't make sense. Python 3.10 reaches its EOL on 2026-10-31, so the added dependency will have to stay until then.

----

It'll probably make sense preparing a patch release because of these changes within the next couple of days, so we don't cause any unnecessary blockers on Linux distros where only the latest version gets packaged (e.g. Arch) - in case they will re-build packages depending on trio.