### PR TITLE
stream.ffmpegmux: add loglevel

### DIFF
--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -250,6 +250,10 @@ class StreamlinkOptions(Options):
           - ``str | None``
           - ``None``
           - Write FFmpeg's stderr stream to the filesystem at the specified path
+        * - ffmpeg-loglevel
+          - ``str | None``
+          - ``None``
+          - Set FFmpeg's ``-loglevel`` value
         * - ffmpeg-fout
           - ``str | None``
           - ``None``
@@ -329,6 +333,7 @@ class StreamlinkOptions(Options):
             "ffmpeg-no-validation": False,
             "ffmpeg-verbose": False,
             "ffmpeg-verbose-path": None,
+            "ffmpeg-loglevel": None,
             "ffmpeg-fout": None,
             "ffmpeg-video-transcode": None,
             "ffmpeg-audio-transcode": None,

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -82,6 +82,7 @@ class MuxedStream(Stream, Generic[TSubstreams]):
 class FFMPEGMuxer(StreamIO):
     __commands__: ClassVar[List[str]] = ["ffmpeg"]
 
+    DEFAULT_LOGLEVEL = "info"
     DEFAULT_OUTPUT_FORMAT = "matroska"
     DEFAULT_VIDEO_CODEC = "copy"
     DEFAULT_AUDIO_CODEC = "copy"
@@ -172,6 +173,7 @@ class FFMPEGMuxer(StreamIO):
                              for stream, np in
                              zip(self.streams, self.pipes)]
 
+        loglevel = session.options.get("ffmpeg-loglevel") or options.pop("loglevel", self.DEFAULT_LOGLEVEL)
         ofmt = session.options.get("ffmpeg-fout") or options.pop("format", self.DEFAULT_OUTPUT_FORMAT)
         outpath = options.pop("outpath", "pipe:1")
         videocodec = session.options.get("ffmpeg-video-transcode") or options.pop("vcodec", self.DEFAULT_VIDEO_CODEC)
@@ -181,7 +183,14 @@ class FFMPEGMuxer(StreamIO):
         copyts = session.options.get("ffmpeg-copyts") or options.pop("copyts", False)
         start_at_zero = session.options.get("ffmpeg-start-at-zero") or options.pop("start_at_zero", False)
 
-        self._cmd = [self.command(session), "-nostats", "-y"]
+        self._cmd = [
+            self.command(session),
+            "-y",
+            "-nostats",
+            "-loglevel",
+            loglevel,
+        ]
+
         for np in self.pipes:
             self._cmd.extend(["-i", str(np.path)])
 

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1156,6 +1156,18 @@ def build_parser():
         """,
     )
     transport_ffmpeg.add_argument(
+        "--ffmpeg-loglevel",
+        type=str,
+        metavar="LOGLEVEL",
+        help="""
+        Change FFmpeg's `-loglevel` value to `LOGLEVEL`.
+
+        Unless --ffmpeg-verbose or --ffmpeg-verbose-path is set, changing the log level won't have any effect.
+
+        Default is "info".
+        """,
+    )
+    transport_ffmpeg.add_argument(
         "--ffmpeg-fout",
         type=str,
         metavar="OUTFORMAT",
@@ -1449,6 +1461,7 @@ _ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]
     ("ffmpeg_no_validation", "ffmpeg-no-validation", None),
     ("ffmpeg_verbose", "ffmpeg-verbose", None),
     ("ffmpeg_verbose_path", "ffmpeg-verbose-path", None),
+    ("ffmpeg_loglevel", "ffmpeg-loglevel", None),
     ("ffmpeg_fout", "ffmpeg-fout", None),
     ("ffmpeg_video_transcode", "ffmpeg-video-transcode", None),
     ("ffmpeg_audio_transcode", "ffmpeg-audio-transcode", None),

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -167,7 +167,8 @@ class TestFFmpegVersionOutput:
 
 
 class TestOpen:
-    FFMPEG_ARGS_DEFAULT_BASE = ["-nostats", "-y"]
+    FFMPEG_ARGS_DEFAULT_BASE = ["-y", "-nostats"]
+    FFMPEG_ARGS_DEFAULT_LOGLEVEL = ["-loglevel", "info"]
     FFMPEG_ARGS_DEFAULT_CODECS = ["-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC, "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC]
     FFMPEG_ARGS_DEFAULT_FORMAT = ["-f", FFMPEGMuxer.DEFAULT_OUTPUT_FORMAT]
     FFMPEG_ARGS_DEFAULT_OUTPUT = ["pipe:1"]
@@ -188,6 +189,7 @@ class TestOpen:
             {},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
                 *FFMPEG_ARGS_DEFAULT_OUTPUT,
@@ -196,9 +198,34 @@ class TestOpen:
         ),
         pytest.param(
             {},
+            {"loglevel": "verbose"},
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-loglevel", "verbose",
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
+            id="loglevel",
+        ),
+        pytest.param(
+            {"ffmpeg-loglevel": "error"},
+            {"loglevel": "verbose"},
+            [
+                *FFMPEG_ARGS_DEFAULT_BASE,
+                "-loglevel", "error",
+                *FFMPEG_ARGS_DEFAULT_CODECS,
+                *FFMPEG_ARGS_DEFAULT_FORMAT,
+                *FFMPEG_ARGS_DEFAULT_OUTPUT,
+            ],
+            id="loglevel-user-override",
+        ),
+        pytest.param(
+            {},
             {"format": "mpegts"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-f", "mpegts",
                 *FFMPEG_ARGS_DEFAULT_OUTPUT,
@@ -210,6 +237,7 @@ class TestOpen:
             {"format": "mpegts"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-f", "avi",
                 *FFMPEG_ARGS_DEFAULT_OUTPUT,
@@ -221,6 +249,7 @@ class TestOpen:
             {"copyts": True},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -233,6 +262,7 @@ class TestOpen:
             {"copyts": False},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -245,6 +275,7 @@ class TestOpen:
             {"copyts": True},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -257,6 +288,7 @@ class TestOpen:
             {"copyts": False},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -269,6 +301,7 @@ class TestOpen:
             {"copyts": True},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts", "-start_at_zero",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -281,6 +314,7 @@ class TestOpen:
             {"copyts": False},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts", "-start_at_zero",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -293,6 +327,7 @@ class TestOpen:
             {"copyts": True, "start_at_zero": False},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -305,6 +340,7 @@ class TestOpen:
             {"copyts": False, "start_at_zero": False},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -317,6 +353,7 @@ class TestOpen:
             {"copyts": True, "start_at_zero": True},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts", "-start_at_zero",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -329,6 +366,7 @@ class TestOpen:
             {"copyts": False, "start_at_zero": True},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-copyts", "-start_at_zero",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -341,6 +379,7 @@ class TestOpen:
             {"vcodec": "avc"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 "-c:v", "avc",
                 "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC,
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -353,6 +392,7 @@ class TestOpen:
             {"vcodec": "avc"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 "-c:v", "divx",
                 "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC,
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -365,6 +405,7 @@ class TestOpen:
             {"acodec": "mp3"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 "-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC,
                 "-c:a", "mp3",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -377,6 +418,7 @@ class TestOpen:
             {"acodec": "mp3"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 "-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC,
                 "-c:a", "ogg",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -389,6 +431,7 @@ class TestOpen:
             {"vcodec": "avc", "acodec": "mp3"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 "-c:v", "avc",
                 "-c:a", "mp3",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -401,6 +444,7 @@ class TestOpen:
             {"vcodec": "avc", "acodec": "mp3"},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 "-c:v", "divx",
                 "-c:a", "ogg",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -413,6 +457,7 @@ class TestOpen:
             {"maps": ["test", "test2"]},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-map", "test",
                 "-map", "test2",
@@ -426,6 +471,7 @@ class TestOpen:
             {"metadata": {"s:a:0": ["language=eng"]}},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-metadata:s:a:0", "language=eng",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -438,6 +484,7 @@ class TestOpen:
             {"metadata": {None: ["title=test"]}},
             [
                 *FFMPEG_ARGS_DEFAULT_BASE,
+                *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
                 *FFMPEG_ARGS_DEFAULT_CODECS,
                 "-metadata", "title=test",
                 *FFMPEG_ARGS_DEFAULT_FORMAT,


### PR DESCRIPTION
Hello.

When creating a plugin using FFMPEGMuxer, I wanted to display a finer log level (verbose, debug) than FFmpeg's info, so I added the argument “--ffmpeg-loglevel”. 

[ffmpeg Documentation: 5.2 Generic options](https://www.ffmpeg.org/ffmpeg.html#Generic-options)

```sample_console
[soprano1125@localhost streamlink]$ ffmpeg -hide_banner -loglevel test
Invalid loglevel "test". Possible levels are numbers or:
"quiet"                                                                                                                                            
"panic"                                                                                                                                            
"fatal"                                                                                                                                            
"error"                                                                                                                                            
"warning"                                                                                                                                          
"info"                                                                                                                                             
"verbose"                                                                                                                                          
"debug"                                                                                                                                            
"trace"                                    
```