### PR TITLE
plugin.api.validate: check parse_qsd() input type

### DIFF
--- a/src/streamlink/plugin/api/validate/_validators.py
+++ b/src/streamlink/plugin/api/validate/_validators.py
@@ -651,4 +651,8 @@ def validator_parse_qsd(*args, **kwargs) -> TransformSchema:
     :raise ValidationError: On parsing error
     """
 
-    return TransformSchema(_parse_qsd, *args, **kwargs, exception=ValidationError, schema=None)
+    def parser(*_args, **_kwargs):
+        validate(AnySchema(str, bytes), _args[0])
+        return _parse_qsd(*_args, **_kwargs, exception=ValidationError, schema=None)
+
+    return TransformSchema(parser, *args, **kwargs)

--- a/tests/test_api_validate.py
+++ b/tests/test_api_validate.py
@@ -1343,13 +1343,20 @@ class TestParseQsdValidator:
             validate.parse_qsd(),
             "foo=bar&foo=baz&qux=quux",
         ) == {"foo": "baz", "qux": "quux"}
+        assert validate.validate(
+            validate.parse_qsd(),
+            b"foo=bar&foo=baz&qux=quux",
+        ) == {b"foo": b"baz", b"qux": b"quux"}
 
     def test_failure(self):
         with pytest.raises(ValidationError) as cm:
             validate.validate(validate.parse_qsd(), 123)
         assert_validationerror(cm.value, """
-            ValidationError:
-              Unable to parse query string: 'int' object has no attribute 'decode' (123)
+            ValidationError(AnySchema):
+              ValidationError(type):
+                Type of 123 should be str, but is int
+              ValidationError(type):
+                Type of 123 should be bytes, but is int
         """)
 
 


### PR DESCRIPTION
Fixes #5931 

Since Python 3.11.9 / 3.12.3 / 3.13.0a6, `urllib.parse.parse_qsl()` now raises a `TypeError` if the input is not a `str`, is truthy and can't be passed to `memoryview()`, like integers for example, hence the test failure which previously just checked an invalid input to that validation schema.