### PR TITLE
release: 6.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## streamlink 6.7.2 (2024-03-23)
+
+Patch release:
+
+- Build: reverted `trio` version requirement bump ([#5902](https://github.com/streamlink/streamlink/pull/5902))
+- Build: fixed incorrect `pytest` version requirement ([#5901](https://github.com/streamlink/streamlink/pull/5901))
+
+[Full changelog](https://github.com/streamlink/streamlink/compare/6.7.1...6.7.2)
+
+
 ## streamlink 6.7.1 (2024-03-19)
 
 Patch release:


### PR DESCRIPTION
Just a small packaging related correction... Bumping Streamlink's AppImages and Windows builds won't be necessary, because there are no relevant application code changes.

Alternatively, we could also not release 6.7.2 in this current state just yet and wait for more (actual) changes, because it's not super important fixing those issues. Releasing this however could ease packaging in some cases. Those packagers chould however also apply the patches themselves.

- Alpine is on trio==0.21 and pytest>=8 (0.22 is now an actual requirement and not an arbitrary version number)
- Debian applies trio<0.25 patches and is on pytest>=8
- Fedora is on trio==0.23.1 and pytest==7.4.3
- FreeBSD is on trio==0.25.0 and pytest==7.4.4
- Gentoo disables new ExceptionGroup tests due to pytest>=8 not being available yet
- NixOS is on trio==0.24.0 and pytest>=8
- openSUSE is still on streamlink==6.5.1 but all deps should be available
- Solus is on trio==0.23.1 and pytest==7.4.3
- Homebrew pulls from pypi in a venv