### PR TITLE
plugins: officially deprecate re-exports

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -1,6 +1,19 @@
 Deprecations
 ============
 
+streamlink 6.8.0
+----------------
+
+streamlink.plugins re-exports
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Importing :class:`NoPluginError <streamlink.exceptions.NoPluginError>`,
+:class:`NoStreamsError <streamlink.exceptions.NoStreamsError>`, :class:`PluginError <streamlink.exceptions.PluginError>`,
+or :class:`Plugin <streamlink.plugin.plugin.Plugin>` from ``streamlink.plugins`` now emits
+a :exc:`StreamlinkDeprecationWarning`. These re-exports have already been deprecated for more than ten years
+and will finally be removed in the next major version. Import from the correct paths instead.
+
+
 streamlink 6.7.0
 ----------------
 

--- a/src/streamlink/plugins/__init__.py
+++ b/src/streamlink/plugins/__init__.py
@@ -1,11 +1,28 @@
-"""
-    New plugins should use streamlink.plugin.Plugin instead
-    of this module, but this is kept here for backwards
-    compatibility.
-"""
+from streamlink.compat import deprecated
 
-from streamlink.exceptions import NoPluginError, NoStreamsError, PluginError
-from streamlink.plugin.plugin import Plugin
+
+deprecated({
+    "NoPluginError": (
+        "streamlink.exceptions.NoPluginError",
+        None,
+        "Importing from streamlink.plugins.NoPluginError has been deprecated",
+    ),
+    "NoStreamsError": (
+        "streamlink.exceptions.NoStreamsError",
+        None,
+        "Importing from streamlink.plugins.NoStreamsError has been deprecated",
+    ),
+    "PluginError": (
+        "streamlink.exceptions.PluginError",
+        None,
+        "Importing from streamlink.plugins.PluginError has been deprecated",
+    ),
+    "Plugin": (
+        "streamlink.plugin.plugin.Plugin",
+        None,
+        "Importing from streamlink.plugins.Plugin has been deprecated",
+    ),
+})
 
 
 __all__ = ["Plugin", "PluginError", "NoStreamsError", "NoPluginError"]

--- a/tests/plugin/testplugin.py
+++ b/tests/plugin/testplugin.py
@@ -2,8 +2,7 @@ import re
 from io import BytesIO
 
 from streamlink import NoStreamsError
-from streamlink.plugin import pluginargument, pluginmatcher
-from streamlink.plugins import Plugin
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.stream import Stream

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -8,8 +8,9 @@ import pytest
 
 import streamlink.plugins
 import tests.plugins
+from streamlink.exceptions import StreamlinkDeprecationWarning
 from streamlink.plugin.plugin import Matcher, Plugin
-from streamlink.utils.module import exec_module
+from streamlink.utils.module import exec_module, load_module
 
 
 plugins_path = streamlink.plugins.__path__[0]
@@ -208,3 +209,19 @@ class TestPluginMetadata:
         indexes = [PLUGIN_METADATA.index(val.split(" ")[0]) for key, val in metadata_items if key == "metadata"]
         assert [PLUGIN_METADATA[i] for i in indexes] == [PLUGIN_METADATA[i] for i in sorted(indexes)], \
             "$metadata metadata values are ordered correctly"
+
+
+@pytest.mark.parametrize(("attr", "msg"), [
+    pytest.param("NoPluginError", "Importing from streamlink.plugins.NoPluginError has been deprecated", id="NoPluginError"),
+    pytest.param("NoStreamsError", "Importing from streamlink.plugins.NoStreamsError has been deprecated", id="NoStreamsError"),
+    pytest.param("PluginError", "Importing from streamlink.plugins.PluginError has been deprecated", id="PluginError"),
+    pytest.param("Plugin", "Importing from streamlink.plugins.Plugin has been deprecated", id="Plugin"),
+])
+def test_deprecated_exports(recwarn: pytest.WarningsRecorder, attr: str, msg: str):
+    plugins_module = load_module("__init__", plugins_path)
+    assert recwarn.list == []
+
+    getattr(plugins_module, attr)
+    assert [(record.filename, record.category, str(record.message)) for record in recwarn.list] == [
+        (__file__, StreamlinkDeprecationWarning, msg),
+    ]


### PR DESCRIPTION
These re-exports don't belong into the `streamlink.plugins` package. This was already deprecated during the Livestreamer era, more than 11 years ago:
https://github.com/streamlink/streamlink/blame/6458c4ac844b2b31e26ce6911d408d1a615d7434/src/streamlink/plugins/__init__.py#L1-L6

https://deploy-preview-6005--streamlink.netlify.app/deprecations