### PR TITLE
cli: add --logformat and --logdateformat

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -99,6 +99,10 @@ class StringFormatter(logging.Formatter):
         self._remove_base = remove_base or []
         self._usesTime = super().usesTime()
 
+        # Validate the format's fields
+        rec = logging.LogRecord("", 1, "", 1, "", None, None)
+        super().format(rec)
+
     def usesTime(self):
         return self._usesTime
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -291,6 +291,33 @@ def build_parser():
         """,
     )
     general.add_argument(
+        "--logformat",
+        metavar="FORMAT",
+        help="""
+        Set a custom logging format.
+
+        See the Python standard library's `logging.Formatter` docs for more information about the logging format
+        and the available `LogRecord` attributes. Streamlink's formatter uses the curly brace style.
+
+        The default format depends on the chosen log level (may include the `asctime` attribute).
+
+        Default is "[{name}][{levelname}] {message}".
+        """,
+    )
+    general.add_argument(
+        "--logdateformat",
+        metavar="DATEFORMAT",
+        help="""
+        Set a custom logging date format.
+
+        This formats the `LogRecord`'s `asctime` attribute via `strftime()`.
+
+        The default date format depends on the chosen log level (may include fractions).
+
+        Default is "%%H:%%M:%%S".
+        """,
+    )
+    general.add_argument(
         "--logfile",
         metavar="FILE",
         help="""

--- a/tests/cli/test_main_logging.py
+++ b/tests/cli/test_main_logging.py
@@ -324,8 +324,8 @@ def test_logformat(argv: list, parser: ArgumentParser, level: int, fmt: str, dat
     assert rootlogger.handlers
     formatter = rootlogger.handlers[0].formatter
     assert isinstance(formatter, StringFormatter)
-    assert formatter.style == "{"
-    assert formatter.fmt == fmt
+    assert isinstance(formatter._style, logging.StrFormatStyle)
+    assert formatter._fmt == fmt
     assert formatter.datefmt == datefmt
 
 

--- a/tests/cli/test_main_logging.py
+++ b/tests/cli/test_main_logging.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from contextlib import nullcontext
 from io import StringIO
 from pathlib import Path
 from textwrap import dedent
@@ -327,6 +328,27 @@ def test_logformat(argv: list, parser: ArgumentParser, level: int, fmt: str, dat
     assert isinstance(formatter._style, logging.StrFormatStyle)
     assert formatter._fmt == fmt
     assert formatter.datefmt == datefmt
+
+
+@pytest.mark.parametrize(
+    ("argv", "raises"),
+    [
+        pytest.param(
+            ["--logformat", "%(message)s"],
+            pytest.raises(ValueError, match=r"^invalid format: no fields$"),
+            id="no-fields",
+        ),
+        pytest.param(
+            ["--logformat", "{doesnotexist}"],
+            pytest.raises(ValueError, match=r"^Formatting field not found in record: 'doesnotexist'$"),
+            id="field-not-found",
+        ),
+    ],
+    indirect=["argv"],
+)
+def test_logformat_error(argv: list, parser: ArgumentParser, raises: nullcontext):
+    with raises:
+        streamlink_cli.main.setup(parser)
 
 
 class TestLogfile:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -177,7 +177,7 @@ class TestLogging:
     @pytest.mark.parametrize("log_failure", [{"style": "invalid"}], indirect=True)
     def test_style_invalid(self, log_failure):
         assert type(log_failure) is ValueError
-        assert str(log_failure) == "Only {} and % formatting styles are supported"
+        assert str(log_failure) == "Style must be one of: %,{,$"
 
     @freezegun.freeze_time("2000-01-02T03:04:05.123456Z")
     @pytest.mark.parametrize("log", [


### PR DESCRIPTION
This allows changing the default log format and log date format, which can be useful in some cases, or for specific applications using Streamlink via its CLI which parse the log output.

There's currently no validation of the format, so if the user inputs invalid variables, the error messages with tracelog will be pretty ugly...

```
$ streamlink -l debug | grep Streamlink
[cli][debug] Streamlink: 6.9.0+10.g9d323e3e
```

```
$ streamlink -l all | grep Streamlink
[13:31:07.558270][cli][debug] Streamlink: 6.9.0+10.g9d323e3e
```

```
$ streamlink -l debug --logformat '[{asctime}][{filename}][{name}][{levelname}] {message}' --logdateformat '%Y-%m-%dT%H:%M:%S.%f' | grep Streamlink
[2024-08-25T13:33:53.689482][main.py][cli][debug] Streamlink: 6.9.0+10.g9d323e3e
```