### PR TITLE
cli: remove deprecated {,plugin-}config paths

### DIFF
--- a/docs/cli/config.rst
+++ b/docs/cli/config.rst
@@ -26,10 +26,6 @@ your platform:
         :bdg-info-line:`Example`
 
         - ``/home/USERNAME/.config/streamlink/config``
-
-        :bdg-danger-line:`Deprecated`
-
-        - ``${HOME}/.streamlinkrc``
     * - macOS
       - :bdg-primary:`Path`
 
@@ -38,11 +34,6 @@ your platform:
         :bdg-info-line:`Example`
 
         - ``/Users/USERNAME/Library/Application Support/streamlink/config``
-
-        :bdg-danger-line:`Deprecated`
-
-        - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/config``
-        - ``${HOME}/.streamlinkrc``
     * - Windows
       - :bdg-primary:`Path`
 
@@ -51,10 +42,6 @@ your platform:
         :bdg-info-line:`Example`
 
         - ``C:\Users\USERNAME\AppData\Roaming\streamlink\config``
-
-        :bdg-danger-line:`Deprecated`
-
-        - ``%APPDATA%\streamlink\streamlinkrc``
 
 You can also specify the location yourself using the :option:`--config` option.
 
@@ -129,10 +116,6 @@ Streamlink expects these configs to be named like the main config but with ``.<p
         :bdg-info-line:`Example`
 
         - ``/home/USERNAME/.config/streamlink/config.twitch``
-
-        :bdg-danger-line:`Deprecated`
-
-        - ``${HOME}/.streamlinkrc.pluginname``
     * - macOS
       - :bdg-primary:`Path`
 
@@ -141,11 +124,6 @@ Streamlink expects these configs to be named like the main config but with ``.<p
         :bdg-info-line:`Example`
 
         - ``/Users/USERNAME/Library/Application Support/streamlink/config.twitch``
-
-        :bdg-danger-line:`Deprecated`
-
-        - ``${XDG_CONFIG_HOME:-${HOME}/.config}/streamlink/config.pluginname``
-        - ``${HOME}/.streamlinkrc.pluginname``
     * - Windows
       - :bdg-primary:`Path`
 
@@ -154,10 +132,6 @@ Streamlink expects these configs to be named like the main config but with ``.<p
         :bdg-info-line:`Example`
 
         - ``C:\Users\USERNAME\AppData\Roaming\streamlink\config.twitch``
-
-        :bdg-danger-line:`Deprecated`
-
-        - ``%APPDATA%\streamlink\streamlinkrc.pluginname``
 
 Have a look at the :ref:`list of plugins <plugins:Plugins>`, or
 check the :option:`--plugins` option to see the name of each built-in plugin.

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -23,7 +23,6 @@ if is_win32:
     APPDATA = Path(os.environ.get("APPDATA") or Path.home() / "AppData")
     CONFIG_FILES = [
         APPDATA / "streamlink" / "config",
-        DeprecatedPath(APPDATA / "streamlink" / "streamlinkrc"),
     ]
     PLUGIN_DIRS = [
         APPDATA / "streamlink" / "plugins",
@@ -33,8 +32,6 @@ elif is_darwin:
     XDG_CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")).expanduser()
     CONFIG_FILES = [
         Path.home() / "Library" / "Application Support" / "streamlink" / "config",
-        DeprecatedPath(XDG_CONFIG_HOME / "streamlink" / "config"),
-        DeprecatedPath(Path.home() / ".streamlinkrc"),
     ]
     PLUGIN_DIRS = [
         Path.home() / "Library" / "Application Support" / "streamlink" / "plugins",
@@ -47,7 +44,6 @@ else:
     XDG_STATE_HOME = Path(os.environ.get("XDG_STATE_HOME", "~/.local/state")).expanduser()
     CONFIG_FILES = [
         XDG_CONFIG_HOME / "streamlink" / "config",
-        DeprecatedPath(Path.home() / ".streamlinkrc"),
     ]
     PLUGIN_DIRS = [
         XDG_DATA_HOME / "streamlink" / "plugins",

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -709,12 +709,6 @@ def setup_config_args(parser, ignore_unknown=False):
     else:
         # Only load first available default config
         for config_file in filter(lambda path: path.is_file(), CONFIG_FILES):  # pragma: no branch
-            if type(config_file) is DeprecatedPath:
-                warnings.warn(
-                    f"Loaded config from deprecated path, see CLI docs for how to migrate: {config_file}",
-                    StreamlinkDeprecationWarning,
-                    stacklevel=1,
-                )
             config_files.append(config_file)
             break
 
@@ -726,12 +720,6 @@ def setup_config_args(parser, ignore_unknown=False):
                 config_file = config_file.with_name(f"{config_file.name}.{pluginname}")
                 if not config_file.is_file():
                     continue
-                if type(config_file) is DeprecatedPath:
-                    warnings.warn(
-                        f"Loaded plugin config from deprecated path, see CLI docs for how to migrate: {config_file}",
-                        StreamlinkDeprecationWarning,
-                        stacklevel=1,
-                    )
                 config_files.append(config_file)
                 break
 

--- a/tests/cli/main/test_setup_config_args.py
+++ b/tests/cli/main/test_setup_config_args.py
@@ -6,8 +6,7 @@ import pytest
 
 import tests.resources
 from streamlink import Streamlink
-from streamlink.exceptions import NoPluginError, StreamlinkDeprecationWarning
-from streamlink_cli.compat import DeprecatedPath
+from streamlink.exceptions import NoPluginError
 from streamlink_cli.main import setup_config_args
 
 
@@ -47,7 +46,7 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
 # noinspection PyTestParametrized
 @pytest.mark.usefixtures("_args", "_config_files")
 @pytest.mark.parametrize(
-    ("_args", "_config_files", "expected", "deprecations"),
+    ("_args", "_config_files", "expected"),
     [
         pytest.param(
             {
@@ -57,13 +56,39 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
             [
                 CONFIGDIR / "primary",
             ],
-            [],
             id="No URL, default config",
+        ),
+        pytest.param(
+            {
+                "no_config": False,
+                "config": [
+                    str(CONFIGDIR / "custom"),
+                ],
+                "url": None,
+            },
+            [
+                CONFIGDIR / "primary",
+            ],
+            [
+                CONFIGDIR / "custom",
+            ],
+            id="No URL, custom config",
+        ),
+        pytest.param(
+            {
+                "no_config": False,
+                "config": [],
+                "url": None,
+            },
+            [
+                CONFIGDIR / "non-existent",
+            ],
+            [],
+            id="No URL, non-existent default config",
         ),
         pytest.param(
             {
@@ -75,9 +100,7 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
-            [],
             [],
             id="No URL, non-existent custom config",
         ),
@@ -89,13 +112,39 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
             [
                 CONFIGDIR / "primary",
             ],
-            [],
             id="No plugin, default config",
+        ),
+        pytest.param(
+            {
+                "no_config": False,
+                "config": [
+                    str(CONFIGDIR / "custom"),
+                ],
+                "url": "noplugin",
+            },
+            [
+                CONFIGDIR / "primary",
+            ],
+            [
+                CONFIGDIR / "custom",
+            ],
+            id="No plugin, custom config",
+        ),
+        pytest.param(
+            {
+                "no_config": False,
+                "config": [],
+                "url": "noplugin",
+            },
+            [
+                CONFIGDIR / "non-existent",
+            ],
+            [],
+            id="No plugin, non-existent default config",
         ),
         pytest.param(
             {
@@ -107,9 +156,7 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
-            [],
             [],
             id="No plugin, non-existent custom config",
         ),
@@ -121,14 +168,12 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
             [
                 CONFIGDIR / "primary",
                 CONFIGDIR / "primary.testplugin",
             ],
-            [],
-            id="Default primary config",
+            id="Testplugin, default config",
         ),
         pytest.param(
             {
@@ -138,25 +183,9 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "non-existent",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
-            [
-                CONFIGDIR / "secondary",
-                CONFIGDIR / "secondary.testplugin",
-            ],
-            [
-                (
-                    StreamlinkDeprecationWarning,
-                    "Loaded config from deprecated path, see CLI docs for how to migrate: "
-                    + f"{CONFIGDIR / 'secondary'}",
-                ),
-                (
-                    StreamlinkDeprecationWarning,
-                    "Loaded plugin config from deprecated path, see CLI docs for how to migrate: "
-                    + f"{CONFIGDIR / 'secondary.testplugin'}",
-                ),
-            ],
-            id="Default secondary config",
+            [],
+            id="Testplugin, non-existent default config",
         ),
         pytest.param(
             {
@@ -168,39 +197,28 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
             [
                 CONFIGDIR / "custom",
                 CONFIGDIR / "primary.testplugin",
             ],
-            [],
-            id="Custom config with primary plugin",
+            id="Testplugin, custom config",
         ),
         pytest.param(
             {
                 "no_config": False,
                 "config": [
-                    str(CONFIGDIR / "custom"),
+                    str(CONFIGDIR / "non-existent"),
                 ],
                 "url": "testplugin",
             },
             [
-                CONFIGDIR / "non-existent",
-                DeprecatedPath(CONFIGDIR / "secondary"),
+                CONFIGDIR / "primary",
             ],
             [
-                CONFIGDIR / "custom",
-                DeprecatedPath(CONFIGDIR / "secondary.testplugin"),
+                CONFIGDIR / "primary.testplugin",
             ],
-            [
-                (
-                    StreamlinkDeprecationWarning,
-                    "Loaded plugin config from deprecated path, see CLI docs for how to migrate: "
-                    + f"{CONFIGDIR / 'secondary.testplugin'}",
-                ),
-            ],
-            id="Custom config with deprecated plugin",
+            id="Testplugin, non-existent custom config",
         ),
         pytest.param(
             {
@@ -214,15 +232,13 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
             },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
             [
                 CONFIGDIR / "secondary",
                 CONFIGDIR / "primary",
                 CONFIGDIR / "primary.testplugin",
             ],
-            [],
-            id="Multiple custom configs",
+            id="Testplugin, multiple custom configs",
         ),
         pytest.param(
             {
@@ -230,10 +246,11 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
                 "config": [],
                 "url": "testplugin",
             },
+            [
+                CONFIGDIR / "primary",
+            ],
             [],
-            [],
-            [],
-            id="No config",
+            id="No config, default config",
         ),
         pytest.param(
             {
@@ -244,37 +261,24 @@ def session(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
                 ],
                 "url": "testplugin",
             },
-            [],
-            [],
-            [],
-            id="No config with multiple custom configs",
-        ),
-        pytest.param(
-            {
-                "no_config": True,
-                "config": [],
-                "url": "testplugin",
-            },
             [
                 CONFIGDIR / "primary",
-                DeprecatedPath(CONFIGDIR / "secondary"),
             ],
             [],
-            [],
-            id="No config with multiple default configs",
+            id="No config, multiple custom configs",
         ),
     ],
     indirect=["_args", "_config_files"],
 )
+@pytest.mark.parametrize("ignore_unknown", [True, False])
 def test_setup_config_args(
     recwarn: pytest.WarningsRecorder,
     setup_args: Mock,
     expected: list,
-    deprecations: list,
+    ignore_unknown: bool,
 ):
     parser = Mock()
-    setup_config_args(parser)
-    assert setup_args.call_args_list == ([call(parser, expected, ignore_unknown=False)] if expected else []), \
-        "Calls setup_args with the correct list of config files"
-    assert [(record.category, str(record.message)) for record in recwarn.list] == deprecations, \
-        "Raises the correct deprecation warnings"
+    setup_config_args(parser, ignore_unknown=ignore_unknown)
+    assert setup_args.call_args_list == (
+        [call(parser, expected, ignore_unknown=ignore_unknown)] if expected else []
+    ), "Calls setup_args with the correct list of config files"


### PR DESCRIPTION
This will remove support for the old and deprecated config file paths in the 7.0.0 release.

Those old config paths have been deprecated since 2.2.0 (2021-06-19):

- https://streamlink.github.io/deprecations.html#config-file-paths
- https://streamlink.github.io/changelog.html#streamlink-2-2-0-2021-06-19

TODO: Update the docs' migrations page