### PR TITLE
docs: fix anchor on install page

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -262,7 +262,7 @@ Package availability
 --------------------
 
 Packaging is not done by the Streamlink maintainers themselves except for
-the `PyPI package <PyPI package and source code_>`_,
+the `PyPI package <pypi-package-and-source-code_>`_,
 the `Windows installers + portable builds <Windows binaries_>`_,
 and the `Linux AppImages <Linux AppImages_>`_.
 


### PR DESCRIPTION
The "PyPI package" anchor in the "Package availability" section currently links to `#id4`, which is a duplicate of `#pypi-package-and-source-code`:
https://streamlink.github.io/install.html#package-availability

This is because the "Windows", "macOS", "Linux and BSD" and "PyPI package and source code" sections all require explicit section labels because of the big icon buttons at the top rendered by `sphinx-design`, which doesn't support the `autosectionlabel` Sphinx extension:
- https://github.com/streamlink/streamlink/blob/6.7.2/docs/install.rst?plain=1#L8
- https://github.com/streamlink/streamlink/blob/6.7.2/docs/install.rst?plain=1#L51
- https://github.com/streamlink/streamlink/blob/6.7.2/docs/install.rst?plain=1#L98
- https://github.com/streamlink/streamlink/blob/6.7.2/docs/install.rst?plain=1#L122
- https://github.com/streamlink/streamlink/blob/6.7.2/docs/install.rst?plain=1#L279

Despite those sections having explicit labels, `autosectionlabel` still goes ahead and adds duplicates for each of them. This isn't bad on its own, but for some reason the duplicate is picked up by the anchor in the "Package availability" text, so we should avoid this by linking to the explicit section label instead.