### PR TITLE
tools: add ASYNC and LOG rules to ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,8 @@ select = [
   "ISC",
   # flake8-no-pep420
   "INP",
+  # flake8-logging
+  "LOG",
   # flake8-pie
   "PIE",
   # flake8-print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,8 @@ select = [
   "PLW",
   # isort
   "I",
+  # flake8-async
+  "ASYNC",
   # flake8-builtins
   "A",
   # flake8-bugbear
@@ -230,6 +232,7 @@ select = [
 ignore = [
   "A003",  # builtin-attribute-shadowing
   "A005",  # builtin-module-shadowing
+  "ASYNC109",  # async-function-with-timeout
   "C408",  # unnecessary-collection-call
   "ISC003",  # explicit-string-concatenation
   "PLC1901",  # compare-to-empty-string

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -116,7 +116,7 @@ async def test_launch(
     headless: bool,
 ):
     async def fake_find_free_port(_):
-        await trio.sleep(0)
+        await trio.lowlevel.checkpoint()
         return 1234
 
     monkeypatch.setattr("streamlink.webbrowser.chromium.find_free_port_ipv4", fake_find_free_port)

--- a/tests/webbrowser/test_webbrowser.py
+++ b/tests/webbrowser/test_webbrowser.py
@@ -88,7 +88,7 @@ class TestLaunch:
         async with webbrowser_launch(timeout=10) as (_nursery, process):
             assert process.poll() is None, "process is still running"
             mock_clock.jump(20)
-            await trio.sleep(0)
+            await trio.lowlevel.checkpoint()
 
         assert process.poll() == (1 if is_win32 else -SIGTERM), "Process has been terminated"
         assert [(record.name, record.levelname, record.msg) for record in caplog.records] == [


### PR DESCRIPTION
This adds some more linting rules for async code and the initialization of logger classes.

Going to add the [`G` ruff rules (flake8-logging-format)](https://docs.astral.sh/ruff/rules/#flake8-logging-format-g) for more code cleanups together with the `ruff format` changes after dropping py38, as the `G` rules will require fixing more than 300 logger calls (no str.format() calls or f-strings as log messages - log message arguments should only be formatted when the log level matches).