### PR TITLE
plugins.pluto: rewrite plugin

### DIFF
--- a/tests/plugins/test_pluto.py
+++ b/tests/plugins/test_pluto.py
@@ -5,56 +5,28 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlPluto(PluginCanHandleUrl):
     __plugin__ = Pluto
 
-    should_match = [
-        "http://www.pluto.tv/live-tv/channel-lineup",
-        "http://pluto.tv/live-tv/channel",
-        "http://pluto.tv/live-tv/channel/",
-        "https://pluto.tv/live-tv/red-bull-tv-2",
-        "https://pluto.tv/live-tv/4k-tv",
-        "http://www.pluto.tv/on-demand/series/leverage/season/1/episode/the-nigerian-job-2009-1-1",
-        "http://pluto.tv/on-demand/series/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3",
-        "https://www.pluto.tv/on-demand/movies/dr.-no-1963-1-1",
-        "http://pluto.tv/on-demand/movies/the-last-dragon-(1985)-1-1",
-        "http://www.pluto.tv/lc/live-tv/channel-lineup",
-        "http://pluto.tv/lc/live-tv/channel",
-        "http://pluto.tv/lc/live-tv/channel/",
-        "https://pluto.tv/lc/live-tv/red-bull-tv-2",
-        "https://pluto.tv/lc/live-tv/4k-tv",
-        "http://www.pluto.tv/lc/on-demand/series/leverage/season/1/episode/the-nigerian-job-2009-1-1",
-        "http://pluto.tv/lc/on-demand/series/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3",
-        "https://www.pluto.tv/lc/on-demand/movies/dr.-no-1963-1-1",
-        "https://www.pluto.tv/lc/on-demand/movies/dr.-no-1963-1-1/",
-        "http://pluto.tv/lc/on-demand/movies/the-last-dragon-(1985)-1-1",
-        "http://pluto.tv/lc/on-demand/movies/the-last-dragon-(1985)-1-1/",
-        "https://pluto.tv/en/on-demand/series/great-british-menu-ptv1/episode/north-west-fish-2009-5-7-ptv1",
-        "https://pluto.tv/en/on-demand/series/great-british-menu-ptv1/episode/north-west-fish-2009-5-7-ptv1/",
-        "https://www.pluto.tv/en/on-demand/series/great-british-menu-ptv1/episode/north-west-fish-2009-5-7-ptv1",
-        "https://www.pluto.tv/en/on-demand/series/great-british-menu-ptv1/episode/north-west-fish-2009-5-7-ptv1/",
+    should_match_groups = [
+        (
+            ("live", "https://pluto.tv/en/live-tv/61409f8d6feb30000766b675"),
+            {"id": "61409f8d6feb30000766b675"},
+        ),
+
+        (
+            ("series", "https://pluto.tv/en/on-demand/series/5e00cd538e67b0dcb2cf3bcd/season/1/episode/60dee91cfc802600134b886d"),
+            {"id_s": "5e00cd538e67b0dcb2cf3bcd", "id_e": "60dee91cfc802600134b886d"},
+        ),
+
+        (
+            ("movies", "https://pluto.tv/en/on-demand/movies/600545d1813b2d001b686fa9"),
+            {"id": "600545d1813b2d001b686fa9"},
+        ),
     ]
 
     should_not_match = [
-        "https://fake.pluto.tv/live-tv/hello",
-        "http://www.pluto.tv/live-tv/channel-lineup/extra",
-        "https://www.pluto.tv/live-tv",
         "https://pluto.tv/live-tv",
-        "https://www.pluto.com/live-tv/swag",
-        "http://pluto.tv/movies/dr.-no-1963-1-1",
-        "http://pluto.tv/on-demand/movies/dr.-no-1/963-1-1",
-        "http://pluto.tv/on-demand/series/dr.-no-1963-1-1",
-        "http://pluto.tv/on-demand/movies/leverage/season/1/episode/the-nigerian-job-2009-1-1",
-        "http://pluto.tv/on-demand/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3",
-        "https://fake.pluto.tv/lc/live-tv/hello",
-        "http://www.pluto.tv/lc/live-tv/channel-lineup/extra",
-        "https://www.pluto.tv/lc/live-tv",
-        "https://pluto.tv/lc/live-tv",
-        "https://www.pluto.com/lc/live-tv/swag",
-        "http://pluto.tv/lc/movies/dr.-no-1963-1-1",
-        "http://pluto.tv/lc/on-demand/movies/dr.-no-1/963-1-1",
-        "http://pluto.tv/lc/on-demand/series/dr.-no-1963-1-1",
-        "http://pluto.tv/lc/on-demand/movies/leverage/season/1/episode/the-nigerian-job-2009-1-1",
-        "http://pluto.tv/lc/on-demand/fear-factor-usa-(lf)/season/5/episode/underwater-safe-bob-car-ramp-2004-5-3",
-        "https://pluto.tv/en/on-demand/series/great-british-menu-ptv1/episode/north-west-fish-2009-5-7-ptv1/extra",
-        "https://pluto.tv/en/on-demand/series/great-british-menu-ptv1/season/5/episode/north-west-fish-2009-5-7-ptv1/extra",
-        "https://www.pluto.tv/en/on-demand/series/great-british-menu-ptv1/episode/north-west-fish-2009-5-7-ptv1/extra",
-        "https://www.pluto.tv/en/on-demand/series/great-british-menu-ptv1/season/5/episode/north-west-fish-2009-5-7-ptv1/extra",
+        "https://pluto.tv/en/live-tv/61409f8d6feb30000766b675/details",
+
+        "https://pluto.tv/en/on-demand/series/5e00cd538e67b0dcb2cf3bcd/details/season/1",
+
+        "https://pluto.tv/en/on-demand/movies/600545d1813b2d001b686fa9/details",
     ]


### PR DESCRIPTION
Fixes #5906 
Fixes #5475
Fixes #5752

As explained in #5906, old input URLs seem dead and unsupported. There's a way to implement a fallback mechanic for old VOD URLs, but I don't think this is necessary, because their whole site now uses URLs with stream/VOD IDs instead of channel/VOD-names.

The site also uses DASH streams for VODs, but that's because of the `drmCapabilities=widevine:L3` query string parameter which gets set. Without it, only HLS streams without DRM are returned, which is what we want anyway. No idea though if that's going to change at some point.

The following stream selection is limited to what they return when using a German IP address. All streams are working fine, namely live channels, shows/series and movies. I haven't tested using a Proxy/VPN.

```
$ ./script/test-plugin-urls.py pluto
:: Finding streams for URL: https://pluto.tv/en/live-tv/61409f8d6feb30000766b675
:: Found streams: 570k, 1000k, 1500k, 2100k, 3100k, worst, best
:: Finding streams for URL: https://pluto.tv/en/on-demand/movies/600545d1813b2d001b686fa9
:: Found streams: 570k, 1000k, 1500k, 2100k, 3100k, worst, best
:: Finding streams for URL: https://pluto.tv/en/on-demand/series/5e00cd538e67b0dcb2cf3bcd/season/1/episode/60dee91cfc802600134b886d
:: Found streams: 570k, 1000k, 1500k, 2100k, 3100k, worst, best
```