### PR TITLE
plugins.twitch: add --twitch-force-client-integrity, remove CI token decoding+parsing logic

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -742,6 +742,11 @@ class TwitchClientIntegrity:
     """,
 )
 @pluginargument(
+    "force-client-integrity",
+    action="store_true",
+    help="Don't attempt requesting the streaming access token without a client-integrity token.",
+)
+@pluginargument(
     "purge-client-integrity",
     action="store_true",
     help="Purge cached Twitch client-integrity token and acquire a new one.",
@@ -837,8 +842,12 @@ class Twitch(Plugin):
         return device_id, token
 
     def _access_token(self, is_live, channel_or_vod):
+        response = ""
+        data = (None, None)
+
         # try without a client-integrity token first (the web player did the same on 2023-05-31)
-        response, *data = self.api.access_token(is_live, channel_or_vod)
+        if not self.options.get("force-client-integrity"):
+            response, *data = self.api.access_token(is_live, channel_or_vod)
 
         # try again with a client-integrity token if the API response was erroneous
         if response != "token":


### PR DESCRIPTION
Resolves #6109 

1. Adds the `--twitch-force-client-integrity-token` plugin argument (I didn't want to add another plugin arg when the CI token stuff was implemented, but since people are actively patching the plugin, let's just add the arg to make their lives a bit easier)
2. Removes the now broken CI token decoding+parsing due to the new token format with encrypted data

I also checked removing the `headless=False` override, and requesting access tokens worked just fine. This however might be because they simply don't care about the `is_bad_bot` flag right now. So what should we do now? Remove the value override and let the user decide again via `--webbrowser-headless` (defaults to `True`)? Should Twitch make any changes though, then people will actively have to set `--webbrowser-headless=false`, which was the point of the override.

@Hakkin, any opinions on that?