### PR TITLE
tests: require pytest 8.0.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ setuptools >=64.0.0  # required for being able to run editable installs
 versioningit >=2.0.0,<4  # required for being able to run editable installs
 
 # tests
-pytest >=6.0.0
+pytest >=8.0.0
 pytest-asyncio
 pytest-trio
 requests-mock


### PR DESCRIPTION
Apparently, pytest's [`ExceptionInfo.group_contains()`](https://docs.pytest.org/en/8.0.x/reference/reference.html#pytest.ExceptionInfo.group_contains) was only just added in pytest 8.0.0:
https://docs.pytest.org/en/8.0.x/changelog.html#additional-support-for-exception-groups-and-notes

I wasn't aware of this, because it's not noted in their docs directly like most stuff. That utility function is required by the updated tests in #5895 when making assertions about `ExceptionGroup`s.

Streamlink's dev-requirements should therefore bump the min-requirement of pytest to 8.0.0.