### PR TITLE
cli: remove deprecated --force-progress argument

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -739,13 +739,6 @@ def build_parser():
         Default is yes.
         """,
     )
-    output.add_argument(
-        "--force-progress",
-        action="store_true",
-        help="""
-        Deprecated in favor of --progress=force.
-        """,
-    )
 
     stream = parser.add_argument_group("Stream options")
     stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -387,13 +387,6 @@ def output_stream(stream, formatter: Formatter):
                 args.progress == "force"
                 or args.progress == "yes" and (sys.stderr.isatty() if sys.stderr else False)
             )
-            if args.force_progress:
-                show_progress = True
-                warnings.warn(
-                    "The --force-progress option has been deprecated in favor of --progress=force",
-                    StreamlinkDeprecationWarning,
-                    stacklevel=1,
-                )
             # TODO: finally clean up the global variable mess and refactor the streamlink_cli package
             # noinspection PyUnboundLocalVariable
             stream_runner = StreamRunner(stream_fd, output, show_progress=show_progress)


### PR DESCRIPTION
One of the breaking changes to be included in 7.0.0.

Deprecation was introduced by #5268 in [5.4.0 on 2023-04-12](https://streamlink.github.io/changelog.html#streamlink-5-4-0-2023-04-12)