### PR TITLE
build: set trio min-requirement back to 0.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
   "pycryptodome >=3.4.3,<4",
   "PySocks >=1.5.6,!=1.5.7",
   "requests >=2.26.0,<3",
-  "trio >=0.25.0,<1",
+  "trio >=0.22.0,<1",
   "trio-websocket >=0.9.0,<1",
   "typing-extensions >=4.0.0",
   "urllib3 >=1.26.0,<3",

--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -166,7 +166,7 @@ class CDPClient:
             ) as cdp_client:
                 return await runner(cdp_client)
 
-        return trio.run(run_wrapper)
+        return trio.run(run_wrapper, strict_exception_groups=True)
 
     @classmethod
     @asynccontextmanager

--- a/src/streamlink/webbrowser/cdp/connection.py
+++ b/src/streamlink/webbrowser/cdp/connection.py
@@ -1,3 +1,4 @@
+# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
 from __future__ import annotations
 
 import dataclasses

--- a/tests/webbrowser/cdp/__init__.py
+++ b/tests/webbrowser/cdp/__init__.py
@@ -1,3 +1,6 @@
+# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
+from __future__ import annotations
+
 from typing import List
 
 import trio


### PR DESCRIPTION
- set `strict_exception_groups=True` in `CDPClient.launch()`
- monkey-patch `trio.run()` early in Streamlink's tests

----

This lifts the dependency requirements of Streamlink a bit. I didn't want to do this initially and bumped trio to `>=0.25`, because it requires patching `trio.run()` in Streamlink's tests, as `pytest-trio` doesn't allow setting custom `trio.run()` args/kwargs.

Since packagers of some Linux distros like Debian have to apply the same kind of patch in order to package Streamlink 6.7.1, we should instead apply the version compatibility fixes here ourselves.