### PR TITLE
docs: bump myst-parser dependency requirement

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -7,7 +7,7 @@ sphinx >=6.0.0,<8
 
 # themes and extensions
 furo ==2023.09.10
-myst-parser >=1.0.0,<3
+myst-parser >=1.0.0,<4
 sphinx-design ==0.5.0
 
 # typing


### PR DESCRIPTION
https://github.com/executablebooks/MyST-Parser/releases/tag/v3.0.0