### PR TITLE
ci.github: fix useragents workflow

### DIFF
--- a/.github/workflows/useragents.yml
+++ b/.github/workflows/useragents.yml
@@ -3,6 +3,7 @@ name: Update user agents
 on:
   schedule:
     - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   update-user-agents:
@@ -17,16 +18,16 @@ jobs:
       - run: python ./script/update-user-agents.py
         env:
           WHATISMYBROWSER_API_KEY: ${{ secrets.WHATISMYBROWSER_API_KEY }}
-      - uses: peter-evans/create-pull-request@6d9c0cdf5825c01278b6e63a0788434e6b3c5e27
+      - uses: peter-evans/create-pull-request@0c2a66fe4af462aa0761939bd32efbdd46592737
         with:
           token: ${{ secrets.STREAMLINKBOT_USERAGENTS_PR }}
           add-paths: |
-            src/streamlink/plugin/api/useragents.py
-          commit-message: "plugin.api: update useragents"
+            src/streamlink/session/http_useragents.py
+          commit-message: "session.http_useragents: update useragents"
           committer: "streamlinkbot <streamlinkbot@users.noreply.github.com>"
           author: "streamlinkbot <streamlinkbot@users.noreply.github.com>"
-          branch: "automated/plugin/api/useragents"
+          branch: "automated/session/http_useragents/update"
           branch-suffix: timestamp
           delete-branch: true
-          title: "plugin.api: update useragents"
+          title: "session.http_useragents: update useragents"
           body: "Automated pull request"


### PR DESCRIPTION
The useragents module was moved/renamed in #6112 last month. Apparently I forgot to add the updated CI workflow file to the commit (leading dot in the path).

This PR fixes that, updates the `peter-evans/create-pull-request` 3rd party action to the latest version, and adds the `workflow_dispatch` event, which I will trigger after merging, so the UAs can be updated for this month.

The CI run from earlier today obviously didn't add the modified file, so nothing was committed and no PR was opened:
https://github.com/streamlink/streamlink/actions/runs/10649258855/job/29519199821#step:6:92