### PR TITLE
tools: add explicit ruff format config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,16 @@ extend-exclude = [
   "src/streamlink_cli/packages/",
 ]
 
+[tool.ruff.format]
+preview = true
+line-ending = "lf"
+quote-style = "double"
+skip-magic-trailing-comma = false
+exclude = [
+  "src/streamlink/plugin/api/useragents.py",
+  "src/streamlink/webbrowser/cdp/devtools/*.py",
+]
+
 [tool.ruff.lint]
 select = [
   # pycodestyle


### PR DESCRIPTION
Except for `preview` (and `exclude`), all these config values are already the default, but let's define them explicitly.
- https://docs.astral.sh/ruff/settings/#format
- https://docs.astral.sh/ruff/formatter/#preview-style

Adding the formatter config doesn't change anything, as we still don't enforce a strict code style. But as said in #6087, I'm going to finally change that after dropping py38.