### PR TITLE
docs: add back Alpine Linux package

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -136,6 +136,10 @@ Linux and BSD
       - See the `Linux AppImages`_ section below
     * - :octicon:`verified` Python pip
       - See the `PyPI package and source code`_ section below
+    * - :octicon:`package-dependents` `Alpine Linux (edge)`_
+      - .. code-block:: bash
+
+            sudo apk add streamlink
     * - :octicon:`package-dependents` `ALT Linux (Sisyphus)`_
       - .. code-block:: bash
 
@@ -210,6 +214,7 @@ Linux and BSD
 
             sudo xbps-install streamlink
 
+.. _Alpine Linux (edge): https://pkgs.alpinelinux.org/packages?name=streamlink
 .. _ALT Linux (Sisyphus): https://packages.altlinux.org/en/sisyphus/srpms/streamlink/
 .. _Arch Linux: https://archlinux.org/packages/extra/any/streamlink/
 .. _Arch Linux (aur, git): https://aur.archlinux.org/packages/streamlink-git/
@@ -239,6 +244,8 @@ Package maintainers
 
     * - Distribution / Platform
       - Maintainer
+    * - Alpine Linux
+      - Hoang Nguyen <folliekazetani at protonmail.com>
     * - ALT Linux
       - Vitaly Lipatov <lav at altlinux.ru>
     * - Arch


### PR DESCRIPTION
This reverts #5980

`trio-websocket` now finally fully supports the `strict_exception_groups=True` breaking change introduced by `trio==0.25`, and fixed its failing tests. This is still unreleased though.
https://github.com/python-trio/trio-websocket/commit/f5fd6d77db16a7b527d670c4045fa1d53e621c35

The Alpine Linux package maintainers have now added the patch to their `py3-trio-websocket` package and restored it and its dependants, namely Streamlink.
https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/72300
https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/72332

With `trio-websocket` being fixed, package maintainers of other distros will hopefully also update their packages soon. Unlike Alpine, they simply kept old versions around.

Btw, these issues never affected Streamlink, because this was only relevant in regards to building `trio-websocket`.