### PR TITLE
plugins.afreeca: reduce login attempts

### DIFF
--- a/src/streamlink/plugins/afreeca.py
+++ b/src/streamlink/plugins/afreeca.py
@@ -177,6 +177,17 @@ class AfreecaTV(Plugin):
 
         self.session.http.headers.update({"Referer": self.url, "Origin": "https://play.afreecatv.com"})
 
+        m = self.match.groupdict()
+        username = m.get("username")
+        bno = m.get("bno")
+        if bno is None:
+            res = self.session.http.get(self.url)
+            m = self._re_bno.search(res.text)
+            if not m:
+                log.error("Could not find broadcast number.")
+                return
+            bno = m.group("bno")
+
         if self.options.get("purge_credentials"):
             self.clear_cookies()
             self._authed = False
@@ -190,17 +201,6 @@ class AfreecaTV(Plugin):
                 log.info("Login was successful")
             else:
                 log.error("Failed to login")
-
-        m = self.match.groupdict()
-        username = m.get("username")
-        bno = m.get("bno")
-        if bno is None:
-            res = self.session.http.get(self.url)
-            m = self._re_bno.search(res.text)
-            if not m:
-                log.error("Could not find broadcast number.")
-                return
-            bno = m.group("bno")
 
         channel = self._get_channel_info(bno, username)
         log.trace(f"{channel!r}")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->
I was getting tons of login attempts when using `--retry-streams` even though the broadcast was off, so I made it so that it only tries to log in when the broadcast is on.

If you look at the commit, you'll see that we've simply moved the code location.

The test used `--afreeca-purge-credentials` to remove cookies.

## Without Login

```console
$ streamlink --loglevel=debug https://play.afreecatv.com/gosegu2

NoTagError: `git describe --long --dirty --always --tags` could not find a tag
[cli][debug] OS:         Linux-6.8.8-4-pve-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.5
[cli][debug] OpenSSL:    OpenSSL 3.3.2 3 Sep 2024
[cli][debug] Streamlink: 0.0.0+unknown
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.2
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://play.afreecatv.com/gosegu2
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin afreeca for URL https://play.afreecatv.com/gosegu2
[plugins.afreeca][error] Login required
error: No playable streams found on this URL: https://play.afreecatv.com/gosegu2
```

## With Login

```console
streamlink --loglevel=debug --afreeca-username=***--afreeca-password=*** https://play.afreecatv.com/gosegu2
NoTagError: `git describe --long --dirty --always --tags` could not find a tag
[cli][debug] OS:         Linux-6.8.8-4-pve-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.5
[cli][debug] OpenSSL:    OpenSSL 3.3.2 3 Sep 2024
[cli][debug] Streamlink: 0.0.0+unknown
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.2
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://play.afreecatv.com/gosegu2
[cli][debug]  --loglevel=debug
[cli][debug]  --afreeca-username=********
[cli][debug]  --afreeca-password=********
[cli][info] Found matching plugin afreeca for URL https://play.afreecatv.com/gosegu2
[plugins.afreeca][debug] Attempting to login using username and password
[plugins.afreeca][debug] Saved cookies: _au, _au3rd, _ausa, _ausb, AbroadChk, AbroadVod, PdboxTicket, PdboxBbs, PdboxUser, isBbs, RDB, PdboxSaveTicket
[plugins.afreeca][info] Login was successful
Available streams: 360p (worst), 540p, 720p, 1080p (best)
```

## No login required streams

```console
$ streamlink --loglevel=debug https://play.afreecatv.com/ecvhao

NoTagError: `git describe --long --dirty --always --tags` could not find a tag
[cli][debug] OS:         Linux-6.8.8-4-pve-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.5
[cli][debug] OpenSSL:    OpenSSL 3.3.2 3 Sep 2024
[cli][debug] Streamlink: 0.0.0+unknown
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.2
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://play.afreecatv.com/ecvhao
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin afreeca for URL https://play.afreecatv.com/ecvhao
Available streams: 360p (worst), 540p, 720p, 1080p (best)
```