### PR TITLE
ci: build docs previews on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+version: 2
+
+build:
+  os: ubuntu-lts-latest
+  tools:
+    python: "3.12"
+  jobs:
+    post_checkout:
+      - "[ ${READTHEDOCS_VERSION_TYPE} = external ] || exit 183"
+      - "git fetch --depth=300 origin +refs/tags/*:refs/tags/*"
+    post_install:
+      - "python -m pip install --upgrade --upgrade-strategy=eager -e ."
+
+python:
+  install:
+    - requirements: docs-requirements.txt
+
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
Testing readthedocs as a hoster for PR preview builds of Streamlink's documentation, because Netlify doesn't bother updating their Python versions which is now causing dependency issues.

Resolves #5543

----

The first attempts will very likely fail. I only quickly glanced through their docs. Will refine the build config later.

There's the `$READTHEDOCS_VERSION_TYPE == external` check, which will abort all other builds apart from PR preview builds:
- https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_VERSION_TYPE
- https://docs.readthedocs.io/en/stable/builds.html#cancelling-builds

PR preview URLs should be added as a status check, similar to netlify:
- https://docs.readthedocs.io/en/stable/pull-requests.html#pull-request-previews

The default RTD URLs should remain 404 (as long as we don't build from a push to master):
- https://streamlink.readthedocs.io/
- http://streamlink.rtfd.io/