### PR TITLE
tests: fix test_onbuild when executed from build directory

### DIFF
--- a/build_backend/test_onbuild.py
+++ b/build_backend/test_onbuild.py
@@ -38,7 +38,13 @@ def build(request: pytest.FixtureRequest, tmp_path: Path, template_fields: dict)
     (pkg_dir / "streamlink").mkdir(parents=True)
     shutil.copy(PROJECT_ROOT / "pyproject.toml", tmp_path / "pyproject.toml")
     shutil.copy(PROJECT_ROOT / "setup.py", tmp_path / "setup.py")
-    shutil.copy(PROJECT_ROOT / "src" / "streamlink" / "_version.py", pkg_dir / "streamlink" / "_version.py")
+
+    # Lookup for the path from the root source directory
+    if Path(PROJECT_ROOT / "src" / "streamlink" / "_version.py").exists():
+        shutil.copy(PROJECT_ROOT / "src" / "streamlink" / "_version.py", pkg_dir / "streamlink" / "_version.py")
+    else:  # pragma: no cover
+        # We didn't find it, use the build location
+        shutil.copy(PROJECT_ROOT / "streamlink" / "_version.py", pkg_dir / "streamlink" / "_version.py")
 
     options = dict(
         is_source=is_source,


### PR DESCRIPTION
When executing tests from the build directory (generated by bdist), the location of the Streamlink source is directly at the root directory and not in a `src` subdirectory.

This is what Debian does when building python packages to ensure newly built files are tested instead of source files.