### PR TITLE
plugins.mangomolo: fix missing Referer header

### DIFF
--- a/src/streamlink/plugins/mangomolo.py
+++ b/src/streamlink/plugins/mangomolo.py
@@ -1,5 +1,6 @@
 """
 $description OTT video platform owned by Alpha Technology Group
+$url player.mangomolo.com
 $url media.gov.kw
 $type live
 """
@@ -38,10 +39,12 @@ class Mangomolo(Plugin):
         self.url = update_scheme("https://", player_url)
 
     def _get_streams(self):
+        headers = {}
         if not self.matches["mangomoloplayer"]:
+            headers["Referer"] = self.url
             self._get_player_url()
 
-        hls_url = self.session.http.get(self.url, schema=validate.Schema(
+        hls_url = self.session.http.get(self.url, headers=headers, schema=validate.Schema(
             re.compile(r"src\s*:\s*(?P<q>[\"'])(?P<url>https?://\S+?\.m3u8\S*?)(?P=q)"),
             validate.none_or_all(validate.get("url")),
         ))


### PR DESCRIPTION
https://github.com/streamlink/streamlink/pull/5852#issuecomment-2038556693

`player.mangomolo.com/v1/live?...` apparently now requires a `Referer` header. The URL in the plugin test cases is from one of the `media.gov.kw` streams and works fine if the referer is set to this host.

```
$ ./script/test-plugin-urls.py mangomolo
:: Finding streams for URL: https://media.gov.kw/LiveTV.aspx?PanChannel=KTV1
:: Found streams: 240p, 360p, 720p, 1080p, worst, best
:: Finding streams for URL: https://media.gov.kw/LiveTV.aspx?PanChannel=KTVSports
:: Found streams: 240p, 360p, 720p, 1080p, worst, best
:: Finding streams for URL: https://player.mangomolo.com/v1/live?id=MTk1&channelid=MzU1&countries=bnVsbA==&w=100%25&h=100%25&autoplay=true&filter=none&signature=9ea6c8ed03b8de6e339d6df2b0685f25&app_id=43
!! Error while fetching streams
```