### PR TITLE
plugins.twitch: fix uppercase channel names

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -274,8 +274,8 @@ class UsherService:
 
         return req.url
 
-    def channel(self, channel, **extra_params):
-        try:
+    def channel(self, channel: str, **extra_params) -> str:
+        with suppress(PluginError):
             extra_params_debug = validate.Schema(
                 validate.get("token"),
                 validate.parse_json(),
@@ -288,11 +288,10 @@ class UsherService:
                 },
             ).validate(extra_params)
             log.debug(f"{extra_params_debug!r}")
-        except PluginError:
-            pass
-        return self._create_url(f"/api/channel/hls/{channel}.m3u8", **extra_params)
 
-    def video(self, video_id, **extra_params):
+        return self._create_url(f"/api/channel/hls/{channel.lower()}.m3u8", **extra_params)
+
+    def video(self, video_id: str, **extra_params) -> str:
         return self._create_url(f"/vod/{video_id}", **extra_params)
 
 


### PR DESCRIPTION
Resolves #6070 

No idea if this justifies having another patch release just yet, considering that the Twitch plugin is priority number one... I'll think about it. Neither Twitch's website, nor my Twitch GUI use uppercase channel names in any way, so CLI users of Streamlink can always use lowercase channel names as a workaround in 6.8.2.

```
$ ./script/test-plugin-urls.py twitch -r CHANNELNAME HasanAbi -i video -i /v -i clip
:: https://player.twitch.tv/?parent=twitch.tv&channel=HasanAbi
::  audio_only, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
:: https://www.twitch.tv/HasanAbi
::  audio_only, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
:: https://www.twitch.tv/HasanAbi/
::  audio_only, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
:: https://www.twitch.tv/HasanAbi/?
::  audio_only, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
:: https://www.twitch.tv/HasanAbi?
::  audio_only, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
```