### PR TITLE
plugins.twitch: remove headless=False override

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -617,12 +617,7 @@ class TwitchClientIntegrity:
                     return await client_session.evaluate(js_get_integrity_token, timeout=eval_timeout)
 
         try:
-            client_integrity = CDPClient.launch(
-                session,
-                acquire_client_integrity_token,
-                # headless mode gets detected by Twitch, so we have to disable it regardless the user config
-                headless=False,
-            )
+            client_integrity = CDPClient.launch(session, acquire_client_integrity_token)
         except BaseExceptionGroup:
             log.exception("Failed acquiring client integrity token")
         except Exception as err:


### PR DESCRIPTION
Follow-up of #6116 

----

Successful streaming access tokens
```
$ streamlink --twitch-force-client-integrity --twitch-purge-client-integrity twitch.tv/gorgc
[cli][info] Found matching plugin twitch for URL twitch.tv/gorgc
[plugins.twitch][info] Removing cached client-integrity token...
[plugins.twitch][info] Acquiring new client-integrity token...
[webbrowser.webbrowser][info] Launching web browser: /usr/bin/chromium (headless=False)
Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)

$ streamlink --twitch-force-client-integrity --twitch-purge-client-integrity --webbrowser-headless=true twitch.tv/gorgc
[cli][info] Found matching plugin twitch for URL twitch.tv/gorgc
[plugins.twitch][info] Removing cached client-integrity token...
[plugins.twitch][info] Acquiring new client-integrity token...
[webbrowser.webbrowser][info] Launching web browser: /usr/bin/chromium (headless=True)
Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
```

Successful GQL API responses
```sh
$ curl 'https://gql.twitch.tv/gql' \
  -s \
  -H 'accept: */*' \
  -H 'accept-language: en-US' \
  -H 'client-id: kimne78kx3ncx6brgo4mv6wki5h1ko' \
  -H 'content-type: text/plain;charset=UTF-8' \
  -H 'origin: https://www.twitch.tv' \
  -H 'referer: https://www.twitch.tv/' \
  -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' \
  $(streamlink --twitch-force-client-integrity --twitch-purge-client-integrity twitch.tv/gorgc >/dev/null 2>&1 && jq -r '.["twitch:client-integrity"].value | "-H \"x-device-id: " + .[0] + "\" -H \"client-integrity: " + .[1] + "\""' "${XDG_CACHE_HOME:-~/.cache}/streamlink/plugin-cache.json") \
  --data-raw '[{"operationName":"BrowsePage_AllDirectories","variables":{"limit":30,"options":{"recommendationsContext":{"platform":"web"},"requestID":"JIRA-VXP-2397","sort":"RELEVANCE","tags":[]}},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"2f67f71ba89f3c0ed26a141ec00da1defecb2303595f5cda4298169549783d9e"}}}]' \
  | jq 'first | .errors'
null

$ curl 'https://gql.twitch.tv/gql' \
  -s \
  -H 'accept: */*' \
  -H 'accept-language: en-US' \
  -H 'client-id: kimne78kx3ncx6brgo4mv6wki5h1ko' \
  -H 'content-type: text/plain;charset=UTF-8' \
  -H 'origin: https://www.twitch.tv' \
  -H 'referer: https://www.twitch.tv/' \
  -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36' \
  $(streamlink --twitch-force-client-integrity --twitch-purge-client-integrity --webbrowser-headless=true twitch.tv/gorgc >/dev/null 2>&1 && jq -r '.["twitch:client-integrity"].value | "-H \"x-device-id: " + .[0] + "\" -H \"client-integrity: " + .[1] + "\""' "${XDG_CACHE_HOME:-~/.cache}/streamlink/plugin-cache.json") \
  --data-raw '[{"operationName":"BrowsePage_AllDirectories","variables":{"limit":30,"options":{"recommendationsContext":{"platform":"web"},"requestID":"JIRA-VXP-2397","sort":"RELEVANCE","tags":[]}},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"2f67f71ba89f3c0ed26a141ec00da1defecb2303595f5cda4298169549783d9e"}}}]' \
  | jq 'first | .errors'
null
```