### PR TITLE
plugins.tvp: sport.tvp.pl handling

### DIFF
--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -34,6 +34,9 @@ log = logging.getLogger(__name__)
 @pluginmatcher(name="tvp_info", pattern=re.compile(
     r"https?://(?:www\.)?tvp\.info/",
 ))
+@pluginmatcher(name="tvp_sport", pattern=re.compile(
+    r"https?://sport\.tvp\.pl/(?P<stream_id>\d+)/.+$",
+))
 class TVP(Plugin):
     _URL_VOD = "https://vod.tvp.pl/api/products/{vod_id}/videos/playlist"
     _URL_INFO_API_TOKEN = "https://api.tvp.pl/tokenizer/token/{token}"
@@ -200,6 +203,8 @@ class TVP(Plugin):
             return self._get_tvp_info_vod()
         if self.matches["vod"]:
             return self._get_vod(self.match["vod_id"])
+        if self.matches["tvp_sport"]:
+            return self._get_formats_from_api(self.match["stream_id"])
         return self._get_live(self.match["channel_id"])
 
 

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -36,7 +36,7 @@ log = logging.getLogger(__name__)
     r"https?://(?:www\.)?tvp\.info/",
 ))
 @pluginmatcher(name="tvp_sport", pattern=re.compile(
-    r"https?://sport\.tvp\.pl/(?P<stream_id>\d+)/.+$",
+    r"https?://sport\.tvp\.pl/(?P<stream_id>\d+)/.+",
 ))
 class TVP(Plugin):
     _URL_VOD = "https://vod.tvp.pl/api/products/{vod_id}/videos/playlist"

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -4,6 +4,7 @@ $url stream.tvp.pl
 $url vod.tvp.pl
 $url tvpstream.vod.tvp.pl
 $url tvp.info
+$url sport.tvp.pl
 $type live, vod
 $metadata id
 $metadata title

--- a/tests/plugins/test_tvp.py
+++ b/tests/plugins/test_tvp.py
@@ -1,6 +1,7 @@
 from streamlink.plugins.tvp import TVP
 from tests.plugins import PluginCanHandleUrl
 
+
 class TestPluginCanHandleUrlTVP(PluginCanHandleUrl):
     __plugin__ = TVP
 
@@ -35,8 +36,8 @@ class TestPluginCanHandleUrlTVP(PluginCanHandleUrl):
         # sport.tvp
         (
             ("tvp_sport", "https://sport.tvp.pl/79514191/paryz-2024-magda-linette-mirra-andriejewa-1-runda-na-zywo-transmisja-online-live-stream-igrzyska-olimpijskie-2872024"),
-            {},
-        )
+            {"stream_id": "79514191"},
+        ),
     ]
 
     should_not_match = [

--- a/tests/plugins/test_tvp.py
+++ b/tests/plugins/test_tvp.py
@@ -1,7 +1,6 @@
 from streamlink.plugins.tvp import TVP
 from tests.plugins import PluginCanHandleUrl
 
-
 class TestPluginCanHandleUrlTVP(PluginCanHandleUrl):
     __plugin__ = TVP
 
@@ -33,6 +32,11 @@ class TestPluginCanHandleUrlTVP(PluginCanHandleUrl):
             ("tvp_info", "https://www.tvp.info/78213165/euro-2024-polska-holandia-12-bartosz-salamon-czuje-sie-winny-za-te-porazke-wideo"),
             {},
         ),
+        # sport.tvp
+        (
+            ("tvp_sport", "https://sport.tvp.pl/79514191/paryz-2024-magda-linette-mirra-andriejewa-1-runda-na-zywo-transmisja-online-live-stream-igrzyska-olimpijskie-2872024"),
+            {},
+        )
     ]
 
     should_not_match = [


### PR DESCRIPTION
Hello,

I've added handling of sport.tvp.pl live videos to the tvp plugin.

Admittedly I have little Python experience, but I tested the changes editing \pkgs\streamlink\plugins\_plugins.json, \pkgs\streamlink\plugins\tvp.py while removing the cached compiled file.