### PR TITLE
Fix OSError (BrokenPipeError) on stdout flush

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -124,6 +124,13 @@ class StreamHandler(logging.StreamHandler):
         super().__init__(*args, **kwargs)
         self._stream_reconfigure()
 
+    def flush(self):
+        try:
+            super().flush()
+        except OSError:
+            # Python doesn't raise BrokenPipeError on Windows
+            pass
+
     def setStream(self, stream):
         res = super().setStream(stream)
         if res:  # pragma: no branch

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -988,4 +988,10 @@ def main():
             else:
                 console.msg(f"error: {msg}")
 
+    # https://docs.python.org/3/library/signal.html#note-on-sigpipe
+    try:
+        sys.stdout.flush()
+    except OSError:
+        del sys.stdout
+
     sys.exit(exit_code)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from datetime import timezone
+from errno import EINVAL, EPIPE
 from inspect import currentframe, getframeinfo
 from io import BytesIO, TextIOWrapper
 from pathlib import Path
@@ -239,6 +240,37 @@ class TestLogging:
         log.info("Bär: 🐻")
         assert getvalue(output) == "[test][info] Bär: 🐻\n"
         assert getvalue(output_ascii) == "[test][info] B\\xe4r: \\U0001f43b\n"
+
+    @pytest.mark.parametrize(
+        "errno",
+        [
+            pytest.param(EPIPE, id="EPIPE", marks=pytest.mark.posix_only),
+            pytest.param(EINVAL, id="EINVAL", marks=pytest.mark.windows_only),
+        ],
+    )
+    def test_brokenpipeerror(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        log: logging.Logger,
+        errno: int,
+    ):
+        def flush(*_, **__):
+            exception = OSError()
+            exception.errno = errno
+            raise exception
+
+        streamhandler = log.handlers[0]
+        assert isinstance(streamhandler, logging.StreamHandler)
+        monkeypatch.setattr(streamhandler.stream, "flush", flush)
+
+        log.setLevel("info")
+        log.info("foo")
+
+        # logging.StreamHandler will write emit()/flush() errors to stderr via handleError()
+        out, err = capsys.readouterr()
+        assert not out
+        assert not err
 
     def test_logfile(self, logfile: str, log: logging.Logger, output: TextIOWrapper):
         log.setLevel("info")


### PR DESCRIPTION
1. This fixes repeated errors being written to stderr whenever a new log message fails to be written to stdout due to the stream pipe being closed by the other process, e.g. when executing `streamlink -l debug | head -n1`. This issue is caused when trying to flush the stdout stream buffer after writing a log message. Python's `logging` module explicitly doesn't handle this case (for some reason).

   The fix is to simply ignore `OSError` (`BrokenPipeError`) in [`logging.StreamHandler.flush()`](https://github.com/python/cpython/blame/v3.12.5/Lib/logging/__init__.py#L1137-L1146). On Windows, `BrokenPipeError` is not raised and instead a simple `OSError` with `errno=EINVAL`.

   As an optimization, follow-up log calls [could all be ignored by overriding `emit()`](https://github.com/python/cpython/blame/v3.12.5/Lib/logging/__init__.py#L1148-L1168) when this exception is caught for the first time, but it's not really important.

   Alternatively, the `StreamHandler`'s [`handleError()` method](https://github.com/python/cpython/blame/v3.12.5/Lib/logging/__init__.py#L1066) could be overridden, which is where the `"--- Logging error ---"` stuff is coming from, but this would remove potentially useful error messages when logging fails in a different way.

2. The second commit fixes the broken stdout pipe raising `OSError` (`BrokenPipeError`) when the Python process exits, as Python always flushes stdout on exit.

   The fix is to [destruct the `sys.stdout` object](https://docs.python.org/3/library/io.html#io.IOBase.__del__), as opposed to redirecting stdout to devnull, as mentioned in the [`SIGPIPE` notes in the stdlib docs](https://docs.python.org/3/library/signal.html#note-on-sigpipe).

   There's no interference with `--stdout`, as there's only a simple flush at the end before calling `sys.exit(...)`.

Only tested on my local machine. Will check later today and then merge if there are no issues.

----

master
```
$ streamlink -l debug | head -n1
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 788, in log_current_versions
    log.debug(f"Python:     {platform.python_version()}")
Message: 'Python:     3.12.4'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 789, in log_current_versions
    log.debug(f"OpenSSL:    {ssl.OPENSSL_VERSION}")
Message: 'OpenSSL:    OpenSSL 3.3.1 4 Jun 2024'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 790, in log_current_versions
    log.debug(f"Streamlink: {streamlink_version}")
Message: 'Streamlink: 6.9.0+13.g18e30397'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 794, in log_current_versions
    log.debug("Dependencies:")
Message: 'Dependencies:'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' certifi: 2024.7.4'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' isodate: 0.6.1'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' lxml: 5.3.0'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' pycountry: 24.6.1'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' pycryptodome: 3.20.0'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' PySocks: 1.7.1'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' requests: 2.32.3'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' trio: 0.26.2'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' trio-websocket: 0.11.1'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' typing-extensions: 4.12.2'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' urllib3: 2.2.2'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 915, in setup
    log_current_versions()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 804, in log_current_versions
    log.debug(f" {name}: {version}")
Message: ' websocket-client: 1.8.0'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 916, in setup
    log_current_arguments(streamlink, parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 817, in log_current_arguments
    log.debug("Arguments:")
Message: 'Arguments:'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 916, in setup
    log_current_arguments(streamlink, parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 829, in log_current_arguments
    log.debug(f" {name}={value if name not in sensitive else '*' * 8}")
Message: ' --loglevel=debug'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 916, in setup
    log_current_arguments(streamlink, parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 829, in log_current_arguments
    log.debug(f" {name}={value if name not in sensitive else '*' * 8}")
Message: ' --player=/usr/bin/mpv'
Arguments: ()
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.12/logging/__init__.py", line 1164, in emit
    self.flush()
  File "/usr/lib/python3.12/logging/__init__.py", line 1144, in flush
    self.stream.flush()
BrokenPipeError: [Errno 32] Broken pipe
Call stack:
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 916, in setup
    log_current_arguments(streamlink, parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 829, in log_current_arguments
    log.debug(f" {name}={value if name not in sensitive else '*' * 8}")
Message: ' --webbrowser-headless=True'
Arguments: ()
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
BrokenPipeError: [Errno 32] Broken pipe
```

PR
```
$ streamlink -l debug | head -n1
[cli][debug] OS:         Linux-6.10.6-1-git-x86_64-with-glibc2.40

$ streamlink -l debug --stdout 2> >(head -n1)
[cli][debug] OS:         Linux-6.10.6-1-git-x86_64-with-glibc2.40

$ streamlink -l debug | head -n1
[cli][debug] OS:         Windows 10
```