### PR TITLE
tools: bump ruff to 0.5.5

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,7 +15,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.5.3
+ruff ==0.5.5
 
 # typing
 mypy ==1.10.1


### PR DESCRIPTION
I've also tried bumping mypy to the latest version, but apparently there's an unresolved bug in regards to overloaded functions and type narrowing of `Any` arguments.