### PR TITLE
webbrowser.cdp.client: update UA in headless mode

### DIFF
--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -8,7 +8,6 @@ import trio
 from streamlink.compat import is_darwin, is_win32
 from streamlink.plugin.api import validate
 from streamlink.session import Streamlink
-from streamlink.session.http_useragents import CHROME
 from streamlink.utils.socket import find_free_port_ipv4, find_free_port_ipv6
 from streamlink.webbrowser.webbrowser import Webbrowser
 
@@ -152,8 +151,6 @@ class ChromiumWebbrowser(Webbrowser):
         self.port = port
         if headless:
             self.arguments.append("--headless=new")
-            # When in headless mode, a headless hint is added to the User-Agent header, which we want to avoid
-            self.arguments.append(f"--user-agent={CHROME}")
 
     @asynccontextmanager
     async def launch(self, timeout: Optional[float] = None) -> AsyncGenerator[trio.Nursery, None]:

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -11,7 +11,6 @@ from requests import Timeout
 from streamlink.compat import is_win32
 from streamlink.exceptions import PluginError
 from streamlink.session import Streamlink
-from streamlink.session.http_useragents import CHROME
 from streamlink.webbrowser.chromium import ChromiumWebbrowser
 from streamlink.webbrowser.exceptions import WebbrowserError
 
@@ -108,7 +107,6 @@ class TestLaunchArgs:
     def test_headless(self, headless: bool):
         webbrowser = ChromiumWebbrowser(headless=headless)
         assert ("--headless=new" in webbrowser.arguments) is headless
-        assert (f"--user-agent={CHROME}" in webbrowser.arguments) is headless
 
 
 @pytest.mark.trio()


### PR DESCRIPTION
- Add `headless` keyword and attribute to `CDPClient`
- If in headless mode, read user-agent from CDP, remove headless hint, and then update UA via `Network.setUserAgentOverride()`
- Remove `--user-agent=...` Chromium launch argument if in headless mode as it also overrides the UA platform

----

Replaces #6111

See #6113 
/ping @Hakkin 

No changes to any plugins / CDPClient implementation yet...

Overriding the UA string via `Network.setUserAgentOverride()` worked in my AWS-WAF test. I don't know the difference between this and `Emulation.setUserAgentOverride()` though. The method from the CDP emulation domain might do more than overriding network request headers.
- https://chromedevtools.github.io/devtools-protocol/1-3/Network/#method-setUserAgentOverride
- https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setUserAgentOverride

I also avoided any other params like `userAgentMetadata` because I don't think it's necessary, as we're only interested in removing the "Headless" part from the UA string, and not change any platform values. So the defaults will be kept by Chromium.

----

So in order to test this in the Twitch plugin, the forced `headless=False` parameter needs to be removed and then specific GQL API endpoints need to be checked with the CI token included. As said in #6113, the streaming access tokens seem to work regardless the (now hidden) `is_bad_bot` status, while some GQL API endpoints allegedly fail. I haven't tested this yet and will check tomorrow. That's it for me today.