### PR TITLE
docs: bump docs-requirements

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -6,7 +6,7 @@ versioningit >=2.0.0,<4  # required for reading the version string when building
 sphinx >=6.0.0,<9
 
 # themes and extensions
-furo ==2024.04.27
+furo ==2024.08.06
 myst-parser >=1.0.0,<5
 sphinx-design ==0.5.0
 

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -3,11 +3,11 @@ setuptools >=64.0.0  # required for reading the version string when building fro
 versioningit >=2.0.0,<4  # required for reading the version string when building from git
 
 # build
-sphinx >=6.0.0,<8
+sphinx >=6.0.0,<9
 
 # themes and extensions
 furo ==2024.04.27
-myst-parser >=1.0.0,<4
+myst-parser >=1.0.0,<5
 sphinx-design ==0.5.0
 
 # typing


### PR DESCRIPTION
This bumps

1. [`myst-parser`](https://github.com/executablebooks/MyST-Parser/releases/tag/v4.0.0) to `>=1.0.0,<5` (from `>=1.0.0,<4`), including [`sphinx`](https://www.sphinx-doc.org/en/master/changes/8.0.html#release-8-0-0-released-jul-29-2024) to `>=6.0.0,<9` (from `>=6.0.0,<8`)
2. the [`furo`](https://pradyunsg.me/furo/changelog/#energetic-eminence) theme to the latest version

I intentionally left out bumping `sphinx-design` to the latest version (`0.6.1`), because it removes support for building the docs on py38. This however also means that the current `sphinx-design ==0.5.0` docs-requirement limits us to `sphinx <8`. That shouldn't be an issue though and will be changed as soon as py38 support will be dropped in October. Even though it's probably super irrelevant keeping py38 support for building the docs right now, I just don't want to introduce this technical breaking change in a non-major-version bump.

py312
```
$ pip list | grep -Ei '(sphinx(_design)?|myst-parser|furo|docutils)\s'
docutils                      0.21.2
furo                          2024.8.6
myst-parser                   4.0.0
Sphinx                        7.4.7
sphinx_design                 0.5.0
```

py38
```
$ pip list | grep -Ei '(sphinx(_design)?|myst-parser|furo|docutils)\s'
docutils                      0.20.1
furo                          2024.8.6
myst-parser                   3.0.1
Sphinx                        7.1.2
sphinx_design                 0.5.0
```

----

If there are any packagers who want to build the docs with `sphinx-design ==0.5.0` and `sphinx >=8.0.0`, this works perfectly fine, apart from one deprecation warning which will need to be fixed at some point in the future.

> ```
> Running Sphinx v8.0.2
> /home/basti/repos/streamlink/docs/conf.py:225: RemovedInSphinx90Warning: Tags.tags is deprecated, use methods on Tags.
>   if not tags.tags.get("man"):  # type: ignore[name-defined]
> ```