### PR TITLE
plugins.kick: fix API queries

### DIFF
--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -33,18 +33,23 @@ class Kick(Plugin):
     _URL_API_VOD = "https://kick.com/api/v1/video/{vod}"
     _URL_API_CLIP = "https://kick.com/api/v2/clips/{clip}"
 
-    def _get_token(self):
-        res = self.session.http.get(self._URL_TOKEN, raise_for_status=False)
-        return res.cookies.get("XSRF-TOKEN", "")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._token = ""
 
     def _get_api_headers(self):
-        token = self._get_token()
+        accept_language = self.session.localization.language_code.replace("_", "-")
+        self.session.http.headers.update({"Accept-Language": accept_language})
+
+        self._token = (
+            self._token
+            or self.session.http.get(self._URL_TOKEN, raise_for_status=False).cookies.get("XSRF-TOKEN", "")
+        )
 
         return {
             "Accept": "application/json",
-            "Accept-Language": "en-US",
             "Referer": self.url,
-            "Authorization": f"Bearer {token}",
+            "Authorization": f"Bearer {self._token}",
         }
 
     def _get_streams_live(self):


### PR DESCRIPTION
Fixes #6018 

@DCxDESIGN please check
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

My guess is that the `Authorization` token is tied to some HTTP headers, and since the `Accept-Language` header is different from the request where the token was obtained, the API returned 403. But that's just my guess, so please check if this PR fixes the issue.

----

```
$ ./script/test-plugin-urls.py kick -r LIVE_CHANNEL xqc -r VIDEO_ID 8bc87173-22f7-493e-a6a8-1ef5d11be9fa -r CLIP_CHANNEL admiralbulldog -r CLIP_ID clip_01HSNHF69RPPR9JX0VQ6WM2YVC
:: Finding streams for URL: https://kick.com/admiralbulldog?clip=clip_01HSNHF69RPPR9JX0VQ6WM2YVC
:: Found streams: clip, worst, best
:: Finding streams for URL: https://kick.com/video/8bc87173-22f7-493e-a6a8-1ef5d11be9fa
:: Found streams: 160p, 360p, 480p, 720p60, 1080p60, worst, best
:: Finding streams for URL: https://kick.com/xqc
:: Found streams: 160p, 360p, 480p, 720p60, 1080p60, worst, best
```