### PR TITLE
plugins.afreeca: Support for password-protected streams

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -52,6 +52,11 @@ class AfreecaHLSStream(HLSStream):
     action="store_true",
     help="Purge cached AfreecaTV credentials to initiate a new session and reauthenticate.",
 )
+@pluginargument(
+    "stream-password",
+    metavar="STREAM_PASSWORD",
+    help="The password for the stream.",
+)
 class AfreecaTV(Plugin):
     _re_bno = re.compile(r"window\.nBroadNo\s*=\s*(?P<bno>\d+);")
 
@@ -120,14 +125,14 @@ class AfreecaTV(Plugin):
         res = self.session.http.post(self.CHANNEL_API_URL, data=data)
         return self.session.http.json(res, schema=self._schema_channel)
 
-    def _get_hls_key(self, broadcast, username, quality):
+    def _get_hls_key(self, broadcast, username, quality, stream_password):
         data = {
             "bid": username,
             "bno": broadcast,
             "from_api": "0",
             "mode": "landing",
             "player_type": "html5",
-            "pwd": "",
+            "pwd": stream_password or "",
             "quality": quality,
             "stream_type": "common",
             "type": "aid",
@@ -143,8 +148,8 @@ class AfreecaTV(Plugin):
         res = self.session.http.get(f"{rmd}/broad_stream_assign.html", params=params)
         return self.session.http.json(res, schema=self._schema_stream)
 
-    def _get_hls_stream(self, broadcast, username, quality, rmd):
-        keyjson = self._get_hls_key(broadcast, username, quality)
+    def _get_hls_stream(self, broadcast, username, quality, rmd, stream_password):
+        keyjson = self._get_hls_key(broadcast, username, quality, stream_password)
 
         if keyjson.get("RESULT") != self.CHANNEL_RESULT_OK:
             return
@@ -177,6 +182,7 @@ class AfreecaTV(Plugin):
     def _get_streams(self):
         login_username = self.get_option("username")
         login_password = self.get_option("password")
+        stream_password = self.get_option("stream-password")
 
         self.session.http.headers.update({"Referer": self.url, "Origin": "https://play.afreecatv.com"})
 
@@ -207,10 +213,7 @@ class AfreecaTV(Plugin):
 
         channel = self._get_channel_info(bno, username)
         log.trace(f"{channel!r}")
-        if channel.get("BPWD") == "Y":
-            log.error("Stream is Password-Protected")
-            return
-        elif channel.get("RESULT") == -6:
+        if channel.get("RESULT") == -6:
             log.error("Login required")
             return
         elif channel.get("RESULT") != self.CHANNEL_RESULT_OK:
@@ -224,10 +227,17 @@ class AfreecaTV(Plugin):
         self.author = channel.get("BJNICK")
         self.title = channel.get("TITLE")
 
+        streams = {}
+
         for qkey in self.QUALITYS:
-            hls_stream = self._get_hls_stream(broadcast, username, qkey, rmd)
-            if hls_stream:
-                yield qkey, hls_stream
+            if hls_stream := self._get_hls_stream(broadcast, username, qkey, rmd, stream_password):
+                streams[qkey] = hls_stream
+
+        if not streams and channel.get("BPWD") == "Y":
+            log.error("Stream is password protected")
+            return
+
+        return streams
 
 
 __plugin__ = AfreecaTV


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
When I used the correct password:

```
$ streamlink --loglevel debug --afreeca-stream-password 71 https://play.afreecatv.com/ecvhao/263153658
NoTagError: `git describe --long --dirty --always --tags` could not find a tag
[cli][debug] OS:         Linux-6.5.13-1-pve-x86_64-with-glibc2.39
[cli][debug] Python:     3.11.8
[cli][debug] OpenSSL:    OpenSSL 3.2.1 30 Jan 2024
[cli][debug] Streamlink: 0.0.0+unknown
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.2.2
[cli][debug]  exceptiongroup: 1.2.1
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.1
[cli][debug]  pycountry: 23.12.11
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.25.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.11.0
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  url=https://play.afreecatv.com/ecvhao/263153658
[cli][debug]  --loglevel=debug
[cli][debug]  --afreeca-stream-password=71
[plugins.afreeca][debug] Restored cookies: _au, _au3rd
[cli][info] Found matching plugin afreeca for URL https://play.afreecatv.com/ecvhao/263153658
Available streams: sd (worst), hd, original (best)
```

When I used the wrong password:

```
$ streamlink --loglevel debug --afreeca-stream-password wrong_password https://play.afreecatv.com/ecvhao/263153658
NoTagError: `git describe --long --dirty --always --tags` could not find a tag
[cli][debug] OS:         Linux-6.5.13-1-pve-x86_64-with-glibc2.39
[cli][debug] Python:     3.11.8
[cli][debug] OpenSSL:    OpenSSL 3.2.1 30 Jan 2024
[cli][debug] Streamlink: 0.0.0+unknown
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.2.2
[cli][debug]  exceptiongroup: 1.2.1
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.1
[cli][debug]  pycountry: 23.12.11
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.31.0
[cli][debug]  trio: 0.25.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.11.0
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.7.0
[cli][debug] Arguments:
[cli][debug]  url=https://play.afreecatv.com/ecvhao/263153658
[cli][debug]  --loglevel=debug
[cli][debug]  --afreeca-stream-password=wrong_password
[plugins.afreeca][debug] Restored cookies: _au, _au3rd
[cli][info] Found matching plugin afreeca for URL https://play.afreecatv.com/ecvhao/263153658
[plugins.afreeca][error] Stream is Password-Protected
error: No playable streams found on this URL: https://play.afreecatv.com/ecvhao/263153658
```