### PR TITLE
docs: bump furo theme version to 2024.04.27

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,7 +6,7 @@ versioningit >=2.0.0,<4  # required for reading the version string when building
 sphinx >=6.0.0,<8
 
 # themes and extensions
-furo ==2023.09.10
+furo ==2024.04.27
 myst-parser >=1.0.0,<4
 sphinx-design ==0.5.0
 


### PR DESCRIPTION
- https://pradyunsg.me/furo/changelog/#bold-burgundy
- https://pradyunsg.me/furo/changelog/#amazing-amethyst

Main changes are `:visted` link colors and disabled search result indexing for search engines.