### PR TITLE
tests: fix cli.main.handle_url tests

### DIFF
--- a/tests/cli/main/conftest.py
+++ b/tests/cli/main/conftest.py
@@ -16,7 +16,7 @@ def argv(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture(autouse=True)
-def _setup(monkeypatch: pytest.MonkeyPatch, session: Streamlink):
+def _setup(monkeypatch: pytest.MonkeyPatch, requests_mock: Mock, session: Streamlink):
     monkeypatch.setattr("streamlink_cli.main.CONFIG_FILES", [])
     monkeypatch.setattr("streamlink_cli.main.streamlink", session)
     monkeypatch.setattr("streamlink_cli.main.setup_streamlink", Mock())


### PR DESCRIPTION
When running `test_handle_url[no-plugin]` and not finding a matching plugin, an HTTP request will be made for checking HTTP redirections. This in turn means that the test's `doesnotexist` hostname will be looked up, which unnecessarily delays test execution.

Simply use the `requests_mock` fixture in all CLI-main tests to mock the session's HTTPAdapter and prevent any DNS lookups.

----

https://github.com/streamlink/streamlink/blob/b788b1e4467ae7813616e637a06fbde83f17ded1/tests/cli/main/test_handle_url.py#L97-L106

[Test (windows-latest, 3.12)](https://github.com/streamlink/streamlink/actions/runs/10866640205/job/30154450498#step:7:299)
```
============================ slowest 10 durations =============================
7.07s call     tests/cli/main/test_handle_url.py::test_handle_url[no-plugin]
```

[Test (ubuntu-latest, 3.12)](https://github.com/streamlink/streamlink/actions/runs/10866640205/job/30154449872#step:7:291)
```
============================= slowest 10 durations =============================
0.90s call     tests/stream/hls/test_hls.py::TestHlsPlaylistReloadTime::test_hls_playlist_reload_time_no_data
```