### PR TITLE
docs: bump sphinx-design to >=0.5.0,<=0.6.1

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -8,7 +8,7 @@ sphinx >=6.0.0,<9
 # themes and extensions
 furo ==2024.08.06
 myst-parser >=1.0.0,<5
-sphinx-design ==0.5.0
+sphinx-design >=0.5.0,<=0.6.1
 
 # typing
 docutils-stubs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -220,9 +220,7 @@ htmlhelp_basename = 'streamlinkdoc'
 # -- Options for manual page output --------------------------------------------
 
 # Only include the man page in builds with the "man" tag set: via `-t man` (see Makefile)
-
-# noinspection PyUnresolvedReferences
-if not tags.tags.get("man"):  # type: ignore[name-defined]
+if "man" not in tags:  # type: ignore[name-defined]
     exclude_patterns.append("_man.rst")
 
 # One entry per manual page. List of tuples


### PR DESCRIPTION
- keep sphinx-design 0.5.0, so docs can still be built on py38
- allow building docs using Sphinx 8 (sphinx-design >=0.6.0)
- fix Sphinx tags deprecation warning

----

- https://sphinx-design.readthedocs.io/en/latest/changelog.html
- https://www.sphinx-doc.org/en/master/changes/8.0.html
- https://github.com/sphinx-doc/sphinx/commit/d2f1acc0cade3b02d24dbdade5533405b6424b1f