### PR TITLE
plugins.yupptv: refactor and fix plugin

### DIFF
--- a/tests/plugins/test_yupptv.py
+++ b/tests/plugins/test_yupptv.py
@@ -6,6 +6,8 @@ class TestPluginCanHandleUrlYuppTV(PluginCanHandleUrl):
     __plugin__ = YuppTV
 
     should_match = [
+        "https://www.yupptv.com/online-tv/wion/live",
+        "https://www.yupptv.com/online-tv/mirror-now/live",
         "https://www.yupptv.com/channels/etv-telugu/live",
         "https://www.yupptv.com/channels/india-today-news/news/25326023/15-jun-2018",
     ]


### PR DESCRIPTION
Resolves #6092 

The plugin extracted the wrong HLS playlist URL from their (garbage) JS code. This is fixed now. I've also refactored the plugin and fixed the bad code style, and I implemented ad filtering, as most streams seem to have preroll ads which then cause an unnecessary stream discontinuity. Ad segments apparently are lacking the `.ts` file extension in the segment URLs, which is used to detect ads. Hopefully this doesn't break actual stream segments. Seemed fine in the streams I checked though. I didn't touch the plugin's authentication logic. No idea if this is working at all. I don't really care though.

@DeltaEpsilon19498 please check the plugin changes and see if any streams which I didn't test are not working correctly
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

----

```
$ ./script/test-plugin-urls.py yupptv
:: https://www.yupptv.com/channels/etv-telugu/live
::  720p, worst, best
:: https://www.yupptv.com/channels/india-today-news/news/25326023/15-jun-2018
:::: This stream requires you to login
!! No streams found
:: https://www.yupptv.com/online-tv/mirror-now/live
::  360p, 576p, 720p, 1080p, worst, best
:: https://www.yupptv.com/online-tv/wion/live
::  216p, 360p, 576p, 720p, worst, best
```

```
$ streamlink -l debug https://www.yupptv.com/online-tv/mirror-now/live best
[cli][debug] OS:         Linux-6.9.9-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.4
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.8.3+7.gb570b3cb
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.7.4
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.2.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.2
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.yupptv.com/online-tv/mirror-now/live
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][info] Found matching plugin yupptv for URL https://www.yupptv.com/online-tv/mirror-now/live
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 360p (worst), 576p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 9188494; Last Sequence: 9188499
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 9188497; End Sequence: None
[stream.hls][debug] Adding segment 9188497 to queue
[stream.hls][debug] Adding segment 9188498 to queue
[stream.hls][debug] Adding segment 9188499 to queue
[stream.hls][debug] Discarding segment 9188497
[stream.hls][info] Filtering out segments and pausing stream output
[stream.hls][debug] Discarding segment 9188498
[stream.hls][debug] Discarding segment 9188499
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 9188500 to queue
[stream.hls][debug] Adding segment 9188501 to queue
[stream.hls][debug] Adding segment 9188502 to queue
[stream.hls][debug] Discarding segment 9188500
[stream.hls][debug] Discarding segment 9188501
[stream.hls][debug] Discarding segment 9188502
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 9188503 to queue
[stream.hls][debug] Adding segment 9188504 to queue
[stream.hls][debug] Adding segment 9188505 to queue
[stream.hls][debug] Discarding segment 9188503
[stream.hls][debug] Discarding segment 9188504
[stream.hls][debug] Discarding segment 9188505
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 9188506 to queue
[stream.hls][debug] Adding segment 9188507 to queue
[stream.hls][debug] Adding segment 9188508 to queue
[stream.hls][debug] Discarding segment 9188506
[stream.hls][debug] Discarding segment 9188507
[stream.hls][debug] Discarding segment 9188508
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 9188509 to queue
[stream.hls][debug] Writing segment 9188509 to output
[stream.hls][debug] Segment 9188509 complete
[stream.hls][warning] Encountered a stream discontinuity. This is unsupported and will result in incoherent output data.
[stream.hls][info] Resuming stream output
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://www.yupptv.com/online-tv/mirror-now/live', '-']
[cli][debug] Writing stream to output
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```