### PR TITLE
cli: handle logging setup exceptions

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -861,15 +861,18 @@ def setup_logger_and_console(
     if filename:
         filename.parent.mkdir(parents=True, exist_ok=True)
 
-    streamhandler = logger.basicConfig(
-        stream=stream,
-        filename=filename,
-        level=level,
-        style="{",
-        format=fmt,
-        datefmt=datefmt,
-        capture_warnings=True,
-    )
+    try:
+        streamhandler = logger.basicConfig(
+            stream=stream,
+            filename=filename,
+            level=level,
+            style="{",
+            format=fmt,
+            datefmt=datefmt,
+            capture_warnings=True,
+        )
+    except Exception as err:
+        raise StreamlinkCLIError(f"Logging setup error: {err}") from err
 
     console = ConsoleOutput(streamhandler.stream, json)
 
@@ -976,8 +979,13 @@ def run(parser: ArgumentParser) -> int:
 
 
 def main():
-    parser = build_parser()
-    setup(parser)
+    try:
+        parser = build_parser()
+        setup(parser)
+    except StreamlinkCLIError as err:
+        sys.stderr.write(f"{err}\n")
+        sys.exit(1)
+
     try:
         exit_code = run(parser)
     except StreamlinkCLIError as err:


### PR DESCRIPTION
Wrap logging setup exceptions in a StreamlinkCLIError and write the exception message to stderr instead of printing the whole stack of the uncaught exception.

----

Follow-up of #6138 

There's no reason for Streamlink to print the entire exception traceback when the user inputs an invalid log format string.

master
```
$ streamlink --logformat foo
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 893, in setup
    setup_logger_and_console(
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 864, in setup_logger_and_console
    streamhandler = logger.basicConfig(
                    ^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/logger.py", line 218, in basicConfig
    formatter = StringFormatter(
                ^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/logger.py", line 98, in __init__
    super().__init__(*args, **kwargs)
  File "/usr/lib/python3.12/logging/__init__.py", line 614, in __init__
    self._style.validate()
  File "/usr/lib/python3.12/logging/__init__.py", line 500, in validate
    raise ValueError('invalid format: no fields')
ValueError: invalid format: no fields
```

PR
```
$ streamlink --logformat foo
Logging setup error: invalid format: no fields
```

----

Other exceptions during setup, e.g. broken third party plugins failing to load, are not caught and still print the full stack.

```
$ streamlink -l debug
Traceback (most recent call last):
  File "/home/basti/.local/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 980, in main
    setup(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 904, in setup
    setup_plugins(args.plugin_dirs)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 700, in setup_plugins
    load_plugins(PLUGIN_DIRS, showwarning=False)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 608, in load_plugins
    success = streamlink.plugins.load_path(directory)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/session/plugins.py", line 106, in load_path
    plugins = self._load_plugins_from_path(path)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/session/plugins.py", line 178, in _load_plugins_from_path
    lookup = self._load_plugin_from_finder(name, finder=finder)  # type: ignore[arg-type]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/session/plugins.py", line 194, in _load_plugin_from_finder
    mod = exec_module(finder, f"streamlink.plugins.{name}")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/utils/module.py", line 34, in exec_module
    spec.loader.exec_module(mod)
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/home/basti/.local/share/streamlink/plugins/foo.py", line 1, in <module>
    0 / 0
    ~~^~~
ZeroDivisionError: division by zero
```