### PR TITLE
tests: fix race condition in named-pipe tests

### DIFF
--- a/tests/utils/test_named_pipe.py
+++ b/tests/utils/test_named_pipe.py
@@ -130,10 +130,11 @@ class TestNamedPipePosix:
         assert pipe.write(b"bar") == 3
         pipe.close()
         assert not pipe.path.is_fifo()
-        reader.done.wait(4000)
+        reader.done.wait(4)
+        reader.join(1)
+        assert not reader.is_alive()
         assert reader.error is None
         assert reader.data == b"foobar"
-        assert not reader.is_alive()
 
 
 @pytest.mark.windows_only()
@@ -196,8 +197,9 @@ class TestNamedPipeWindows:
         assert pipe.write(b"foo") == 3
         assert pipe.write(b"bar") == 3
         assert pipe.write(b"\x00") == 1
-        reader.done.wait(4000)
+        reader.done.wait(4)
+        reader.join(1)
+        assert not reader.is_alive()
         assert reader.error is None
         assert reader.data == b"foobar"
-        assert not reader.is_alive()
         pipe.close()


### PR DESCRIPTION
Scheduled tests failed today:
https://github.com/streamlink/streamlink/actions/runs/10821794638/job/30024523254#step:7:286

Join reader thread after awaiting its `done` event before continuing with test assertions (and fix incorrect timeout values).
https://github.com/streamlink/streamlink/blob/5d9b7163b931b77678a438758f76e582e572dde4/tests/utils/test_named_pipe.py#L27-L32
