### PR TITLE
ci.codecov: add build_backend status check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -32,7 +32,6 @@ coverage:
       streamlink:
         threshold: 1
         paths:
-          - "build_backend/"
           - "src/streamlink/"
           - "!src/streamlink/plugins/"
       streamlink_cli:
@@ -49,3 +48,8 @@ coverage:
         target: 100
         paths:
           - "tests/"
+      build_backend:
+        # build_backend should always be fully covered
+        target: 100
+        paths:
+          - "build_backend/"


### PR DESCRIPTION
This adds a dedicated `build_backend` code coverage status check. The build backend should always be fully covered.

Its tests are currently not part of the `test` status check while its main module files are part of the `streamlink` status check, which isn't ideal.