### PR TITLE
tools: bump ruff to 0.5.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.5.1
+ruff ==0.5.3
 
 # typing
 mypy ==1.10.1


### PR DESCRIPTION
With `ruff 0.5.3` now considering its built-in language server to be stable and `ruff-lsp` not being necessary anymore, I'm thinking about using its formatter to reformat all files and then making its format mandatory as a CI check that runs `ruff format --diff`. Most major editors have support for auto-formatting via the LSP, so there's no reason not to finally clean up bad code styles. This could however make it more difficult for new and existing contributors to submit good PRs, but I don't think it'd be too bad if the docs are updated accordingly. I'm not a fan of commit hooks, so auto-reformat hooks on commit won't happen (local client setups should never be in the way of submitting PR).
- https://github.com/astral-sh/ruff/releases/tag/0.5.3
- https://docs.astral.sh/ruff/editors/

`ruff format` is almost fully compatible to `black`, except in a few cases (which are dealt with a bit better):
- https://docs.astral.sh/ruff/formatter/
- https://docs.astral.sh/ruff/formatter/black/

There are however a couple of cases where waiting for the py38 support end would make sense, namely multiline `with` statements. Huge code reformat commits are ugly and should be added to `.git-blame-ignore-revs`, so waiting and only doing it once is probably a better idea.