### PR TITLE
cli: remove console.exit()

### DIFF
--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -82,16 +82,5 @@ class ConsoleOutput:
         msg = dumps(out, cls=JSONEncoder, indent=2)
         self.output.write(f"{msg}\n")
 
-        if isinstance(out, dict) and out.get("error"):
-            sys.exit(1)
-
-    def exit(self, msg: str) -> None:
-        if self.json:
-            self.msg_json(error=msg)
-        else:
-            self.msg(f"error: {msg}")
-
-        sys.exit(1)
-
 
 __all__ = ["ConsoleOutput", "ConsoleUserInputRequester"]

--- a/src/streamlink_cli/exceptions.py
+++ b/src/streamlink_cli/exceptions.py
@@ -1,0 +1,7 @@
+class StreamlinkCLIError(Exception):
+    def __init__(self, *args, code=1):
+        super().__init__(*args)
+        self.code = code
+
+    def __str__(self):
+        return super().__str__() or str(self.__context__ or "")

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -12,7 +12,7 @@ from contextlib import closing, suppress
 from gettext import gettext
 from pathlib import Path
 from time import sleep
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, List, Mapping, Optional, Type, Union
 
 import streamlink.logger as logger
 from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __version__ as streamlink_version
@@ -175,7 +175,7 @@ def create_http_server(host: Optional[str] = None, port: int = 0) -> HTTPOutput:
 
 def output_stream_http(
     plugin: Plugin,
-    initial_streams: Dict[str, Stream],
+    initial_streams: Mapping[str, Stream],
     formatter: Formatter,
     external: bool = False,
     continuous: bool = True,
@@ -386,7 +386,7 @@ def output_stream(stream, formatter: Formatter):
     return True
 
 
-def handle_stream(plugin: Plugin, streams: Dict[str, Stream], stream_name: str) -> None:
+def handle_stream(plugin: Plugin, streams: Mapping[str, Stream], stream_name: str) -> None:
     """Decides what to do with the selected stream.
 
     Depending on arguments it can be one of these:
@@ -448,14 +448,14 @@ def handle_stream(plugin: Plugin, streams: Dict[str, Stream], stream_name: str) 
                 break
 
 
-def fetch_streams(plugin: Plugin) -> Dict[str, Stream]:
+def fetch_streams(plugin: Plugin) -> Mapping[str, Stream]:
     """Fetches streams using correct parameters."""
 
     return plugin.streams(stream_types=args.stream_types,
                           sorting_excludes=args.stream_sorting_excludes)
 
 
-def fetch_streams_with_retry(plugin: Plugin, interval: float, count: int) -> Optional[Dict[str, Stream]]:
+def fetch_streams_with_retry(plugin: Plugin, interval: float, count: int) -> Optional[Mapping[str, Stream]]:
     """Attempts to fetch streams repeatedly
        until some are returned or limit hit."""
 
@@ -487,7 +487,7 @@ def fetch_streams_with_retry(plugin: Plugin, interval: float, count: int) -> Opt
     return streams
 
 
-def resolve_stream_name(streams: Dict[str, Stream], stream_name: str) -> str:
+def resolve_stream_name(streams: Mapping[str, Stream], stream_name: str) -> str:
     """Returns the real stream name of a synonym."""
 
     if stream_name in STREAM_SYNONYMS and stream_name in streams:
@@ -498,7 +498,7 @@ def resolve_stream_name(streams: Dict[str, Stream], stream_name: str) -> str:
     return stream_name
 
 
-def format_valid_streams(plugin: Plugin, streams: Dict[str, Stream]) -> str:
+def format_valid_streams(plugin: Plugin, streams: Mapping[str, Stream]) -> str:
     """Formats a dict of streams.
 
     Filters out synonyms and displays them next to

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -80,30 +80,6 @@ class TestConsoleOutput:
         """).lstrip()
         assert test_list1 == ["foo", "bar"]
 
-    def test_msg_json_error(self):
-        output = StringIO()
-        console = ConsoleOutput(output, json=True)
-        with pytest.raises(SystemExit) as cm:
-            console.msg_json({"error": "bad"})
-        assert cm.value.code == 1
-        assert output.getvalue() == '{\n  "error": "bad"\n}\n'
-
-    def test_exit(self):
-        output = StringIO()
-        console = ConsoleOutput(output)
-        with pytest.raises(SystemExit) as cm:
-            console.exit("error")
-        assert cm.value.code == 1
-        assert output.getvalue() == "error: error\n"
-
-    def test_exit_json(self):
-        output = StringIO()
-        console = ConsoleOutput(output, json=True)
-        with pytest.raises(SystemExit) as cm:
-            console.exit("error")
-        assert cm.value.code == 1
-        assert output.getvalue() == '{\n  "error": "error"\n}\n'
-
     def test_ask(self, monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr("builtins.input", Mock(return_value="hello"))
 

--- a/tests/cli/test_main_check_file_output.py
+++ b/tests/cli/test_main_check_file_output.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
+from streamlink_cli.exceptions import StreamlinkCLIError
 from streamlink_cli.main import check_file_output
 from streamlink_cli.output.file import FileOutput
 
@@ -83,7 +84,7 @@ def prompt(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
         {"exists": True},
         False,
         {"isatty": False},
-        pytest.raises(SystemExit),
+        pytest.raises(StreamlinkCLIError),
         [
             ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
             ("streamlink.cli", "debug", "Checking file output"),
@@ -118,12 +119,12 @@ def test_exists(
     ),
     pytest.param(
         {"ask": "n"},
-        pytest.raises(SystemExit),
+        pytest.raises(StreamlinkCLIError),
         id="no",
     ),
     pytest.param(
         {"ask": None},
-        pytest.raises(SystemExit),
+        pytest.raises(StreamlinkCLIError),
         id="error",
     ),
 ], indirect=["prompt"])


### PR DESCRIPTION
Second attempt: #5044

Had these changes stashed for a while and forgot about it... This cleans up the random `console.exit()` calls and instead raises a `StreamlinkCLIError` exception, which is then caught in the `main()` function.

There's still a lot to do here in the future. For example, the entire `ConsoleOutput` implementation is pretty bad, especially in combination with the regular logging system and the download progress output, where it interweaves the progess and log lines. In the previous PR I also rewrote some tests. I didn't do this here and just did some bare minimum fixing of the existing tests, because it doesn't make sense writing/updating tests for the flawed CLI main module. Hopefully at some point in the future, the entire CLI will be rewritten with a clean design.

This newly added `StreamlinkCLIError` exception class allows adding proper exit codes. Currently everything's set to exit code 1, just like it is now (except the untouched parts where 128+2 is returned on SigInt/SigTerm). Adding specific exit codes for different kinds of errors can be figured out for the next major version release.

The error behavior and error output format should be the same compared to master. Lots of tests are missing though, so there's potential for me to have changed something by accident.