### PR TITLE
cli: fix passthrough without player

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -292,6 +292,12 @@ def output_stream_passthrough(stream, formatter: Formatter):
     except TypeError:
         raise StreamlinkCLIError("The stream specified cannot be translated to a URL") from None
 
+    if not args.player:
+        raise StreamlinkCLIError(
+            "The default player (VLC) does not seem to be installed."
+            + " You must specify the path to a player executable with --player.",
+        )
+
     output = PlayerOutput(
         path=args.player,
         args=args.player_args,

--- a/tests/cli/main/test_output_stream_passthrough.py
+++ b/tests/cli/main/test_output_stream_passthrough.py
@@ -1,0 +1,31 @@
+import re
+from pathlib import Path
+
+import pytest
+
+import streamlink_cli.main
+import tests
+from streamlink.session import Streamlink
+
+
+@pytest.fixture(autouse=True)
+def session(session: Streamlink):
+    session.plugins.load_path(Path(tests.__path__[0]) / "plugin")
+
+    return session
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [pytest.param(["--player-passthrough=hls", "http://test.se", "hls"], id="no-player")],
+    indirect=["argv"],
+)
+def test_no_player(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], argv: list):
+    monkeypatch.setattr("streamlink_cli.argparser.find_default_player", lambda *_, **__: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        streamlink_cli.main.main()
+    assert exc_info.value.code == 1
+
+    out, _err = capsys.readouterr()
+    assert re.search(r"error: The default player \(\w+\) does not seem to be installed\.", out)


### PR DESCRIPTION
Fixes #6206 

```
$ env PATH="" ~/venv/streamlink-312/bin/python -m streamlink --no-config -l debug --player-passthrough=hls twitch.tv/esl_dota2 best
NotVCSError: Git not installed; assuming this isn't a Git repository
[cli][debug] OS:         Linux-6.11.0-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.6
[cli][debug] OpenSSL:    OpenSSL 3.3.2 3 Sep 2024
[cli][debug] Streamlink: 0.0.0+unknown
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.20.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.26.2
[cli][debug]  trio-websocket: 0.12.0.dev0
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=twitch.tv/esl_dota2
[cli][debug]  stream=['best']
[cli][debug]  --no-config=True
[cli][debug]  --loglevel=debug
[cli][debug]  --player-passthrough=['hls']
[cli][info] Found matching plugin twitch for URL twitch.tv/esl_dota2
[plugins.twitch][debug] Getting live HLS streams for esl_dota2
[plugins.twitch][debug] {'adblock': False, 'geoblock_reason': '', 'hide_ads': False, 'server_ads': True, 'show_ads': True}
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
error: The default player (VLC) does not seem to be installed. You must specify the path to a player executable with --player.
```