### PR TITLE
plugins.kick: restore plugin with new HTTPAdapter

### DIFF
--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -1,0 +1,204 @@
+"""
+$description Global live-streaming and video hosting social platform owned by Kick Streaming Pty Ltd.
+$url kick.com
+$type live, vod
+$metadata id
+$metadata author
+$metadata category
+$metadata title
+"""
+
+import re
+from ssl import OP_NO_TICKET
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.session.http import SSLContextAdapter
+from streamlink.stream.hls import HLSStream
+
+
+class KickAdapter(SSLContextAdapter):
+    def get_ssl_context(self):
+        ctx = super().get_ssl_context()
+        ctx.options &= ~OP_NO_TICKET
+
+        return ctx
+
+
+@pluginmatcher(
+    name="live",
+    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/(?!video/)(?P<channel>[^/?]+)$"),
+)
+@pluginmatcher(
+    name="vod",
+    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/video/(?P<vod>[^/?]+)"),
+)
+@pluginmatcher(
+    name="clip",
+    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/(?!video/)(?P<channel>[^/?]+)\?clip=(?P<clip>[^&]+)$"),
+)
+class Kick(Plugin):
+    _URL_TOKEN = "https://kick.com/"
+    _URL_API_LIVESTREAM = "https://kick.com/api/v2/channels/{channel}/livestream"
+    _URL_API_VOD = "https://kick.com/api/v1/video/{vod}"
+    _URL_API_CLIP = "https://kick.com/api/v2/clips/{clip}"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session.http.mount("https://kick.com/", KickAdapter())
+
+    def _get_token(self):
+        res = self.session.http.get(self._URL_TOKEN, raise_for_status=False)
+        return res.cookies.get("XSRF-TOKEN", "")
+
+    def _get_api_headers(self):
+        token = self._get_token()
+
+        return {
+            "Accept": "application/json",
+            "Accept-Language": "en-US",
+            "Referer": self.url,
+            "Authorization": f"Bearer {token}",
+        }
+
+    def _get_streams_live(self):
+        self.author = self.match["channel"]
+
+        data = self.session.http.get(
+            self._URL_API_LIVESTREAM.format(channel=self.author),
+            acceptable_status=(200, 404),
+            headers=self._get_api_headers(),
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    validate.all(
+                        {"message": str},
+                        validate.transform(lambda _: None),
+                    ),
+                    validate.all(
+                        {"data": None},
+                        validate.transform(lambda _: None),
+                    ),
+                    validate.all(
+                        {
+                            "data": {
+                                "playback_url": validate.url(path=validate.endswith(".m3u8")),
+                                "id": int,
+                                "category": {"name": str},
+                                "session_title": str,
+                            },
+                        },
+                        validate.get("data"),
+                        validate.union_get(
+                            "playback_url",
+                            "id",
+                            ("category", "name"),
+                            "session_title",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        if not data:
+            return
+
+        hls_url, self.id, self.category, self.title = data
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+    def _get_streams_vod(self):
+        self.id = self.match["vod"]
+
+        data = self.session.http.get(
+            self._URL_API_VOD.format(vod=self.id),
+            acceptable_status=(200, 404),
+            headers=self._get_api_headers(),
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    validate.all(
+                        {"message": str},
+                        validate.transform(lambda _: None),
+                    ),
+                    validate.all(
+                        {
+                            "source": validate.url(path=validate.endswith(".m3u8")),
+                            "livestream": {
+                                "session_title": str,
+                                "channel": {
+                                    "user": {
+                                        "username": str,
+                                    },
+                                },
+                            },
+                        },
+                        validate.union_get(
+                            "source",
+                            ("livestream", "channel", "user", "username"),
+                            ("livestream", "session_title"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        if not data:
+            return
+
+        hls_url, self.author, self.title = data
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+    def _get_streams_clip(self):
+        self.id = self.match["clip"]
+        self.author = self.match["channel"]
+
+        data = self.session.http.get(
+            self._URL_API_CLIP.format(clip=self.id),
+            acceptable_status=(200, 404),
+            headers=self._get_api_headers(),
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    validate.all(
+                        {"message": str},
+                        validate.transform(lambda _: None),
+                    ),
+                    validate.all(
+                        {"clip": None},
+                        validate.transform(lambda _: None),
+                    ),
+                    validate.all(
+                        {
+                            "clip": {
+                                "clip_url": validate.url(path=validate.endswith(".m3u8")),
+                                "category": {"name": str},
+                                "title": str,
+                            },
+                        },
+                        validate.get("clip"),
+                        validate.union_get(
+                            "clip_url",
+                            ("category", "name"),
+                            "title",
+                        ),
+                    ),
+                ),
+            ),
+        )
+        if not data:
+            return
+
+        hls_url, self.category, self.title = data
+
+        return {"clip": HLSStream(self.session, hls_url)}
+
+    def _get_streams(self):
+        if self.matches["live"]:
+            return self._get_streams_live()
+        if self.matches["vod"]:
+            return self._get_streams_vod()
+        if self.matches["clip"]:
+            return self._get_streams_clip()
+
+
+__plugin__ = Kick

--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -1,3 +1,4 @@
+import ssl
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from typing import Any, Union
 
@@ -68,10 +69,13 @@ _Exception: TypeAlias = type[Exception]
 
 # ----
 
-class TLSNoDHAdapter(HTTPAdapter):
+class SSLContextAdapter(HTTPAdapter):
+    def get_ssl_context(self) -> ssl.SSLContext: ...
+
+class TLSNoDHAdapter(SSLContextAdapter):
     ...
 
-class TLSSecLevel1Adapter(HTTPAdapter):
+class TLSSecLevel1Adapter(SSLContextAdapter):
     ...
 
 class HTTPSession(Session):

--- a/tests/plugins/test_kick.py
+++ b/tests/plugins/test_kick.py
@@ -1,0 +1,12 @@
+from streamlink.plugins.kick import Kick
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlKick(PluginCanHandleUrl):
+    __plugin__ = Kick
+
+    should_match_groups = [
+        (("live", "https://kick.com/LIVE_CHANNEL"), {"channel": "LIVE_CHANNEL"}),
+        (("vod", "https://kick.com/video/VIDEO_ID"), {"vod": "VIDEO_ID"}),
+        (("clip", "https://kick.com/CLIP_CHANNEL?clip=CLIP_ID"), {"channel": "CLIP_CHANNEL", "clip": "CLIP_ID"}),
+    ]


### PR DESCRIPTION
Three commits:
1. Add new test markers for excluding specific python versions
2. Refactor custom HTTPAdapter classes, so urllib3's SSLContext can be customized easily
3. Restore the plugin and use custom HTTPAdapter that disables the [`OP_NO_TICKET`](https://docs.python.org/3/library/ssl.html#ssl.OP_NO_TICKET) SSLContext option

See https://github.com/streamlink/streamlink/issues/6018#issuecomment-2153150008

----

Working plugin from this PR branch using OpenSSL 3.0.13

```
$ docker run --rm -it ghcr.io/streamlink/appimage-buildenv-x86_64@sha256:537b8ef991c77cc633d932654aff3372cf7b4c233bb775b5ba8aa191dface5b1 bash -c '/opt/python/cp312-cp312/bin/python -m venv /venv;source /venv/bin/activate;pip install -q git+https://github.com/bastimeyer/streamlink@plugins/kick/restore;streamlink -l debug kick.com/xqc'
[session][debug] Loading plugin: kick
[cli][info] streamlink is running as root! Be careful!
[cli][debug] OS:         Linux-6.9.2-1-git-x86_64-with-glibc2.17
[cli][debug] Python:     3.12.3
[cli][debug] OpenSSL:    OpenSSL 3.0.13 30 Jan 2024
[cli][debug] Streamlink: 6.7.3+41.g096d9701
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.6.2
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.25.1
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.1
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=kick.com/xqc
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin kick for URL kick.com/xqc
[utils.l10n][debug] Language code: en_US
Available streams: 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
```