### PR TITLE
build: add warning comments to plugins.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,8 +93,9 @@ jobs:
         run: |
           set -x
           unzip -p ./dist/streamlink-*-any.whl 'streamlink-*.dist-info/RECORD' | grep 'streamlink/plugins/_plugins.json'
-          unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | jq -e 'keys > 0'
-          unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | jq
+          unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | grep -E '^\s*//'
+          unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | grep -vE '^\s*//' | jq -e 'keys > 0'
+          unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | grep -vE '^\s*//' | jq
 
   documentation:
     name: Test docs

--- a/src/streamlink/session/plugins.py
+++ b/src/streamlink/session/plugins.py
@@ -202,6 +202,9 @@ class StreamlinkPlugins:
         return mod, mod.__plugin__
 
 
+_RE_STRIP_JSON_COMMENTS = re.compile(rb"^(?:\s*//[^\n]*\n+)+")
+
+
 _TListOfConstants: TypeAlias = List[Union[None, bool, int, float, str]]
 _TConstantOrListOfConstants: TypeAlias = Union[None, bool, int, float, str, _TListOfConstants]
 _TMappingOfConstantOrListOfConstants: TypeAlias = Dict[str, _TConstantOrListOfConstants]
@@ -275,6 +278,7 @@ class StreamlinkPluginsData:
 
     @classmethod
     def _parse(cls, content: bytes) -> Tuple[Dict[str, Matchers], Dict[str, Arguments]]:
+        content = _RE_STRIP_JSON_COMMENTS.sub(b"", content)
         data: Dict[str, _TPluginData] = json.loads(content)
 
         try:

--- a/tests/session/test_plugins.py
+++ b/tests/session/test_plugins.py
@@ -289,6 +289,35 @@ class TestLoadPluginsData:
         assert session.plugins.get_names() == ["fake"]
         assert [(record.name, record.levelname, record.message) for record in caplog.get_records(when="setup")] == logs
 
+    # noinspection JsonStandardCompliance
+    @pytest.mark.parametrize(
+        "pluginsdata",
+        [
+            pytest.param(
+                # language=json
+                """
+                    // foo
+                    // bar
+                    {
+                        "testplugin": {
+                            "matchers": [
+                                {"pattern": "foo"}
+                            ],
+                            "arguments": []
+                        }
+                    }
+                """,
+                id="json-comments",
+            ),
+        ],
+        indirect=True,
+    )
+    def test_strip_json_comment(self, caplog: pytest.LogCaptureFixture, session: Streamlink, pluginsdata: str):
+        assert "fake" not in session.plugins
+        assert "testplugin" not in session.plugins
+        assert session.plugins.get_names() == ["testplugin"]
+        assert [(record.name, record.levelname, record.message) for record in caplog.get_records(when="setup")] == []
+
     @pytest.mark.parametrize("pluginsdata", [
         pytest.param(
             # language=json


### PR DESCRIPTION
This adds warning comments to the plugins JSON file, so people who randomly try to modify plugin matchers don't break their Streamlink install. The comments are removed from the read data before parsing the actual JSON payload.