### PR TITLE
plugins.pialive: new plugin

### DIFF
--- a/src/streamlink/plugins/pialive.py
+++ b/src/streamlink/plugins/pialive.py
@@ -67,8 +67,8 @@ class PiaLive(Plugin):
             ),
         )["data"]["movie_one_tag"]
         player_url = validate.Schema(
-                validate.regex(re.compile(r"\s+src=([\"'])(?P<player_url>.*?)\1")),
-            ).validate(player_script_tag)["player_url"]
+            validate.regex(re.compile(r"\s+src=([\"'])(?P<player_url>.*?)\1")),
+        ).validate(player_script_tag)["player_url"]
 
         if not player_url:
             log.error("Player URL not found")
@@ -81,9 +81,7 @@ class PiaLive(Plugin):
         if player_url.startswith(self._ULIZA_URL_PLAYER_DATA):
             m3u8_url = self.session.http.get(
                 player_url,
-                headers={
-                    "Referer": self._URL_BASE,
-                },
+                headers={"Referer": self._URL_BASE},
                 schema=validate.Schema(
                     re.compile(rf"""{re.escape(self._ULIZA_URL_PLAYLIST)}[^"']+"""),
                     validate.none_or_all(

--- a/src/streamlink/plugins/pialive.py
+++ b/src/streamlink/plugins/pialive.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(re.compile(
-    r"https://player\.pia-live\.jp/stream/(?P<video_key>[\w-]+)",
+    r"https?://player\.pia-live\.jp/stream/(?P<video_key>[\w-]+)",
 ))
 class PiaLive(Plugin):
     _URL_BASE = "https://player.pia-live.jp/"

--- a/src/streamlink/plugins/pialive.py
+++ b/src/streamlink/plugins/pialive.py
@@ -1,0 +1,102 @@
+"""
+$description Japanese live-streaming and video hosting platform owned by PIA Corporation.
+$url ulizaportal.jp
+$type live, vod
+$metadata id
+$metadata title
+$account Purchased tickets are required.
+$notes Tickets purchased at "PIA LIVE STREAM" are used for this platform.
+"""
+
+import logging
+import re
+import time
+from urllib.parse import parse_qsl, urlparse, urlencode
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(re.compile(
+    r"https://player\.pia-live\.jp/stream/(?P<video_key>[\w-]+)",
+))
+class PiaLive(Plugin):
+    _URL_BASE = "https://player.pia-live.jp/"
+    _URL_API = "https://api.pia-live.jp/"
+    _ULIZA_URL_PLAYER_DATA = "https://player-api.p.uliza.jp/v1/players/"
+    _ULIZA_URL_PLAYLIST = "https://vms-api.p.uliza.jp/v1/prog-index.m3u8"
+
+    def _extract_vars_validate_pattern(self, xml_xpath, variable):
+        return validate.all(
+            validate.xml_xpath_string(xml_xpath),
+            str,
+            validate.regex(re.compile(rf'(?:var|const)\s+{variable}\s*=\s*(["\'])(?P<value>(?:(?!\1).)+)\1')),
+            validate.get("value"),
+        )
+
+    def _get_streams(self):
+        self.video_key = self.match.group("video_key")
+        self.title, programCode, prod_configure_path = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.union((
+                    validate.xml_xpath_string(".//head/title[1]/text()"),
+                    self._extract_vars_validate_pattern(".//script[contains(text(),'programCode')][1]/text()", "programCode"),
+                    validate.xml_xpath_string(".//script[@type='text/javascript'][contains(@src,'/statics/js/s_prod')][1]/@src")
+            ))
+        ))
+        apiKey = self.session.http.get(
+            self._URL_BASE + prod_configure_path,
+            schema=validate.Schema(
+                validate.parse_html(),
+                self._extract_vars_validate_pattern("", "APIKEY")
+            ),
+            headers={"Referer": self._URL_BASE}
+        )
+
+        player_script_tag = self.session.http.post(
+            f'{self._URL_API}/perf/player-tag-list/{programCode}',
+            headers={"Content-Type": "application/x-www-form-urlencoded", "Referer": self._URL_BASE},
+            data=urlencode({"play_url": self.video_key, "api_key": apiKey}),
+            schema=validate.Schema(
+                validate.parse_json()
+            )
+        )['data']['movie_one_tag']
+        player_url = validate.Schema(
+                validate.regex(re.compile(r'\s+src=(["\'])(?P<player_url>.*?)\1'))
+            ).validate(player_script_tag)["player_url"]
+        
+        if not player_url:
+            log.error("Player URL not found")
+            return None
+
+        return self.handle_embed_player(player_url)
+
+    def handle_embed_player(self, player_url):
+        m3u8_url = None
+        if player_url.startswith(self._ULIZA_URL_PLAYER_DATA):
+            m3u8_url = self.session.http.get(
+                player_url,
+                headers={
+                    "Referer": self._URL_BASE,
+                },
+                schema=validate.Schema(
+                    re.compile(rf"""{re.escape(self._ULIZA_URL_PLAYLIST)}[^"']+"""),
+                    validate.none_or_all(
+                        validate.get(0),
+                        validate.url(),
+                    ),
+                ),
+            )
+        if not m3u8_url:
+            log.error("Platform not supported yet.")
+            return None
+        
+        return HLSStream.parse_variant_playlist(self.session, m3u8_url)
+
+__plugin__ = PiaLive

--- a/src/streamlink/plugins/pialive.py
+++ b/src/streamlink/plugins/pialive.py
@@ -33,7 +33,7 @@ class PiaLive(Plugin):
         return validate.all(
             validate.xml_xpath_string(xml_xpath),
             str,
-            validate.regex(re.compile(rf'(?:var|const)\s+{variable}\s*=\s*(["\'])(?P<value>(?:(?!\1).)+)\1')),
+            validate.regex(re.compile(rf"(?:var|const)\s+{variable}\s*=\s*([\"'])(?P<value>(?:(?!\1).)+)\1")),
             validate.get("value"),
         )
 
@@ -67,7 +67,7 @@ class PiaLive(Plugin):
             ),
         )["data"]["movie_one_tag"]
         player_url = validate.Schema(
-                validate.regex(re.compile(r'\s+src=(["\'])(?P<player_url>.*?)\1')),
+                validate.regex(re.compile(r"\s+src=([\"'])(?P<player_url>.*?)\1")),
             ).validate(player_script_tag)["player_url"]
 
         if not player_url:

--- a/src/streamlink/plugins/pialive.py
+++ b/src/streamlink/plugins/pialive.py
@@ -33,7 +33,7 @@ class PiaLive(Plugin):
         return validate.all(
             validate.xml_xpath_string(xml_xpath),
             str,
-            validate.regex(re.compile(rf"(?:var|const)\s+{variable}\s*=\s*([\"'])(?P<value>(?:(?!\1).)+)\1")),
+            validate.regex(re.compile(rf"""(?:var|const)\s+{variable}\s*=\s*(["'])(?P<value>(?:(?!\1).)+)\1""")),
             validate.get("value"),
         )
 
@@ -67,7 +67,7 @@ class PiaLive(Plugin):
             ),
         )["data"]["movie_one_tag"]
         player_url = validate.Schema(
-            validate.regex(re.compile(r"\s+src=([\"'])(?P<player_url>.*?)\1")),
+            validate.regex(re.compile(r"""\s+src=(["'])(?P<player_url>.*?)\1""")),
         ).validate(player_script_tag)["player_url"]
 
         if not player_url:
@@ -91,7 +91,7 @@ class PiaLive(Plugin):
                 ),
             )
         if not m3u8_url:
-            log.error("Platform not supported yet.")
+            log.error("Platform not supported yet")
             return None
 
         return HLSStream.parse_variant_playlist(self.session, m3u8_url)

--- a/tests/plugins/test_pialive.py
+++ b/tests/plugins/test_pialive.py
@@ -1,0 +1,17 @@
+from streamlink.plugins.pialive import PiaLive
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlPiaLive(PluginCanHandleUrl):
+    __plugin__ = PiaLive
+
+    should_match_groups = [
+        (
+            "https://player.pia-live.jp/stream/4JagFBEIM14s_hK9aXHKf3k3F3bY5eoHFQxu68TC6krUDqGOwN4d61dCWQYOd6CTxl4hjya9dsfEZGsM4uGOUdax60lEI4twsXGXf7crmz8Gk__GhupTrWxA7RFRVt76",
+            {"video_key": "4JagFBEIM14s_hK9aXHKf3k3F3bY5eoHFQxu68TC6krUDqGOwN4d61dCWQYOd6CTxl4hjya9dsfEZGsM4uGOUdax60lEI4twsXGXf7crmz8Gk__GhupTrWxA7RFRVt76"},
+        ),
+    ]
+
+    should_not_match = [
+        "https://player.pia-live.jp/",
+    ]


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Add support for the website https://pia-live.jp. This website sells tickets for 5 streaming platforms ( [`ULIZA`](https://uliza.jp/), [`VIMEO`](https://vimeo.com/), [`Smart STREAM`](https://www.smartstream.ne.jp/), [`Theater ZA`](https://za.theater/), [`Live Extreme`](https://www.live-extreme.net/) ) ( https://pia-live.jp/requirement?lang=en ).

![image](https://github.com/user-attachments/assets/8fbe2d3b-c338-40b1-af7b-780b4e87274a)

In this PR, I currently **only add support** for [`ULIZA`](https://uliza.jp/), which has already been implemented in `plugins/piaulizaportal.py` #5508 . Because I don't know how to call another plugin from the current plugin,  part of the logic in that file has been reused.

By the way, I've also found the [`VIMEO`](https://vimeo.com/) plugin in the `plugins/vimeo.py` file, but unfortunately there isn't any url for testing now.

e.g:
- [こながめでたい日２０２４の視聴ページ](https://player.pia-live.jp/stream/4JagFBEIM14s_hK9aXHKf3k3F3bY5eoHFQxu68TC6krUDqGOwN4d61dCWQYOd6CTxl4hjya9dsfEZGsM4uGOUdax60lEI4twsXGXf7crmz8Gk__GhupTrWxA7RFRVt76)  This video will expire on 2024/9/1.