### PR TITLE
ci.github: add Python 3.13-dev test runners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 10
+    after_n_builds: 12
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
           python -m pip install -U
           -e .
           -r dev-requirements.txt
-          shtab
         continue-on-error: ${{ matrix.continue || false }}
       - name: Install optional Python dependencies
         if: ${{ ! startsWith(matrix['python-version'], '3.13') }}
@@ -60,9 +59,6 @@ jobs:
       - name: Test
         continue-on-error: ${{ matrix.continue || false }}
         run: pytest -r a --cov --cov-branch --cov-report=xml --durations 10
-      - name: Build shell completions
-        continue-on-error: ${{ matrix.continue || false }}
-        run: bash ./script/build-shell-completions.sh
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}
@@ -89,8 +85,14 @@ jobs:
       - name: Install Python dependencies
         run: >
           python -m pip install -U
+          -e .
           -r dev-requirements.txt
-          build wheel
+          build
+          wheel
+          shtab
+      - name: Build shell completions
+        continue-on-error: ${{ matrix.continue || false }}
+        run: bash ./script/build-shell-completions.sh
       - name: Build sdist and wheels
         run: ./script/build-and-sign.sh
       - name: Plugins JSON

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,13 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-#        include:
-#          - runs-on: ubuntu-latest
-#            python-version: "3.13-dev"
-#            continue: true
-#          - runs-on: windows-latest
-#            python-version: "3.13-dev"
-#            continue: true
+        include:
+          - runs-on: ubuntu-latest
+            python-version: "3.13-dev"
+            continue: true
+          - runs-on: windows-latest
+            python-version: "3.13-dev"
+            continue: true
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,13 @@ jobs:
           python -m pip install -U
           -e .
           -r dev-requirements.txt
-          brotli
           shtab
         continue-on-error: ${{ matrix.continue || false }}
+      - name: Install optional Python dependencies
+        if: ${{ ! startsWith(matrix['python-version'], '3.13') }}
+        run: >
+          python -m pip install -U
+          brotli
       - name: Test
         continue-on-error: ${{ matrix.continue || false }}
         run: pytest -r a --cov --cov-branch --cov-report=xml --durations 10


### PR DESCRIPTION
First CPython 3.13 beta release will be tagged in a week:
https://peps.python.org/pep-0719/#release-schedule

This PR adds CI test runners for 3.13 with the required compatibility wheels of certain dependencies.

But let's not merge this yet...