### PR TITLE
tools: bump ruff to 0.4.5 and fix issues

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.4.4
+ruff ==0.4.5
 
 # typing
 mypy ==1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,6 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-ignore-init-module-imports = true
 select = [
   # pycodestyle
   "E",


### PR DESCRIPTION
https://github.com/astral-sh/ruff/releases/tag/v0.4.5