### PR TITLE
Add Xvfb support for webbrowser

### DIFF
--- a/src/streamlink/webbrowser/cdp/devtools/page.py
+++ b/src/streamlink/webbrowser/cdp/devtools/page.py
@@ -1115,6 +1115,7 @@ class ClientNavigationReason(enum.Enum):
     PAGE_BLOCK_INTERSTITIAL = "pageBlockInterstitial"
     RELOAD = "reload"
     ANCHOR_CLICK = "anchorClick"
+    INITIAL_FRAME_NAVIGATION = "initialFrameNavigation"
 
     def to_json(self) -> str:
         return self.value


### PR DESCRIPTION
Submitting a PR on a generated file to draw attention to issue and solution, and I have no idea where the CDP generator is, or if this is possible.

Feel free to close PR when done reading this.

Background:

Running streamlink on a headless linux server, and headless webbrowser no longer worked for site in question.

Solution: 

Configured streamlink to run Chromium in non-headless mode using Xvfb as a display. Had to add a single line to CDR Page for it Xvfb/Streamlink to work together.