### PR TITLE
webbrowser.chromium: skip proxy on WS URL request

### DIFF
--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -185,6 +185,9 @@ class ChromiumWebbrowser(Webbrowser):
             retry_backoff=0.25,
             retry_max_backoff=0.25,
             timeout=0.1,
+            proxies={
+                "http": "",
+            },
             schema=validate.Schema(
                 validate.parse_json(),
                 {"webSocketDebuggerUrl": validate.url(scheme="ws")},


### PR DESCRIPTION
This skips using http-session proxies (set via `--http-proxy`) when requesting Chromium's IPC websocket URL when using the webbrowser API.

See https://github.com/streamlink/streamlink/discussions/6129#discussioncomment-10315629

It does NOT forward any proxy settings to the launched Chromium process. This is still unsupported.

----

The following example acquires an integrity token using the local IP address, while making any regular HTTP requests using the set proxy.

```
$ streamlink --http-proxy socks5h://localhost:1920 --twitch-force-client-integrity --twitch-purge-client-integrity twitch.tv/gorgc best
[cli][info] Found matching plugin twitch for URL twitch.tv/gorgc
[plugins.twitch][info] Removing cached client-integrity token...
[plugins.twitch][info] Acquiring new client-integrity token...
[webbrowser.webbrowser][info] Launching web browser: /usr/bin/chromium (headless=True)
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: /usr/bin/mpv
[plugins.twitch][info] Will skip ad segments
[plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[plugins.twitch][info] Waiting for pre-roll ads to finish, be patient
[plugins.twitch][info] Detected advertisement break of 15 seconds
[stream.hls][info] Filtering out segments and pausing stream output
[plugins.twitch][info] This is not a low latency stream
[stream.hls][warning] Encountered a stream discontinuity. This is unsupported and will result in incoherent output data.
[stream.hls][info] Resuming stream output
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```