### PR TITLE
webbrowser.cdp.client: add max_buffer_size param

### DIFF
--- a/src/streamlink/webbrowser/cdp/connection.py
+++ b/src/streamlink/webbrowser/cdp/connection.py
@@ -60,7 +60,8 @@ class CDPEventListener(Generic[TEvent]):
     _sender: trio.MemorySendChannel[TEvent]
     _receiver: trio.MemoryReceiveChannel[TEvent]
 
-    def __init__(self, event_channels: TEventChannels, event: Type[TEvent], max_buffer_size: int = MAX_BUFFER_SIZE):
+    def __init__(self, event_channels: TEventChannels, event: Type[TEvent], max_buffer_size: Optional[int] = None):
+        max_buffer_size = MAX_BUFFER_SIZE if max_buffer_size is None else max_buffer_size
         self._sender, self._receiver = trio.open_memory_channel(max_buffer_size)
         event_channels[event].add(self._sender)
 
@@ -204,7 +205,7 @@ class CDPBase:
 
         return response
 
-    def listen(self, event: Type[TEvent], max_buffer_size: int = MAX_BUFFER_SIZE) -> CDPEventListener[TEvent]:
+    def listen(self, event: Type[TEvent], max_buffer_size: Optional[int] = None) -> CDPEventListener[TEvent]:
         """
         Listen to a CDP event and return a new :class:`CDPEventListener` instance.
 

--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -11,7 +11,7 @@ from trio.testing import MockClock, wait_all_tasks_blocked
 from trio_websocket import CloseReason, ConnectionClosed, ConnectionTimeout  # type: ignore[import]
 
 from streamlink.compat import ExceptionGroup
-from streamlink.webbrowser.cdp.connection import CDPConnection, CDPEventListener, CDPSession
+from streamlink.webbrowser.cdp.connection import MAX_BUFFER_SIZE, CDPConnection, CDPEventListener, CDPSession
 from streamlink.webbrowser.cdp.devtools.target import SessionID, TargetID
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT
 from streamlink.webbrowser.cdp.exceptions import CDPError
@@ -644,10 +644,14 @@ class TestHandleEvent:
         assert FakeEvent not in cdp_connection.event_channels
         listener1 = cdp_connection.listen(FakeEvent)
         listener2 = cdp_connection.listen(FakeEvent)
-        listener3 = cdp_connection.listen(FakeEvent)
+        listener3 = cdp_connection.listen(FakeEvent, max_buffer_size=MAX_BUFFER_SIZE * 2)
         listeners = listener1, listener2, listener3
         assert FakeEvent in cdp_connection.event_channels
         assert len(cdp_connection.event_channels[FakeEvent]) == 3
+
+        assert listener1._sender.statistics().max_buffer_size == MAX_BUFFER_SIZE
+        assert listener2._sender.statistics().max_buffer_size == MAX_BUFFER_SIZE
+        assert listener3._sender.statistics().max_buffer_size == MAX_BUFFER_SIZE * 2
 
         results = []
 


### PR DESCRIPTION
Allow the `CDPClientSession` (via `CDPClient.session()`) to set custom memory channel buffer sizes, so that more HTTP requests/responses can be buffered without blocking
