### PR TITLE
plugins.sportschau: fix sportschau

### DIFF
--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -1,7 +1,9 @@
 """
-$description German sports magazine live stream, owned by ARD.
+$description German sports magazine live streams and VOD content, owned by ARD.
 $url sportschau.de
 $type live
+$metadata id
+$metadata title
 """
 
 import logging
@@ -15,33 +17,62 @@ from streamlink.stream.http import HTTPStream
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(
-    re.compile(
-        r"https?://(?:\w+\.)*sportschau\.de/",
-    )
-)
+@pluginmatcher(re.compile(r"https?://(?:\w+\.)*sportschau\.de/"))
 class Sportschau(Plugin):
-    def _get_streams(self):
-        streams = self.session.http.get(
-            self.url,
-            schema=validate.Schema(
-                validate.parse_html(),
-                validate.xml_xpath_string("(//*[@data-v-type='MediaPlayer'])[1]/@data-v"),
-                validate.parse_json(),
-                validate.get("mc"),
-                validate.get("streams"),
+    _schema_media = validate.Schema(
+        validate.parse_html(),
+        validate.xml_xpath_string(".//*[@data-v-type='MediaPlayer'][@data-v][1]/@data-v"),
+        validate.none_or_all(
+            validate.parse_json(),
+            {
+                "mc": {
+                    validate.optional("id"): str,
+                    "meta": {
+                        "title": str,
+                    },
+                    "streams": [
+                        validate.all(
+                            {
+                                "media": [
+                                    validate.all(
+                                        {
+                                            "mimeType": str,
+                                            "url": validate.url(),
+                                        },
+                                        validate.union_get(
+                                            "mimeType",
+                                            "url",
+                                        ),
+                                    ),
+                                ],
+                            },
+                            validate.get("media"),
+                        ),
+                    ],
+                },
+            },
+            validate.get("mc"),
+            validate.union_get(
+                "id",
+                ("meta", "title"),
+                "streams",
             ),
-        )
-        for stream in streams:
-            for media in stream.get("media"):
-                url = media.get("url")
-                is_hls = media.get("mimeType") == "application/vnd.apple.mpegurl"
-                is_audio_only = stream.get("isAudioOnly")
-                if is_hls:
+        ),
+    )
+
+    def _get_streams(self):
+        data = self.session.http.get(self.url, schema=self._schema_media)
+        if not data:
+            return
+
+        self.id, self.title, streams = data
+
+        for media in streams:
+            for mime_type, url in media:
+                if mime_type == "application/vnd.apple.mpegurl":
                     yield from HLSStream.parse_variant_playlist(self.session, url).items()
                 else:
-                    media_type = "audio" if is_audio_only else "video"
-                    yield media_type, HTTPStream(self.session, url)
+                    yield "audio", HTTPStream(self.session, url)
 
 
 __plugin__ = Sportschau

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -14,6 +14,7 @@ from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
 
+
 log = logging.getLogger(__name__)
 
 

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -72,7 +72,7 @@ class Sportschau(Plugin):
             for mime_type, url in media:
                 if mime_type == "application/vnd.apple.mpegurl":
                     yield from HLSStream.parse_variant_playlist(self.session, url).items()
-                else:
+                elif mime_type.startswith("audio/"):
                     yield "audio", HTTPStream(self.session, url)
 
 

--- a/src/streamlink/plugins/sportschau.py
+++ b/src/streamlink/plugins/sportschau.py
@@ -11,44 +11,37 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
 from streamlink.stream.http import HTTPStream
-from streamlink.utils.url import update_scheme
-
 
 log = logging.getLogger(__name__)
 
 
-@pluginmatcher(re.compile(
-    r"https?://(?:\w+\.)*sportschau\.de/",
-))
+@pluginmatcher(
+    re.compile(
+        r"https?://(?:\w+\.)*sportschau\.de/",
+    )
+)
 class Sportschau(Plugin):
     def _get_streams(self):
-        player_js = self.session.http.get(self.url, schema=validate.Schema(
-            re.compile(r"https?:(//deviceids-medp.wdr.de/ondemand/\S+\.js)"),
-            validate.none_or_all(
-                validate.get(1),
-                validate.transform(lambda url: update_scheme("https://", url)),
+        streams = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string("(//*[@data-v-type='MediaPlayer'])[1]/@data-v"),
+                validate.parse_json(),
+                validate.get("mc"),
+                validate.get("streams"),
             ),
-        ))
-        if not player_js:
-            return
-
-        log.debug(f"Found player js {player_js}")
-        data = self.session.http.get(player_js, schema=validate.Schema(
-            validate.regex(re.compile(r"\$mediaObject\.jsonpHelper\.storeAndPlay\(({.+})\);?")),
-            validate.get(1),
-            validate.parse_json(),
-            validate.get("mediaResource"),
-            validate.get("dflt"),
-            {
-                validate.optional("audioURL"): validate.url(),
-                validate.optional("videoURL"): validate.url(),
-            },
-        ))
-
-        if data.get("videoURL"):
-            yield from HLSStream.parse_variant_playlist(self.session, update_scheme("https:", data.get("videoURL"))).items()
-        if data.get("audioURL"):
-            yield "audio", HTTPStream(self.session, update_scheme("https:", data.get("audioURL")))
+        )
+        for stream in streams:
+            for media in stream.get("media"):
+                url = media.get("url")
+                is_hls = media.get("mimeType") == "application/vnd.apple.mpegurl"
+                is_audio_only = stream.get("isAudioOnly")
+                if is_hls:
+                    yield from HLSStream.parse_variant_playlist(self.session, url).items()
+                else:
+                    media_type = "audio" if is_audio_only else "video"
+                    yield media_type, HTTPStream(self.session, url)
 
 
 __plugin__ = Sportschau

--- a/tests/plugins/test_sportschau.py
+++ b/tests/plugins/test_sportschau.py
@@ -8,4 +8,5 @@ class TestPluginCanHandleUrlSportschau(PluginCanHandleUrl):
     should_match = [
         "https://www.sportschau.de/fussball/uefa-euro-2024/spaniens-europameister-begeistert-empfangen,em-spanien-feier-100.html",
         "https://www.sportschau.de/olympia/live/schwimmen-finals-m-f,livestream-olympia-schwimmen-110.html",
+        "https://www.sportschau.de/podcasts/sportschau-olympia-podcast/tag-6-vier-gewinnt,audio-tag-6-vier-gewinnt-100.html",
     ]

--- a/tests/plugins/test_sportschau.py
+++ b/tests/plugins/test_sportschau.py
@@ -6,6 +6,6 @@ class TestPluginCanHandleUrlSportschau(PluginCanHandleUrl):
     __plugin__ = Sportschau
 
     should_match = [
-        "http://www.sportschau.de/wintersport/videostream-livestream---wintersport-im-ersten-242.html",
-        "https://www.sportschau.de/weitere/allgemein/video-kite-surf-world-tour-100.html",
+        "https://www.sportschau.de/fussball/uefa-euro-2024/spaniens-europameister-begeistert-empfangen,em-spanien-feier-100.html",
+        "https://www.sportschau.de/olympia/live/schwimmen-finals-m-f,livestream-olympia-schwimmen-110.html",
     ]


### PR DESCRIPTION
The current plugin for sportschau.de is not working. 

Example: https://www.sportschau.de/olympia/sportschiessen-luftpistole-10m-mixed-im-re-live,video-olympia-sportschiessen-104.html
```
streamlink https://www.sportschau.de/olympia/sportschiessen-luftpistole-10m-mixed-im-re-live,video-olympia-sportschiessen-104.html
[cli][info] Found matching plugin sportschau for URL https://www.sportschau.de/olympia/sportschiessen-luftpistole-10m-mixed-im-re-live,video-olympia-sportschiessen-104.html
error: No playable streams found on this URL: https://www.sportschau.de/olympia/sportschiessen-luftpistole-10m-mixed-im-re-live,video-olympia-sportschiessen-104.html
```

This PR fixes it.
