### PR TITLE
plugins.welt: fix validation schema

### DIFF
--- a/src/streamlink/plugins/welt.py
+++ b/src/streamlink/plugins/welt.py
@@ -27,7 +27,7 @@ class Welt(Plugin):
             validate.xml_xpath_string("""
                 .//script
                 [@type='application/json']
-                [starts-with(@data-ref,'WeltVideoPlayer-') or @data-content='VideoPlayer.Config']
+                [starts-with(@data-internal-ref,'WeltVideoPlayer-') or @data-content='VideoPlayer.Config']
                 /text()
             """),
             validate.none_or_all(


### PR DESCRIPTION
```
$ ./script/test-plugin-urls.py welt
:: Finding streams for URL: https://welt.de/tv-programm-live-stream/
:: Found streams: 360p_alt, 360p, 432p_alt, 432p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
:: Finding streams for URL: https://www.welt.de/mediathek/dokumentation/space/strip-the-cosmos/sendung192055593/Strip-the-Cosmos-Die-Megastuerme-der-Planeten.html
:: Found streams: 200k, 1000k, 1500k, 2000k, worst, best
:: Finding streams for URL: https://www.welt.de/mediathek/magazin/gesellschaft/sendung247758214/Die-Welt-am-Wochenende-Auf-hoher-See-mit-der-Gorch-Fock.html
:: Found streams: 700k, 1200k, 2400k, 4800k, worst, best
:: Finding streams for URL: https://www.welt.de/tv-programm-live-stream/
:: Found streams: 360p_alt, 360p, 432p_alt, 432p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
:: Finding streams for URL: https://www.welt.de/tv-programm-n24-doku/
:: Found streams: 360p_alt, 360p, 432p_alt, 432p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
```