### PR TITLE
release: 6.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## streamlink 6.9.0 (2024-08-12)
+
+- Added: `streamlink.plugin.api.webbrowser` subpackage with the `aws_waf` module ([#6102](https://github.com/streamlink/streamlink/pull/6102), [#6118](https://github.com/streamlink/streamlink/pull/6118))
+- Added: `max_buffer_size` kwarg to `CDPClient.session()` ([#6101](https://github.com/streamlink/streamlink/pull/6101))
+- Added: webbrowser `User-Agent` header override in headless mode ([#6114](https://github.com/streamlink/streamlink/pull/6114))
+- Changed: default value of `--webbrowser-headless` from `True` to `False` ([#6116](https://github.com/streamlink/streamlink/pull/6116))
+- Changed: unicode characters to be unescaped in JSON output, if possible ([#6080](https://github.com/streamlink/streamlink/pull/6080))
+- Fixed: potential character encoding issues in Streamlink's logger ([#6081](https://github.com/streamlink/streamlink/pull/6081))
+- Updated plugins:
+  - nicolive: updated plugin matcher ([#6127](https://github.com/streamlink/streamlink/pull/6127))
+  - okru: fixed validation schema ([#6085](https://github.com/streamlink/streamlink/pull/6085))
+  - radionet: removed plugin ([#6091](https://github.com/streamlink/streamlink/pull/6091))
+  - sportschau: fixed plugin (HLS streams with packed audio streams remain unsupported) ([#6104](https://github.com/streamlink/streamlink/pull/6104))
+  - tiktok: fixed room ID validation schema ([#6106](https://github.com/streamlink/streamlink/pull/6106))
+  - tvp: added support for sport.tvp.pl ([#6097](https://github.com/streamlink/streamlink/pull/6097))
+  - twitch: added `--twitch-force-client-integrity` ([#6113](https://github.com/streamlink/streamlink/pull/6113))
+  - twitch: fixed broken client-integrity token decoding+parsing ([#6113](https://github.com/streamlink/streamlink/pull/6113))
+  - twitch: removed the `headless=False` override ([#6117](https://github.com/streamlink/streamlink/pull/6117))
+  - vimeo: removed error messages for unsupported DASH streams ([#6128](https://github.com/streamlink/streamlink/pull/6128))
+  - vk: fixed validation schema ([#6096](https://github.com/streamlink/streamlink/pull/6096))
+  - vtvgo: resolved AWS Web Application Firewall bot detection ([#6102](https://github.com/streamlink/streamlink/pull/6102))
+  - yupptv: fixed plugin, added ad filtering ([#6093](https://github.com/streamlink/streamlink/pull/6093))
+- Docs: added webbrowser API metadata to plugin descriptions ([#6115](https://github.com/streamlink/streamlink/pull/6115))
+- Docs: updated build-dependencies and the furo theme ([#6126](https://github.com/streamlink/streamlink/pull/6126))
+
+[Full changelog](https://github.com/streamlink/streamlink/compare/6.8.3...6.9.0)
+
+
 ## streamlink 6.8.3 (2024-07-11)
 
 Patch release:


### PR DESCRIPTION
I'd also like to include the bloomberg plugin fixes (#6107) in this release, but I still haven't gotten any feedback from anyone so far. All it takes is running the plugin from the PR branch and a confirmation that the webbrowser fallback does indeed work should the initial HTTP request not include the streams JSON data. Takes one minute... I'm getting valid JSON data without the need for the fallback, so I can't test this.

Then there's the Windows builds and Linux AppImages changes (#6052). I said I wanted to do this in the next minor version bump, but I think I'll wait until 7.0.0 which will pull the plug for py38 entirely in October, which is less than two months away.

- https://github.com/streamlink/streamlink/compare/6.8.3...bastimeyer:releases/6.9.0
- https://streamlink--6119.org.readthedocs.build/changelog.html