### PR TITLE
docs: remove Alpine Linux from install page, add ALT Linux package, add back Void Linux package

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -199,6 +199,10 @@ Linux and BSD
       - .. code-block:: bash
 
             sudo eopkg install streamlink
+    * - :octicon:`package-dependents` `Void`_
+      - .. code-block:: bash
+
+            sudo xbps-install streamlink
 
 .. _ALT Linux (Sisyphus): https://packages.altlinux.org/en/sisyphus/srpms/streamlink/
 .. _Arch Linux: https://archlinux.org/packages/extra/any/streamlink/
@@ -212,6 +216,7 @@ Linux and BSD
 .. _NixOS: https://github.com/NixOS/nixpkgs/tree/master/pkgs/applications/video/streamlink
 .. _openSUSE: https://build.opensuse.org/package/show/multimedia:apps/streamlink
 .. _Solus: https://github.com/getsolus/packages/tree/main/packages/s/streamlink
+.. _Void: https://github.com/void-linux/void-packages/tree/master/srcpkgs/streamlink
 
 .. _Installing AUR packages: https://wiki.archlinux.org/index.php/Arch_User_Repository
 .. _Installing Debian backported packages: https://wiki.debian.org/Backports
@@ -249,6 +254,8 @@ Package maintainers
       - Simon Puchert <simonpuchert at alice.de>
     * - Solus
       - Joey Riches <josephriches at gmail.com>
+    * - Void
+      - Tom Strausbaugh <tstrausbaugh at straustech.net>
     * - Windows binaries
       - Sebastian Meyer <mail at bastimeyer.de>
     * - Linux AppImages


### PR DESCRIPTION
Multiple changes in one PR because of unnecessary merge conflicts if merged independently. The first commit also can't be reverted once the package issues are resolved because of outdated package infos that require an update (stable repo instead of edge/testing and also old package maintainer).

----

1. Temporarily remove Alpine Linux from the doc's install page:
    Alpine has currently removed `streamlink` from their package repos because of `py-trio-websocket` build errors. See the linked issue in the commit message(s):

    - https://github.com/alpinelinux/aports/commit/16c818e837ee45ede77266e6c2e7aed926cd70b5
    - https://github.com/alpinelinux/aports/commit/3fb5e5333a607af417e2d71fbbc9be594bc57374

2. Add newly added ALT Linux package to install page:
    Not sure how relevant ALT Linux is, but let's add it nevertheless... `streamlink` is currently only in their "Sisyphus" repo, which looks like the equivalent to Debian's "sid" repo.

3. Add back Void package to install page:
    https://github.com/void-linux/void-packages/commit/eb128070bad236248d003c02f5f2f692dc7b6335