### PR TITLE
plugins.pluzz: refactor, upd API URL, fix schemas

### DIFF
--- a/tests/plugins/test_pluzz.py
+++ b/tests/plugins/test_pluzz.py
@@ -6,17 +6,31 @@ class TestPluginCanHandleUrlPluzz(PluginCanHandleUrl):
     __plugin__ = Pluzz
 
     should_match = [
-        "https://www.france.tv/france-2/direct.html",
-        "https://www.france.tv/france-3/direct.html",
-        "https://www.france.tv/france-4/direct.html",
-        "https://www.france.tv/france-5/direct.html",
-        "https://www.france.tv/franceinfo/direct.html",
-        "https://www.france.tv/france-2/journal-20h00/141003-edition-du-lundi-8-mai-2017.html",
-        "https://france3-regions.francetvinfo.fr/bourgogne-franche-comte/direct/franche-comte",
-        "https://www.francetvinfo.fr/en-direct/tv.html",
-        "https://www.francetvinfo.fr/meteo/orages/inondations-dans-le-gard-plus-de-deux-mois-de-pluie-en-quelques-heures-des"
-        + "-degats-mais-pas-de-victime_4771265.html",
-        "https://la1ere.francetvinfo.fr/info-en-continu-24-24",
-        "https://la1ere.francetvinfo.fr/programme-video/france-3_outremer-ledoc/diffusion/"
-        + "2958951-polynesie-les-sages-de-l-ocean.html",
+        ("francetv", "https://www.france.tv/france-2/direct.html"),
+        ("francetv", "https://www.france.tv/france-3/direct.html"),
+        ("francetv", "https://www.france.tv/france-4/direct.html"),
+        ("francetv", "https://www.france.tv/france-5/direct.html"),
+        ("francetv", "https://www.france.tv/franceinfo/direct.html"),
+        ("francetv", "https://www.france.tv/france-2/journal-20h00/141003-edition-du-lundi-8-mai-2017.html"),
+
+        (
+            "francetvinfofr",
+            "https://www.francetvinfo.fr/en-direct/tv.html",
+        ),
+        (
+            "francetvinfofr",
+            "https://www.francetvinfo.fr/meteo/orages/inondations-dans-le-gard-plus-de-deux-mois-de-pluie-en-quelques-heures-des-degats-mais-pas-de-victime_4771265.html",
+        ),
+        (
+            "francetvinfofr",
+            "https://france3-regions.francetvinfo.fr/bourgogne-franche-comte/direct/franche-comte",
+        ),
+        (
+            "francetvinfofr",
+            "https://la1ere.francetvinfo.fr/programme-video/france-3_outremer-ledoc/diffusion/2958951-polynesie-les-sages-de-l-ocean.html",
+        ),
+        (
+            "francetvinfofr",
+            "https://la1ere.francetvinfo.fr/info-en-continu-24-24",
+        ),
     ]


### PR DESCRIPTION
- Split into separate matchers for each supported site
- Update API URL
- Fix video ID validation schema
- Fix token URL validation schema
- Remove unnecessary `update_qsd()` calls

----

Resolves #6047

@uNouss please check if something's not working correctly that's not covered by the test URLs
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

```
$ HTTPS_PROXY=socks5h://localhost:1920 ./script/test-plugin-urls.py pluzz
:: Finding streams for URL: https://france3-regions.francetvinfo.fr/bourgogne-franche-comte/direct/franche-comte
:: Found streams: 216p, 360p, 540p, 720p, worst, best
:: Finding streams for URL: https://la1ere.francetvinfo.fr/info-en-continu-24-24
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://la1ere.francetvinfo.fr/programme-video/france-3_outremer-ledoc/diffusion/2958951-polynesie-les-sages-de-l-ocean.html
:: Found streams: 216p, 360p, 540p, 720p, worst, best
:: Finding streams for URL: https://www.france.tv/france-2/direct.html
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.france.tv/france-2/journal-20h00/141003-edition-du-lundi-8-mai-2017.html
:: Found streams: 144p, 180p, 288p, 396p, 576p, worst, best
:: Finding streams for URL: https://www.france.tv/france-3/direct.html
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.france.tv/france-4/direct.html
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.france.tv/france-5/direct.html
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.france.tv/franceinfo/direct.html
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.francetvinfo.fr/en-direct/tv.html
:: Found streams: 144p, 216p, 360p, 540p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.francetvinfo.fr/meteo/orages/inondations-dans-le-gard-plus-de-deux-mois-de-pluie-en-quelques-heures-des-degats-mais-pas-de-victime_4771265.html
:: Found streams: 216p, 360p, 540p, 720p, worst, best
```

The error message when being geo-blocked isn't ideal, but I don't care...

```
$ streamlink https://www.france.tv/france-2/direct.html
[cli][info] Found matching plugin pluzz for URL https://www.france.tv/france-2/direct.html
error: Unable to open URL: https://k7.ftven.fr/videos/006194ea-117d-4bcf-94a9-153d999c59ae (422 Client Error: Unprocessable Entity for url: https://k7.ftven.fr/videos/006194ea-117d-4bcf-94a9-153d999c59ae?country_code=DE&w=1920&h=1080&player_version=5.51.35&domain=www.france.tv&device_type=mobile&browser=chrome&browser_version=125&os=ios&gmt=%2B0200)
```

The new API response contains two different token URL for getting the HLS/DASH stream URLs, `dai` and `akamai`. The `dai` one didn't seem to work, and the regular TV live streams (didn't check anything else) were using `akamai`, so I went with that. No idea if a fallback to `dai` might be required in the future. For now it's simply ignored...

Also probably worth mentioning is that the website requires a login, because the initial JSON payload with the video-ID has this property set: `"isLoginRequired": true`. Their API doesn't seem to care though.