### PR TITLE
session.http: re-use SSLContext in ProxyManager

### DIFF
--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -213,6 +213,10 @@ class SSLContextAdapter(HTTPAdapter):
         kwargs["ssl_context"] = self.get_ssl_context()
         return super().init_poolmanager(*args, **kwargs)
 
+    def proxy_manager_for(self, *args, **kwargs):
+        kwargs["ssl_context"] = self.poolmanager.connection_pool_kw["ssl_context"]
+        return super().proxy_manager_for(*args, **kwargs)
+
 
 class TLSNoDHAdapter(SSLContextAdapter):
     def get_ssl_context(self) -> ssl.SSLContext:

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -125,3 +125,11 @@ class TestHTTPAdapters:
         assert isinstance(ssl_context, SSLContext)
         assert self._has_dh_ciphers(ssl_context)
         assert self._has_weak_digest_ciphers(ssl_context)
+
+    @pytest.mark.parametrize("proxy", ["http", "socks4", "socks5"])
+    def test_proxymanager_ssl_context(self, proxy: str):
+        adapter = SSLContextAdapter()
+        proxymanager = adapter.proxy_manager_for(f"{proxy}://")
+        ssl_context_poolmanager = adapter.poolmanager.connection_pool_kw.get("ssl_context")
+        ssl_context_proxymanager = proxymanager.connection_pool_kw.get("ssl_context")
+        assert ssl_context_poolmanager is ssl_context_proxymanager


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/issues/6018#issuecomment-2155891229

This uses a reference of the same `SSLContext` object in the `urllib3.ProxyManager`'s connection pool keywords as the regular `urllib3.PoolManager`.

I can't verify the proxy issue on kick.com though, as kick is blocking my entire server network. I'm using a socks5 tunnel via OpenSSH on my server, and regular HTTPS requests from the server don't work either.

Re-using the same SSLContext however is the correct thing to do:
- https://github.com/urllib3/urllib3/blob/2.2.1/src/urllib3/poolmanager.py#L587
- https://github.com/urllib3/urllib3/blob/2.2.1/src/urllib3/contrib/socks.py#L228
- https://github.com/urllib3/urllib3/blob/1.26.0/src/urllib3/poolmanager.py#L495
- https://github.com/urllib3/urllib3/blob/1.26.0/src/urllib3/contrib/socks.py#L212-L214

Example from related projects:
- https://github.com/yt-dlp/yt-dlp/blame/2024.05.27/yt_dlp/networking/_requests.py#L165-L182