### PR TITLE
cli: add devnull fallback for missing stdout fd

### DIFF
--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,9 +1,17 @@
 import sys
+from os import devnull
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO
 
 
-stdout: BinaryIO = sys.stdout.buffer
+try:
+    stdout: BinaryIO = sys.stdout.buffer
+except AttributeError:  # pragma: no cover
+    from atexit import register as _atexit_register
+
+    stdout = open(devnull, "wb")
+    _atexit_register(stdout.close)
+    del _atexit_register
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1037,7 +1037,7 @@ def main():
     # https://docs.python.org/3/library/signal.html#note-on-sigpipe
     try:
         sys.stdout.flush()
-    except OSError:
+    except (AttributeError, OSError):
         del sys.stdout
 
     sys.exit(exit_code)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -374,7 +374,10 @@ def output_stream(stream, formatter: Formatter):
     try:
         with closing(output):
             log.debug("Writing stream to output")
-            show_progress = args.progress == "force" or args.progress == "yes" and sys.stderr.isatty()
+            show_progress = (
+                args.progress == "force"
+                or args.progress == "yes" and (sys.stderr.isatty() if sys.stderr else False)
+            )
             if args.force_progress:
                 show_progress = True
                 warnings.warn(

--- a/src/streamlink_cli/streamrunner.py
+++ b/src/streamlink_cli/streamrunner.py
@@ -97,7 +97,7 @@ class StreamRunner:
             elif output.record:
                 filename = output.record.filename
 
-        if filename and show_progress:
+        if filename and show_progress and sys.stderr:
             self.progress = Progress(sys.stderr, filename)
 
     def run(

--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -88,6 +88,13 @@ class TestStdoutStderr:
         assert out == stdout
         assert err == stderr
 
+    def test_no_stdout(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("sys.stdout", None)
+
+        with pytest.raises(SystemExit) as excinfo:
+            streamlink_cli.main.main()
+        assert excinfo.value.code == 0
+
     @pytest.mark.parametrize(
         "errno",
         [

--- a/tests/cli/test_compat.py
+++ b/tests/cli/test_compat.py
@@ -1,0 +1,30 @@
+import importlib.util
+from io import BufferedWriter
+from os import devnull
+from unittest.mock import Mock, call
+
+import pytest
+
+import streamlink_cli.compat
+
+
+def test_no_stdout(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("sys.stdout", None)
+
+    mock_atexit_register = Mock()
+    monkeypatch.setattr("atexit.register", mock_atexit_register)
+
+    spec = importlib.util.find_spec("streamlink_cli.compat")
+    assert spec
+    assert spec.loader
+
+    module = importlib.util.module_from_spec(spec)
+    assert module is not streamlink_cli.compat
+
+    spec.loader.exec_module(module)
+    assert module.sys.stdout is None
+    assert isinstance(module.stdout, BufferedWriter)
+    assert module.stdout.name == devnull
+
+    assert mock_atexit_register.call_args_list == [call(module.stdout.close)]
+    module.stdout.close()  # close manually, since we've mocked the atexit.register() call

--- a/tests/cli/test_streamrunner.py
+++ b/tests/cli/test_streamrunner.py
@@ -558,26 +558,38 @@ class TestHTTPServer:
 
 class TestHasProgress:
     @pytest.mark.parametrize(
-        "output",
+        ("output", "stderr"),
         [
             pytest.param(
                 FakePlayerOutput(Path("mocked")),
+                True,
                 id="Player output without record",
             ),
             pytest.param(
                 FakeFileOutput(fd=Mock()),
+                True,
                 id="FileOutput with file descriptor",
             ),
             pytest.param(
                 FakeHTTPOutput(),
+                True,
                 id="HTTPServer",
+            ),
+            pytest.param(
+                FakeFileOutput(filename=Path("mocked")),
+                False,
+                id="no-stderr",
             ),
         ],
     )
     def test_no_progress(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         output: Union[FakePlayerOutput, FakeFileOutput, FakeHTTPOutput],
+        stderr: bool,
     ):
+        if not stderr:
+            monkeypatch.setattr("sys.stderr", None)
         stream_runner = FakeStreamRunner(StreamIO(), output, show_progress=True)
         assert not stream_runner.progress
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,11 +1,13 @@
 import logging
+import os
+import sys
 import warnings
 from datetime import timezone
 from errno import EINVAL, EPIPE
 from inspect import currentframe, getframeinfo
 from io import BytesIO, TextIOWrapper
 from pathlib import Path
-from typing import Iterable, Tuple, Type
+from typing import Iterable, Optional, Tuple, Type
 
 import freezegun
 import pytest
@@ -43,13 +45,19 @@ def log(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, output:
     if "logfile" in request.fixturenames:
         params["filename"] = request.getfixturevalue("logfile")
 
+    stream: Optional[TextIOWrapper] = output
+    if not params.pop("stdout", True):
+        stream = None
+    if not params.pop("stderr", True):
+        monkeypatch.setattr("sys.stderr", None)
+
     fakeroot = logging.getLogger("streamlink.test")
 
     monkeypatch.setattr("streamlink.logger.root", fakeroot)
     monkeypatch.setattr("streamlink.utils.times.LOCAL", timezone.utc)
 
-    handler = logger.basicConfig(stream=output, **params)
-    assert isinstance(handler, logging.Handler)
+    handler = logger.basicConfig(stream=stream, **params)
+    assert isinstance(handler, logging.StreamHandler)
 
     yield fakeroot
 
@@ -240,6 +248,28 @@ class TestLogging:
         log.info("Bär: 🐻")
         assert getvalue(output) == "[test][info] Bär: 🐻\n"
         assert getvalue(output_ascii) == "[test][info] B\\xe4r: \\U0001f43b\n"
+
+    @pytest.mark.parametrize(
+        "log",
+        [pytest.param({"stdout": False}, id="no-stdout")],
+        indirect=["log"],
+    )
+    def test_no_stdout(self, log: logging.Logger):
+        assert log.handlers
+        handler = log.handlers[0]
+        assert isinstance(handler, logging.StreamHandler)
+        assert handler.stream is sys.stderr
+
+    @pytest.mark.parametrize(
+        "log",
+        [pytest.param({"stdout": False, "stderr": False}, id="no-stdout-no-stderr")],
+        indirect=["log"],
+    )
+    def test_no_stdout_no_stderr(self, log: logging.Logger):
+        assert log.handlers
+        handler = log.handlers[0]
+        assert isinstance(handler, logging.FileHandler)
+        assert handler.stream.name.endswith(os.devnull)
 
     @pytest.mark.parametrize(
         "errno",


### PR DESCRIPTION
Follow-up of #6142

This fixes the case where `sys.stdout` is `None`, when the Python process doesn't have the stdout file descriptor (fd1). This can be forced in BASH for example, by appending `>&-`.

```py
import pathlib,os,sys
pid = str(os.getpid())
fd1 = pathlib.Path("/proc", pid, "fd", "1")
sys.stderr.write(f"{pid=}\n{sys.stdout is None=}\n{fd1.readlink() if fd1.exists() else None=}\n")
```
```sh
$ python <<< "${CODE}"
pid='318408'
sys.stdout is None=False
fd1.readlink() if fd1.exists() else None=PosixPath('/dev/pts/2')
```
```sh
$ python <<< "${CODE}" >&-
pid='318428'
sys.stdout is None=True
fd1.readlink() if fd1.exists() else None=None
```

Currently on master, this results in an `AttributeError`, as the `streamlink_cli.compat` module assigns its `stdout` attribute to `sys.stdout.buffer`, the binary output stream used for writing stream content to stdout (e.g. `--stdout`).

So when fd1 is missing and `sys.stdout is None`, we need a fallback stream. Simply use a devnull output stream in this case (and close it on exit).

When stdout is missing, the logging stream and console output stream will automatically be stderr.

----

master
```
$ streamlink >&-
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-312/bin/streamlink", line 5, in <module>
    from streamlink_cli.main import main
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 25, in <module>
    from streamlink_cli.argparser import ArgumentParser, build_parser, setup_session_options
  File "/home/basti/repos/streamlink/src/streamlink_cli/argparser.py", line 13, in <module>
    from streamlink_cli.constants import STREAM_PASSTHROUGH
  File "/home/basti/repos/streamlink/src/streamlink_cli/constants.py", line 7, in <module>
    from streamlink_cli.compat import DeprecatedPath
  File "/home/basti/repos/streamlink/src/streamlink_cli/compat.py", line 6, in <module>
    stdout: BinaryIO = sys.stdout.buffer
                       ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'buffer'
```

PR
```
$ streamlink >&-
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io
```
```
$ streamlink --stdout httpstream://file:///dev/zero best >&-
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
^C[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```

----

Removing stderr as well is currently unsupported, and the process will stop because of a failure of the logging / console output setup, which falls back to stderr if stdout is None. Maybe I'll have a look at this later, too.

```
$ streamlink >&- 2>&-; echo $?
1
```