### PR TITLE
plugins.vidio: fix stream token, add metadata

### DIFF
--- a/tests/plugins/test_vidio.py
+++ b/tests/plugins/test_vidio.py
@@ -8,6 +8,7 @@ class TestPluginCanHandleUrlVidio(PluginCanHandleUrl):
     should_match = [
         "https://www.vidio.com/live/204-sctv-tv-stream",
         "https://www.vidio.com/live/5075-dw-tv-stream",
+        "https://www.vidio.com/live/777-metro-tv",
         "https://www.vidio.com/watch/766861-5-rekor-fantastis-zidane-bersama-real-madrid",
     ]
 


### PR DESCRIPTION
Fixes #6056 

```
$ ./script/test-plugin-urls.py vidio
:: Finding streams for URL: https://www.vidio.com/live/204-sctv-tv-stream
:: Found streams: 240p_alt, 240p, 360p_alt, 360p, 480p_alt, 480p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
:: Finding streams for URL: https://www.vidio.com/live/5075-dw-tv-stream
:: Found streams: 240p, 360p, 480p, 720p, 1080p, worst, best
:: Finding streams for URL: https://www.vidio.com/live/777-metro-tv
:: Found streams: 240p, 360p, 480p, 720p, worst, best
:: Finding streams for URL: https://www.vidio.com/watch/766861-5-rekor-fantastis-zidane-bersama-real-madrid
:: Found streams: 270p, 360p, 720p, worst, best
```

```
$ streamlink -j https://www.vidio.com/live/5075-dw-tv-stream best | jq .metadata
{
  "id": "5075",
  "author": null,
  "category": null,
  "title": "DW English"
}
```