### PR TITLE
tools: bump ruff to 0.5.1 and fix issues

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.5.0
+ruff ==0.5.1
 
 # typing
 mypy ==1.10.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,10 @@ combine-as-imports = true
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
+[tool.ruff.lint.flake8-pytest-style]
+fixture-parentheses = true
+mark-parentheses = true
+
 [tool.ruff.lint.flake8-quotes]
 avoid-escape = false
 


### PR DESCRIPTION
Ruff 0.5.1 reverted the forced decorator parentheses config for pytest fixtures and test markers.
https://github.com/astral-sh/ruff/pull/12106

Let's keep the parentheses though, because it's all about consistency. Test fixtures and markers with parameters obviously require them, so I don't see a reason to follow the new default config of ruff and remove them where no parameters are involved.