### PR TITLE
plugins.cnbce: new plugin

### DIFF
--- a/src/streamlink/plugins/cnbce.py
+++ b/src/streamlink/plugins/cnbce.py
@@ -1,0 +1,38 @@
+"""
+$description Turkish live TV channel owned by NBCUniversal Media.
+$url cnbce.com
+$type live
+$region Turkey
+"""
+
+import logging
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(re.compile(r"https?://(?:www\.)?cnbce\.com/canli-yayin"))
+class CNBCE(Plugin):
+    _URL_API = "https://www.cnbce.com/api/live-stream/source"
+
+    def _get_streams(self):
+        hls_url = self.session.http.post(self._URL_API, schema=validate.Schema(
+            validate.parse_json(),
+            {
+                "source": validate.url(path=validate.endswith(".m3u8")),
+            },
+            validate.get("source"),
+        ))
+        if self.session.http.get(hls_url, raise_for_status=False).status_code != 200:
+            log.error("Could not access stream (geo-blocked content, etc.)")
+            return
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+
+__plugin__ = CNBCE

--- a/tests/plugins/test_cnbce.py
+++ b/tests/plugins/test_cnbce.py
@@ -1,0 +1,10 @@
+from streamlink.plugins.cnbce import CNBCE
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlCNBCE(PluginCanHandleUrl):
+    __plugin__ = CNBCE
+
+    should_match = [
+        "https://www.cnbce.com/canli-yayin",
+    ]


### PR DESCRIPTION
Resolves #6028 
https://en.wikipedia.org/wiki/CNBC-e

Content is geo-restricted. Checked using a VPN from Cyprus...

@ipstreet312 Please check and post a debug log
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

----

Geo-restriction
```
$ streamlink https://www.cnbce.com/canli-yayin
[cli][info] Found matching plugin cnbce for URL https://www.cnbce.com/canli-yayin
[plugins.cnbce][error] Could not access stream (geo-blocked content, etc.)
error: No playable streams found on this URL: https://www.cnbce.com/canli-yayin
```

With VPN
```
$ streamlink -l debug https://www.cnbce.com/canli-yayin best
[cli][debug] OS:         Linux-6.9.3-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.3
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.7.4+20.g225a8ed2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.6.2
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.25.1
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.1
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.cnbce.com/canli-yayin
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin cnbce for URL https://www.cnbce.com/canli-yayin
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 360p (worst), 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 40165; Last Sequence: 40344
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 40342; End Sequence: None
[stream.hls][debug] Adding segment 40342 to queue
[stream.hls][debug] Adding segment 40343 to queue
[stream.hls][debug] Adding segment 40344 to queue
[stream.hls][debug] Writing segment 40342 to output
[stream.hls][debug] Segment 40342 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://www.cnbce.com/canli-yayin', '-']
[stream.hls][debug] Writing segment 40343 to output
[stream.hls][debug] Segment 40343 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Writing segment 40344 to output
[stream.hls][debug] Segment 40344 complete
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```