### PR TITLE
logger: backslashreplace stream encoding errors

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -125,6 +125,23 @@ class StringFormatter(logging.Formatter):
         return super().format(record)
 
 
+class StreamHandler(logging.StreamHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._stream_reconfigure()
+
+    def setStream(self, stream):
+        res = super().setStream(stream)
+        if res:  # pragma: no branch
+            self._stream_reconfigure()
+
+        return res
+
+    def _stream_reconfigure(self):
+        # make stream write calls escape unsupported characters (stdout/stderr encoding is not guaranteed to be utf-8)
+        self.stream.reconfigure(errors="backslashreplace")
+
+
 class WarningLogRecord(logging.LogRecord):
     msg: WarningMessage  # type: ignore[assignment]
 
@@ -195,7 +212,7 @@ def basicConfig(
         if filename is not None:
             handler = logging.FileHandler(filename, filemode, encoding="utf-8")
         else:
-            handler = logging.StreamHandler(stream)
+            handler = StreamHandler(stream)
 
         # noinspection PyTypeChecker
         formatter = StringFormatter(


### PR DESCRIPTION
Follow-up of #6080 

This prevents potential character encoding errors on the logger's default streams, stdout and stderr, depending on the default stream encoding.

----

master
```
$ PYTHONIOENCODING=ascii streamlink -l debug -p mpv -a '"--title=🐻"' httpstream://file:///dev/zero best
[cli][debug] OS:         Linux-6.9.9-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.4
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.8.3+1.g09c19cf8
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.7.4
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.2
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=httpstream://file:///dev/zero
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1163, in emit
    stream.write(msg + self.terminator)
UnicodeEncodeError: 'ascii' codec can't encode character '\U0001f43b' in position 37: ordinal not in range(128)
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 953, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 889, in setup
    log_current_arguments(streamlink, parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 829, in log_current_arguments
    log.debug(f" {name}={value if name not in sensitive else '*' * 8}")
Message: ' --player-args="--title=\U0001f43b"'
Arguments: ()
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[plugins.http][debug] URL=file:///dev/zero; params={}
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Starting player: mpv
[cli][debug] Pre-buffering 8192 bytes
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1163, in emit
    stream.write(msg + self.terminator)
UnicodeEncodeError: 'ascii' codec can't encode character '\U0001f43b' in position 133: ordinal not in range(128)
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 955, in main
    exit_code = run(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 927, in run
    handle_url()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 564, in handle_url
    handle_stream(plugin, streams, stream_name)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 436, in handle_stream
    success = output_stream(stream, formatter)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 349, in output_stream
    output.open()
  File "/home/basti/repos/streamlink/src/streamlink_cli/output/abc.py", line 9, in open
    self._open()
  File "/home/basti/repos/streamlink/src/streamlink_cli/output/player.py", line 255, in _open
    self._open_subprocess(args)
  File "/home/basti/repos/streamlink/src/streamlink_cli/output/player.py", line 271, in _open_subprocess
    log.debug(f"Opening subprocess: {args!r}{f', env: {self.env!r}' if self.env else ''}")
Message: "Opening subprocess: ['/home/basti/.local/bin/mpv', '--force-media-title=httpstream://file:///dev/zero', '--title=\U0001f43b', '-']"
Arguments: ()
[cli][debug] Writing stream to output
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

PR
```
$ PYTHONIOENCODING=ascii streamlink -l debug -p mpv -a '"--title=🐻"' httpstream://file:///dev/zero best
[cli][debug] OS:         Linux-6.9.9-1-git-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.4
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.8.3+2.g140c62da
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.7.4
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.2
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=httpstream://file:///dev/zero
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --player-args="--title=\U0001f43b"
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[plugins.http][debug] URL=file:///dev/zero; params={}
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Starting player: mpv
[cli][debug] Pre-buffering 8192 bytes
[cli.output][debug] Opening subprocess: ['/home/basti/.local/bin/mpv', '--force-media-title=httpstream://file:///dev/zero', '--title=\U0001f43b', '-']
[cli][debug] Writing stream to output
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```