### PR TITLE
Change default value of --webbrowser-headless to False

### DIFF
--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -296,7 +296,7 @@ class StreamlinkOptions(Options):
           - The maximum amount of time for waiting on a single CDP command response
         * - webbrowser-headless
           - ``bool``
-          - ``True``
+          - ``False``
           - Whether to launch the webbrowser in headless mode or not
     """
 
@@ -340,7 +340,7 @@ class StreamlinkOptions(Options):
             "webbrowser-cdp-host": None,
             "webbrowser-cdp-port": None,
             "webbrowser-cdp-timeout": 2.0,
-            "webbrowser-headless": True,
+            "webbrowser-headless": False,
         })
         self.session = session
 

--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -179,7 +179,7 @@ class CDPClient:
         cdp_host: Optional[str] = None,
         cdp_port: Optional[int] = None,
         cdp_timeout: Optional[float] = None,
-        headless: bool = True,
+        headless: bool = False,
     ) -> AsyncGenerator[Self, None]:
         webbrowser = ChromiumWebbrowser(executable=executable, host=cdp_host, port=cdp_port, headless=headless)
         nursery: trio.Nursery

--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -181,9 +181,9 @@ class CDPClient:
         cdp_timeout: Optional[float] = None,
         headless: bool = False,
     ) -> AsyncGenerator[Self, None]:
-        webbrowser = ChromiumWebbrowser(executable=executable, host=cdp_host, port=cdp_port, headless=headless)
+        webbrowser = ChromiumWebbrowser(executable=executable, host=cdp_host, port=cdp_port)
         nursery: trio.Nursery
-        async with webbrowser.launch(timeout=timeout) as nursery:
+        async with webbrowser.launch(headless=headless, timeout=timeout) as nursery:
             websocket_url = webbrowser.get_websocket_url(session)
             cdp_connection: CDPConnection
             async with CDPConnection.create(websocket_url, timeout=cdp_timeout) as cdp_connection:

--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -143,7 +143,7 @@ class ChromiumWebbrowser(Webbrowser):
         *args,
         host: Optional[str] = None,
         port: Optional[int] = None,
-        headless: bool = True,
+        headless: bool = False,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1359,7 +1359,9 @@ def build_parser():
         Whether to launch the web browser in headless mode or not.
         When enabled, it stays completely hidden and doesn't require a desktop environment to run.
 
-        Default is true.
+        Please be aware that headless mode might be blocked by websites which implement bot detections.
+
+        Default is false.
         """,
     )
 

--- a/tests/webbrowser/cdp/test_client.py
+++ b/tests/webbrowser/cdp/test_client.py
@@ -87,7 +87,7 @@ class TestLaunch:
     @pytest.mark.parametrize(("session", "options"), [
         pytest.param(
             {},
-            dict(executable=None, timeout=20.0, cdp_host=None, cdp_port=None, cdp_timeout=2.0, headless=True),
+            dict(executable=None, timeout=20.0, cdp_host=None, cdp_port=None, cdp_timeout=2.0, headless=False),
             id="Default options",
         ),
         pytest.param(
@@ -97,9 +97,9 @@ class TestLaunch:
                 "webbrowser-cdp-host": "::1",
                 "webbrowser-cdp-port": 1234,
                 "webbrowser-cdp-timeout": 12.34,
-                "webbrowser-headless": False,
+                "webbrowser-headless": True,
             },
-            dict(executable="foo", timeout=123.45, cdp_host="::1", cdp_port=1234, cdp_timeout=12.34, headless=False),
+            dict(executable="foo", timeout=123.45, cdp_host="::1", cdp_port=1234, cdp_timeout=12.34, headless=True),
             id="Custom options",
         ),
     ], indirect=["session"])

--- a/tests/webbrowser/conftest.py
+++ b/tests/webbrowser/conftest.py
@@ -55,10 +55,16 @@ def webbrowser_launch(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCapture
         webbrowser.executable = sys.executable
         webbrowser.arguments = ["-c", "import sys; sys.exit(int(sys.stdin.readline()))", *webbrowser.arguments]
 
+        headless = kwargs.get("headless", False)
+
         async with webbrowser.launch(*args, **kwargs) as nursery:
             assert isinstance(nursery, trio.Nursery)
             assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [
-                ("streamlink.webbrowser.webbrowser", "info", f"Launching web browser: {sys.executable}"),
+                (
+                    "streamlink.webbrowser.webbrowser",
+                    "info",
+                    f"Launching web browser: {sys.executable} ({headless=})",
+                ),
             ]
             caplog.records.clear()
             # wait until the process has launched, so we can test it

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -98,7 +98,7 @@ class TestLaunchArgs:
         webbrowser = ChromiumWebbrowser()
         assert "--password-store=basic" in webbrowser.arguments
         assert "--use-mock-keychain" in webbrowser.arguments
-        assert "--headless=new" in webbrowser.arguments
+        assert "--headless=new" not in webbrowser.arguments
         assert not any(arg.startswith("--remote-debugging-host") for arg in webbrowser.arguments)
         assert not any(arg.startswith("--remote-debugging-port") for arg in webbrowser.arguments)
         assert not any(arg.startswith("--user-data-dir") for arg in webbrowser.arguments)


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/pull/6114#issuecomment-2269268484

Since headless mode can potentially be detected, we shouldn't set it as the default mode. Plugins should always work reliably in their default configuration without users having to change Streamlink's default options should there be a change of headless mode detection by the website a plugin covers with Streamlink's webbrowser API. It doesn't matter that a short web browser window might appear on the user's screen (in the default configuration).

So, this changes the default value of `--webbrowser-headless` from `True` to `False` and now also logs which mode Chromium is being launched in. I don't consider this a "breaking change" (wouldn't be a real one anyway as it's only a change in behavior), as the entire API is marked as unstable, and we've also only been shipping it in the Twitch plugin which so far (still) overrides the value and sets it to `False` anyway. Recently we've updated the vtvgo plugin with a web browser requirement, but this hasn't made it into a stable release yet.

I'm going to remove the override from the Twitch plugin in a follow-up PR, which means that with the new defaults, nothing will change here and users will be able to set headless mode via `--webbrowser-headless=True`. Users who insisted on having a client-integrity token included in Twitch API requests so far needed to have a patched plugin version anyway, because Twitch removed the requirement after a couple of days, so the webbrowser API was never actually used by default, but with the recent addition of `--twitch-force-client-integrity`, users will now be able to get CI tokens with and without headless mode, or not (as long as Twitch keeps the requirement disabled).

This change of default value also means that the CLI arg needs to be set explicitly in environments without a desktop (actual headless requirement).

----

Opinions on the log message and updated argument help text? Should this be made more clear? I don't really want this to be verbose, because it's logged on the info level every time the process is launched.