### PR TITLE
plugins.bilibili: fix schema for offline channels

### DIFF
--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -72,14 +72,17 @@ class Bilibili(Plugin):
                 {
                     "code": 0,
                     "data": {
-                        "playurl_info": {
-                            "playurl": {
-                                "stream": self._schema_streams(),
+                        "playurl_info": validate.none_or_all(
+                            {
+                                "playurl": {
+                                    "stream": self._schema_streams(),
+                                },
                             },
-                        },
+                            validate.get(("playurl", "stream")),
+                        ),
                     },
                 },
-                validate.get(("data", "playurl_info", "playurl", "stream")),
+                validate.get(("data", "playurl_info")),
             ),
         )
 
@@ -96,11 +99,14 @@ class Bilibili(Plugin):
                         "roomInitRes": {
                             "data": {
                                 "live_status": int,
-                                "playurl_info": {
-                                    "playurl": {
-                                        "stream": self._schema_streams(),
+                                "playurl_info": validate.none_or_all(
+                                    {
+                                        "playurl": {
+                                            "stream": self._schema_streams(),
+                                        },
                                     },
-                                },
+                                    validate.get(("playurl", "stream")),
+                                ),
                             },
                         },
                         "roomInfoRes": {
@@ -124,7 +130,7 @@ class Bilibili(Plugin):
                         ("roomInfoRes", "data", "room_info", "area_name"),
                         ("roomInfoRes", "data", "room_info", "title"),
                         ("roomInitRes", "data", "live_status"),
-                        ("roomInitRes", "data", "playurl_info", "playurl", "stream"),
+                        ("roomInitRes", "data", "playurl_info"),
                     ),
                 ),
             ),


### PR DESCRIPTION
Fixes #6031 

Offline

```
$ streamlink -l debug https://live.bilibili.com/22529135
[cli][debug] OS:         Linux-6.9.3-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.3
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.7.4+20.g3bf12192
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.6.2
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.25.1
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.1
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://live.bilibili.com/22529135
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin bilibili for URL https://live.bilibili.com/22529135
[plugins.bilibili][info] Channel is offline
error: No playable streams found on this URL: https://live.bilibili.com/22529135
```

Online

```
$ streamlink -l debug https://live.bilibili.com/388
[cli][debug] OS:         Linux-6.9.3-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.3
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.7.4+20.g3bf12192
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.6.2
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.25.1
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.1
[cli][debug]  urllib3: 2.2.1
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://live.bilibili.com/388
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin bilibili for URL https://live.bilibili.com/388
Available streams: live_alt, live (worst, best)
```