### PR TITLE
plugins.showroom: fix geo-block check

### DIFF
--- a/src/streamlink/plugins/showroom.py
+++ b/src/streamlink/plugins/showroom.py
@@ -84,7 +84,7 @@ class Showroom(Plugin):
         )
 
         res = self.session.http.get(url, acceptable_status=(200, 403, 404))
-        if res.headers["Content-Type"] != "application/x-mpegURL":
+        if res.headers["Content-Type"] not in ("application/x-mpegURL", "application/vnd.apple.mpegurl"):
             log.error("This stream is restricted")
             return
 


### PR DESCRIPTION
Fixes #5909 

The HLS streams now have the correct `Content-Type` header according to [rfc8216](https://datatracker.ietf.org/doc/html/rfc8216#section-4), namely `application/vnd.apple.mpegurl`.

```
$ curl -I https://hls-css.live.showroom-live.com/live/17d0561da8f8c7d0e2f70005699c3088916f1b91b60a7dc8bde88ebb69da054b_default.m3u8 | grep content-type
content-type: application/vnd.apple.mpegurl
```

Streams are working fine with this fix when accessing from a Japanese IP address:

```
$ streamlink https://www.showroom-live.com/r/SAKURAGI_RICO best
[cli][info] Found matching plugin showroom for URL https://www.showroom-live.com/r/SAKURAGI_RICO
[cli][info] Available streams: 144p (worst), 360p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /usr/bin/mpv
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```