### PR TITLE
plugins.vtvgo: acquire AWS WAF token

### DIFF
--- a/src/streamlink/plugin/api/aws_waf.py
+++ b/src/streamlink/plugin/api/aws_waf.py
@@ -1,0 +1,89 @@
+import logging
+import time
+from typing import Optional
+from urllib.parse import urlparse
+
+import trio
+from requests.cookies import RequestsCookieJar
+
+from streamlink.compat import BaseExceptionGroup
+from streamlink.session import Streamlink
+from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools
+
+
+log = logging.getLogger(__name__)
+
+
+class AWSWAF:
+    """
+    Solves the AWS Web Application Firewall challenge in a locally spawned web browser.
+    Headless mode is detected by AWS.
+    """
+
+    HOSTNAME = ".token.awswaf.com"
+    TOKEN = "aws-waf-token"
+    EXPIRATION = 3600 * 24 * 4
+
+    def __init__(self, session: Streamlink, headless: bool = False):
+        self.session = session
+        self.headless = headless
+
+    def acquire(self, url: str) -> bool:
+        send: trio.MemorySendChannel[Optional[str]]
+        receive: trio.MemoryReceiveChannel[Optional[str]]
+
+        data = None
+        send, receive = trio.open_memory_channel(1)
+        timeout = self.session.get_option("webbrowser-timeout")
+
+        async def on_request(client_session: CDPClientSession, request: devtools.fetch.RequestPaused):
+            cookies = request.request.headers.get("Cookie", "")
+            cookie = next((cookie for cookie in cookies.split(";") if cookie.startswith(f"{self.TOKEN}=")), None)
+
+            req_url = request.request.url
+            hostname = urlparse(req_url).hostname
+            # pass through all requests if the cookie wasn't set yet and the request URL is the initial one or an AWS one
+            if cookie is None and (req_url == url or hostname and hostname.endswith(self.HOSTNAME)):
+                return await client_session.continue_request(request)
+
+            # return cookie once found
+            if cookie is not None:
+                await send.send(cookie)
+
+            # block all unneeded requests
+            return await client_session.fulfill_request(request, body="")
+
+        async def acquire_token(client: CDPClient):
+            client_session: CDPClientSession
+            async with client.session(max_buffer_size=100) as client_session:
+                client_session.add_request_handler(on_request, on_request=True)
+                with trio.move_on_after(timeout):
+                    async with client_session.navigate(url) as frame_id:
+                        await client_session.loaded(frame_id)
+                        return await receive.receive()
+
+        try:
+            data = CDPClient.launch(
+                self.session,
+                acquire_token,
+                headless=self.headless,
+            )
+        except BaseExceptionGroup:
+            log.exception("Failed acquiring AWS WAF token")
+        except Exception as err:
+            log.error(err)
+
+        if not data:
+            log.error("No AWS WAF token has been acquired")
+            return False
+
+        domain = urlparse(url).hostname
+        cookiejar = RequestsCookieJar()
+        cookiejar.set(
+            *data.split("=", 1),
+            domain="" if not domain else f".{domain}",
+            expires=time.time() + self.EXPIRATION,
+        )
+        self.session.http.cookies.update(cookiejar)
+
+        return True

--- a/src/streamlink/plugins/vtvgo.py
+++ b/src/streamlink/plugins/vtvgo.py
@@ -9,45 +9,55 @@ import re
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
+from streamlink.plugin.api.aws_waf import AWSWAF
 from streamlink.stream.hls import HLSStream
 
 
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(re.compile(
-    r"https?://vtvgo\.vn/xem-truc-tuyen-kenh-",
-))
+@pluginmatcher(re.compile(r"https?://vtvgo\.vn/xem-truc-tuyen-kenh-"))
 class VTVgo(Plugin):
     AJAX_URL = "https://vtvgo.vn/ajax-get-stream"
 
     def _get_streams(self):
-        # get cookies
-        self.session.http.get("https://vtvgo.vn/")
+        if (
+            not self.session.http.cookies.get(AWSWAF.TOKEN)
+            or not self.session.http.get(self.url).content
+        ):
+            log.info("Getting new AWS WAF token (bot-detection)")
+            if not AWSWAF(self.session).acquire(self.url):
+                return
+            self.save_cookies()
 
-        self.session.http.headers.update({
-            "Origin": "https://vtvgo.vn",
-            "Referer": self.url,
-            "Sec-Fetch-Site": "same-origin",
-            "X-Requested-With": "XMLHttpRequest",
-        })
+        self.session.http.headers.update(
+            {
+                "Origin": "https://vtvgo.vn",
+                "Referer": self.url,
+                "Sec-Fetch-Site": "same-origin",
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        )
 
-        params = self.session.http.get(self.url, schema=validate.Schema(
-            validate.parse_html(),
-            validate.xml_xpath_string(".//script[contains(text(),'setplayer(')][1]/text()"),
-            validate.none_or_all(
-                validate.regex(
-                    re.compile(r"""var\s+(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;"""),
-                    method="findall",
+        params = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[contains(text(),'setplayer(')][1]/text()"),
+                validate.none_or_all(
+                    validate.regex(
+                        re.compile(r"""var\s+(?P<key>(?:type_)?id|time|token)\s*=\s*["']?(?P<value>[^"']+)["']?;"""),
+                        method="findall",
+                    ),
+                    [
+                        ("id", int),
+                        ("type_id", str),
+                        ("time", str),
+                        ("token", str),
+                    ],
                 ),
-                [
-                    ("id", int),
-                    ("type_id", str),
-                    ("time", str),
-                    ("token", str),
-                ],
             ),
-        ))
+        )
         if not params:
             return
 


### PR DESCRIPTION
Resolves #6099 

1. This adds the `plugin.api.aws_waf` module which uses Streamlink's webbrowser API in order to get an AWS Web Application Firewall token
2. Fixes the vtvgo plugin's bot-detection issue by acquiring an AWS WAF token

The token is cached for four days once successfully acquired. Chromium's headless mode unfortunately does not work because AWS detects it, so it's disabled (`--webbrowser-headless` has no effect).

```
$ ./script/test-plugin-urls.py vtvgo
:: https://vtvgo.vn/xem-truc-tuyen-kenh-k%C3%AAnh-vtv5-t%C3%A2y-nguy%C3%AAn-163.html
:::: Getting new AWS WAF token (bot-detection)
:::: Launching web browser: /usr/bin/chromium
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv1-1.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv2-2.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv3-3.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv4-4.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv5-5.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv5-t%C3%A2y-nam-b%E1%BB%99-7.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv6-6.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv7-27.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv8-36.html
::  480p, 720p, worst, best
:: https://vtvgo.vn/xem-truc-tuyen-kenh-vtv9-39.html
::  480p, 720p, worst, best
```

----

@HuynhNhan0104 please test and report back with a debug log, so I know it's working correctly.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback