### PR TITLE
cli.utils.formatter: respect max file name length

### DIFF
--- a/src/streamlink_cli/utils/formatter.py
+++ b/src/streamlink_cli/utils/formatter.py
@@ -2,17 +2,18 @@ from pathlib import Path
 from typing import Optional
 
 from streamlink.utils.formatter import Formatter as _BaseFormatter
-from streamlink_cli.utils.path import replace_chars, replace_path
+from streamlink_cli.utils.path import replace_chars, replace_path, truncate_path
 
 
 class Formatter(_BaseFormatter):
     title = _BaseFormatter.format
 
-    def path(self, pathlike: str, charmap: Optional[str] = None) -> Path:
+    def path(self, pathlike: str, charmap: Optional[str] = None, max_filename_length: int = 255) -> Path:
         def mapper(s):
             return replace_chars(s, charmap)
 
-        def format_part(part):
-            return self._format(part, mapper, {})
+        def format_part(part: str, isfile: bool) -> str:
+            formatted = self._format(part, mapper, {})
+            return truncate_path(formatted, max_filename_length, keep_extension=isfile)
 
         return replace_path(pathlike, format_part)

--- a/src/streamlink_cli/utils/path.py
+++ b/src/streamlink_cli/utils/path.py
@@ -35,6 +35,28 @@ def replace_chars(path: str, charmap: Optional[str] = None, replacement: str = R
     return pattern.sub(replacement, path)
 
 
+# This method does not take care of unicode modifier characters when truncating
+def truncate_path(path: str, length: int = 255, keep_extension: bool = True) -> str:
+    if len(path) <= length:
+        return path
+
+    parts = path.rsplit(".", 1)
+
+    # no file name extension (no dot separator in path or file name extension too long):
+    # truncate the whole thing
+    if not keep_extension or len(parts) == 1 or len(parts[1]) > 10:
+        encoded = path.encode("utf-8")
+        truncated = encoded[:length]
+        decoded = truncated.decode("utf-8", errors="ignore")
+        return decoded
+
+    # truncate file name, but keep file name extension
+    encoded = parts[0].encode("utf-8")
+    truncated = encoded[:length - len(parts[1]) - 1]
+    decoded = truncated.decode("utf-8", errors="ignore")
+    return f"{decoded}.{parts[1]}"
+
+
 def replace_path(pathlike: Union[str, Path], mapper: Callable[[str], str]) -> Path:
     def get_part(part):
         newpart = mapper(part)

--- a/src/streamlink_cli/utils/path.py
+++ b/src/streamlink_cli/utils/path.py
@@ -57,9 +57,12 @@ def truncate_path(path: str, length: int = 255, keep_extension: bool = True) -> 
     return f"{decoded}.{parts[1]}"
 
 
-def replace_path(pathlike: Union[str, Path], mapper: Callable[[str], str]) -> Path:
-    def get_part(part):
-        newpart = mapper(part)
+def replace_path(pathlike: Union[str, Path], mapper: Callable[[str, bool], str]) -> Path:
+    def get_part(part: str, isfile: bool) -> str:
+        newpart = mapper(part, isfile)
         return REPLACEMENT if part != newpart and newpart in SPECIAL_PATH_PARTS else newpart
 
-    return Path(*(get_part(part) for part in Path(pathlike).expanduser().parts))
+    parts = Path(pathlike).expanduser().parts
+    last = len(parts) - 1
+
+    return Path(*(get_part(part, i == last) for i, part in enumerate(parts)))

--- a/tests/cli/utils/test_path.py
+++ b/tests/cli/utils/test_path.py
@@ -1,6 +1,4 @@
-import os
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -68,14 +66,14 @@ def test_replace_path():
 
 
 @pytest.mark.posix_only()
-def test_replace_path_expanduser_posix():
-    with patch.object(os, "environ", {"HOME": "/home/foo"}):
-        assert replace_path("~/bar", lambda s: s) == Path("/home/foo/bar")
-        assert replace_path("foo/bar", lambda s: dict(foo="~").get(s, s)) == Path("~/bar")
+@pytest.mark.parametrize("os_environ", [pytest.param({"HOME": "/home/foo"}, id="posix")], indirect=True)
+def test_replace_path_expanduser_posix(os_environ):
+    assert replace_path("~/bar", lambda s: s) == Path("/home/foo/bar")
+    assert replace_path("foo/bar", lambda s: dict(foo="~").get(s, s)) == Path("~/bar")
 
 
 @pytest.mark.windows_only()
-def test_replace_path_expanduser_windows():
-    with patch.object(os, "environ", {"USERPROFILE": "C:\\Users\\foo"}):
-        assert replace_path("~\\bar", lambda s: s) == Path("C:\\Users\\foo\\bar")
-        assert replace_path("foo\\bar", lambda s: dict(foo="~").get(s, s)) == Path("~\\bar")
+@pytest.mark.parametrize("os_environ", [pytest.param({"USERPROFILE": "C:\\Users\\foo"}, id="windows")], indirect=True)
+def test_replace_path_expanduser_windows(os_environ):
+    assert replace_path("~\\bar", lambda s: s) == Path("C:\\Users\\foo\\bar")
+    assert replace_path("foo\\bar", lambda s: dict(foo="~").get(s, s)) == Path("~\\bar")

--- a/tests/cli/utils/test_path.py
+++ b/tests/cli/utils/test_path.py
@@ -59,7 +59,7 @@ def test_replace_chars_replacement():
 
 
 def test_replace_path():
-    def mapper(s):
+    def mapper(s, *_):
         return dict(foo=".", bar="..").get(s, s)
 
     path = Path("foo", ".", "bar", "..", "baz")
@@ -70,15 +70,15 @@ def test_replace_path():
 @pytest.mark.posix_only()
 @pytest.mark.parametrize("os_environ", [pytest.param({"HOME": "/home/foo"}, id="posix")], indirect=True)
 def test_replace_path_expanduser_posix(os_environ):
-    assert replace_path("~/bar", lambda s: s) == Path("/home/foo/bar")
-    assert replace_path("foo/bar", lambda s: dict(foo="~").get(s, s)) == Path("~/bar")
+    assert replace_path("~/bar", lambda s, *_: s) == Path("/home/foo/bar")
+    assert replace_path("foo/bar", lambda s, *_: dict(foo="~").get(s, s)) == Path("~/bar")
 
 
 @pytest.mark.windows_only()
 @pytest.mark.parametrize("os_environ", [pytest.param({"USERPROFILE": "C:\\Users\\foo"}, id="windows")], indirect=True)
 def test_replace_path_expanduser_windows(os_environ):
-    assert replace_path("~\\bar", lambda s: s) == Path("C:\\Users\\foo\\bar")
-    assert replace_path("foo\\bar", lambda s: dict(foo="~").get(s, s)) == Path("~\\bar")
+    assert replace_path("~\\bar", lambda s, *_: s) == Path("C:\\Users\\foo\\bar")
+    assert replace_path("foo\\bar", lambda s, *_: dict(foo="~").get(s, s)) == Path("~\\bar")
 
 
 text = alphabet * 10


### PR DESCRIPTION
Fixes #5919 

To make sense of this in just a few seconds, just have a look at the two tests added in the last commit...