### PR TITLE
build: only require exceptiongroup on py<3.11

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -448,7 +448,8 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
       - Used for loading the CA bundle extracted from the Mozilla Included CA Certificate List
     * - runtime
       - `exceptiongroup`_
-      - Used for ``ExceptionGroup`` handling, to allow writing compatible code on all supported Python versions
+      - Only required when ``python_version<"3.11"`` |br|
+        Used for ``ExceptionGroup`` handling
     * - runtime
       - `isodate`_
       - Used for parsing ISO8601 strings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dynamic = [
 requires-python = ">=3.8"
 dependencies = [
   "certifi",
-  "exceptiongroup",
+  "exceptiongroup ; python_version<'3.11'",
   "isodate",
   "lxml >=4.6.4,<6",
   "pycountry",

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -5,8 +5,12 @@ import sys
 import warnings
 from typing import Any, Callable, Dict, Optional, Tuple
 
-# import exceptiongroup, so it can monkeypatch ExceptionGroup logic on <=py311
-import exceptiongroup  # noqa: F401
+
+try:
+    from builtins import BaseExceptionGroup, ExceptionGroup  # type: ignore[attr-defined]
+except ImportError:  # pragma: no cover
+    from exceptiongroup import BaseExceptionGroup, ExceptionGroup  # type: ignore[import]
+
 
 from streamlink.exceptions import StreamlinkDeprecationWarning
 
@@ -72,6 +76,8 @@ def deprecated(items: Dict[str, Tuple[Optional[str], Any, Any]]) -> None:
 
 
 __all__ = [
+    "BaseExceptionGroup",
+    "ExceptionGroup",
     "deprecated",
     "detect_encoding",
     "is_darwin",

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -541,7 +541,7 @@ class TwitchClientIntegrity:
         headers: Mapping[str, str],
         device_id: str,
     ) -> Optional[Tuple[str, int]]:
-        from exceptiongroup import BaseExceptionGroup  # noqa: PLC0415, I001
+        from streamlink.compat import BaseExceptionGroup  # noqa: PLC0415
         from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools  # noqa: PLC0415
 
         url = f"https://www.twitch.tv/{channel}"

--- a/src/streamlink/webbrowser/webbrowser.py
+++ b/src/streamlink/webbrowser/webbrowser.py
@@ -8,8 +8,8 @@ from subprocess import DEVNULL
 from typing import AsyncContextManager, AsyncGenerator, Generator, List, Optional, Union
 
 import trio
-from exceptiongroup import BaseExceptionGroup
 
+from streamlink.compat import BaseExceptionGroup
 from streamlink.utils.path import resolve_executable
 from streamlink.webbrowser.exceptions import WebbrowserError
 

--- a/tests/webbrowser/cdp/test_client.py
+++ b/tests/webbrowser/cdp/test_client.py
@@ -4,9 +4,9 @@ from unittest.mock import ANY, AsyncMock, Mock, call
 
 import pytest
 import trio
-from exceptiongroup import ExceptionGroup
 from trio.testing import wait_all_tasks_blocked
 
+from streamlink.compat import ExceptionGroup
 from streamlink.session import Streamlink
 from streamlink.webbrowser.cdp.client import CDPClient, CDPClientSession, RequestPausedHandler
 from streamlink.webbrowser.cdp.connection import CDPConnection, CDPSession

--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -7,10 +7,10 @@ from unittest.mock import AsyncMock
 
 import pytest
 import trio
-from exceptiongroup import ExceptionGroup
 from trio.testing import MockClock, wait_all_tasks_blocked
 from trio_websocket import CloseReason, ConnectionClosed, ConnectionTimeout  # type: ignore[import]
 
+from streamlink.compat import ExceptionGroup
 from streamlink.webbrowser.cdp.connection import CDPConnection, CDPEventListener, CDPSession
 from streamlink.webbrowser.cdp.devtools.target import SessionID, TargetID
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT

--- a/tests/webbrowser/test_webbrowser.py
+++ b/tests/webbrowser/test_webbrowser.py
@@ -7,9 +7,8 @@ from typing import List, Optional
 
 import pytest
 import trio
-from exceptiongroup import BaseExceptionGroup
 
-from streamlink.compat import is_win32
+from streamlink.compat import BaseExceptionGroup, is_win32
 from streamlink.webbrowser.exceptions import WebbrowserError
 from streamlink.webbrowser.webbrowser import Webbrowser
 


### PR DESCRIPTION
- Add `python_version<"3.11"` environment marker to `exceptiongroup`:
  It's a no-op package on Python 3.11 and above, so we don't have to require it on all Python versions.
- Update compatibility imports
- Update dependency docs

----

`exceptiongroup` was added in #5895.

`exceptiongroup` also includes a bugfix for `contextlib.suppress` on `<3.12.1`, but that shouldn't be relevant to us:
https://github.com/agronholm/exceptiongroup/blob/1.2.1/src/exceptiongroup/__init__.py#L43-L46

The reason for this dependency update is that some distros like Arch have already started phasing out their `python-exceptiongroup` package because of their single Python 3.12 package where this compat lib is not needed:
https://archlinux.org/todo/drop-python-exceptiongroup/

For some reason though, they simple dropped the dependency from their `streamlink` PKGBUILD and called it a day:
https://gitlab.archlinux.org/archlinux/packaging/packages/streamlink/-/commit/956f62c4719bebb3311fbbee337ab780ad8baf4e