### PR TITLE
tests: rewrite cli.output.file tests

### DIFF
--- a/src/streamlink_cli/output/file.py
+++ b/src/streamlink_cli/output/file.py
@@ -26,7 +26,7 @@ class FileOutput(Output):
     def _open(self):
         if self.filename:
             self.filename.parent.mkdir(parents=True, exist_ok=True)
-            self.fd = open(self.filename, "wb")
+            self.fd = self.filename.open("wb")
 
         if self.record:
             self.record.open()

--- a/tests/cli/output/test_file.py
+++ b/tests/cli/output/test_file.py
@@ -1,83 +1,103 @@
-import os
-import unittest
+from contextlib import contextmanager
+from io import BufferedRandom, BufferedWriter
 from pathlib import Path
-from unittest.mock import Mock, call, patch
+from typing import Iterator
 
 import pytest
 
 from streamlink_cli.output import FileOutput
 
 
-@patch("streamlink_cli.output.file.stdout")
-class TestFileOutput(unittest.TestCase):
-    @staticmethod
-    def subject(filename, fd):
-        fo_record = FileOutput(fd=fd)
-        fo_main = FileOutput(filename=filename, record=fo_record)
+@contextmanager
+def _create_fd(root: Path, name: str) -> Iterator[BufferedRandom]:
+    fd = (root / name).open("w+b")
+    try:
+        yield fd
+    finally:
+        fd.close()
 
-        return fo_main, fo_record
 
-    def test_init(self, mock_stdout: Mock):
-        mock_path = Mock(spec=Path("foo", "bar"))
-        fo_main, fo_record = self.subject(mock_path, mock_stdout)
+@pytest.fixture()
+def fd(tmp_path: Path):
+    with _create_fd(tmp_path, "file") as fd:
+        yield fd
 
-        assert not fo_main.opened
-        assert fo_main.filename is mock_path
-        assert fo_main.fd is None
-        assert fo_main.record is fo_record
 
-        assert not fo_main.record.opened
-        assert fo_main.record.filename is None
-        assert fo_main.record.fd is mock_stdout
-        assert fo_main.record.record is None
+@pytest.fixture(autouse=True)
+def fake_stdout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    # can't use in-memory io.BytesIO, since fd.fileno() is called on Windows
+    with _create_fd(tmp_path, "stdout") as fd:
+        monkeypatch.setattr("streamlink_cli.output.file.stdout", fd)
+        yield fd
 
-    def test_early_close(self, mock_stdout: Mock):
-        mock_path = Mock(spec=Path("foo", "bar"))
-        fo_main, _fo_record = self.subject(mock_path, mock_stdout)
 
-        fo_main.close()  # doesn't raise
+def test_early_close(tmp_path: Path, fd: BufferedRandom):
+    filename = tmp_path / "foo" / "bar"
+    fo = FileOutput(filename=filename, record=FileOutput(fd=fd))
+    assert isinstance(fo.record, FileOutput)
+    assert not fo.opened
+    assert not fo.record.opened
+    assert not filename.exists()
 
-    def test_early_write(self, mock_stdout: Mock):
-        mock_path = Mock(spec=Path("foo", "bar"))
-        fo_main, _fo_record = self.subject(mock_path, mock_stdout)
+    fo.close()
+    fo.record.close()
 
-        with pytest.raises(OSError, match=r"^Output is not opened$"):
-            fo_main.write(b"foo")
 
-    def _test_open(self, mock_open: Mock, mock_stdout: Mock):
-        mock_path = Mock(spec=Path("foo", "bar"))
-        mock_fd = mock_open(mock_path, "wb")
-        fo_main, _fo_record = self.subject(mock_path, mock_stdout)
+def test_early_write(tmp_path: Path):
+    filename = tmp_path / "foo" / "bar"
+    fo = FileOutput(filename=filename)
 
-        fo_main.open()
-        assert fo_main.opened
-        assert fo_main.record.opened
-        assert mock_path.parent.mkdir.call_args_list == [call(parents=True, exist_ok=True)]
-        assert fo_main.fd is mock_fd
+    assert not fo.opened
+    assert not filename.exists()
+    with pytest.raises(OSError, match=r"^Output is not opened$"):
+        fo.write(b"foo")
 
-        fo_main.write(b"foo")
-        assert mock_fd.write.call_args_list == [call(b"foo")]
-        assert mock_stdout.write.call_args_list == [call(b"foo")]
 
-        fo_main.close()
-        assert mock_fd.close.call_args_list == [call()]
-        assert mock_stdout.close.call_args_list == []
-        assert not fo_main.opened
-        assert not fo_main.record.opened
+def test_open_write_close(tmp_path: Path, fd: BufferedRandom):
+    filename = tmp_path / "foo" / "bar"
+    fo = FileOutput(filename=filename, record=FileOutput(fd=fd))
+    assert fo.fd is None
+    assert isinstance(fo.record, FileOutput)
 
-        return mock_path
+    fo.open()
+    assert fo.opened
+    assert fo.record.opened
+    assert filename.parent.is_dir()
+    assert filename.is_file()
+    assert isinstance(fo.fd, BufferedWriter)
+    assert isinstance(fo.record.fd, BufferedRandom)
 
-    @pytest.mark.posix_only()
-    @patch("builtins.open")
-    def test_open_posix(self, mock_open: Mock, mock_stdout: Mock):
-        self._test_open(mock_open, mock_stdout)
+    fo.write(b"foo")
+    fo.write(b"bar")
+    fo.write(b"baz")
+    fo.fd.flush()
+    fo.record.fd.flush()
+    assert filename.read_bytes() == b"foobarbaz"
+    fo.record.fd.seek(0)
+    assert fo.record.fd.read() == b"foobarbaz"
 
-    @pytest.mark.windows_only()
-    @patch("streamlink_cli.output.file.msvcrt")
-    @patch("builtins.open")
-    def test_open_windows(self, mock_open: Mock, mock_msvcrt: Mock, mock_stdout: Mock):
-        mock_path = self._test_open(mock_open, mock_stdout)
-        assert mock_msvcrt.setmode.call_args_list == [
-            call(mock_stdout.fileno(), os.O_BINARY),
-            call(mock_open(mock_path, "wb").fileno(), os.O_BINARY),
-        ]
+    fo.close()
+    assert not fo.opened
+    assert not fo.record.opened
+    assert fo.fd.closed
+    assert fo.record.fd.closed
+
+
+def test_write_stdout(fake_stdout: BufferedRandom):
+    fo = FileOutput(fd=fake_stdout)
+    assert fo.fd is fake_stdout
+    assert fo.filename is None
+    assert fo.record is None
+
+    fo.open()
+    assert fo.opened
+
+    fo.write(b"foo")
+    fo.write(b"bar")
+    fo.write(b"baz")
+    fo.fd.seek(0)
+    assert fo.fd.read() == b"foobarbaz"
+
+    fo.close()
+    assert not fo.opened
+    assert not fo.fd.closed


### PR DESCRIPTION
Continuing with some test rewrites, this PR rewrites the `FileOutput` tests based on pytest. The only `unittest.TestCase`-based tests remaining are now HLS integration tests.