### PR TITLE
docs: drop i686 Linux AppImages and x86+py38 Windows builds

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -571,76 +571,36 @@ Windows binaries
     .. grid-item-card::
         :padding: 3
         :class-header: sd-text-center
-        :class-footer: sd-text-center sd-bg-transparent sd-border-0
+        :class-body: sd-py-0
+        :class-footer: sd-text-center sd-bg-transparent sd-border-0 sd-pt-0 sd-pb-3
 
         :fas:`gears` **Installer**
         ^^^
 
+        - Windows 10+
         - Adds itself to the system's ``PATH`` env var
         - Automatically creates a :ref:`config file <cli/config:Configuration file>`
         - Sets :option:`--ffmpeg-ffmpeg` in config file
 
         +++
-        .. grid:: 2
-            :gutter: 1
-            :padding: 0
-
-            .. grid-item::
-                :class: sd-text-right
-
-                Windows 10+
-
-            .. grid-item::
-
-                :bdg-link-success-line:`x86_64 <https://github.com/streamlink/windows-builds/releases>`
-                :bdg-link-primary-line:`x86 <https://github.com/streamlink/windows-builds/releases>`
-
-            .. grid-item::
-                :class: sd-text-right
-
-                Windows 7 (py38)
-
-            .. grid-item::
-
-                :bdg-link-secondary-line:`x86_64 <https://github.com/streamlink/windows-builds/releases>`
-                :bdg-link-secondary-line:`x86 <https://github.com/streamlink/windows-builds/releases>`
+        :bdg-link-success-line:`x86_64 <https://github.com/streamlink/windows-builds/releases>`
 
     .. grid-item-card::
         :padding: 3
         :class-header: sd-text-center
-        :class-footer: sd-text-center sd-bg-transparent sd-border-0
+        :class-body: sd-py-0
+        :class-footer: sd-text-center sd-bg-transparent sd-border-0 sd-pt-0 sd-pb-3
 
         :fas:`file-zipper` **Portable archive**
         ^^^
 
+        - Windows 10+
         - No :ref:`config file <cli/config:Configuration file>` created automatically
         - :option:`--ffmpeg-ffmpeg` must be set manually
         - No pre-compiled Python bytecode
 
         +++
-        .. grid:: 2
-            :gutter: 1
-            :padding: 0
-
-            .. grid-item::
-                :class: sd-text-right
-
-                Windows 10+
-
-            .. grid-item::
-
-                :bdg-link-success-line:`x86_64 <https://github.com/streamlink/windows-builds/releases>`
-                :bdg-link-primary-line:`x86 <https://github.com/streamlink/windows-builds/releases>`
-
-            .. grid-item::
-                :class: sd-text-right
-
-                Windows 7 (py38)
-
-            .. grid-item::
-
-                :bdg-link-secondary-line:`x86_64 <https://github.com/streamlink/windows-builds/releases>`
-                :bdg-link-secondary-line:`x86 <https://github.com/streamlink/windows-builds/releases>`
+        :bdg-link-success-line:`x86_64 <https://github.com/streamlink/windows-builds/releases>`
 
 **Contents**
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -715,7 +715,7 @@ Linux AppImages
 
 **Architectures**
 
-.. grid:: 3
+.. grid:: 2
     :padding: 0
 
     .. grid-item-card::
@@ -729,12 +729,6 @@ Linux AppImages
         :text-align: center
 
         :bdg-link-success-line:`aarch64 <https://github.com/streamlink/streamlink-appimage/releases>`
-
-    .. grid-item-card::
-        :padding: 3
-        :text-align: center
-
-        :bdg-link-primary-line:`i686 <https://github.com/streamlink/streamlink-appimage/releases>`
 
 **Contents**
 
@@ -766,20 +760,27 @@ Linux AppImages
 
 **How-To**
 
-1. Download the AppImage file matching your CPU architecture (run :command:`uname -m` to check)
+1. Verify that the system is running on at least
+   `glibc <glibc-wikipedia_>`_ `2.28 (Aug 2018) <glibc-release-distro-mapping_>`_ (see :command:`ld.so --version`)
 
-2. Set the executable flag via a file browser or :command:`chmod +x filename` from a command-line shell
+2. Download the AppImage file matching the system's CPU architecture (see :command:`uname --machine`)
 
-   .. code-block:: bash
-
-      # AppImage file names include the release version, Python version, platform name and CPU architecture
-      chmod +x streamlink-5.3.0-1-cp311-cp311-manylinux2014_x86_64.AppImage
-
-3. Run the AppImage with any command-line parameters supported by Streamlink
+3. Set the executable flag via a file browser or :command:`chmod +x filename` from a command-line shell
 
    .. code-block:: bash
 
-      ./streamlink-5.3.0-1-cp311-cp311-manylinux2014_x86_64.AppImage --loglevel=debug
+      # AppImage file names include the release version,
+      # the Python version, platform name and CPU architecture
+      chmod +x streamlink-7.0.0-1-cp312-cp312-manylinux_2_28_x86_64.AppImage
+
+4. Run the AppImage with any command-line parameters supported by Streamlink
+
+   .. code-block:: bash
+
+      ./streamlink-7.0.0-1-cp312-cp312-manylinux_2_28_x86_64.AppImage --loglevel=debug
+
+.. _glibc-wikipedia: https://en.wikipedia.org/wiki/Glibc
+.. _glibc-release-distro-mapping: https://sourceware.org/glibc/wiki/Release#Distribution_Branch_Mapping
 
 
 What are AppImages?


### PR DESCRIPTION
Closes #5732 

I'm going to merge this PR once the Linux AppImage and Windows builds have been updated. I don't know though when this will happen, because it's not particularly urgent to update the AppImages right now. I'll probably do this on Streamlink's next release with a minor version bump (`6.9.x`).

----

### Linux AppImages

CentOS 7 will reach its EOL at the end of this week on 2024-07-01, which is what the `pypa/manylinux2014` docker images are based on, which in turn is what Streamlink's AppImages are currently based on. This means that the AppImages will have to switch to newer manylinux images, namely `manylinux_2_28` (AlmaLinux 8 based with glibc 2.28), which will be the end for "32 bit" i686 AppImages.

- https://endoflife.date/centos
- https://github.com/pypa/manylinux/blob/095daf5fc97b98aa0f1e48c3a594df654caa09ee/README.rst#manylinux2014-centos-7-based-glibc-217
- https://peps.python.org/pep-0599/#rationale

### Windows builds

Since it's less work for me to do both things at the same time, I'm also going to drop the "32 bit" x86 builds for Windows, as well as the py38-based builds for Windows 7, even though py38 will see its EOL at the end of October (13 weeks from now). Streamlink's extended support for W7 via additional py38 builds has been going on for long enough, so I absolutely don't care about anyone using this OS in 2024 who won't be able to upgrade after this. Streamlink 7.0.0 won't support py38 anyway.

- https://endoflife.date/windows

And before anyone asks about ARM64/aarch64 builds for Windows (I left space for that in the docs layout), I've recently explained it here:
https://github.com/streamlink/windows-builds/issues/10