### PR TITLE
plugins.pandalive: fix missing HTTP headers

### DIFF
--- a/tests/plugins/test_pandalive.py
+++ b/tests/plugins/test_pandalive.py
@@ -6,6 +6,5 @@ class TestPluginCanHandleUrlPandalive(PluginCanHandleUrl):
     __plugin__ = Pandalive
 
     should_match = [
-        "https://www.pandalive.co.kr/live/play/pocet00",
-        "https://www.pandalive.co.kr/live/play/rladbfl1208",
+        "https://www.pandalive.co.kr/live/play/CHANNEL",
     ]


### PR DESCRIPTION
Fixes #6147

```
$ ./script/test-plugin-urls.py pandalive -m -r CHANNEL s22unn22
:: https://www.pandalive.co.kr/live/play/s22unn22
:::: Broadcast type: rec
::  160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': 'ෆ세은ෆ (s22unn22)', 'category': None, 'title': '[녹] 오늘 낮 3시방송 본방사수!!!'}
```

```
$ streamlink -l debug https://www.pandalive.co.kr/live/play/s22unn22 best
[cli][debug] OS:         Linux-6.10.6-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.4
[cli][debug] OpenSSL:    OpenSSL 3.3.1 4 Jun 2024
[cli][debug] Streamlink: 6.9.0+18.g0ea86fbf
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.7.4
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.2
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.2
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.pandalive.co.kr/live/play/s22unn22
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin pandalive for URL https://www.pandalive.co.kr/live/play/s22unn22
[plugins.pandalive][debug] Media code: s22unn22
[plugins.pandalive][info] Broadcast type: rec
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 8353; Last Sequence: 8366
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 8364; End Sequence: None
[stream.hls][debug] Adding segment 8364 to queue
[stream.hls][debug] Adding segment 8365 to queue
[stream.hls][debug] Adding segment 8366 to queue
[stream.hls][debug] Writing segment 8364 to output
[stream.hls][debug] Segment 8364 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://www.pandalive.co.kr/live/play/s22unn22', '-']
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Writing segment 8365 to output
[stream.hls][debug] Segment 8365 complete
[stream.hls][debug] Adding segment 8367 to queue
[stream.hls][debug] Writing segment 8366 to output
[stream.hls][debug] Segment 8366 complete
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```