### PR TITLE
chore: typing: PEP 563, PEP 585, PEP 604, PEP 613

### DIFF
--- a/build_backend/__init__.py
+++ b/build_backend/__init__.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import shlex
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any
 
 from setuptools import build_meta as _build_meta
 
@@ -15,8 +17,8 @@ from setuptools.command.egg_info import egg_info as _egg_info
 
 
 def get_requires_for_build_wheel(  # type: ignore[no-redef]
-    config_settings: Optional[dict] = None,
-) -> List[str]:  # pragma: no cover
+    config_settings: dict | None = None,
+) -> list[str]:  # pragma: no cover
     # Streamlink publishes three wheels on PyPI: the generic "any" wheel, the "win32" wheel and the "win-amd64" wheel:
     # The Windows-wheels are special, because they include a "gui_scripts" entry point, which is used by the `pip` frontend
     # to generate the "streamlinkw" launcher, which doesn't open a terminal window when launching it from a GUI application.
@@ -47,11 +49,11 @@ def get_requires_for_build_wheel(  # type: ignore[no-redef]
 
 
 def _filter_cmd_option_args(
-    config_settings: Optional[dict],
+    config_settings: dict | None,
     key: str,
     # https://github.com/pypa/setuptools/blob/v71.1.0/setuptools/_distutils/fancy_getopt.py#L47-L54
     # https://github.com/pypa/setuptools/blob/v71.1.0/setuptools/_distutils/fancy_getopt.py#L152-L156
-    options: List[Union[Tuple[str, Optional[str], str], Tuple[str, Optional[str], str, Any]]],
+    options: list[tuple[str, str | None, str] | tuple[str, str | None, str, Any]],
 ) -> None:
     """Filter out args which are not recognized by a specific command and its options"""
 
@@ -68,7 +70,7 @@ def _filter_cmd_option_args(
             result.append(item)
             continue
         full: str
-        shorthand: Optional[str]
+        shorthand: str | None
         for full, shorthand, *_ in options:
             is_boolean = full[-1] != "="
             is_shorthand = shorthand is not None and item == f"-{shorthand}"

--- a/build_backend/commands.py
+++ b/build_backend/commands.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from typing import Dict, Type
 
 from setuptools import Command
 from setuptools.command.build_py import build_py
@@ -29,6 +30,6 @@ class StreamlinkBuildPyCommand(build_py, Command):
         self._build_plugins_json()
 
 
-cmdclass: Dict[str, Type[Command]] = {
+cmdclass: dict[str, type[Command]] = {
     "build_py": StreamlinkBuildPyCommand,
 }

--- a/build_backend/onbuild.py
+++ b/build_backend/onbuild.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import re
+from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Generator, Generic, Optional, TypeVar, Union
+from typing import Any, Generic, TypeVar
 
 
 try:
@@ -18,11 +21,11 @@ except ImportError:  # pragma: no cover
 def onbuild(
     *,
     is_source: bool,
-    template_fields: Dict[str, Any],
-    params: Dict[str, Any],
+    template_fields: dict[str, Any],
+    params: dict[str, Any],
     # backward compatibility for `versioningit <3.0.0`
-    build_dir: Optional[Union[str, Path]] = None,
-    file_provider: Optional[SetuptoolsFileProvider] = None,
+    build_dir: str | Path | None = None,
+    file_provider: SetuptoolsFileProvider | None = None,
 ):
     """
     Remove the ``versioningit`` build-requirement from Streamlink's source distribution.

--- a/build_backend/plugins_json.py
+++ b/build_backend/plugins_json.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import ast
 import json
@@ -6,7 +8,11 @@ import sys
 from dataclasses import asdict, dataclass, is_dataclass
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, ClassVar, Dict, Generic, List, Optional, TextIO, Tuple, Type, TypeVar, Union
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TextIO, TypeVar
+
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 
 DEFAULT_PLUGINSPATH = Path(__file__).parents[1] / "src" / "streamlink" / "plugins"
@@ -18,9 +24,9 @@ PLUGINSJSON_COMMENTS = [
     "https://streamlink.github.io/",
 ]
 
-TListOfConstants = List[Union[None, bool, int, float, str]]
-TConstantOrListOfConstants = Union[None, bool, int, float, str, TListOfConstants]
-TMappingOfConstantOrListOfConstants = Dict[str, TConstantOrListOfConstants]
+TListOfConstants: TypeAlias = "list[bool | int | float | str | None]"
+TConstantOrListOfConstants: TypeAlias = "bool | int | float | str | TListOfConstants | None"
+TMappingOfConstantOrListOfConstants: TypeAlias = "dict[str, TConstantOrListOfConstants]"
 
 
 class ParseError(ValueError):
@@ -38,36 +44,36 @@ class PluginMatcher:
     HIGH_PRIORITY: ClassVar[int] = 30
 
     pattern: str
-    flags: Optional[int] = None
-    priority: Optional[int] = None
-    name: Optional[str] = None
+    flags: int | None = None
+    priority: int | None = None
+    name: str | None = None
 
 
 @dataclass
 class PluginArgument:
     name: str
-    action: Optional[str] = None
-    nargs: Optional[Union[int, str]] = None
+    action: str | None = None
+    nargs: int | str | None = None
     const: TConstantOrListOfConstants = None
     default: TConstantOrListOfConstants = None
-    type: Optional[str] = None
-    type_args: Optional[TListOfConstants] = None
-    type_kwargs: Optional[TMappingOfConstantOrListOfConstants] = None
-    choices: Optional[TListOfConstants] = None
-    required: Optional[bool] = None
-    help: Optional[str] = None
-    metavar: Optional[Union[str, List[str]]] = None
-    dest: Optional[str] = None
-    requires: Optional[Union[str, List[str]]] = None
-    prompt: Optional[str] = None
-    sensitive: Optional[bool] = None
-    argument_name: Optional[str] = None
+    type: str | None = None
+    type_args: TListOfConstants | None = None
+    type_kwargs: TMappingOfConstantOrListOfConstants | None = None
+    choices: TListOfConstants | None = None
+    required: bool | None = None
+    help: str | None = None
+    metavar: str | list[str] | None = None
+    dest: str | None = None
+    requires: str | list[str] | None = None
+    prompt: str | None = None
+    sensitive: bool | None = None
+    argument_name: str | None = None
 
 
 @dataclass
 class Plugin:
-    matchers: List[PluginMatcher]
-    arguments: List[PluginArgument]
+    matchers: list[PluginMatcher]
+    arguments: list[PluginArgument]
 
 
 _TParseResult = TypeVar("_TParseResult")
@@ -79,9 +85,9 @@ class Parser(ast.NodeVisitor, Generic[_TParseResult]):
 
 
 class ParseCall(ast.NodeVisitor):
-    _PARSERS: ClassVar[Dict[str, Type[ast.NodeVisitor]]] = {}
+    _PARSERS: ClassVar[dict[str, type[ast.NodeVisitor]]] = {}
 
-    def visit_Call(self, node: ast.Call) -> Dict[str, Any]:
+    def visit_Call(self, node: ast.Call) -> dict[str, Any]:
         parsers = self._PARSERS
 
         data = {}
@@ -104,7 +110,7 @@ class ParseCall(ast.NodeVisitor):
 
 class ParseConstant(ast.NodeVisitor):
     NAME: str = "constant"
-    TYPE: Union[Type, Tuple[Type, ...]] = str
+    TYPE: type | tuple[type, ...] = str
     REQUIRED: bool = False
 
     def generic_visit(self, node: ast.AST):
@@ -122,7 +128,7 @@ class ParseConstantOrSequenceOfConstants(ParseConstant):
         super().__init__()
         self._sequence = False
 
-    def _visit_sequence(self, node: Union[ast.List, ast.Tuple]):
+    def _visit_sequence(self, node: ast.List | ast.Tuple):
         if self._sequence:
             raise ParseError(f"Invalid {self.NAME} type", node)
 
@@ -150,7 +156,7 @@ class ParseMappingOfConstants(ParseConstantOrSequenceOfConstants):
         super().__init__()
         self._mapping = False
 
-    def _visit_sequence(self, node: Union[ast.List, ast.Tuple]):
+    def _visit_sequence(self, node: ast.List | ast.Tuple):
         if not self._mapping:
             raise ParseError(f"Invalid {self.NAME} type", node)
 
@@ -191,7 +197,7 @@ class ParsePluginMatcher(ParseCall, Parser[PluginMatcher]):
             REQUIRED = True
 
         class ParseFlags(ParseBinOpOr):
-            _ATTRIBUTES: ClassVar[Dict[str, int]] = {
+            _ATTRIBUTES: ClassVar[dict[str, int]] = {
                 "I": re.RegexFlag.IGNORECASE,
                 "IGNORECASE": re.RegexFlag.IGNORECASE,
                 "S": re.RegexFlag.DOTALL,
@@ -206,7 +212,7 @@ class ParsePluginMatcher(ParseCall, Parser[PluginMatcher]):
 
                 return self._ATTRIBUTES[node.attr]
 
-        _PARSERS: ClassVar[Dict[str, Type[ast.NodeVisitor]]] = {
+        _PARSERS: ClassVar[dict[str, type[ast.NodeVisitor]]] = {
             "pattern": ParsePattern,
             "flags": ParseFlags,
         }
@@ -240,7 +246,7 @@ class ParsePluginMatcher(ParseCall, Parser[PluginMatcher]):
         NAME = "@pluginmatcher priority"
         TYPE = int
 
-        _ATTRIBUTES: ClassVar[Dict[str, int]] = {
+        _ATTRIBUTES: ClassVar[dict[str, int]] = {
             "NO_PRIORITY": PluginMatcher.NO_PRIORITY,
             "LOW_PRIORITY": PluginMatcher.LOW_PRIORITY,
             "NORMAL_PRIORITY": PluginMatcher.NORMAL_PRIORITY,
@@ -256,7 +262,7 @@ class ParsePluginMatcher(ParseCall, Parser[PluginMatcher]):
     class ParseName(ParseConstant):
         NAME = "@pluginmatcher name"
 
-    _PARSERS: ClassVar[Dict[str, Type[ast.NodeVisitor]]] = {
+    _PARSERS: ClassVar[dict[str, type[ast.NodeVisitor]]] = {
         "pattern": ParseReCompile,
         "priority": ParsePriority,
         "name": ParseName,
@@ -350,7 +356,7 @@ class ParsePluginArgument(ParseCall, Parser[PluginArgument]):
     class ParseArgumentName(ParseConstant):
         NAME = "@pluginargument argument_name"
 
-    _PARSERS: ClassVar[Dict[str, Type[ast.NodeVisitor]]] = {
+    _PARSERS: ClassVar[dict[str, type[ast.NodeVisitor]]] = {
         "name": ParseName,
         "action": ParseAction,
         "nargs": ParseNArgs,
@@ -382,9 +388,9 @@ class ParsePluginArgument(ParseCall, Parser[PluginArgument]):
 class PluginVisitor(ast.NodeVisitor):
     def __init__(self) -> None:
         super().__init__()
-        self.name: Optional[str] = None
-        self.matchers: List[PluginMatcher] = []
-        self.arguments: List[PluginArgument] = []
+        self.name: str | None = None
+        self.matchers: list[PluginMatcher] = []
+        self.arguments: list[PluginArgument] = []
         self.exports: bool = False
 
     def generic_visit(self, node: ast.AST):
@@ -429,12 +435,12 @@ class PluginVisitor(ast.NodeVisitor):
                 self.arguments.append(argument)
 
 
-Output = Dict[str, Plugin]
+Output: TypeAlias = "dict[str, Plugin]"
 
 
 class JSONEncoder(json.JSONEncoder):  # pragma: no cover
     @staticmethod
-    def _filter_dataclass_none_value(items: List[Tuple[str, Any]]) -> Dict[str, Any]:
+    def _filter_dataclass_none_value(items: list[tuple[str, Any]]) -> dict[str, Any]:
         return {key: val for key, val in items if val is not None}
 
     def default(self, o: Any) -> Any:
@@ -476,7 +482,7 @@ def build(pluginsdir: Path = DEFAULT_PLUGINSPATH) -> Output:
     return dict(sorted(data.items()))
 
 
-def to_json(data: Output, fd: Optional[TextIO] = None, comments: Optional[List[str]] = None, pretty: bool = False) -> None:
+def to_json(data: Output, fd: TextIO | None = None, comments: list[str] | None = None, pretty: bool = False) -> None:
     outputformat = {"separators": (",", ": "), "indent": 2} if pretty else {"separators": (",", ":")}
     _fd: TextIO = fd or sys.stdout
     for line in (PLUGINSJSON_COMMENTS if comments is None else comments):

--- a/build_backend/test_plugins_json.py
+++ b/build_backend/test_plugins_json.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import ast
 import re
 from contextlib import nullcontext, suppress
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, List, Optional, Type
+from typing import Any
 
 import pytest
 
@@ -131,7 +133,7 @@ class MappingOfConstants(ParseMappingOfConstants):
         id="moc-no-nested-mappings",
     ),
 ])
-def test_parse_sequence_or_mapping(parser: Type[ast.NodeVisitor], code: str, expected: Any, raises: nullcontext):
+def test_parse_sequence_or_mapping(parser: type[ast.NodeVisitor], code: str, expected: Any, raises: nullcontext):
     tree = ast.parse(code)
     item: ast.AST = tree.body[0].value  # type: ignore
     with raises:
@@ -1106,8 +1108,8 @@ def test_plugin(test_plugin_code: str):
 def test_build(
     capsys: pytest.CaptureFixture,
     test_plugins_dir: Path,
-    comments: Optional[List[str]],
-    expected_comments: List[str],
+    comments: list[str] | None,
+    expected_comments: list[str],
 ):
     data = build(test_plugins_dir)
     to_json(data, comments=comments, pretty=True)

--- a/docs/ext_html_template_vars.py
+++ b/docs/ext_html_template_vars.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from sphinx.addnodes import document
 from sphinx.application import Sphinx
@@ -11,7 +13,7 @@ def update_context(
     app: Sphinx,
     pagename: str,
     templatename: str,
-    context: Dict[str, Any],
+    context: dict[str, Any],
     doctree: document,
 ) -> None:
     for k, v in getattr(app.config, _CONFIG_VAR).items():

--- a/docs/ext_plugins.py
+++ b/docs/ext_plugins.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import abc
 import ast
 import pkgutil
 import re
 import tokenize
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
@@ -30,7 +33,7 @@ class IMetadataItem(IDatalistItem):
 class MetadataItem(IMetadataItem):
     def __init__(self, title: str):
         self.title = title
-        self.value: Optional[str] = None
+        self.value: str | None = None
 
     def set(self, value: str) -> None:
         self.value = value
@@ -44,7 +47,7 @@ class MetadataItem(IMetadataItem):
 class MetadataList(IMetadataItem):
     def __init__(self, title: str):
         self.title = title
-        self.value: List[str] = []
+        self.value: list[str] = []
 
     def set(self, value: str) -> None:
         self.value.append(value)
@@ -165,7 +168,7 @@ class PluginArguments(ast.NodeVisitor, IDatalistItem):
 class PluginMetadata:
     def __init__(self, name: str, pluginast):
         self.name: str = name
-        self.items: Dict[str, IMetadataItem] = dict(
+        self.items: dict[str, IMetadataItem] = dict(
             description=MetadataItem("Description"),
             url=MetadataList("URL(s)"),
             type=MetadataItem("Type"),
@@ -175,7 +178,7 @@ class PluginMetadata:
             account=MetadataItem("Account"),
             notes=MetadataList("Notes"),
         )
-        self.additional: List[IDatalistItem] = [
+        self.additional: list[IDatalistItem] = [
             PluginArguments(name, pluginast),
             PluginOnGithub(name),
         ]
@@ -220,7 +223,7 @@ class PluginFinder:
             if pluginmetadata:
                 yield pluginmetadata
 
-    def _parse_plugin(self, pluginname: str, pluginfile: Path) -> Optional[PluginMetadata]:
+    def _parse_plugin(self, pluginname: str, pluginfile: Path) -> PluginMetadata | None:
         with pluginfile.open() as handle:
             # read until the first token has been parsed
             for tokeninfo in tokenize.generate_tokens(handle.readline):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -292,6 +292,7 @@ show_column_numbers = true
 warn_no_return = false
 files = [
   "build_backend",
+  "script/",
   "src/streamlink/",
   "src/streamlink_cli/",
   "tests/",

--- a/script/test-plugin-urls.py
+++ b/script/test-plugin-urls.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 import argparse
 import importlib
 import logging
 import re
 import sys
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator, List, Optional, Set, Tuple, Type
 
 from streamlink import Streamlink
 from streamlink.logger import basicConfig
@@ -107,9 +109,9 @@ class PluginUrlTester:
         self.logcolor: str = args.color
         self.logger: logging.Logger = self._get_logger()
 
-        self.ignorelist: List[str] = args.ignore or []
-        self.replacelist: List[Tuple[str, str]] = args.replace or []
-        self.urls: Set[str] = set()
+        self.ignorelist: list[str] = args.ignore or []
+        self.replacelist: list[tuple[str, str]] = args.replace or []
+        self.urls: set[str] = set()
 
     def _get_logger(self) -> logging.Logger:
         logger = logging.getLogger(__name__)
@@ -146,7 +148,7 @@ class PluginUrlTester:
         except Exception as err:
             raise ImportError(f"Could not load test module of plugin {self.pluginname}: {err}") from err
 
-        PluginCanHandleUrlSubclass: Optional[Type[PluginCanHandleUrl]] = next(
+        PluginCanHandleUrlSubclass: type[PluginCanHandleUrl] | None = next(
             (
                 item
                 for item in module.__dict__.values()

--- a/script/update-user-agents.py
+++ b/script/update-user-agents.py
@@ -1,18 +1,21 @@
 #!/usr/bin/env python
 
+from __future__ import annotations
+
 import argparse
 import re
 import sys
+from collections.abc import Mapping, Sequence
 from os import getenv
 from pathlib import Path
-from typing import Any, Mapping, Sequence, Union
+from typing import Any
 
 import requests
 
 
 ROOT = Path(__file__).parents[1].resolve()
 
-MAPPING: Mapping[str, Sequence[Union[str, int]]] = {
+MAPPING: Mapping[str, Sequence[str | int]] = {
     "ANDROID": ("android", "standard", "sample_user_agents", "chrome", 0),
     "CHROME": ("chrome", "windows", "sample_user_agents", "standard", 0),
     "CHROME_OS": ("chrome-os", "standard", "sample_user_agents", "x86_64", 0),

--- a/src/streamlink/cache.py
+++ b/src/streamlink/cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import shutil
@@ -6,7 +8,7 @@ from contextlib import suppress
 from datetime import datetime
 from pathlib import Path
 from time import time
-from typing import Any, Dict, Optional, Union
+from typing import Any
 
 from streamlink.compat import is_win32
 
@@ -28,7 +30,7 @@ CACHE_DIR = Path(xdg_cache) / "streamlink"
 class Cache:
     def __init__(
         self,
-        filename: Union[str, Path],
+        filename: str | Path,
         key_prefix: str = "",
     ):
         """
@@ -41,7 +43,7 @@ class Cache:
         self.key_prefix = key_prefix
         self.filename = CACHE_DIR / Path(filename)
 
-        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._cache: dict[str, dict[str, Any]] = {}
 
     def _load(self):
         self._cache = {}
@@ -88,7 +90,7 @@ class Cache:
         key: str,
         value: Any,
         expires: float = 60 * 60 * 24 * 7,
-        expires_at: Optional[datetime] = None,
+        expires_at: datetime | None = None,
     ) -> None:
         """
         Store the given value using the key name and expiration time.
@@ -121,7 +123,7 @@ class Cache:
     def get(
         self,
         key: str,
-        default: Optional[Any] = None,
+        default: Any | None = None,
     ) -> Any:
         """
         Attempt to retrieve the given key from the cache.
@@ -146,7 +148,7 @@ class Cache:
         else:
             return default
 
-    def get_all(self) -> Dict[str, Any]:
+    def get_all(self) -> dict[str, Any]:
         """
         Retrieve all cached key-value pairs.
 

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import importlib
 import inspect
 import os
 import sys
 import warnings
-from typing import Any, Callable, Dict, Optional, Tuple
+from collections.abc import Callable, Mapping
+from typing import Any
 
 
 try:
@@ -29,7 +32,7 @@ is_win32 = os.name == "nt"
 detect_encoding = charset_normalizer.detect
 
 
-def deprecated(items: Dict[str, Tuple[Optional[str], Any, Any]]) -> None:
+def deprecated(items: Mapping[str, tuple[str | None, Any, Any]]) -> None:
     """
     Deprecate specific module attributes.
 
@@ -44,7 +47,7 @@ def deprecated(items: Dict[str, Tuple[Optional[str], Any, Any]]) -> None:
     """
 
     mod_globals = inspect.stack()[1].frame.f_globals
-    orig_getattr: Optional[Callable[[str], Any]] = mod_globals.get("__getattr__", None)
+    orig_getattr: Callable[[str], Any] | None = mod_globals.get("__getattr__", None)
 
     def __getattr__(name: str) -> Any:
         if name in items:

--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -1,12 +1,15 @@
+from __future__ import annotations
+
 import logging
 import sys
 import warnings
+from collections.abc import Iterator
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
 from os import devnull
 from pathlib import Path
 from sys import version_info
 from threading import Lock
-from typing import IO, TYPE_CHECKING, Iterator, List, Literal, Optional, Union
+from typing import IO, TYPE_CHECKING, Literal
 
 # noinspection PyProtectedMember
 from warnings import WarningMessage
@@ -95,7 +98,7 @@ _config_lock = Lock()
 
 
 class StringFormatter(logging.Formatter):
-    def __init__(self, *args, remove_base: Optional[List[str]] = None, **kwargs):
+    def __init__(self, *args, remove_base: list[str] | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         self._remove_base = remove_base or []
         self._usesTime = super().usesTime()
@@ -201,14 +204,14 @@ def capturewarnings(capture=False):
 
 # noinspection PyShadowingBuiltins,PyPep8Naming
 def basicConfig(
-    filename: Optional[Union[str, Path]] = None,
+    filename: str | Path | None = None,
     filemode: str = "a",
-    stream: Optional[IO] = None,
-    level: Optional[str] = None,
+    stream: IO | None = None,
+    level: str | None = None,
     format: str = FORMAT_BASE,  # noqa: A002  # TODO: rename to "fmt" (breaking)
     style: Literal["%", "{", "$"] = FORMAT_STYLE,
     datefmt: str = FORMAT_DATE,
-    remove_base: Optional[List[str]] = None,
+    remove_base: list[str] | None = None,
     capture_warnings: bool = False,
 ) -> logging.StreamHandler:
     with _config_lock:

--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -1,19 +1,8 @@
+from __future__ import annotations
+
 import argparse
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Iterable,
-    Iterator,
-    List,
-    Literal,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from typing import Any, ClassVar, Literal, TypeVar
 
 
 class Options:
@@ -30,7 +19,7 @@ class Options:
     _MAP_SETTERS: ClassVar[Mapping[str, Callable[[Any, str, Any], None]]] = {}
     """Optional setter mapping for :class:`Options` subclasses"""
 
-    def __init__(self, defaults: Optional[Mapping[str, Any]] = None):
+    def __init__(self, defaults: Mapping[str, Any] | None = None):
         if not defaults:
             defaults = {}
 
@@ -42,7 +31,7 @@ class Options:
         return name.replace("_", "-")
 
     @classmethod
-    def _normalize_dict(cls, src: Mapping[str, Any]) -> Dict[str, Any]:
+    def _normalize_dict(cls, src: Mapping[str, Any]) -> dict[str, Any]:
         normalize_key = cls._normalize_key
         return {normalize_key(key): value for key, value in src.items()}
 
@@ -124,21 +113,21 @@ class Argument:
         self,
         name: str,
         # `ArgumentParser.add_argument()` keywords
-        action: Optional[str] = None,
-        nargs: Optional[Union[int, Literal["?", "*", "+"]]] = None,
+        action: str | None = None,
+        nargs: int | Literal["?", "*", "+"] | None = None,
         const: Any = None,
         default: Any = None,
-        type: Optional[Callable[[Any], Union[_TChoices, Any]]] = None,  # noqa: A002
-        choices: Optional[_TChoices] = None,
+        type: Callable[[Any], _TChoices | Any] | None = None,  # noqa: A002
+        choices: _TChoices | None = None,
         required: bool = False,
-        help: Optional[str] = None,  # noqa: A002
-        metavar: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
-        dest: Optional[str] = None,
+        help: str | None = None,  # noqa: A002
+        metavar: str | list[str] | tuple[str, ...] | None = None,
+        dest: str | None = None,
         # additional `Argument()` keywords
-        requires: Optional[Union[str, List[str], Tuple[str, ...]]] = None,
-        prompt: Optional[str] = None,
+        requires: str | list[str] | tuple[str, ...] | None = None,
+        prompt: str | None = None,
         sensitive: bool = False,
-        argument_name: Optional[str] = None,
+        argument_name: str | None = None,
     ):
         """
         Accepts most of the parameters accepted by :meth:`argparse.ArgumentParser.add_argument()`, except that
@@ -174,11 +163,11 @@ class Argument:
         self.nargs = nargs
         self.const = const
         self.type = type
-        self.choices: Optional[Tuple[Any, ...]] = tuple(choices) if choices else None
+        self.choices: tuple[Any, ...] | None = tuple(choices) if choices else None
         self.required = required
         # argparse compares the object identity of argparse.SUPPRESS
         self.help = argparse.SUPPRESS if help == argparse.SUPPRESS else help
-        self.metavar: Optional[Union[str, Tuple[str, ...]]] = (
+        self.metavar: str | tuple[str, ...] | None = (
             tuple(metavar)
             if metavar is not None and not isinstance(metavar, str)
             else metavar
@@ -187,7 +176,7 @@ class Argument:
         self._default = default
         self._dest = self._normalize_dest(dest) if dest else None
 
-        self.requires: Tuple[str, ...] = (
+        self.requires: tuple[str, ...] = (
             tuple(requires)
             if requires is not None and not isinstance(requires, str)
             else ((requires,) if requires is not None else ())
@@ -290,7 +279,7 @@ class Arguments:
     def add(self, argument: Argument) -> None:
         self.arguments[argument.name] = argument
 
-    def get(self, name: str) -> Optional[Argument]:
+    def get(self, name: str) -> Argument | None:
         return self.arguments.get(name)
 
     def requires(self, name: str) -> Iterator[Argument]:

--- a/src/streamlink/plugin/api/validate/_exception.py
+++ b/src/streamlink/plugin/api/validate/_exception.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from textwrap import indent
-from typing import Optional, Sequence, Union
 
 
 class ValidationError(ValueError):
@@ -9,12 +11,12 @@ class ValidationError(ValueError):
 
     MAX_LENGTH = 60
 
-    errors: Union[str, Exception, Sequence[Union[str, Exception]]]
+    errors: str | Exception | Sequence[str | Exception]
 
     def __init__(
         self,
         *errors,
-        schema: Optional[Union[str, object]] = None,
+        schema: str | object | None = None,
         **errkeywords,
     ):
         self.schema = schema

--- a/src/streamlink/plugin/api/validate/_schemas.py
+++ b/src/streamlink/plugin/api/validate/_schemas.py
@@ -1,4 +1,8 @@
-from typing import Any, Callable, FrozenSet, List, Literal, Optional, Pattern, Sequence, Set, Tuple, Type, Union
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from re import Pattern
+from typing import Any, Literal
 
 
 class SchemaContainer:
@@ -229,7 +233,7 @@ class GetItemSchema:
 
     def __init__(
         self,
-        item: Union[Any, Tuple[Any]],
+        item: Any | tuple,
         default: Any = None,
         strict: bool = False,
     ):
@@ -295,7 +299,7 @@ class UnionGetSchema:
     def __init__(
         self,
         *getters,
-        seq: Type[Union[Tuple, List, Set, FrozenSet]] = tuple,
+        seq: type[tuple | list | set | frozenset] = tuple,
     ):
         self.getters: Sequence[GetItemSchema] = tuple(GetItemSchema(getter) for getter in getters)
         self.seq = seq
@@ -383,10 +387,10 @@ class XmlElementSchema:
     # signature is weird because of backwards compatiblity
     def __init__(
         self,
-        tag: Optional[Any] = None,
-        text: Optional[Any] = None,
-        attrib: Optional[Any] = None,
-        tail: Optional[Any] = None,
+        tag: Any = None,
+        text: Any = None,
+        attrib: Any = None,
+        tail: Any = None,
     ):
         self.tag = tag
         self.attrib = attrib

--- a/src/streamlink/plugin/api/validate/_validate.py
+++ b/src/streamlink/plugin/api/validate/_validate.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from collections import abc
 from copy import copy, deepcopy
 from functools import singledispatch
 from re import Pattern
-from typing import Any, Type, Union
+from typing import Any
 
 from lxml.etree import Element, iselement
 
@@ -32,7 +34,7 @@ class Schema(AllSchema):
     which by default raises :class:`PluginError <streamlink.exceptions.PluginError>` on error.
     """
 
-    def validate(self, value: Any, name: str = "result", exception: Type[Exception] = PluginError) -> Any:
+    def validate(self, value: Any, name: str = "result", exception: type[Exception] = PluginError) -> Any:
         try:
             return validate(self, value)
         except ValidationError as err:
@@ -74,7 +76,7 @@ def _validate_type(schema: type, value):
 @validate.register(tuple)
 @validate.register(set)
 @validate.register(frozenset)
-def _validate_sequence(schema: Union[list, tuple, set, frozenset], value):
+def _validate_sequence(schema: list | tuple | set | frozenset, value):
     cls = type(schema)
     validate(cls, value)
     any_schemas = AnySchema(*schema)
@@ -405,7 +407,7 @@ def _validate_union_dict(schema: dict, value):
 @validate_union.register(tuple)
 @validate_union.register(set)
 @validate_union.register(frozenset)
-def _validate_union_sequence(schemas: Union[list, tuple, set, frozenset], value):
+def _validate_union_sequence(schemas: list | tuple | set | frozenset, value):
     return type(schemas)(
         validate(schema, value) for schema in schemas
     )

--- a/src/streamlink/plugin/api/validate/_validators.py
+++ b/src/streamlink/plugin/api/validate/_validators.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import operator
-from typing import Any, Callable, Dict, Literal, Optional, Tuple
+from collections.abc import Callable, Mapping
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from lxml.etree import XPathError, iselement
@@ -17,7 +20,7 @@ from streamlink.utils.parse import (
 
 # String related validators
 
-_validator_length_ops: Dict[str, Tuple[Callable, str]] = {
+_validator_length_ops: Mapping[str, tuple[Callable, str]] = {
     "lt": (operator.lt, "Length must be <{number}, but value is {value}"),
     "le": (operator.le, "Length must be <={number}, but value is {value}"),
     "eq": (operator.eq, "Length must be =={number}, but value is {value}"),
@@ -372,7 +375,7 @@ def validator_map(func: Callable[..., Any]) -> TransformSchema:
 
 def validator_xml_find(
     path: str,
-    namespaces: Optional[Dict[str, str]] = None,
+    namespaces: Mapping[str, str] | None = None,
 ) -> TransformSchema:
     """
     Utility function for finding an XML element using :meth:`Element.find()`.
@@ -421,7 +424,7 @@ def validator_xml_find(
 
 def validator_xml_findall(
     path: str,
-    namespaces: Optional[Dict[str, str]] = None,
+    namespaces: Mapping[str, str] | None = None,
 ) -> TransformSchema:
     """
     Utility function for finding XML elements using :meth:`Element.findall()`.
@@ -453,7 +456,7 @@ def validator_xml_findall(
 
 def validator_xml_findtext(
     path: str,
-    namespaces: Optional[Dict[str, str]] = None,
+    namespaces: Mapping[str, str] | None = None,
 ) -> AllSchema:
     """
     Utility function for finding an XML element using :meth:`Element.find()` and returning its ``text`` attribute.
@@ -484,8 +487,8 @@ def validator_xml_findtext(
 
 def validator_xml_xpath(
     xpath: str,
-    namespaces: Optional[Dict[str, str]] = None,
-    extensions: Optional[Dict[Tuple[Optional[str], str], Callable[..., Any]]] = None,
+    namespaces: Mapping[str, str] | None = None,
+    extensions: Mapping[tuple[str | None, str], Callable[..., Any]] | None = None,
     smart_strings: bool = True,
     **variables,
 ) -> TransformSchema:
@@ -535,8 +538,8 @@ def validator_xml_xpath(
 
 def validator_xml_xpath_string(
     xpath: str,
-    namespaces: Optional[Dict[str, str]] = None,
-    extensions: Optional[Dict[Tuple[Optional[str], str], Callable[..., Any]]] = None,
+    namespaces: Mapping[str, str] | None = None,
+    extensions: Mapping[tuple[str | None, str], Callable[..., Any]] | None = None,
     **variables,
 ) -> TransformSchema:
     """

--- a/src/streamlink/plugin/api/webbrowser/aws_waf.py
+++ b/src/streamlink/plugin/api/webbrowser/aws_waf.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import time
-from typing import Optional
 from urllib.parse import urlparse
 
 import trio
@@ -28,8 +29,8 @@ class AWSWAF:
         self.session = session
 
     def acquire(self, url: str) -> bool:
-        send: trio.MemorySendChannel[Optional[str]]
-        receive: trio.MemoryReceiveChannel[Optional[str]]
+        send: trio.MemorySendChannel[str | None]
+        receive: trio.MemoryReceiveChannel[str | None]
 
         data = None
         send, receive = trio.open_memory_channel(1)

--- a/src/streamlink/plugin/api/websocket.py
+++ b/src/streamlink/plugin/api/websocket.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import json
 import logging
 from threading import RLock, Thread, current_thread
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 from urllib.parse import unquote_plus, urlparse
 
 from certifi import where as certify_where
@@ -30,16 +32,16 @@ class WebsocketClient(Thread):
         self,
         session: Streamlink,
         url: str,
-        subprotocols: Optional[List[str]] = None,
-        header: Optional[Union[List[str], Dict[str, str]]] = None,
-        cookie: Optional[str] = None,
-        sockopt: Optional[Tuple] = None,
-        sslopt: Optional[Dict] = None,
-        host: Optional[str] = None,
-        origin: Optional[str] = None,
+        subprotocols: list[str] | None = None,
+        header: list[str] | dict[str, str] | None = None,
+        cookie: str | None = None,
+        sockopt: tuple | None = None,
+        sslopt: dict | None = None,
+        host: str | None = None,
+        origin: str | None = None,
         suppress_origin: bool = False,
-        ping_interval: Union[int, float] = 0,
-        ping_timeout: Optional[Union[int, float]] = None,
+        ping_interval: int | float = 0,
+        ping_timeout: int | float | None = None,
         ping_payload: str = "",
     ):
         if rootlogger.level <= TRACE:
@@ -52,8 +54,8 @@ class WebsocketClient(Thread):
         if not any(True for h in header if h.startswith("User-Agent: ")):
             header.append(f"User-Agent: {session.http.headers['User-Agent']!s}")
 
-        proxy_options: Dict[str, Any] = {}
-        http_proxy: Optional[str] = session.get_option("http-proxy")
+        proxy_options: dict[str, Any] = {}
+        http_proxy: str | None = session.get_option("http-proxy")
         if http_proxy:
             p = urlparse(http_proxy)
             proxy_options["proxy_type"] = p.scheme
@@ -120,11 +122,11 @@ class WebsocketClient(Thread):
 
     def reconnect(
         self,
-        url: Optional[str] = None,
-        subprotocols: Optional[List[str]] = None,
-        header: Optional[Union[List, Dict]] = None,
-        cookie: Optional[str] = None,
-        closeopts: Optional[Dict] = None,
+        url: str | None = None,
+        subprotocols: list[str] | None = None,
+        header: list | dict | None = None,
+        cookie: str | None = None,
+        closeopts: dict | None = None,
     ) -> None:
         with self._reconnect_lock:
             # ws connection is not active (anymore)
@@ -140,14 +142,14 @@ class WebsocketClient(Thread):
                 cookie=self.ws.cookie if cookie is None else cookie,
             )
 
-    def close(self, status: int = STATUS_NORMAL, reason: Union[str, bytes] = "", timeout: int = 3) -> None:
+    def close(self, status: int = STATUS_NORMAL, reason: str | bytes = "", timeout: int = 3) -> None:
         if isinstance(reason, str):
             reason = bytes(reason, encoding="utf-8")
         self.ws.close(status=status, reason=reason, timeout=timeout)
         if self.is_alive() and current_thread() is not self:
             self.join()
 
-    def send(self, data: Union[str, bytes], opcode: int = ABNF.OPCODE_TEXT) -> None:
+    def send(self, data: str | bytes, opcode: int = ABNF.OPCODE_TEXT) -> None:
         return self.ws.send(data, opcode)
 
     def send_json(self, data: Any) -> None:
@@ -181,5 +183,5 @@ class WebsocketClient(Thread):
     def on_cont_message(self, wsapp: WebSocketApp, data: bytes, cont: Any) -> None:
         pass  # pragma: no cover
 
-    def on_data(self, wsapp: WebSocketApp, data: Union[bytes, str], data_type: int, cont: Any) -> None:
+    def on_data(self, wsapp: WebSocketApp, data: bytes | str, data_type: int, cont: Any) -> None:
         pass  # pragma: no cover

--- a/src/streamlink/plugins/douyin.py
+++ b/src/streamlink/plugins/douyin.py
@@ -7,10 +7,11 @@ $metadata author
 $metadata title
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import uuid
-from typing import Dict
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -29,7 +30,7 @@ log = logging.getLogger(__name__)
 class Douyin(Plugin):
     _STATUS_LIVE = 2
 
-    QUALITY_WEIGHTS: Dict[str, int] = {}
+    QUALITY_WEIGHTS: dict[str, int] = {}
 
     @classmethod
     def stream_weight(cls, key):

--- a/src/streamlink/plugins/filmon.py
+++ b/src/streamlink/plugins/filmon.py
@@ -5,10 +5,12 @@ $type live, vod
 $notes Some VODs are mp4 which may not stream, use -o to download
 """
 
+from __future__ import annotations
+
 import logging
 import re
 import time
-from typing import Iterator, List, Tuple
+from collections.abc import Iterator
 from urllib.parse import urlparse, urlunparse
 
 from streamlink.exceptions import PluginError, StreamError
@@ -20,8 +22,6 @@ from streamlink.stream.http import HTTPStream
 
 
 log = logging.getLogger(__name__)
-
-_StreamData = Tuple[str, str, int]
 
 
 class FilmOnHLSStreamWorker(HLSStreamWorker):
@@ -58,7 +58,7 @@ class FilmOnHLS(HLSStream):
         self.watch_timeout = 0.0
         self._first_netloc = ""
 
-    def _get_stream_data(self) -> Iterator[_StreamData]:
+    def _get_stream_data(self) -> Iterator[tuple[str, str, int]]:
         if self.channel:
             log.debug(f"Reloading FilmOn channel playlist: {self.channel}")
             yield from self.api.channel(self.channel)
@@ -110,7 +110,7 @@ class FilmOnAPI:
     def __init__(self, session):
         self.session = session
 
-    def channel(self, channel) -> List[_StreamData]:
+    def channel(self, channel) -> list[tuple[str, str, int]]:
         num = 1
         while True:
             # retry for 50X errors or validation errors at the same time
@@ -135,7 +135,7 @@ class FilmOnAPI:
                 num = num + 1
                 time.sleep(self.TIMEOUT)
 
-    def vod(self, vod_id) -> List[_StreamData]:
+    def vod(self, vod_id) -> list[tuple[str, str, int]]:
         return self.session.http.get(
             self.vod_url.format(vod_id),
             schema=validate.Schema(

--- a/src/streamlink/plugins/huya.py
+++ b/src/streamlink/plugins/huya.py
@@ -7,6 +7,8 @@ $metadata author
 $metadata title
 """
 
+from __future__ import annotations
+
 import base64
 import hashlib
 import logging
@@ -15,7 +17,6 @@ import re
 import sys
 import time
 from html import unescape as html_unescape
-from typing import Dict
 from urllib.parse import parse_qsl, unquote
 
 from streamlink.plugin import Plugin, pluginmatcher
@@ -33,7 +34,7 @@ log = logging.getLogger(__name__)
     ),
 )
 class Huya(Plugin):
-    QUALITY_WEIGHTS: Dict[str, int] = {}
+    QUALITY_WEIGHTS: dict[str, int] = {}
 
     _STREAM_URL_QUERYSTRING_PARAMS = "wsTime", "fm", "ctype", "fs"
 

--- a/src/streamlink/plugins/rtve.py
+++ b/src/streamlink/plugins/rtve.py
@@ -6,11 +6,13 @@ $metadata id
 $region Spain
 """
 
+from __future__ import annotations
+
 import logging
 import re
 from base64 import b64decode
+from collections.abc import Iterator, Sequence
 from io import BytesIO
-from typing import Iterator, Sequence, Tuple
 from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, PluginError, pluginmatcher
@@ -56,7 +58,7 @@ class Base64Reader:
         a, b, c, d = self.read(4)
         return a << 24 | b << 16 | c << 8 | d
 
-    def read_chunk(self) -> Tuple[str, Sequence[int]]:
+    def read_chunk(self) -> tuple[str, Sequence[int]]:
         size = self.read_int()
         chunktype = self.read_chars(4)
         chunkdata = self.read(size)
@@ -114,7 +116,7 @@ class ZTNR:
         return cls._get_url(data, cls._get_alphabet(alphabet))
 
     @classmethod
-    def translate(cls, data: str) -> Iterator[Tuple[str, str]]:
+    def translate(cls, data: str) -> Iterator[tuple[str, str]]:
         reader = Base64Reader(data.replace("\n", ""))
         for chunk_type, chunk_data in reader:
             if chunk_type == "IEND":

--- a/src/streamlink/plugins/tiktok.py
+++ b/src/streamlink/plugins/tiktok.py
@@ -7,9 +7,10 @@ $metadata author
 $metadata title
 """
 
+from __future__ import annotations
+
 import logging
 import re
-from typing import Dict
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -25,7 +26,7 @@ log = logging.getLogger(__name__)
     ),
 )
 class TikTok(Plugin):
-    QUALITY_WEIGHTS: Dict[str, int] = {}
+    QUALITY_WEIGHTS: dict[str, int] = {}
 
     _URL_WEB_LIVE = "https://www.tiktok.com/@{channel}/live"
     _URL_API_LIVE_DETAIL = "https://www.tiktok.com/api/live/detail/?aid=1988&roomID={room_id}"

--- a/src/streamlink/plugins/tvp.py
+++ b/src/streamlink/plugins/tvp.py
@@ -12,9 +12,10 @@ $region Poland
 $notes Some live streams and VODs may be geo-restricted. Authentication is not supported.
 """
 
+from __future__ import annotations
+
 import logging
 import re
-from typing import List, Optional, Tuple
 
 from streamlink.exceptions import NoStreamsError
 from streamlink.plugin import Plugin, pluginmatcher
@@ -75,8 +76,8 @@ class TVP(Plugin):
             if mime_type == "application/dash+xml":
                 yield from DASHStream.parse_manifest(self.session, url).items()
 
-    def _get_video_id(self, channel_id: Optional[str]):
-        items: List[Tuple[int, int]] = self.session.http.get(
+    def _get_video_id(self, channel_id: str | None):
+        items: list[tuple[int, int]] = self.session.http.get(
             self.url,
             headers={
                 # required, otherwise the next request for retrieving the HLS URL will be aborted by the server
@@ -114,7 +115,7 @@ class TVP(Plugin):
 
         return items[0][1] if items else None
 
-    def _get_live(self, channel_id: Optional[str]):
+    def _get_live(self, channel_id: str | None):
         self.id = self._get_video_id(channel_id)
         if not self.id:
             log.error("Could not find video ID")

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import re
 import ssl
 import time
 import warnings
-from typing import Any, Dict, Pattern, Tuple
+from typing import Any
 
 import requests.adapters
 import urllib3
@@ -62,13 +64,13 @@ requests.adapters.HTTPResponse = _HTTPResponse  # type: ignore[misc]
 # > encodings.
 class Urllib3UtilUrlPercentReOverride:
     # urllib3>=2.0.0: _PERCENT_RE, urllib3<2.0.0: PERCENT_RE
-    _re_percent_encoding: Pattern \
+    _re_percent_encoding: re.Pattern \
         = getattr(urllib3.util.url, "_PERCENT_RE", getattr(urllib3.util.url, "PERCENT_RE", re.compile(r"%[a-fA-F0-9]{2}")))
 
     # urllib3>=1.25.8
     # https://github.com/urllib3/urllib3/blame/1.25.8/src/urllib3/util/url.py#L219-L227
     @classmethod
-    def subn(cls, repl: Any, string: str, count: Any = None) -> Tuple[str, int]:
+    def subn(cls, repl: Any, string: str, count: Any = None) -> tuple[str, int]:
         return string, len(cls._re_percent_encoding.findall(string))
 
 
@@ -81,7 +83,7 @@ _VALID_REQUEST_ARGS = "method", "url", "headers", "files", "data", "params", "au
 
 
 class HTTPSession(Session):
-    params: Dict
+    params: dict
 
     def __init__(self):
         super().__init__()
@@ -137,7 +139,7 @@ class HTTPSession(Session):
         return self.get(url, stream=True).url
 
     @staticmethod
-    def valid_request_args(**req_keywords) -> Dict:
+    def valid_request_args(**req_keywords) -> dict:
         return {k: v for k, v in req_keywords.items() if k in _VALID_REQUEST_ARGS}
 
     def prepare_new_request(self, **req_keywords) -> PreparedRequest:

--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -1,6 +1,6 @@
 import ssl
 from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
-from typing import Any, Union
+from typing import Any
 
 # noinspection PyUnresolvedReferences
 from _typeshed import SupportsItems, SupportsRead  # noqa: PLC2701
@@ -35,8 +35,8 @@ _Data: TypeAlias = (
     | tuple[tuple[Any, Any], ...]
     | Mapping[Any, Any]
 )
-_Auth: TypeAlias = Union[tuple[str, str], AuthBase, Callable[[PreparedRequest], PreparedRequest]]
-_Cert: TypeAlias = Union[str, tuple[str, str]]
+_Auth: TypeAlias = tuple[str, str] | AuthBase | Callable[[PreparedRequest], PreparedRequest]
+_Cert: TypeAlias = str | tuple[str, str]
 _FileName: TypeAlias = str | None
 _FileContent: TypeAlias = SupportsRead[str | bytes] | str | bytes
 _FileContentType: TypeAlias = str
@@ -51,15 +51,16 @@ _HooksInput: TypeAlias = Mapping[str, Iterable[_Hook] | _Hook]
 
 _ParamsMappingKeyType: TypeAlias = str | bytes | float
 _ParamsMappingValueType: TypeAlias = str | bytes | float | Iterable[str | bytes | float] | None
-_Params: TypeAlias = Union[
-    SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType],
-    tuple[_ParamsMappingKeyType, _ParamsMappingValueType],
-    Iterable[tuple[_ParamsMappingKeyType, _ParamsMappingValueType]],
-    str | bytes,
-]
+_Params: TypeAlias = (
+    SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType]
+    | tuple[_ParamsMappingKeyType, _ParamsMappingValueType]
+    | Iterable[tuple[_ParamsMappingKeyType, _ParamsMappingValueType]]
+    | str
+    | bytes
+)
 _TextMapping: TypeAlias = MutableMapping[str, str]
 _HeadersUpdateMapping: TypeAlias = Mapping[str, str | bytes | None]
-_Timeout: TypeAlias = Union[float, tuple[float, float], tuple[float, None]]
+_Timeout: TypeAlias = float | tuple[float, float] | tuple[float, None]
 _Verify: TypeAlias = bool | str
 
 # END: borrowed from typeshed / types-requests

--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import warnings
+from collections.abc import Callable, Iterator, Mapping
 from pathlib import Path
 from socket import AF_INET, AF_INET6
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, Iterator, Mapping, Tuple
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import urllib3.util.connection as urllib3_util_connection
 from requests.adapters import HTTPAdapter
@@ -304,7 +307,7 @@ class StreamlinkOptions(Options):
           - Whether to launch the webbrowser in headless mode or not
     """
 
-    def __init__(self, session: "Streamlink") -> None:
+    def __init__(self, session: Streamlink) -> None:
         super().__init__(defaults={
             "user-input-requester": None,
             "locale": None,
@@ -352,7 +355,7 @@ class StreamlinkOptions(Options):
     # ---- utils
 
     @staticmethod
-    def _parse_key_equals_value_string(delimiter: str, value: str) -> Iterator[Tuple[str, str]]:
+    def _parse_key_equals_value_string(delimiter: str, value: str) -> Iterator[tuple[str, str]]:
         for keyval in value.split(delimiter):
             try:
                 key, val = keyval.split("=", 1)
@@ -421,7 +424,7 @@ class StreamlinkOptions(Options):
         self.session.http.mount("https://", adapter)
 
     @staticmethod
-    def _factory_set_http_attr_key_equals_value(delimiter: str) -> Callable[["StreamlinkOptions", str, Any], None]:
+    def _factory_set_http_attr_key_equals_value(delimiter: str) -> Callable[[StreamlinkOptions, str, Any], None]:
         def inner(self: "StreamlinkOptions", key: str, value: Any) -> None:
             getattr(self.session.http, self._OPTIONS_HTTP_ATTRS[key]).update(
                 value if isinstance(value, dict) else dict(self._parse_key_equals_value_string(delimiter, value)),
@@ -430,8 +433,8 @@ class StreamlinkOptions(Options):
         return inner
 
     @staticmethod
-    def _factory_set_deprecated(name: str, mapper: Callable[[Any], Any]) -> Callable[["StreamlinkOptions", str, Any], None]:
-        def inner(self: "StreamlinkOptions", key: str, value: Any) -> None:
+    def _factory_set_deprecated(name: str, mapper: Callable[[Any], Any]) -> Callable[[StreamlinkOptions, str, Any], None]:
+        def inner(self: StreamlinkOptions, key: str, value: Any) -> None:
             self.set_explicit(name, mapper(value))
             warnings.warn(
                 f"`{key}` has been deprecated in favor of the `{name}` option",
@@ -447,7 +450,7 @@ class StreamlinkOptions(Options):
 
     # ----
 
-    _OPTIONS_HTTP_ATTRS: ClassVar[Dict[str, str]] = {
+    _OPTIONS_HTTP_ATTRS: ClassVar[Mapping[str, str]] = {
         "http-cookies": "cookies",
         "http-headers": "headers",
         "http-query-params": "params",
@@ -457,7 +460,7 @@ class StreamlinkOptions(Options):
         "http-timeout": "timeout",
     }
 
-    _MAP_GETTERS: ClassVar[Mapping[str, Callable[["StreamlinkOptions", str], Any]]] = {
+    _MAP_GETTERS: ClassVar[Mapping[str, Callable[[StreamlinkOptions, str], Any]]] = {
         "http-proxy": _get_http_proxy,
         "https-proxy": _get_http_proxy,
         "http-cookies": _get_http_attr,
@@ -469,7 +472,7 @@ class StreamlinkOptions(Options):
         "http-timeout": _get_http_attr,
     }
 
-    _MAP_SETTERS: ClassVar[Mapping[str, Callable[["StreamlinkOptions", str, Any], None]]] = {
+    _MAP_SETTERS: ClassVar[Mapping[str, Callable[[StreamlinkOptions, str, Any], None]]] = {
         "interface": _set_interface,
         "ipv4": _set_ipv4_ipv6,
         "ipv6": _set_ipv4_ipv6,

--- a/src/streamlink/session/plugins.py
+++ b/src/streamlink/session/plugins.py
@@ -7,10 +7,11 @@ import json
 import logging
 import pkgutil
 import re
+from collections.abc import Iterator, Mapping
 from contextlib import suppress
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Dict, Iterator, List, Literal, Optional, Tuple, Type, Union
+from typing import TYPE_CHECKING, Literal
 
 import streamlink.plugins
 from streamlink.options import Argument, Arguments
@@ -60,11 +61,11 @@ class StreamlinkPlugins:
 
     def __init__(self, builtin: bool = True, lazy: bool = True):
         # Loaded plugins
-        self._plugins: Dict[str, Type[Plugin]] = {}
+        self._plugins: dict[str, type[Plugin]] = {}
 
         # Data of built-in plugins which can be loaded lazily
-        self._matchers: Dict[str, Matchers] = {}
-        self._arguments: Dict[str, Arguments] = {}
+        self._matchers: dict[str, Matchers] = {}
+        self._arguments: dict[str, Arguments] = {}
 
         # Attempt to load built-in plugins lazily first
         if builtin and lazy:
@@ -78,11 +79,11 @@ class StreamlinkPlugins:
         if builtin and not lazy:
             self.load_builtin()
 
-    def __getitem__(self, item: str) -> Type[Plugin]:
+    def __getitem__(self, item: str) -> type[Plugin]:
         """Access a loaded plugin class by name"""
         return self._plugins[item]
 
-    def __setitem__(self, key: str, value: Type[Plugin]) -> None:
+    def __setitem__(self, key: str, value: type[Plugin]) -> None:
         """Add/override a plugin class by name"""
         self._plugins[key] = value
 
@@ -94,11 +95,11 @@ class StreamlinkPlugins:
         """Check if a plugin is loaded"""
         return item in self._plugins
 
-    def get_names(self) -> List[str]:
+    def get_names(self) -> list[str]:
         """Get a list of the names of all available plugins"""
         return sorted(self._plugins.keys() | self._matchers.keys())
 
-    def get_loaded(self) -> Dict[str, Type[Plugin]]:
+    def get_loaded(self) -> dict[str, type[Plugin]]:
         """Get a mapping of all loaded plugins"""
         return dict(self._plugins)
 
@@ -106,14 +107,14 @@ class StreamlinkPlugins:
         """Load Streamlink's built-in plugins"""
         return self.load_path(_PLUGINS_PATH)
 
-    def load_path(self, path: Union[Path, str]) -> bool:
+    def load_path(self, path: str | Path) -> bool:
         """Load plugins from a custom directory"""
         plugins = self._load_plugins_from_path(path)
         self.update(plugins)
 
         return bool(plugins)
 
-    def update(self, plugins: Dict[str, Type[Plugin]]):
+    def update(self, plugins: Mapping[str, type[Plugin]]):
         """Add/override loaded plugins"""
         self._plugins.update(plugins)
 
@@ -121,7 +122,7 @@ class StreamlinkPlugins:
         """Remove all loaded plugins from the session"""
         self._plugins.clear()
 
-    def iter_arguments(self) -> Iterator[Tuple[str, Arguments]]:
+    def iter_arguments(self) -> Iterator[tuple[str, Arguments]]:
         """Iterate through all plugins and their :class:`Arguments <streamlink.options.Arguments>`"""
         yield from (
             (name, plugin.arguments)
@@ -134,7 +135,7 @@ class StreamlinkPlugins:
             if arguments and name not in self._plugins
         )
 
-    def iter_matchers(self) -> Iterator[Tuple[str, Matchers]]:
+    def iter_matchers(self) -> Iterator[tuple[str, Matchers]]:
         """Iterate through all plugins and their :class:`Matchers <streamlink.plugin.plugin.Matchers>`"""
         yield from (
             (name, plugin.matchers)
@@ -147,9 +148,9 @@ class StreamlinkPlugins:
             if matchers and name not in self._plugins
         )
 
-    def match_url(self, url: str) -> Optional[Tuple[str, Type[Plugin]]]:
+    def match_url(self, url: str) -> tuple[str, type[Plugin]] | None:
         """Find a matching plugin by URL and load plugins which haven't been loaded yet"""
-        match: Optional[str] = None
+        match: str | None = None
         priority: int = NO_PRIORITY
 
         for name, matchers in self.iter_matchers():
@@ -172,13 +173,13 @@ class StreamlinkPlugins:
 
         return match, self._plugins[match]
 
-    def _load_plugin_from_path(self, name: str, path: Path) -> Optional[Tuple[ModuleType, Type[Plugin]]]:
+    def _load_plugin_from_path(self, name: str, path: Path) -> tuple[ModuleType, type[Plugin]] | None:
         finder = get_finder(path)
 
         return self._load_plugin_from_finder(name, finder)
 
-    def _load_plugins_from_path(self, path: Union[Path, str]) -> Dict[str, Type[Plugin]]:
-        plugins: Dict[str, Type[Plugin]] = {}
+    def _load_plugins_from_path(self, path: str | Path) -> dict[str, type[Plugin]]:
+        plugins: dict[str, type[Plugin]] = {}
         for finder, name, _ in pkgutil.iter_modules([str(path)]):
             lookup = self._load_plugin_from_finder(name, finder=finder)  # type: ignore[arg-type]
             if lookup is None:
@@ -193,7 +194,7 @@ class StreamlinkPlugins:
         return plugins
 
     @staticmethod
-    def _load_plugin_from_finder(name: str, finder: PathEntryFinderProtocol) -> Optional[Tuple[ModuleType, Type[Plugin]]]:
+    def _load_plugin_from_finder(name: str, finder: PathEntryFinderProtocol) -> tuple[ModuleType, type[Plugin]] | None:
         try:
             # set the full plugin module name, even for sideloaded plugins
             mod = exec_module(finder, f"streamlink.plugins.{name}", override=True)
@@ -209,47 +210,46 @@ class StreamlinkPlugins:
 
 _RE_STRIP_JSON_COMMENTS = re.compile(rb"^(?:\s*//[^\n]*\n+)+")
 
-
-_TListOfConstants: TypeAlias = List[Union[None, bool, int, float, str]]
-_TConstantOrListOfConstants: TypeAlias = Union[None, bool, int, float, str, _TListOfConstants]
-_TMappingOfConstantOrListOfConstants: TypeAlias = Dict[str, _TConstantOrListOfConstants]
+_TListOfConstants: TypeAlias = "list[bool | int | float | str | None]"
+_TConstantOrListOfConstants: TypeAlias = "bool | int | float | str | _TListOfConstants | None"
+_TMappingOfConstantOrListOfConstants: TypeAlias = "dict[str, _TConstantOrListOfConstants]"
 
 
 class _TPluginMatcherData(TypedDict):
     pattern: str
-    flags: Optional[int]
-    priority: Optional[int]
-    name: Optional[str]
+    flags: int | None
+    priority: int | None
+    name: str | None
 
 
 class _TPluginArgumentData(TypedDict):
     name: str
-    action: Optional[str]
-    nargs: Optional[Union[int, Literal["*", "?", "+"]]]
+    action: str | None
+    nargs: int | Literal["*", "?", "+"] | None
     const: _TConstantOrListOfConstants
     default: _TConstantOrListOfConstants
-    type: Optional[str]
-    type_args: Optional[_TListOfConstants]
-    type_kwargs: Optional[_TMappingOfConstantOrListOfConstants]
-    choices: Optional[_TListOfConstants]
-    required: Optional[bool]
-    help: Optional[str]
-    metavar: Optional[Union[str, List[str]]]
-    dest: Optional[str]
-    requires: Optional[Union[str, List[str]]]
-    prompt: Optional[str]
-    sensitive: Optional[bool]
-    argument_name: Optional[str]
+    type: str | None
+    type_args: _TListOfConstants | None
+    type_kwargs: _TMappingOfConstantOrListOfConstants | None
+    choices: _TListOfConstants | None
+    required: bool | None
+    help: str | None
+    metavar: str | list[str] | None
+    dest: str | None
+    requires: str | list[str] | None
+    prompt: str | None
+    sensitive: bool | None
+    argument_name: str | None
 
 
 class _TPluginData(TypedDict):
-    matchers: List[_TPluginMatcherData]
-    arguments: List[_TPluginArgumentData]
+    matchers: list[_TPluginMatcherData]
+    arguments: list[_TPluginArgumentData]
 
 
 class StreamlinkPluginsData:
     @classmethod
-    def load(cls) -> Optional[Tuple[Dict[str, Matchers], Dict[str, Arguments]]]:
+    def load(cls) -> tuple[dict[str, Matchers], dict[str, Arguments]] | None:
         # specific errors get logged, others are ignored intentionally
         with suppress(Exception):
             content = _PLUGINSDATA_PATH.read_bytes()
@@ -282,9 +282,9 @@ class StreamlinkPluginsData:
             raise Exception
 
     @classmethod
-    def _parse(cls, content: bytes) -> Tuple[Dict[str, Matchers], Dict[str, Arguments]]:
+    def _parse(cls, content: bytes) -> tuple[dict[str, Matchers], dict[str, Arguments]]:
         content = _RE_STRIP_JSON_COMMENTS.sub(b"", content)
-        data: Dict[str, _TPluginData] = json.loads(content)
+        data: dict[str, _TPluginData] = json.loads(content)
 
         try:
             matchers = cls._build_matchers(data)
@@ -301,7 +301,7 @@ class StreamlinkPluginsData:
         return matchers, arguments
 
     @classmethod
-    def _build_matchers(cls, data: Dict[str, _TPluginData]) -> Dict[str, Matchers]:
+    def _build_matchers(cls, data: dict[str, _TPluginData]) -> dict[str, Matchers]:
         res = {}
         for pluginname, plugindata in data.items():
             matchers = Matchers()
@@ -322,7 +322,7 @@ class StreamlinkPluginsData:
         )
 
     @classmethod
-    def _build_arguments(cls, data: Dict[str, _TPluginData]) -> Dict[str, Arguments]:
+    def _build_arguments(cls, data: dict[str, _TPluginData]) -> dict[str, Arguments]:
         res = {}
         for pluginname, plugindata in data.items():
             if not plugindata.get("arguments"):
@@ -337,7 +337,7 @@ class StreamlinkPluginsData:
         return res
 
     @staticmethod
-    def _build_argument(data: _TPluginArgumentData) -> Optional[Argument]:
+    def _build_argument(data: _TPluginArgumentData) -> Argument | None:
         name: str = data.get("name")  # type: ignore[assignment]
         _typedata = data.get("type")
         if not _typedata:

--- a/src/streamlink/session/session.py
+++ b/src/streamlink/session/session.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import logging
 import warnings
+from collections.abc import Mapping
 from functools import lru_cache
-from typing import Any, Dict, Optional, Tuple, Type
+from typing import Any
 
 import streamlink.compat  # noqa: F401
 from streamlink import __version__
@@ -28,7 +31,7 @@ class Streamlink:
 
     def __init__(
         self,
-        options: Optional[Dict[str, Any]] = None,
+        options: Mapping[str, Any] | None = None,
         *,
         plugins_builtin: bool = True,
         plugins_lazy: bool = True,
@@ -86,7 +89,7 @@ class Streamlink:
         self,
         url: str,
         follow_redirect: bool = True,
-    ) -> Tuple[str, Type[Plugin], str]:
+    ) -> tuple[str, type[Plugin], str]:
         """
         Attempts to find a plugin that can use this URL.
 
@@ -119,7 +122,7 @@ class Streamlink:
 
         raise NoPluginError
 
-    def resolve_url_no_redirect(self, url: str) -> Tuple[str, Type[Plugin], str]:
+    def resolve_url_no_redirect(self, url: str) -> tuple[str, type[Plugin], str]:
         """
         Attempts to find a plugin that can use this URL.
 
@@ -131,7 +134,7 @@ class Streamlink:
 
         return self.resolve_url(url, follow_redirect=False)
 
-    def streams(self, url: str, options: Optional[Options] = None, **params):
+    def streams(self, url: str, options: Options | None = None, **params):
         """
         Attempts to find a plugin and extracts streams from the *url* if a plugin was found.
 

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
 import copy
 import itertools
 import logging
 from collections import defaultdict
+from collections.abc import Mapping
 from contextlib import contextmanager, suppress
 from datetime import datetime
 from time import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 from urllib.parse import urlparse, urlunparse
 
 from requests import Response
@@ -26,8 +29,8 @@ log = logging.getLogger(".".join(__name__.split(".")[:-1]))
 
 
 class DASHStreamWriter(SegmentedStreamWriter[DASHSegment, Response]):
-    reader: "DASHStreamReader"
-    stream: "DASHStream"
+    reader: DASHStreamReader
+    stream: DASHStream
 
     def fetch(self, segment: DASHSegment):
         if self.closed:
@@ -73,9 +76,9 @@ class DASHStreamWriter(SegmentedStreamWriter[DASHSegment, Response]):
 
 
 class DASHStreamWorker(SegmentedStreamWorker[DASHSegment, Response]):
-    reader: "DASHStreamReader"
-    writer: "DASHStreamWriter"
-    stream: "DASHStream"
+    reader: DASHStreamReader
+    writer: DASHStreamWriter
+    stream: DASHStream
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -169,13 +172,13 @@ class DASHStreamReader(SegmentedStreamReader[DASHSegment, Response]):
     __worker__ = DASHStreamWorker
     __writer__ = DASHStreamWriter
 
-    worker: "DASHStreamWorker"
-    writer: "DASHStreamWriter"
-    stream: "DASHStream"
+    worker: DASHStreamWorker
+    writer: DASHStreamWriter
+    stream: DASHStream
 
     def __init__(
         self,
-        stream: "DASHStream",
+        stream: DASHStream,
         representation: Representation,
         timestamp: datetime,
     ):
@@ -196,8 +199,8 @@ class DASHStream(Stream):
         self,
         session: Streamlink,
         mpd: MPD,
-        video_representation: Optional[Representation] = None,
-        audio_representation: Optional[Representation] = None,
+        video_representation: Representation | None = None,
+        audio_representation: Representation | None = None,
         **kwargs,
     ):
         """
@@ -237,7 +240,7 @@ class DASHStream(Stream):
         return self.mpd.url
 
     @staticmethod
-    def fetch_manifest(session: Streamlink, url_or_manifest: str, **request_args) -> Tuple[str, Dict[str, Any]]:
+    def fetch_manifest(session: Streamlink, url_or_manifest: str, **request_args) -> tuple[str, dict[str, Any]]:
         if url_or_manifest.startswith("<?xml"):
             return url_or_manifest, {}
 
@@ -254,7 +257,7 @@ class DASHStream(Stream):
         return manifest, dict(url=url, base_url=base_url)
 
     @staticmethod
-    def parse_mpd(manifest: str, mpd_params: Dict[str, Any]) -> MPD:
+    def parse_mpd(manifest: str, mpd_params: Mapping[str, Any]) -> MPD:
         node = parse_xml(manifest, ignore_ns=True)
 
         return MPD(node, **mpd_params)
@@ -268,7 +271,7 @@ class DASHStream(Stream):
         with_video_only: bool = False,
         with_audio_only: bool = False,
         **kwargs,
-    ) -> Dict[str, "DASHStream"]:
+    ) -> dict[str, DASHStream]:
         """
         Parse a DASH manifest file and return its streams.
 
@@ -288,8 +291,8 @@ class DASHStream(Stream):
             raise PluginError(f"Failed to parse MPD manifest: {err}") from err
 
         source = mpd_params.get("url", "MPD manifest")
-        video: List[Optional[Representation]] = [None] if with_audio_only else []
-        audio: List[Optional[Representation]] = [None] if with_video_only else []
+        video: list[Representation | None] = [None] if with_audio_only else []
+        audio: list[Representation | None] = [None] if with_video_only else []
 
         # Search for suitable video and audio representations
         for aset in mpd.periods[period].adaptationSets:

--- a/src/streamlink/stream/dash/segment.py
+++ b/src/streamlink/stream/dash/segment.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional, Tuple
 from urllib.parse import urlparse
 
 from streamlink.stream.segmented.segment import Segment
@@ -24,7 +25,7 @@ class DASHSegment(Segment):
     available_at: datetime = EPOCH_START
     init: bool = False
     content: bool = True
-    byterange: Optional[Tuple[int, Optional[int]]] = None
+    byterange: tuple[int, int | None] | None = None
 
     @property
     def name(self) -> str:

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -1,14 +1,17 @@
+from __future__ import annotations
+
 import concurrent.futures
 import logging
 import re
 import subprocess
 import sys
 import threading
+from collections.abc import Sequence
 from contextlib import suppress
 from functools import lru_cache
 from pathlib import Path
 from shutil import which
-from typing import Any, ClassVar, Dict, Generic, List, Optional, Sequence, TextIO, TypeVar, Union
+from typing import Any, ClassVar, Generic, TextIO, TypeVar
 
 from streamlink import StreamError
 from streamlink.stream.stream import Stream, StreamIO
@@ -46,8 +49,8 @@ class MuxedStream(Stream, Generic[TSubstreams]):
 
         super().__init__(session)
         self.substreams: Sequence[TSubstreams] = substreams
-        self.subtitles: Dict[str, Stream] = options.pop("subtitles", {})
-        self.options: Dict[str, Any] = options
+        self.subtitles: dict[str, Stream] = options.pop("subtitles", {})
+        self.options: dict[str, Any] = options
 
     def open(self):
         fds = []
@@ -80,17 +83,17 @@ class MuxedStream(Stream, Generic[TSubstreams]):
 
 
 class FFMPEGMuxer(StreamIO):
-    __commands__: ClassVar[List[str]] = ["ffmpeg"]
+    __commands__: ClassVar[list[str]] = ["ffmpeg"]
 
     DEFAULT_LOGLEVEL = "info"
     DEFAULT_OUTPUT_FORMAT = "matroska"
     DEFAULT_VIDEO_CODEC = "copy"
     DEFAULT_AUDIO_CODEC = "copy"
 
-    FFMPEG_VERSION: Optional[str] = None
+    FFMPEG_VERSION: str | None = None
     FFMPEG_VERSION_TIMEOUT = 4.0
 
-    errorlog: Union[int, TextIO]
+    errorlog: int | TextIO
 
     @classmethod
     def is_usable(cls, session):
@@ -106,7 +109,7 @@ class FFMPEGMuxer(StreamIO):
 
     @classmethod
     @lru_cache(maxsize=128)
-    def _resolve_command(cls, command: Optional[str] = None, validate: bool = True) -> Optional[str]:
+    def _resolve_command(cls, command: str | None = None, validate: bool = True) -> str | None:
         if command:
             resolved = which(command)
         else:
@@ -277,13 +280,13 @@ class FFmpegVersionOutput(ProcessOutput):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.version: Optional[str] = None
-        self.output: List[str] = []
+        self.version: str | None = None
+        self.output: list[str] = []
 
     def onexit(self, code: int) -> bool:
         return code == 0 and self.version is not None
 
-    def onstdout(self, idx: int, line: str) -> Optional[bool]:
+    def onstdout(self, idx: int, line: str) -> bool | None:
         # only validate the very first line of the stdout stream
         if idx == 0:
             match = self._re_version.match(line)

--- a/src/streamlink/stream/hls/m3u8.py
+++ b/src/streamlink/stream/hls/m3u8.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import logging
 import math
 import re
 from binascii import Error as BinasciiError, unhexlify
+from collections.abc import Callable, Iterator, Mapping
 from datetime import datetime, timedelta
-from typing import Callable, ClassVar, Dict, Generic, Iterator, List, Mapping, Optional, Tuple, Type, TypeVar, Union
+from typing import ClassVar, Generic, TypeVar
 from urllib.parse import urljoin, urlparse
 
 from isodate import ISO8601Error, parse_datetime  # type: ignore[import]
@@ -40,29 +43,29 @@ THLSPlaylist_co = TypeVar("THLSPlaylist_co", bound=HLSPlaylist, covariant=True)
 
 
 class M3U8(Generic[THLSSegment_co, THLSPlaylist_co]):
-    def __init__(self, uri: Optional[str] = None):
+    def __init__(self, uri: str | None = None):
         self.uri = uri
 
         self.is_endlist: bool = False
         self.is_master: bool = False
 
-        self.allow_cache: Optional[bool] = None  # version < 7
-        self.discontinuity_sequence: Optional[int] = None
-        self.iframes_only: Optional[bool] = None  # version >= 4
-        self.media_sequence: Optional[int] = None
-        self.playlist_type: Optional[str] = None
-        self.targetduration: Optional[float] = None
-        self.start: Optional[Start] = None
-        self.version: Optional[int] = None
+        self.allow_cache: bool | None = None  # version < 7
+        self.discontinuity_sequence: int | None = None
+        self.iframes_only: bool | None = None  # version >= 4
+        self.media_sequence: int | None = None
+        self.playlist_type: str | None = None
+        self.targetduration: float | None = None
+        self.start: Start | None = None
+        self.version: int | None = None
 
-        self.media: List[Media] = []
-        self.dateranges: List[DateRange] = []
+        self.media: list[Media] = []
+        self.dateranges: list[DateRange] = []
 
-        self.playlists: List[THLSPlaylist_co] = []
-        self.segments: List[THLSSegment_co] = []
+        self.playlists: list[THLSPlaylist_co] = []
+        self.segments: list[THLSSegment_co] = []
 
     @classmethod
-    def is_date_in_daterange(cls, date: Optional[datetime], daterange: DateRange):
+    def is_date_in_daterange(cls, date: datetime | None, daterange: DateRange):
         if date is None or daterange.start_date is None:
             return None
 
@@ -107,9 +110,9 @@ class M3U8ParserMeta(type):
 
 class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M3U8ParserMeta):
     # Can't set type vars as classvars yet (PEP 526 issue)
-    __m3u8__: ClassVar[Type[M3U8[HLSSegment, HLSPlaylist]]] = M3U8
-    __segment__: ClassVar[Type[HLSSegment]] = HLSSegment
-    __playlist__: ClassVar[Type[HLSPlaylist]] = HLSPlaylist
+    __m3u8__: ClassVar[type[M3U8[HLSSegment, HLSPlaylist]]] = M3U8
+    __segment__: ClassVar[type[HLSSegment]] = HLSSegment
+    __playlist__: ClassVar[type[HLSPlaylist]] = HLSPlaylist
 
     _TAGS: ClassVar[Mapping[str, Callable[[Self, str], None]]]
 
@@ -138,22 +141,22 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
     _tag_re = re.compile(r"#(?P<tag>[\w-]+)(:(?P<value>.+))?")
     _res_re = re.compile(r"(\d+)x(\d+)")
 
-    def __init__(self, base_uri: Optional[str] = None):
+    def __init__(self, base_uri: str | None = None):
         self.m3u8: TM3U8_co = self.__m3u8__(base_uri)  # type: ignore[assignment]  # PEP 696 might solve this
 
         self._expect_playlist: bool = False
-        self._streaminf: Optional[Dict[str, str]] = None
+        self._streaminf: dict[str, str] | None = None
 
         self._expect_segment: bool = False
-        self._extinf: Optional[ExtInf] = None
-        self._byterange: Optional[ByteRange] = None
+        self._extinf: ExtInf | None = None
+        self._byterange: ByteRange | None = None
         self._discontinuity: bool = False
-        self._map: Optional[Map] = None
-        self._key: Optional[Key] = None
-        self._date: Optional[datetime] = None
+        self._map: Map | None = None
+        self._key: Key | None = None
+        self._date: datetime | None = None
 
     @classmethod
-    def create_stream_info(cls, streaminf: Mapping[str, Optional[str]], streaminfoclass=None):
+    def create_stream_info(cls, streaminf: Mapping[str, str | None], streaminfoclass=None):
         program_id = streaminf.get("PROGRAM-ID")
 
         try:
@@ -187,7 +190,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
             )
 
     @classmethod
-    def split_tag(cls, line: str) -> Union[Tuple[str, str], Tuple[None, None]]:
+    def split_tag(cls, line: str) -> tuple[str, str] | tuple[None, None]:
         match = cls._tag_re.match(line)
 
         if match:
@@ -196,10 +199,10 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
         return None, None
 
     @classmethod
-    def parse_attributes(cls, value: str) -> Dict[str, str]:
+    def parse_attributes(cls, value: str) -> dict[str, str]:
         pos = 0
         length = len(value)
-        res: Dict[str, str] = {}
+        res: dict[str, str] = {}
         while pos < length:
             match = cls._attr_re.match(value, pos)
             if match is None:
@@ -216,7 +219,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
         return value == "YES"
 
     @classmethod
-    def parse_byterange(cls, value: str) -> Optional[ByteRange]:
+    def parse_byterange(cls, value: str) -> ByteRange | None:
         match = cls._range_re.match(value)
         if match is None:
             return None
@@ -239,7 +242,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
         )
 
     @staticmethod
-    def parse_hex(value: Optional[str]) -> Optional[bytes]:
+    def parse_hex(value: str | None) -> bytes | None:
         if value is None:
             return None
 
@@ -253,7 +256,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
         return None
 
     @staticmethod
-    def parse_iso8601(value: Optional[str]) -> Optional[datetime]:
+    def parse_iso8601(value: str | None) -> datetime | None:
         try:
             return None if value is None else parse_datetime(value)
         except (ISO8601Error, ValueError):
@@ -261,7 +264,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
             return None
 
     @staticmethod
-    def parse_timedelta(value: Optional[str]) -> Optional[timedelta]:
+    def parse_timedelta(value: str | None) -> timedelta | None:
         return None if value is None else timedelta(seconds=float(value))
 
     @classmethod
@@ -560,7 +563,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
             playlist = self.get_playlist(self.uri(line))
             self.m3u8.playlists.append(playlist)
 
-    def parse(self, data: Union[str, Response]) -> TM3U8_co:
+    def parse(self, data: str | Response) -> TM3U8_co:
         lines: Iterator[str]
         if isinstance(data, str):
             lines = iter(filter(bool, data.splitlines()))
@@ -651,9 +654,9 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
 
 
 def parse_m3u8(
-    data: Union[str, Response],
-    base_uri: Optional[str] = None,
-    parser: Type[M3U8Parser[TM3U8_co, THLSSegment_co, THLSPlaylist_co]] = M3U8Parser,
+    data: str | Response,
+    base_uri: str | None = None,
+    parser: type[M3U8Parser[TM3U8_co, THLSSegment_co, THLSPlaylist_co]] = M3U8Parser,
 ) -> TM3U8_co:
     """
     Parse an M3U8 playlist from a string of data or an HTTP response.

--- a/src/streamlink/stream/hls/segment.py
+++ b/src/streamlink/stream/hls/segment.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Dict, List, NamedTuple, Optional, Union
+from typing import NamedTuple
 
 from streamlink.stream.segmented.segment import Segment
 
@@ -13,54 +15,54 @@ class Resolution(NamedTuple):
 # EXTINF
 class ExtInf(NamedTuple):
     duration: float  # version >= 3: float
-    title: Optional[str]
+    title: str | None
 
 
 # EXT-X-BYTERANGE
 class ByteRange(NamedTuple):  # version >= 4
     range: int
-    offset: Optional[int]
+    offset: int | None
 
 
 # EXT-X-DATERANGE
 class DateRange(NamedTuple):
-    id: Optional[str]
-    classname: Optional[str]
-    start_date: Optional[datetime]
-    end_date: Optional[datetime]
-    duration: Optional[timedelta]
-    planned_duration: Optional[timedelta]
+    id: str | None
+    classname: str | None
+    start_date: datetime | None
+    end_date: datetime | None
+    duration: timedelta | None
+    planned_duration: timedelta | None
     end_on_next: bool
-    x: Dict[str, str]
+    x: dict[str, str]
 
 
 # EXT-X-KEY
 class Key(NamedTuple):
     method: str
-    uri: Optional[str]
-    iv: Optional[bytes]  # version >= 2
-    key_format: Optional[str]  # version >= 5
-    key_format_versions: Optional[str]  # version >= 5
+    uri: str | None
+    iv: bytes | None  # version >= 2
+    key_format: str | None  # version >= 5
+    key_format_versions: str | None  # version >= 5
 
 
 # EXT-X-MAP
 class Map(NamedTuple):
     uri: str
-    key: Optional[Key]
-    byterange: Optional[ByteRange]
+    key: Key | None
+    byterange: ByteRange | None
 
 
 # EXT-X-MEDIA
 class Media(NamedTuple):
-    uri: Optional[str]
+    uri: str | None
     type: str
     group_id: str
-    language: Optional[str]
+    language: str | None
     name: str
     default: bool
     autoselect: bool
     forced: bool
-    characteristics: Optional[str]
+    characteristics: str | None
 
 
 # EXT-X-START
@@ -72,36 +74,36 @@ class Start(NamedTuple):
 # EXT-X-STREAM-INF
 class StreamInfo(NamedTuple):
     bandwidth: int
-    program_id: Optional[str]  # version < 6
-    codecs: List[str]
-    resolution: Optional[Resolution]
-    audio: Optional[str]
-    video: Optional[str]
-    subtitles: Optional[str]
+    program_id: str | None  # version < 6
+    codecs: list[str]
+    resolution: Resolution | None
+    audio: str | None
+    video: str | None
+    subtitles: str | None
 
 
 # EXT-X-I-FRAME-STREAM-INF
 class IFrameStreamInfo(NamedTuple):
     bandwidth: int
-    program_id: Optional[str]
-    codecs: List[str]
-    resolution: Optional[Resolution]
-    video: Optional[str]
+    program_id: str | None
+    codecs: list[str]
+    resolution: Resolution | None
+    video: str | None
 
 
 @dataclass
 class HLSPlaylist:
     uri: str
-    stream_info: Union[StreamInfo, IFrameStreamInfo]
-    media: List[Media]
+    stream_info: StreamInfo | IFrameStreamInfo
+    media: list[Media]
     is_iframe: bool
 
 
 @dataclass
 class HLSSegment(Segment):
-    title: Optional[str]
-    key: Optional[Key]
+    title: str | None
+    key: Key | None
     discontinuity: bool
-    byterange: Optional[ByteRange]
-    date: Optional[datetime]
-    map: Optional[Map]
+    byterange: ByteRange | None
+    date: datetime | None
+    map: Map | None

--- a/src/streamlink/stream/http.py
+++ b/src/streamlink/stream/http.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from __future__ import annotations
 
 from streamlink.exceptions import StreamError
 from streamlink.session import Streamlink
@@ -13,7 +13,7 @@ class HTTPStream(Stream):
 
     __shortname__ = "http"
 
-    args: Dict
+    args: dict
     """A dict of keyword arguments passed to :meth:`requests.Session.request`, such as method, headers, cookies, etc."""
 
     def __init__(

--- a/src/streamlink/stream/segmented/segmented.py
+++ b/src/streamlink/stream/segmented/segmented.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import logging
 import queue
+from collections.abc import Generator
 from concurrent import futures
 from concurrent.futures import Future
 from threading import Event, Thread, current_thread
-from typing import ClassVar, Generator, Generic, Optional, Tuple, Type, TypeVar
+from typing import ClassVar, Generic, TypeVar
 
 from streamlink.buffers import RingBuffer
 from streamlink.stream.segmented.concurrent import ThreadPoolExecutor
@@ -37,8 +38,8 @@ class AwaitableMixin:
 
 TSegment = TypeVar("TSegment", bound=Segment)
 TResult = TypeVar("TResult")
-TResultFuture: TypeAlias = "Future[Optional[TResult]]"
-TQueueItem: TypeAlias = Optional[Tuple[TSegment, TResultFuture, Tuple]]
+TResultFuture: TypeAlias = "Future[TResult | None]"
+TQueueItem: TypeAlias = "tuple[TSegment, TResultFuture, tuple]"
 
 
 class SegmentedStreamWriter(AwaitableMixin, Thread, Generic[TSegment, TResult]):
@@ -54,9 +55,9 @@ class SegmentedStreamWriter(AwaitableMixin, Thread, Generic[TSegment, TResult]):
         self,
         reader: SegmentedStreamReader,
         size: int = 20,
-        retries: Optional[int] = None,
-        threads: Optional[int] = None,
-        timeout: Optional[float] = None,
+        retries: int | None = None,
+        threads: int | None = None,
+        timeout: float | None = None,
     ) -> None:
         super().__init__(daemon=True, name=f"Thread-{self.__class__.__name__}")
 
@@ -89,7 +90,7 @@ class SegmentedStreamWriter(AwaitableMixin, Thread, Generic[TSegment, TResult]):
         self.reader.close()
         self.executor.shutdown(wait=True, cancel_futures=True)
 
-    def put(self, segment: Optional[TSegment]) -> None:
+    def put(self, segment: TSegment | None) -> None:
         """
         Adds a segment to the download pool and write queue.
         """
@@ -97,7 +98,7 @@ class SegmentedStreamWriter(AwaitableMixin, Thread, Generic[TSegment, TResult]):
         if self.closed:  # pragma: no cover
             return
 
-        future: Optional[TResultFuture]
+        future: TResultFuture | None
         if segment is None:
             future = None
         else:
@@ -105,7 +106,7 @@ class SegmentedStreamWriter(AwaitableMixin, Thread, Generic[TSegment, TResult]):
 
         self.queue(segment, future)
 
-    def queue(self, segment: Optional[TSegment], future: Optional[TResultFuture], *data) -> None:
+    def queue(self, segment: TSegment | None, future: TResultFuture | None, *data) -> None:
         """
         Puts values into a queue but aborts if this thread is closed.
         """
@@ -125,10 +126,10 @@ class SegmentedStreamWriter(AwaitableMixin, Thread, Generic[TSegment, TResult]):
         return self._queue.get(block=True, timeout=0.5)
 
     @staticmethod
-    def _future_result(future: TResultFuture) -> Optional[TResult]:
+    def _future_result(future: TResultFuture) -> TResult | None:
         return future.result(timeout=0.5)
 
-    def fetch(self, segment: TSegment) -> Optional[TResult]:
+    def fetch(self, segment: TSegment) -> TResult | None:
         """
         Fetches a segment.
         Should be overridden by the inheriting class.
@@ -223,8 +224,8 @@ class SegmentedStreamWorker(AwaitableMixin, Thread, Generic[TSegment, TResult]):
 
 
 class SegmentedStreamReader(StreamIO, Generic[TSegment, TResult]):
-    __worker__: ClassVar[Type[SegmentedStreamWorker]] = SegmentedStreamWorker
-    __writer__: ClassVar[Type[SegmentedStreamWriter]] = SegmentedStreamWriter
+    __worker__: ClassVar[type[SegmentedStreamWorker]] = SegmentedStreamWorker
+    __writer__: ClassVar[type[SegmentedStreamWriter]] = SegmentedStreamWriter
 
     worker: SegmentedStreamWorker[TSegment, TResult]
     writer: SegmentedStreamWriter[TSegment, TResult]

--- a/src/streamlink/stream/stream.py
+++ b/src/streamlink/stream/stream.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import json
 import logging
@@ -51,7 +53,7 @@ class Stream:
     def to_manifest_url(self):
         raise TypeError(f"<{self.__class__.__name__} [{self.shortname()}]> cannot be translated to a manifest URL")
 
-    def open(self) -> "StreamIO":
+    def open(self) -> StreamIO:
         """
         Attempts to open a connection to the stream.
         Returns a file-like object that can be used to read the stream data.

--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import re
-from typing import Any, Generic, List, Optional, Tuple, Type, TypeVar
+from typing import Any, Generic, TypeVar
 
 
 _BOOLEAN_TRUE = "yes", "1", "true", "on"
@@ -21,17 +23,17 @@ def boolean(value: str) -> bool:
     return value.lower() in _BOOLEAN_TRUE
 
 
-def comma_list(values: str) -> List[str]:
+def comma_list(values: str) -> list[str]:
     return [val.strip() for val in values.split(",")]
 
 
 # noinspection PyPep8Naming
 class comma_list_filter:
-    def __init__(self, acceptable: List[str], unique: bool = False):
+    def __init__(self, acceptable: list[str], unique: bool = False):
         self.acceptable = tuple(acceptable)
         self.unique = unique
 
-    def __call__(self, values: str) -> List[str]:
+    def __call__(self, values: str) -> list[str]:
         res = [item for item in comma_list(values) if item in self.acceptable]
         return sorted(set(res)) if self.unique else res
 
@@ -50,7 +52,7 @@ def filesize(value: str) -> int:
     return num(int, ge=1)(size)
 
 
-def keyvalue(value: str) -> Tuple[str, str]:
+def keyvalue(value: str) -> tuple[str, str]:
     match = _KEYVALUE_RE.match(value.lstrip())
     if not match:
         raise ValueError("Invalid key=value format")
@@ -65,17 +67,17 @@ _TNum = TypeVar("_TNum", int, float)
 class num(Generic[_TNum]):
     def __init__(
         self,
-        numtype: Type[_TNum],
-        ge: Optional[_TNum] = None,
-        gt: Optional[_TNum] = None,
-        le: Optional[_TNum] = None,
-        lt: Optional[_TNum] = None,
+        numtype: type[_TNum],
+        ge: _TNum | None = None,
+        gt: _TNum | None = None,
+        le: _TNum | None = None,
+        lt: _TNum | None = None,
     ):
-        self.numtype: Type[_TNum] = numtype
-        self.ge: Optional[_TNum] = ge
-        self.gt: Optional[_TNum] = gt
-        self.le: Optional[_TNum] = le
-        self.lt: Optional[_TNum] = lt
+        self.numtype: type[_TNum] = numtype
+        self.ge: _TNum | None = ge
+        self.gt: _TNum | None = gt
+        self.le: _TNum | None = le
+        self.lt: _TNum | None = lt
         self.__name__ = numtype.__name__
 
     def __call__(self, value: Any) -> _TNum:

--- a/src/streamlink/utils/cache.py
+++ b/src/streamlink/utils/cache.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections import OrderedDict
-from typing import Generic, Optional, OrderedDict as TOrderedDict, TypeVar
+from typing import Generic, TypeVar
 
 
 TCacheKey = TypeVar("TCacheKey")
@@ -8,10 +10,10 @@ TCacheValue = TypeVar("TCacheValue")
 
 class LRUCache(Generic[TCacheKey, TCacheValue]):
     def __init__(self, num: int):
-        self.cache: TOrderedDict[TCacheKey, TCacheValue] = OrderedDict()
+        self.cache: OrderedDict[TCacheKey, TCacheValue] = OrderedDict()
         self.num = num
 
-    def get(self, key: TCacheKey) -> Optional[TCacheValue]:
+    def get(self, key: TCacheKey) -> TCacheValue | None:
         if key not in self.cache:
             return None
         self.cache.move_to_end(key)

--- a/src/streamlink/utils/data.py
+++ b/src/streamlink/utils/data.py
@@ -1,7 +1,9 @@
-from typing import Any, Dict, List, Union
+from __future__ import annotations
+
+from typing import Any
 
 
-def search_dict(data: Union[Dict, List], key: Any):
+def search_dict(data: dict | list, key: Any):
     """
     Search for a key in a nested dict, or list of nested dicts, and return the values.
 

--- a/src/streamlink/utils/formatter.py
+++ b/src/streamlink/utils/formatter.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from string import Formatter as StringFormatter
-from typing import Any, Callable, Dict, Optional
+from typing import Any
 
 
 # we only need string.Formatter for calling its parse() method, which returns `_string.formatter_parser(string)`.
@@ -13,15 +16,15 @@ def _identity(obj):
 class Formatter:
     def __init__(
         self,
-        mapping: Dict[str, Callable[[], Any]],
-        formatting: Optional[Dict[str, Callable[[Any, str], Any]]] = None,
+        mapping: dict[str, Callable[[], Any]],
+        formatting: dict[str, Callable[[Any, str], Any]] | None = None,
     ):
         super().__init__()
-        self.mapping: Dict[str, Callable[[], Any]] = mapping
-        self.formatting: Dict[str, Callable[[Any, str], Any]] = formatting or {}
-        self.cache: Dict[str, Any] = {}
+        self.mapping: dict[str, Callable[[], Any]] = mapping
+        self.formatting: dict[str, Callable[[Any, str], Any]] = formatting or {}
+        self.cache: dict[str, Any] = {}
 
-    def _get_value(self, field_name: str, format_spec: Optional[str], defaults: Dict[str, str]) -> Any:
+    def _get_value(self, field_name: str, format_spec: str | None, defaults: dict[str, str]) -> Any:
         if field_name not in self.mapping:
             return defaults.get(field_name, f"{{{field_name}}}" if not format_spec else f"{{{field_name}:{format_spec}}}")
 
@@ -43,7 +46,7 @@ class Formatter:
 
         return value
 
-    def _format(self, string: str, mapper: Callable[[str], str], defaults: Dict[str, str]) -> str:
+    def _format(self, string: str, mapper: Callable[[str], str], defaults: dict[str, str]) -> str:
         result = []
 
         for literal_text, field_name, format_spec, _conversion in _stringformatter.parse(string):
@@ -58,5 +61,5 @@ class Formatter:
 
         return "".join(result)
 
-    def format(self, string: str, defaults: Optional[Dict[str, str]] = None) -> str:
+    def format(self, string: str, defaults: dict[str, str] | None = None) -> str:
         return self._format(string, _identity, defaults or {})

--- a/src/streamlink/utils/l10n.py
+++ b/src/streamlink/utils/l10n.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import locale
 import logging
-from typing import Optional
 from warnings import catch_warnings
 
 from pycountry import countries, languages  # type: ignore[import]
@@ -152,7 +153,7 @@ class Localization:
             self._language_code = DEFAULT_LANGUAGE_CODE
         log.debug(f"Language code: {self._language_code}")
 
-    def equivalent(self, language: Optional[str] = None, country: Optional[str] = None) -> bool:
+    def equivalent(self, language: str | None = None, country: str | None = None) -> bool:
         try:
             return (
                 (not language or self.language == self.get_language(language))

--- a/src/streamlink/utils/module.py
+++ b/src/streamlink/utils/module.py
@@ -6,14 +6,14 @@ from importlib.util import module_from_spec
 from pathlib import Path
 from pkgutil import get_importer
 from types import ModuleType
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:  # pragma: no cover
     from _typeshed.importlib import PathEntryFinderProtocol
 
 
-def get_finder(path: Union[Path, str]) -> PathEntryFinderProtocol:
+def get_finder(path: str | Path) -> PathEntryFinderProtocol:
     path = str(path)
     finder = get_importer(path)
     if not finder:
@@ -22,7 +22,7 @@ def get_finder(path: Union[Path, str]) -> PathEntryFinderProtocol:
     return finder
 
 
-def load_module(name: str, path: Union[Path, str], override: bool = False) -> ModuleType:
+def load_module(name: str, path: str | Path, override: bool = False) -> ModuleType:
     finder = get_finder(path)
 
     return exec_module(finder, name, override)

--- a/src/streamlink/utils/named_pipe.py
+++ b/src/streamlink/utils/named_pipe.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import logging
 import os
@@ -6,7 +8,6 @@ import tempfile
 import threading
 from contextlib import suppress
 from pathlib import Path
-from typing import Type
 
 from streamlink.compat import is_win32
 
@@ -134,7 +135,7 @@ class NamedPipeWindows(NamedPipeBase):
             self.pipe = None
 
 
-NamedPipe: Type[NamedPipeBase]
+NamedPipe: type[NamedPipeBase]
 if not is_win32:
     NamedPipe = NamedPipePosix
 else:

--- a/src/streamlink/utils/path.py
+++ b/src/streamlink/utils/path.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 from pathlib import Path
 from shutil import which
-from typing import List, Optional, Union
 
 
 def resolve_executable(
-    custom: Optional[Union[str, Path]] = None,
-    names: Optional[List[str]] = None,
-    fallbacks: Optional[List[Union[str, Path]]] = None,
-) -> Optional[Union[str, Path]]:
+    custom: str | Path | None = None,
+    names: list[str] | None = None,
+    fallbacks: list[str | Path] | None = None,
+) -> str | Path | None:
     if custom:
         return which(custom)
 

--- a/src/streamlink/utils/processoutput.py
+++ b/src/streamlink/utils/processoutput.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import math
+from collections.abc import Callable
 from contextlib import suppress
 from functools import partial
 from subprocess import PIPE
-from typing import BinaryIO, Callable, List, Optional, Union
+from typing import BinaryIO
 
 import trio
 
@@ -13,10 +16,10 @@ class ProcessOutput:
 
     def __init__(
         self,
-        command: List[str],
+        command: list[str],
         timeout: float = math.inf,
         wait_terminate: float = 2.0,
-        stdin: Optional[Union[int, bytes, BinaryIO]] = PIPE,
+        stdin: int | bytes | BinaryIO | None = PIPE,
     ):
         self.command = command
         self.timeout = timeout
@@ -65,7 +68,7 @@ class ProcessOutput:
         result = self.onexit(code)
         await self._send_channel.send(result)
 
-    async def _onoutput(self, callback: Callable[[int, str], Optional[bool]], stream: trio.abc.ReceiveChannel[bytes]):
+    async def _onoutput(self, callback: Callable[[int, str], bool | None], stream: trio.abc.ReceiveChannel[bytes]):
         idx = 0
         async for line in stream:
             try:
@@ -81,8 +84,8 @@ class ProcessOutput:
     def onexit(self, code: int) -> bool:
         return code == 0
 
-    def onstdout(self, idx: int, line: str) -> Optional[bool]:
+    def onstdout(self, idx: int, line: str) -> bool | None:
         pass
 
-    def onstderr(self, idx: int, line: str) -> Optional[bool]:
+    def onstderr(self, idx: int, line: str) -> bool | None:
         pass

--- a/src/streamlink/utils/socket.py
+++ b/src/streamlink/utils/socket.py
@@ -1,4 +1,6 @@
-from typing import Callable, Coroutine
+from __future__ import annotations
+
+from collections.abc import Callable, Coroutine
 
 import trio
 

--- a/src/streamlink/utils/times.py
+++ b/src/streamlink/utils/times.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import re
+from collections.abc import Callable
 from datetime import datetime, timezone, tzinfo
-from typing import Callable, Generic, Type, TypeVar
+from typing import Generic, TypeVar
 
 from isodate import LOCAL, parse_datetime  # type: ignore[import]
 
@@ -95,8 +98,8 @@ class _HoursMinutesSeconds(Generic[_THMS]):
         re.VERBOSE | re.IGNORECASE,
     )
 
-    def __init__(self, return_type: Type[_THMS]):
-        self._return_type: Type[_THMS] = return_type
+    def __init__(self, return_type: type[_THMS]):
+        self._return_type: type[_THMS] = return_type
 
     def __call__(self, value: str) -> _THMS:
         if self._re_float.match(value):

--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import base64
 import re
+from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any, AsyncGenerator, Awaitable, Callable, Coroutine, List, Mapping, Optional, Set
+from typing import Any
 
 import trio
 
@@ -19,7 +22,7 @@ except ImportError:  # pragma: no cover
     from typing_extensions import Self, TypeAlias
 
 
-TRequestHandlerCallable: TypeAlias = Callable[["CDPClientSession", fetch.RequestPaused], Awaitable]
+TRequestHandlerCallable: TypeAlias = "Callable[[CDPClientSession, fetch.RequestPaused], Awaitable]"
 
 
 _re_url_pattern_wildcard = re.compile(r"(.+?)?(\\+)?([*?])")
@@ -65,7 +68,7 @@ class RequestPausedHandler:
 class CMRequestProxy:
     body: str
     response_code: int
-    response_headers: Optional[Mapping[str, str]]
+    response_headers: Mapping[str, str] | None
 
 
 class CDPClient:
@@ -96,12 +99,12 @@ class CDPClient:
         cls,
         session: Streamlink,
         runner: Callable[[Self], Coroutine],
-        executable: Optional[str] = None,
-        timeout: Optional[float] = None,
-        cdp_host: Optional[str] = None,
-        cdp_port: Optional[int] = None,
-        cdp_timeout: Optional[float] = None,
-        headless: Optional[bool] = None,
+        executable: str | None = None,
+        timeout: float | None = None,
+        cdp_host: str | None = None,
+        cdp_port: int | None = None,
+        cdp_timeout: float | None = None,
+        headless: bool | None = None,
     ) -> Any:
         """
         Start a new :mod:`trio` runloop and do the following things:
@@ -174,11 +177,11 @@ class CDPClient:
     async def run(
         cls,
         session: Streamlink,
-        executable: Optional[str] = None,
-        timeout: Optional[float] = None,
-        cdp_host: Optional[str] = None,
-        cdp_port: Optional[int] = None,
-        cdp_timeout: Optional[float] = None,
+        executable: str | None = None,
+        timeout: float | None = None,
+        cdp_host: str | None = None,
+        cdp_port: int | None = None,
+        cdp_timeout: float | None = None,
         headless: bool = False,
     ) -> AsyncGenerator[Self, None]:
         webbrowser = ChromiumWebbrowser(executable=executable, host=cdp_host, port=cdp_port)
@@ -193,8 +196,8 @@ class CDPClient:
     async def session(
         self,
         fail_unhandled_requests: bool = False,
-        max_buffer_size: Optional[int] = None,
-    ) -> AsyncGenerator["CDPClientSession", None]:
+        max_buffer_size: int | None = None,
+    ) -> AsyncGenerator[CDPClientSession, None]:
         """
         Create a new CDP session on an empty target (browser tab).
 
@@ -218,13 +221,13 @@ class CDPClientSession:
         cdp_client: CDPClient,
         cdp_session: CDPSession,
         fail_unhandled_requests: bool = False,
-        max_buffer_size: Optional[int] = None,
+        max_buffer_size: int | None = None,
     ):
         self.cdp_client = cdp_client
         self.cdp_session = cdp_session
         self._fail_unhandled = fail_unhandled_requests
-        self._request_handlers: List[RequestPausedHandler] = []
-        self._requests_handled: Set[str] = set()
+        self._request_handlers: list[RequestPausedHandler] = []
+        self._requests_handled: set[str] = set()
         self._max_buffer_size = max_buffer_size
 
     def add_request_handler(
@@ -250,7 +253,7 @@ class CDPClientSession:
         )
 
     @asynccontextmanager
-    async def navigate(self, url: str, referrer: Optional[str] = None) -> AsyncGenerator[page.FrameId, None]:
+    async def navigate(self, url: str, referrer: str | None = None) -> AsyncGenerator[page.FrameId, None]:
         """
         Async context manager for opening the URL with an optional referrer and starting the optional interception
         of network requests and responses.
@@ -306,7 +309,7 @@ class CDPClientSession:
             if frame_stopped_loading.frame_id == frame_id:
                 return
 
-    async def evaluate(self, expression: str, await_promise: bool = True, timeout: Optional[float] = None) -> Any:
+    async def evaluate(self, expression: str, await_promise: bool = True, timeout: float | None = None) -> Any:
         """
         Evaluate an optionally async JavaScript expression and return its result.
 
@@ -332,10 +335,10 @@ class CDPClientSession:
     async def continue_request(
         self,
         request: fetch.RequestPaused,
-        url: Optional[str] = None,
-        method: Optional[str] = None,
-        post_data: Optional[str] = None,
-        headers: Optional[Mapping[str, str]] = None,
+        url: str | None = None,
+        method: str | None = None,
+        post_data: str | None = None,
+        headers: Mapping[str, str] | None = None,
     ):
         """
         Continue a request and optionally override the request method, URL, POST data or request headers.
@@ -352,7 +355,7 @@ class CDPClientSession:
     async def fail_request(
         self,
         request: fetch.RequestPaused,
-        error_reason: Optional[str] = None,
+        error_reason: str | None = None,
     ):
         """
         Let a request fail, with an optional error reason which defaults to ``BlockedByClient``.
@@ -367,8 +370,8 @@ class CDPClientSession:
         self,
         request: fetch.RequestPaused,
         response_code: int = 200,
-        response_headers: Optional[Mapping[str, str]] = None,
-        body: Optional[str] = None,
+        response_headers: Mapping[str, str] | None = None,
+        body: str | None = None,
     ) -> None:
         """
         Fulfill a response and override its status code, headers and body.
@@ -386,7 +389,7 @@ class CDPClientSession:
         self,
         request: fetch.RequestPaused,
         response_code: int = 200,
-        response_headers: Optional[Mapping[str, str]] = None,
+        response_headers: Mapping[str, str] | None = None,
     ) -> AsyncGenerator[CMRequestProxy, None]:
         """
         Async context manager wrapper around :meth:`fulfill_request()` which retrieves the response body,
@@ -409,7 +412,7 @@ class CDPClientSession:
         )
 
     @staticmethod
-    def _headers_entries_from_mapping(headers: Optional[Mapping[str, str]]):
+    def _headers_entries_from_mapping(headers: Mapping[str, str] | None):
         return None if headers is None else [
             fetch.HeaderEntry(name=name, value=value)
             for name, value in headers.items()

--- a/src/streamlink/webbrowser/cdp/devtools/browser.py
+++ b/src/streamlink/webbrowser/cdp/devtools/browser.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.page as page
 import streamlink.webbrowser.cdp.devtools.target as target
@@ -64,19 +65,19 @@ class Bounds:
     Browser window bounds information
     """
     #: The offset from the left edge of the screen to the window in pixels.
-    left: typing.Optional[int] = None
+    left: int | None = None
 
     #: The offset from the top edge of the screen to the window in pixels.
-    top: typing.Optional[int] = None
+    top: int | None = None
 
     #: The window width in pixels.
-    width: typing.Optional[int] = None
+    width: int | None = None
 
     #: The window height in pixels.
-    height: typing.Optional[int] = None
+    height: int | None = None
 
     #: The window state. Default to normal.
-    window_state: typing.Optional[WindowState] = None
+    window_state: WindowState | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -167,20 +168,20 @@ class PermissionDescriptor:
     name: str
 
     #: For "midi" permission, may also specify sysex control.
-    sysex: typing.Optional[bool] = None
+    sysex: bool | None = None
 
     #: For "push" permission, may specify userVisibleOnly.
     #: Note that userVisibleOnly = true is the only currently supported type.
-    user_visible_only: typing.Optional[bool] = None
+    user_visible_only: bool | None = None
 
     #: For "clipboard" permission, may specify allowWithoutSanitization.
-    allow_without_sanitization: typing.Optional[bool] = None
+    allow_without_sanitization: bool | None = None
 
     #: For "fullscreen" permission, must specify allowWithoutGesture:true.
-    allow_without_gesture: typing.Optional[bool] = None
+    allow_without_gesture: bool | None = None
 
     #: For "camera" permission, may specify panTiltZoom.
-    pan_tilt_zoom: typing.Optional[bool] = None
+    pan_tilt_zoom: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -269,7 +270,7 @@ class Histogram:
     count: int
 
     #: Buckets.
-    buckets: typing.List[Bucket]
+    buckets: list[Bucket]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -292,9 +293,9 @@ class Histogram:
 def set_permission(
     permission: PermissionDescriptor,
     setting: PermissionSetting,
-    origin: typing.Optional[str] = None,
-    browser_context_id: typing.Optional[BrowserContextID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    origin: str | None = None,
+    browser_context_id: BrowserContextID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set permission settings for given origin.
 
@@ -320,10 +321,10 @@ def set_permission(
 
 
 def grant_permissions(
-    permissions: typing.List[PermissionType],
-    origin: typing.Optional[str] = None,
-    browser_context_id: typing.Optional[BrowserContextID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    permissions: list[PermissionType],
+    origin: str | None = None,
+    browser_context_id: BrowserContextID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Grant specific permissions to the given origin and reject all others.
 
@@ -347,8 +348,8 @@ def grant_permissions(
 
 
 def reset_permissions(
-    browser_context_id: typing.Optional[BrowserContextID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    browser_context_id: BrowserContextID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Reset all permission management for all origins.
 
@@ -366,10 +367,10 @@ def reset_permissions(
 
 def set_download_behavior(
     behavior: str,
-    browser_context_id: typing.Optional[BrowserContextID] = None,
-    download_path: typing.Optional[str] = None,
-    events_enabled: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    browser_context_id: BrowserContextID | None = None,
+    download_path: str | None = None,
+    events_enabled: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set the behavior when downloading a file.
 
@@ -397,8 +398,8 @@ def set_download_behavior(
 
 def cancel_download(
     guid: str,
-    browser_context_id: typing.Optional[BrowserContextID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    browser_context_id: BrowserContextID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Cancel a download if in progress
 
@@ -418,7 +419,7 @@ def cancel_download(
     yield cmd_dict
 
 
-def close() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def close() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Close browser gracefully.
     """
@@ -428,7 +429,7 @@ def close() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def crash() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def crash() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Crashes browser on the main thread.
 
@@ -440,7 +441,7 @@ def crash() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def crash_gpu_process() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def crash_gpu_process() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Crashes GPU process.
 
@@ -452,7 +453,7 @@ def crash_gpu_process() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def get_version() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, str, str, str, str]]:
+def get_version() -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, str, str, str, str]]:
     """
     Returns version information.
 
@@ -477,7 +478,7 @@ def get_version() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str
     )
 
 
-def get_browser_command_line() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+def get_browser_command_line() -> Generator[T_JSON_DICT, T_JSON_DICT, list[str]]:
     """
     Returns the command line switches for the browser process if, and only if
     --enable-automation is on the commandline.
@@ -494,9 +495,9 @@ def get_browser_command_line() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typ
 
 
 def get_histograms(
-    query: typing.Optional[str] = None,
-    delta: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[Histogram]]:
+    query: str | None = None,
+    delta: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[Histogram]]:
     """
     Get Chrome histograms.
 
@@ -521,8 +522,8 @@ def get_histograms(
 
 def get_histogram(
     name: str,
-    delta: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, Histogram]:
+    delta: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, Histogram]:
     """
     Get a Chrome histogram by name.
 
@@ -546,7 +547,7 @@ def get_histogram(
 
 def get_window_bounds(
     window_id: WindowID,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, Bounds]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, Bounds]:
     """
     Get position and size of the browser window.
 
@@ -566,8 +567,8 @@ def get_window_bounds(
 
 
 def get_window_for_target(
-    target_id: typing.Optional[target.TargetID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[WindowID, Bounds]]:
+    target_id: target.TargetID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[WindowID, Bounds]]:
     """
     Get the browser window that contains the devtools target.
 
@@ -596,7 +597,7 @@ def get_window_for_target(
 def set_window_bounds(
     window_id: WindowID,
     bounds: Bounds,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set position and/or size of the browser window.
 
@@ -616,9 +617,9 @@ def set_window_bounds(
 
 
 def set_dock_tile(
-    badge_label: typing.Optional[str] = None,
-    image: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    badge_label: str | None = None,
+    image: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set dock tile details, platform-specific.
 
@@ -641,7 +642,7 @@ def set_dock_tile(
 
 def execute_browser_command(
     command_id: BrowserCommandId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Invoke custom browser commands used by telemetry.
 
@@ -660,7 +661,7 @@ def execute_browser_command(
 
 def add_privacy_sandbox_enrollment_override(
     url: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Allows a site to use privacy sandbox features that require enrollment
     without the site actually being enrolled. Only supported on page targets.

--- a/src/streamlink/webbrowser/cdp/devtools/debugger.py
+++ b/src/streamlink/webbrowser/cdp/devtools/debugger.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
@@ -58,7 +59,7 @@ class Location:
     line_number: int
 
     #: Column number in the script (0-based).
-    column_number: typing.Optional[int] = None
+    column_number: int | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -147,22 +148,22 @@ class CallFrame:
     url: str
 
     #: Scope chain for this call frame.
-    scope_chain: typing.List[Scope]
+    scope_chain: list[Scope]
 
     #: ``this`` object for this call frame.
     this: runtime.RemoteObject
 
     #: Location in the source code.
-    function_location: typing.Optional[Location] = None
+    function_location: Location | None = None
 
     #: The value being returned, if the function is at return point.
-    return_value: typing.Optional[runtime.RemoteObject] = None
+    return_value: runtime.RemoteObject | None = None
 
     #: Valid only while the VM is paused and indicates whether this frame
     #: can be restarted or not. Note that a ``true`` value here does not
     #: guarantee that Debugger#restartFrame with this CallFrameId will be
     #: successful, but it is very likely.
-    can_be_restarted: typing.Optional[bool] = None
+    can_be_restarted: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -208,13 +209,13 @@ class Scope:
     #: variables as its properties.
     object_: runtime.RemoteObject
 
-    name: typing.Optional[str] = None
+    name: str | None = None
 
     #: Location in the source code where scope starts
-    start_location: typing.Optional[Location] = None
+    start_location: Location | None = None
 
     #: Location in the source code where scope ends
-    end_location: typing.Optional[Location] = None
+    end_location: Location | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -273,9 +274,9 @@ class BreakLocation:
     line_number: int
 
     #: Column number in the script (0-based).
-    column_number: typing.Optional[int] = None
+    column_number: int | None = None
 
-    type_: typing.Optional[str] = None
+    type_: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -300,10 +301,10 @@ class BreakLocation:
 @dataclass
 class WasmDisassemblyChunk:
     #: The next chunk of disassembled lines.
-    lines: typing.List[str]
+    lines: list[str]
 
     #: The bytecode offsets describing the start of each line.
-    bytecode_offsets: typing.List[int]
+    bytecode_offsets: list[int]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -343,7 +344,7 @@ class DebugSymbols:
     type_: str
 
     #: URL of the external symbol source.
-    external_url: typing.Optional[str] = None
+    external_url: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -362,8 +363,8 @@ class DebugSymbols:
 
 def continue_to_location(
     location: Location,
-    target_call_frames: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    target_call_frames: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Continues execution until specific location is reached.
 
@@ -381,7 +382,7 @@ def continue_to_location(
     yield cmd_dict
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables debugger for given page.
     """
@@ -392,8 +393,8 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 
 def enable(
-    max_scripts_cache_size: typing.Optional[float] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, runtime.UniqueDebuggerId]:
+    max_scripts_cache_size: float | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, runtime.UniqueDebuggerId]:
     """
     Enables debugger for the given page. Clients should not assume that the debugging has been
     enabled until the result for this command is received.
@@ -415,14 +416,14 @@ def enable(
 def evaluate_on_call_frame(
     call_frame_id: CallFrameId,
     expression: str,
-    object_group: typing.Optional[str] = None,
-    include_command_line_api: typing.Optional[bool] = None,
-    silent: typing.Optional[bool] = None,
-    return_by_value: typing.Optional[bool] = None,
-    generate_preview: typing.Optional[bool] = None,
-    throw_on_side_effect: typing.Optional[bool] = None,
-    timeout: typing.Optional[runtime.TimeDelta] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[runtime.RemoteObject, typing.Optional[runtime.ExceptionDetails]]]:
+    object_group: str | None = None,
+    include_command_line_api: bool | None = None,
+    silent: bool | None = None,
+    return_by_value: bool | None = None,
+    generate_preview: bool | None = None,
+    throw_on_side_effect: bool | None = None,
+    timeout: runtime.TimeDelta | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[runtime.RemoteObject, runtime.ExceptionDetails | None]]:
     """
     Evaluates expression on a given call frame.
 
@@ -470,9 +471,9 @@ def evaluate_on_call_frame(
 
 def get_possible_breakpoints(
     start: Location,
-    end: typing.Optional[Location] = None,
-    restrict_to_function: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[BreakLocation]]:
+    end: Location | None = None,
+    restrict_to_function: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[BreakLocation]]:
     """
     Returns possible locations for breakpoint. scriptId in start and end range locations should be
     the same.
@@ -498,7 +499,7 @@ def get_possible_breakpoints(
 
 def get_script_source(
     script_id: runtime.ScriptId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, typing.Optional[str]]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, str | None]]:
     """
     Returns source for the script with given id.
 
@@ -523,7 +524,7 @@ def get_script_source(
 
 def disassemble_wasm_module(
     script_id: runtime.ScriptId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.Optional[str], int, typing.List[int], WasmDisassemblyChunk]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str | None, int, list[int], WasmDisassemblyChunk]]:
     """
 
 
@@ -554,7 +555,7 @@ def disassemble_wasm_module(
 
 def next_wasm_disassembly_chunk(
     stream_id: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, WasmDisassemblyChunk]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, WasmDisassemblyChunk]:
     """
     Disassemble the next chunk of lines for the module corresponding to the
     stream. If disassembly is complete, this API will invalidate the streamId
@@ -578,7 +579,7 @@ def next_wasm_disassembly_chunk(
 
 def get_wasm_bytecode(
     script_id: runtime.ScriptId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     This command is deprecated. Use getScriptSource instead.
 
@@ -597,7 +598,7 @@ def get_wasm_bytecode(
 
 def get_stack_trace(
     stack_trace_id: runtime.StackTraceId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, runtime.StackTrace]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, runtime.StackTrace]:
     """
     Returns stack trace with given ``stackTraceId``.
 
@@ -616,7 +617,7 @@ def get_stack_trace(
     return runtime.StackTrace.from_json(json["stackTrace"])
 
 
-def pause() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def pause() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Stops on the next JavaScript statement.
     """
@@ -628,7 +629,7 @@ def pause() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def pause_on_async_call(
     parent_stack_trace_id: runtime.StackTraceId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -647,7 +648,7 @@ def pause_on_async_call(
 
 def remove_breakpoint(
     breakpoint_id: BreakpointId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Removes JavaScript breakpoint.
 
@@ -664,8 +665,8 @@ def remove_breakpoint(
 
 def restart_frame(
     call_frame_id: CallFrameId,
-    mode: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.List[CallFrame], typing.Optional[runtime.StackTrace], typing.Optional[runtime.StackTraceId]]]:
+    mode: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[list[CallFrame], runtime.StackTrace | None, runtime.StackTraceId | None]]:
     """
     Restarts particular call frame from the beginning. The old, deprecated
     behavior of ``restartFrame`` is to stay paused and allow further CDP commands
@@ -706,8 +707,8 @@ def restart_frame(
 
 
 def resume(
-    terminate_on_resume: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    terminate_on_resume: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Resumes JavaScript execution.
 
@@ -726,9 +727,9 @@ def resume(
 def search_in_content(
     script_id: runtime.ScriptId,
     query: str,
-    case_sensitive: typing.Optional[bool] = None,
-    is_regex: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[SearchMatch]]:
+    case_sensitive: bool | None = None,
+    is_regex: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[SearchMatch]]:
     """
     Searches for given string in script content.
 
@@ -755,7 +756,7 @@ def search_in_content(
 
 def set_async_call_stack_depth(
     max_depth: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables or disables async call stacks tracking.
 
@@ -771,8 +772,8 @@ def set_async_call_stack_depth(
 
 
 def set_blackbox_patterns(
-    patterns: typing.List[str],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    patterns: list[str],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Replace previous blackbox patterns with passed ones. Forces backend to skip stepping/pausing in
     scripts with url matching one of the patterns. VM will try to leave blackboxed script by
@@ -793,8 +794,8 @@ def set_blackbox_patterns(
 
 def set_blackboxed_ranges(
     script_id: runtime.ScriptId,
-    positions: typing.List[ScriptPosition],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    positions: list[ScriptPosition],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Makes backend skip steps in the script in blackboxed ranges. VM will try leave blacklisted
     scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful.
@@ -818,8 +819,8 @@ def set_blackboxed_ranges(
 
 def set_breakpoint(
     location: Location,
-    condition: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[BreakpointId, Location]]:
+    condition: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[BreakpointId, Location]]:
     """
     Sets JavaScript breakpoint at a given location.
 
@@ -847,7 +848,7 @@ def set_breakpoint(
 
 def set_instrumentation_breakpoint(
     instrumentation: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, BreakpointId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, BreakpointId]:
     """
     Sets instrumentation breakpoint.
 
@@ -866,12 +867,12 @@ def set_instrumentation_breakpoint(
 
 def set_breakpoint_by_url(
     line_number: int,
-    url: typing.Optional[str] = None,
-    url_regex: typing.Optional[str] = None,
-    script_hash: typing.Optional[str] = None,
-    column_number: typing.Optional[int] = None,
-    condition: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[BreakpointId, typing.List[Location]]]:
+    url: str | None = None,
+    url_regex: str | None = None,
+    script_hash: str | None = None,
+    column_number: int | None = None,
+    condition: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[BreakpointId, list[Location]]]:
     """
     Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this
     command is issued, all existing parsed scripts will have breakpoints resolved and returned in
@@ -914,8 +915,8 @@ def set_breakpoint_by_url(
 
 def set_breakpoint_on_function_call(
     object_id: runtime.RemoteObjectId,
-    condition: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, BreakpointId]:
+    condition: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, BreakpointId]:
     """
     Sets JavaScript breakpoint before each call to the given function.
     If another function was created from the same source as a given one,
@@ -941,7 +942,7 @@ def set_breakpoint_on_function_call(
 
 def set_breakpoints_active(
     active: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Activates / deactivates all breakpoints on the page.
 
@@ -958,7 +959,7 @@ def set_breakpoints_active(
 
 def set_pause_on_exceptions(
     state: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions,
     or caught exceptions, no exceptions. Initial pause on exceptions state is ``none``.
@@ -976,7 +977,7 @@ def set_pause_on_exceptions(
 
 def set_return_value(
     new_value: runtime.CallArgument,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Changes return value in top frame. Available only at return break position.
 
@@ -996,9 +997,9 @@ def set_return_value(
 def set_script_source(
     script_id: runtime.ScriptId,
     script_source: str,
-    dry_run: typing.Optional[bool] = None,
-    allow_top_frame_editing: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.Optional[typing.List[CallFrame]], typing.Optional[bool], typing.Optional[runtime.StackTrace], typing.Optional[runtime.StackTraceId], str, typing.Optional[runtime.ExceptionDetails]]]:
+    dry_run: bool | None = None,
+    allow_top_frame_editing: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[list[CallFrame] | None, bool | None, runtime.StackTrace | None, runtime.StackTraceId | None, str, runtime.ExceptionDetails | None]]:
     """
     Edits JavaScript source live.
 
@@ -1045,7 +1046,7 @@ def set_script_source(
 
 def set_skip_all_pauses(
     skip: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Makes page not interrupt on any pauses (breakpoint, exception, dom exception etc).
 
@@ -1065,7 +1066,7 @@ def set_variable_value(
     variable_name: str,
     new_value: runtime.CallArgument,
     call_frame_id: CallFrameId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Changes value of variable in a callframe. Object-based scopes are not supported and must be
     mutated manually.
@@ -1088,9 +1089,9 @@ def set_variable_value(
 
 
 def step_into(
-    break_on_async_call: typing.Optional[bool] = None,
-    skip_list: typing.Optional[typing.List[LocationRange]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    break_on_async_call: bool | None = None,
+    skip_list: list[LocationRange] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Steps into the function call.
 
@@ -1109,7 +1110,7 @@ def step_into(
     yield cmd_dict
 
 
-def step_out() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def step_out() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Steps out of the function call.
     """
@@ -1120,8 +1121,8 @@ def step_out() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 
 def step_over(
-    skip_list: typing.Optional[typing.List[LocationRange]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    skip_list: list[LocationRange] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Steps over the statement.
 
@@ -1163,19 +1164,19 @@ class Paused:
     Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria.
     """
     #: Call stack the virtual machine stopped on.
-    call_frames: typing.List[CallFrame]
+    call_frames: list[CallFrame]
     #: Pause reason.
     reason: str
     #: Object containing break-specific auxiliary properties.
-    data: typing.Optional[dict]
+    data: dict | None
     #: Hit breakpoints IDs
-    hit_breakpoints: typing.Optional[typing.List[str]]
+    hit_breakpoints: list[str] | None
     #: Async stack trace, if any.
-    async_stack_trace: typing.Optional[runtime.StackTrace]
+    async_stack_trace: runtime.StackTrace | None
     #: Async stack trace, if any.
-    async_stack_trace_id: typing.Optional[runtime.StackTraceId]
+    async_stack_trace_id: runtime.StackTraceId | None
     #: Never present, will be removed.
-    async_call_stack_trace_id: typing.Optional[runtime.StackTraceId]
+    async_call_stack_trace_id: runtime.StackTraceId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> Paused:
@@ -1228,23 +1229,23 @@ class ScriptFailedToParse:
     #: Content hash of the script, SHA-256.
     hash_: str
     #: Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'``'isolated'``'worker', frameId: string}
-    execution_context_aux_data: typing.Optional[dict]
+    execution_context_aux_data: dict | None
     #: URL of source map associated with script (if any).
-    source_map_url: typing.Optional[str]
+    source_map_url: str | None
     #: True, if this script has sourceURL.
-    has_source_url: typing.Optional[bool]
+    has_source_url: bool | None
     #: True, if this script is ES6 module.
-    is_module: typing.Optional[bool]
+    is_module: bool | None
     #: This script length.
-    length: typing.Optional[int]
+    length: int | None
     #: JavaScript top stack frame of where the script parsed event was triggered if available.
-    stack_trace: typing.Optional[runtime.StackTrace]
+    stack_trace: runtime.StackTrace | None
     #: If the scriptLanguage is WebAssembly, the code section offset in the module.
-    code_offset: typing.Optional[int]
+    code_offset: int | None
     #: The language of the script.
-    script_language: typing.Optional[ScriptLanguage]
+    script_language: ScriptLanguage | None
     #: The name the embedder supplied for this script.
-    embedder_name: typing.Optional[str]
+    embedder_name: str | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ScriptFailedToParse:
@@ -1293,27 +1294,27 @@ class ScriptParsed:
     #: Content hash of the script, SHA-256.
     hash_: str
     #: Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'``'isolated'``'worker', frameId: string}
-    execution_context_aux_data: typing.Optional[dict]
+    execution_context_aux_data: dict | None
     #: True, if this script is generated as a result of the live edit operation.
-    is_live_edit: typing.Optional[bool]
+    is_live_edit: bool | None
     #: URL of source map associated with script (if any).
-    source_map_url: typing.Optional[str]
+    source_map_url: str | None
     #: True, if this script has sourceURL.
-    has_source_url: typing.Optional[bool]
+    has_source_url: bool | None
     #: True, if this script is ES6 module.
-    is_module: typing.Optional[bool]
+    is_module: bool | None
     #: This script length.
-    length: typing.Optional[int]
+    length: int | None
     #: JavaScript top stack frame of where the script parsed event was triggered if available.
-    stack_trace: typing.Optional[runtime.StackTrace]
+    stack_trace: runtime.StackTrace | None
     #: If the scriptLanguage is WebAssembly, the code section offset in the module.
-    code_offset: typing.Optional[int]
+    code_offset: int | None
     #: The language of the script.
-    script_language: typing.Optional[ScriptLanguage]
+    script_language: ScriptLanguage | None
     #: If the scriptLanguage is WebAssembly, the source of debug symbols for the module.
-    debug_symbols: typing.Optional[typing.List[DebugSymbols]]
+    debug_symbols: list[DebugSymbols] | None
     #: The name the embedder supplied for this script.
-    embedder_name: typing.Optional[str]
+    embedder_name: str | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ScriptParsed:

--- a/src/streamlink/webbrowser/cdp/devtools/dom.py
+++ b/src/streamlink/webbrowser/cdp/devtools/dom.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.page as page
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
@@ -233,82 +234,82 @@ class Node:
     node_value: str
 
     #: The id of the parent node if any.
-    parent_id: typing.Optional[NodeId] = None
+    parent_id: NodeId | None = None
 
     #: Child count for ``Container`` nodes.
-    child_node_count: typing.Optional[int] = None
+    child_node_count: int | None = None
 
     #: Child nodes of this node when requested with children.
-    children: typing.Optional[typing.List[Node]] = None
+    children: list[Node] | None = None
 
     #: Attributes of the ``Element`` node in the form of flat array ``[name1, value1, name2, value2]``.
-    attributes: typing.Optional[typing.List[str]] = None
+    attributes: list[str] | None = None
 
     #: Document URL that ``Document`` or ``FrameOwner`` node points to.
-    document_url: typing.Optional[str] = None
+    document_url: str | None = None
 
     #: Base URL that ``Document`` or ``FrameOwner`` node uses for URL completion.
-    base_url: typing.Optional[str] = None
+    base_url: str | None = None
 
     #: ``DocumentType``'s publicId.
-    public_id: typing.Optional[str] = None
+    public_id: str | None = None
 
     #: ``DocumentType``'s systemId.
-    system_id: typing.Optional[str] = None
+    system_id: str | None = None
 
     #: ``DocumentType``'s internalSubset.
-    internal_subset: typing.Optional[str] = None
+    internal_subset: str | None = None
 
     #: ``Document``'s XML version in case of XML documents.
-    xml_version: typing.Optional[str] = None
+    xml_version: str | None = None
 
     #: ``Attr``'s name.
-    name: typing.Optional[str] = None
+    name: str | None = None
 
     #: ``Attr``'s value.
-    value: typing.Optional[str] = None
+    value: str | None = None
 
     #: Pseudo element type for this node.
-    pseudo_type: typing.Optional[PseudoType] = None
+    pseudo_type: PseudoType | None = None
 
     #: Pseudo element identifier for this node. Only present if there is a
     #: valid pseudoType.
-    pseudo_identifier: typing.Optional[str] = None
+    pseudo_identifier: str | None = None
 
     #: Shadow root type.
-    shadow_root_type: typing.Optional[ShadowRootType] = None
+    shadow_root_type: ShadowRootType | None = None
 
     #: Frame ID for frame owner elements.
-    frame_id: typing.Optional[page.FrameId] = None
+    frame_id: page.FrameId | None = None
 
     #: Content document for frame owner elements.
-    content_document: typing.Optional[Node] = None
+    content_document: Node | None = None
 
     #: Shadow root list for given element host.
-    shadow_roots: typing.Optional[typing.List[Node]] = None
+    shadow_roots: list[Node] | None = None
 
     #: Content document fragment for template elements.
-    template_content: typing.Optional[Node] = None
+    template_content: Node | None = None
 
     #: Pseudo elements associated with this node.
-    pseudo_elements: typing.Optional[typing.List[Node]] = None
+    pseudo_elements: list[Node] | None = None
 
     #: Deprecated, as the HTML Imports API has been removed (crbug.com/937746).
     #: This property used to return the imported document for the HTMLImport links.
     #: The property is always undefined now.
-    imported_document: typing.Optional[Node] = None
+    imported_document: Node | None = None
 
     #: Distributed nodes for given insertion point.
-    distributed_nodes: typing.Optional[typing.List[BackendNode]] = None
+    distributed_nodes: list[BackendNode] | None = None
 
     #: Whether the node is SVG.
-    is_svg: typing.Optional[bool] = None
+    is_svg: bool | None = None
 
-    compatibility_mode: typing.Optional[CompatibilityMode] = None
+    compatibility_mode: CompatibilityMode | None = None
 
-    assigned_slot: typing.Optional[BackendNode] = None
+    assigned_slot: BackendNode | None = None
 
-    is_scrollable: typing.Optional[bool] = None
+    is_scrollable: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -417,7 +418,7 @@ class DetachedElementInfo:
     """
     tree_node: Node
 
-    retained_node_ids: typing.List[NodeId]
+    retained_node_ids: list[NodeId]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -448,7 +449,7 @@ class RGBA:
     b: int
 
     #: The alpha component, in the [0-1] range (default: 1).
-    a: typing.Optional[float] = None
+    a: float | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -473,11 +474,11 @@ class Quad(list):
     """
     An array of quad vertices, x immediately followed by y for each point, points clock-wise.
     """
-    def to_json(self) -> typing.List[float]:
+    def to_json(self) -> list[float]:
         return self
 
     @classmethod
-    def from_json(cls, json: typing.List[float]) -> Quad:
+    def from_json(cls, json: list[float]) -> Quad:
         return cls(json)
 
     def __repr__(self):
@@ -508,7 +509,7 @@ class BoxModel:
     height: int
 
     #: Shape outside coordinates
-    shape_outside: typing.Optional[ShapeOutsideInfo] = None
+    shape_outside: ShapeOutsideInfo | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -544,10 +545,10 @@ class ShapeOutsideInfo:
     bounds: Quad
 
     #: Shape coordinate details
-    shape: typing.List[typing.Any]
+    shape: list[Any]
 
     #: Margin shape bounds
-    margin_shape: typing.List[typing.Any]
+    margin_shape: list[Any]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -624,7 +625,7 @@ class CSSComputedStyleProperty:
 
 def collect_class_names_from_subtree(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[str]]:
     """
     Collects class names for the node with given id and all of it's child nodes.
 
@@ -646,8 +647,8 @@ def collect_class_names_from_subtree(
 def copy_to(
     node_id: NodeId,
     target_node_id: NodeId,
-    insert_before_node_id: typing.Optional[NodeId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+    insert_before_node_id: NodeId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Creates a deep copy of the specified node and places it into the target container before the
     given anchor.
@@ -673,12 +674,12 @@ def copy_to(
 
 
 def describe_node(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-    depth: typing.Optional[int] = None,
-    pierce: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, Node]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+    depth: int | None = None,
+    pierce: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, Node]:
     """
     Describes node given its id, does not require domain to be enabled. Does not start tracking any
     objects, can be used for automation.
@@ -710,11 +711,11 @@ def describe_node(
 
 
 def scroll_into_view_if_needed(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-    rect: typing.Optional[Rect] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+    rect: Rect | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Scrolls the specified rect of the given node into view if not already visible.
     Note: exactly one between nodeId, backendNodeId and objectId should be passed
@@ -741,7 +742,7 @@ def scroll_into_view_if_needed(
     yield cmd_dict
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables DOM agent for the given page.
     """
@@ -753,7 +754,7 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def discard_search_results(
     search_id: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Discards search results from the session with the given id. ``getSearchResults`` should no longer
     be called for that search.
@@ -772,8 +773,8 @@ def discard_search_results(
 
 
 def enable(
-    include_whitespace: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    include_whitespace: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables DOM agent for the given page.
 
@@ -790,10 +791,10 @@ def enable(
 
 
 def focus(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Focuses the given element.
 
@@ -817,7 +818,7 @@ def focus(
 
 def get_attributes(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[str]]:
     """
     Returns attributes for the specified node.
 
@@ -835,10 +836,10 @@ def get_attributes(
 
 
 def get_box_model(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, BoxModel]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, BoxModel]:
     """
     Returns boxes for the given node.
 
@@ -863,10 +864,10 @@ def get_box_model(
 
 
 def get_content_quads(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[Quad]]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[Quad]]:
     """
     Returns quads that describe node position on the page. This method
     might return multiple quads for inline nodes.
@@ -894,9 +895,9 @@ def get_content_quads(
 
 
 def get_document(
-    depth: typing.Optional[int] = None,
-    pierce: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, Node]:
+    depth: int | None = None,
+    pierce: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, Node]:
     """
     Returns the root DOM node (and optionally the subtree) to the caller.
     Implicitly enables the DOM domain events for the current target.
@@ -919,9 +920,9 @@ def get_document(
 
 
 def get_flattened_document(
-    depth: typing.Optional[int] = None,
-    pierce: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[Node]]:
+    depth: int | None = None,
+    pierce: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[Node]]:
     """
     Returns the root DOM node (and optionally the subtree) to the caller.
     Deprecated, as it is not designed to work well with the rest of the DOM agent.
@@ -946,9 +947,9 @@ def get_flattened_document(
 
 def get_nodes_for_subtree_by_style(
     node_id: NodeId,
-    computed_styles: typing.List[CSSComputedStyleProperty],
-    pierce: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]:
+    computed_styles: list[CSSComputedStyleProperty],
+    pierce: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[NodeId]]:
     """
     Finds nodes with a given computed style in a subtree.
 
@@ -975,9 +976,9 @@ def get_nodes_for_subtree_by_style(
 def get_node_for_location(
     x: int,
     y: int,
-    include_user_agent_shadow_dom: typing.Optional[bool] = None,
-    ignore_pointer_events_none: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[BackendNodeId, page.FrameId, typing.Optional[NodeId]]]:
+    include_user_agent_shadow_dom: bool | None = None,
+    ignore_pointer_events_none: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[BackendNodeId, page.FrameId, NodeId | None]]:
     """
     Returns node id at given location. Depending on whether DOM domain is enabled, nodeId is
     either returned or not.
@@ -1012,10 +1013,10 @@ def get_node_for_location(
 
 
 def get_outer_html(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Returns node's HTML markup.
 
@@ -1041,7 +1042,7 @@ def get_outer_html(
 
 def get_relayout_boundary(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Returns the id of the nearest ancestor that is a relayout boundary.
 
@@ -1064,7 +1065,7 @@ def get_search_results(
     search_id: str,
     from_index: int,
     to_index: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[NodeId]]:
     """
     Returns search results from given ``fromIndex`` to given ``toIndex`` from the search with the given
     identifier.
@@ -1088,7 +1089,7 @@ def get_search_results(
     return [NodeId.from_json(i) for i in json["nodeIds"]]
 
 
-def hide_highlight() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def hide_highlight() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Hides any highlight.
     """
@@ -1098,7 +1099,7 @@ def hide_highlight() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def highlight_node() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def highlight_node() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Highlights DOM node.
     """
@@ -1108,7 +1109,7 @@ def highlight_node() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def highlight_rect() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def highlight_rect() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Highlights given rectangle.
     """
@@ -1118,7 +1119,7 @@ def highlight_rect() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def mark_undoable_state() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def mark_undoable_state() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Marks last undoable state.
 
@@ -1133,8 +1134,8 @@ def mark_undoable_state() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 def move_to(
     node_id: NodeId,
     target_node_id: NodeId,
-    insert_before_node_id: typing.Optional[NodeId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+    insert_before_node_id: NodeId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Moves node into the new container, places it before the given anchor.
 
@@ -1158,8 +1159,8 @@ def move_to(
 
 def perform_search(
     query: str,
-    include_user_agent_shadow_dom: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, int]]:
+    include_user_agent_shadow_dom: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, int]]:
     """
     Searches for a given string in the DOM tree. Use ``getSearchResults`` to access search results or
     ``cancelSearch`` to end this search session.
@@ -1190,7 +1191,7 @@ def perform_search(
 
 def push_node_by_path_to_frontend(
     path: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Requests that the node is sent to the caller given its path. // FIXME, use XPath
 
@@ -1210,8 +1211,8 @@ def push_node_by_path_to_frontend(
 
 
 def push_nodes_by_backend_ids_to_frontend(
-    backend_node_ids: typing.List[BackendNodeId],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]:
+    backend_node_ids: list[BackendNodeId],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[NodeId]]:
     """
     Requests that a batch of nodes is sent to the caller given their backend node ids.
 
@@ -1233,7 +1234,7 @@ def push_nodes_by_backend_ids_to_frontend(
 def query_selector(
     node_id: NodeId,
     selector: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Executes ``querySelector`` on a given node.
 
@@ -1255,7 +1256,7 @@ def query_selector(
 def query_selector_all(
     node_id: NodeId,
     selector: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[NodeId]]:
     """
     Executes ``querySelectorAll`` on a given node.
 
@@ -1274,7 +1275,7 @@ def query_selector_all(
     return [NodeId.from_json(i) for i in json["nodeIds"]]
 
 
-def get_top_layer_elements() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]:
+def get_top_layer_elements() -> Generator[T_JSON_DICT, T_JSON_DICT, list[NodeId]]:
     """
     Returns NodeIds of current top layer elements.
     Top layer is rendered closest to the user within a viewport, therefore its elements always
@@ -1294,7 +1295,7 @@ def get_top_layer_elements() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typin
 def get_element_by_relation(
     node_id: NodeId,
     relation: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Returns the NodeId of the matched element according to certain relations.
 
@@ -1315,7 +1316,7 @@ def get_element_by_relation(
     return NodeId.from_json(json["nodeId"])
 
 
-def redo() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def redo() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Re-does the last undone action.
 
@@ -1330,7 +1331,7 @@ def redo() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 def remove_attribute(
     node_id: NodeId,
     name: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Removes attribute with given name from an element with given id.
 
@@ -1349,7 +1350,7 @@ def remove_attribute(
 
 def remove_node(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Removes node with given id.
 
@@ -1366,9 +1367,9 @@ def remove_node(
 
 def request_child_nodes(
     node_id: NodeId,
-    depth: typing.Optional[int] = None,
-    pierce: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    depth: int | None = None,
+    pierce: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Requests that children of the node with given id are returned to the caller in form of
     ``setChildNodes`` events where not only immediate children are retrieved, but all children down to
@@ -1393,7 +1394,7 @@ def request_child_nodes(
 
 def request_node(
     object_id: runtime.RemoteObjectId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Requests that the node is sent to the caller given the JavaScript node object reference. All
     nodes that form the path from the node to the root are also sent to the client as a series of
@@ -1413,11 +1414,11 @@ def request_node(
 
 
 def resolve_node(
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_group: typing.Optional[str] = None,
-    execution_context_id: typing.Optional[runtime.ExecutionContextId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, runtime.RemoteObject]:
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_group: str | None = None,
+    execution_context_id: runtime.ExecutionContextId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, runtime.RemoteObject]:
     """
     Resolves the JavaScript node object for a given NodeId or BackendNodeId.
 
@@ -1448,7 +1449,7 @@ def set_attribute_value(
     node_id: NodeId,
     name: str,
     value: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets attribute for an element with given id.
 
@@ -1470,8 +1471,8 @@ def set_attribute_value(
 def set_attributes_as_text(
     node_id: NodeId,
     text: str,
-    name: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    name: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets attributes on element with given id. This method is useful when user edits some existing
     attribute value and types in several attribute name/value pairs.
@@ -1493,11 +1494,11 @@ def set_attributes_as_text(
 
 
 def set_file_input_files(
-    files: typing.List[str],
-    node_id: typing.Optional[NodeId] = None,
-    backend_node_id: typing.Optional[BackendNodeId] = None,
-    object_id: typing.Optional[runtime.RemoteObjectId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    files: list[str],
+    node_id: NodeId | None = None,
+    backend_node_id: BackendNodeId | None = None,
+    object_id: runtime.RemoteObjectId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets files for the given file input element.
 
@@ -1523,7 +1524,7 @@ def set_file_input_files(
 
 def set_node_stack_traces_enabled(
     enable: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets if stack traces should be captured for Nodes. See ``Node.getNodeStackTraces``. Default is disabled.
 
@@ -1542,7 +1543,7 @@ def set_node_stack_traces_enabled(
 
 def get_node_stack_traces(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Optional[runtime.StackTrace]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, runtime.StackTrace | None]:
     """
     Gets stack traces associated with a Node. As of now, only provides stack trace for Node creation.
 
@@ -1563,7 +1564,7 @@ def get_node_stack_traces(
 
 def get_file_info(
     object_id: runtime.RemoteObjectId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Returns file information for the given
     File wrapper.
@@ -1583,7 +1584,7 @@ def get_file_info(
     return str(json["path"])
 
 
-def get_detached_dom_nodes() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[DetachedElementInfo]]:
+def get_detached_dom_nodes() -> Generator[T_JSON_DICT, T_JSON_DICT, list[DetachedElementInfo]]:
     """
     Returns list of detached nodes
 
@@ -1600,7 +1601,7 @@ def get_detached_dom_nodes() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typin
 
 def set_inspected_node(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables console to refer to the node with given id via $x (see Command Line API for more details
     $x functions).
@@ -1621,7 +1622,7 @@ def set_inspected_node(
 def set_node_name(
     node_id: NodeId,
     name: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Sets node name for a node with given id.
 
@@ -1643,7 +1644,7 @@ def set_node_name(
 def set_node_value(
     node_id: NodeId,
     value: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets node value for a node with given id.
 
@@ -1663,7 +1664,7 @@ def set_node_value(
 def set_outer_html(
     node_id: NodeId,
     outer_html: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets node HTML markup, returns new node id.
 
@@ -1680,7 +1681,7 @@ def set_outer_html(
     yield cmd_dict
 
 
-def undo() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def undo() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Undoes the last performed action.
 
@@ -1694,7 +1695,7 @@ def undo() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def get_frame_owner(
     frame_id: page.FrameId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[BackendNodeId, typing.Optional[NodeId]]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[BackendNodeId, NodeId | None]]:
     """
     Returns iframe node that owns iframe with the given domain.
 
@@ -1721,10 +1722,10 @@ def get_frame_owner(
 
 def get_container_for_node(
     node_id: NodeId,
-    container_name: typing.Optional[str] = None,
-    physical_axes: typing.Optional[PhysicalAxes] = None,
-    logical_axes: typing.Optional[LogicalAxes] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Optional[NodeId]]:
+    container_name: str | None = None,
+    physical_axes: PhysicalAxes | None = None,
+    logical_axes: LogicalAxes | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId | None]:
     """
     Returns the query container of the given node based on container query
     conditions: containerName, physical, and logical axes. If no axes are
@@ -1757,7 +1758,7 @@ def get_container_for_node(
 
 def get_querying_descendants_for_container(
     node_id: NodeId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[NodeId]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[NodeId]]:
     """
     Returns the descendants of a container query container that have
     container queries against this container.
@@ -1779,8 +1780,8 @@ def get_querying_descendants_for_container(
 
 def get_anchor_element(
     node_id: NodeId,
-    anchor_specifier: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
+    anchor_specifier: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, NodeId]:
     """
     Returns the target anchor element of the given anchor query according to
     https://www.w3.org/TR/css-anchor-position-1/#target.
@@ -1934,7 +1935,7 @@ class DistributedNodesUpdated:
     #: Insertion point where distributed nodes were updated.
     insertion_point_id: NodeId
     #: Distributed nodes for given insertion point.
-    distributed_nodes: typing.List[BackendNode]
+    distributed_nodes: list[BackendNode]
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> DistributedNodesUpdated:
@@ -1968,7 +1969,7 @@ class InlineStyleInvalidated:
     Fired when ``Element``'s inline style is modified via a CSS property modification.
     """
     #: Ids of the nodes for which the inline styles have been invalidated.
-    node_ids: typing.List[NodeId]
+    node_ids: list[NodeId]
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> InlineStyleInvalidated:
@@ -2067,7 +2068,7 @@ class SetChildNodes:
     #: Parent node id to populate with children.
     parent_id: NodeId
     #: Child nodes array.
-    nodes: typing.List[Node]
+    nodes: list[Node]
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> SetChildNodes:

--- a/src/streamlink/webbrowser/cdp/devtools/emulation.py
+++ b/src/streamlink/webbrowser/cdp/devtools/emulation.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.dom as dom
 import streamlink.webbrowser.cdp.devtools.network as network
@@ -169,16 +170,16 @@ class UserAgentMetadata:
     mobile: bool
 
     #: Brands appearing in Sec-CH-UA.
-    brands: typing.Optional[typing.List[UserAgentBrandVersion]] = None
+    brands: list[UserAgentBrandVersion] | None = None
 
     #: Brands appearing in Sec-CH-UA-Full-Version-List.
-    full_version_list: typing.Optional[typing.List[UserAgentBrandVersion]] = None
+    full_version_list: list[UserAgentBrandVersion] | None = None
 
-    full_version: typing.Optional[str] = None
+    full_version: str | None = None
 
-    bitness: typing.Optional[str] = None
+    bitness: str | None = None
 
-    wow64: typing.Optional[bool] = None
+    wow64: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -239,11 +240,11 @@ class SensorType(enum.Enum):
 
 @dataclass
 class SensorMetadata:
-    available: typing.Optional[bool] = None
+    available: bool | None = None
 
-    minimum_frequency: typing.Optional[float] = None
+    minimum_frequency: float | None = None
 
-    maximum_frequency: typing.Optional[float] = None
+    maximum_frequency: float | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -334,11 +335,11 @@ class SensorReadingQuaternion:
 
 @dataclass
 class SensorReading:
-    single: typing.Optional[SensorReadingSingle] = None
+    single: SensorReadingSingle | None = None
 
-    xyz: typing.Optional[SensorReadingXYZ] = None
+    xyz: SensorReadingXYZ | None = None
 
-    quaternion: typing.Optional[SensorReadingQuaternion] = None
+    quaternion: SensorReadingQuaternion | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -386,7 +387,7 @@ class PressureState(enum.Enum):
 
 @dataclass
 class PressureMetadata:
-    available: typing.Optional[bool] = None
+    available: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -416,7 +417,7 @@ class DisabledImageType(enum.Enum):
         return cls(json)
 
 
-def can_emulate() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
+def can_emulate() -> Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     """
     Tells whether emulation is supported.
 
@@ -429,7 +430,7 @@ def can_emulate() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     return bool(json["result"])
 
 
-def clear_device_metrics_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_device_metrics_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears the overridden device metrics.
     """
@@ -439,7 +440,7 @@ def clear_device_metrics_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT
     yield cmd_dict
 
 
-def clear_geolocation_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_geolocation_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears the overridden Geolocation Position and Error.
     """
@@ -449,7 +450,7 @@ def clear_geolocation_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, N
     yield cmd_dict
 
 
-def reset_page_scale_factor() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def reset_page_scale_factor() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Requests that page scale factor is reset to initial values.
 
@@ -463,7 +464,7 @@ def reset_page_scale_factor() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None
 
 def set_focus_emulation_enabled(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables or disables simulating a focused and active page.
 
@@ -481,8 +482,8 @@ def set_focus_emulation_enabled(
 
 
 def set_auto_dark_mode_override(
-    enabled: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    enabled: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Automatically render all web contents using a dark theme.
 
@@ -502,7 +503,7 @@ def set_auto_dark_mode_override(
 
 def set_cpu_throttling_rate(
     rate: float,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables CPU throttling to emulate slow CPUs.
 
@@ -518,8 +519,8 @@ def set_cpu_throttling_rate(
 
 
 def set_default_background_color_override(
-    color: typing.Optional[dom.RGBA] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    color: dom.RGBA | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets or clears an override of the default background color of the frame. This override is used
     if the content does not specify one.
@@ -541,17 +542,17 @@ def set_device_metrics_override(
     height: int,
     device_scale_factor: float,
     mobile: bool,
-    scale: typing.Optional[float] = None,
-    screen_width: typing.Optional[int] = None,
-    screen_height: typing.Optional[int] = None,
-    position_x: typing.Optional[int] = None,
-    position_y: typing.Optional[int] = None,
-    dont_set_visible_size: typing.Optional[bool] = None,
-    screen_orientation: typing.Optional[ScreenOrientation] = None,
-    viewport: typing.Optional[page.Viewport] = None,
-    display_feature: typing.Optional[DisplayFeature] = None,
-    device_posture: typing.Optional[DevicePosture] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    scale: float | None = None,
+    screen_width: int | None = None,
+    screen_height: int | None = None,
+    position_x: int | None = None,
+    position_y: int | None = None,
+    dont_set_visible_size: bool | None = None,
+    screen_orientation: ScreenOrientation | None = None,
+    viewport: page.Viewport | None = None,
+    display_feature: DisplayFeature | None = None,
+    device_posture: DevicePosture | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides the values of device screen dimensions (window.screen.width, window.screen.height,
     window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media
@@ -606,7 +607,7 @@ def set_device_metrics_override(
 
 def set_device_posture_override(
     posture: DevicePosture,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Start reporting the given posture value to the Device Posture API.
     This override can also be set in setDeviceMetricsOverride().
@@ -624,7 +625,7 @@ def set_device_posture_override(
     yield cmd_dict
 
 
-def clear_device_posture_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_device_posture_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears a device posture override set with either setDeviceMetricsOverride()
     or setDevicePostureOverride() and starts using posture information from the
@@ -641,7 +642,7 @@ def clear_device_posture_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT
 
 def set_scrollbars_hidden(
     hidden: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -660,7 +661,7 @@ def set_scrollbars_hidden(
 
 def set_document_cookie_disabled(
     disabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -679,8 +680,8 @@ def set_document_cookie_disabled(
 
 def set_emit_touch_events_for_mouse(
     enabled: bool,
-    configuration: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    configuration: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -701,9 +702,9 @@ def set_emit_touch_events_for_mouse(
 
 
 def set_emulated_media(
-    media: typing.Optional[str] = None,
-    features: typing.Optional[typing.List[MediaFeature]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    media: str | None = None,
+    features: list[MediaFeature] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Emulates the given media type or media feature for CSS media queries.
 
@@ -724,7 +725,7 @@ def set_emulated_media(
 
 def set_emulated_vision_deficiency(
     type_: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Emulates the given vision deficiency.
 
@@ -740,10 +741,10 @@ def set_emulated_vision_deficiency(
 
 
 def set_geolocation_override(
-    latitude: typing.Optional[float] = None,
-    longitude: typing.Optional[float] = None,
-    accuracy: typing.Optional[float] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    latitude: float | None = None,
+    longitude: float | None = None,
+    accuracy: float | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
     unavailable.
@@ -768,7 +769,7 @@ def set_geolocation_override(
 
 def get_overridden_sensor_information(
     type_: SensorType,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, float]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, float]:
     """
 
 
@@ -790,8 +791,8 @@ def get_overridden_sensor_information(
 def set_sensor_override_enabled(
     enabled: bool,
     type_: SensorType,
-    metadata: typing.Optional[SensorMetadata] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    metadata: SensorMetadata | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides a platform sensor of a given type. If ``enabled`` is true, calls to
     Sensor.start() will use a virtual sensor as backend rather than fetching
@@ -820,7 +821,7 @@ def set_sensor_override_enabled(
 def set_sensor_override_readings(
     type_: SensorType,
     reading: SensorReading,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Updates the sensor readings reported by a sensor type previously overridden
     by setSensorOverrideEnabled.
@@ -843,8 +844,8 @@ def set_sensor_override_readings(
 def set_pressure_source_override_enabled(
     enabled: bool,
     source: PressureSource,
-    metadata: typing.Optional[PressureMetadata] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    metadata: PressureMetadata | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides a pressure source of a given type, as used by the Compute
     Pressure API, so that updates to PressureObserver.observe() are provided
@@ -872,7 +873,7 @@ def set_pressure_source_override_enabled(
 def set_pressure_state_override(
     source: PressureSource,
     state: PressureState,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Provides a given pressure state that will be processed and eventually be
     delivered to PressureObserver users. ``source`` must have been previously
@@ -896,7 +897,7 @@ def set_pressure_state_override(
 def set_idle_override(
     is_user_active: bool,
     is_screen_unlocked: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides the Idle state.
 
@@ -913,7 +914,7 @@ def set_idle_override(
     yield cmd_dict
 
 
-def clear_idle_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_idle_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears Idle state overrides.
     """
@@ -925,7 +926,7 @@ def clear_idle_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def set_navigator_overrides(
     platform: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides value returned by the javascript navigator object.
 
@@ -944,7 +945,7 @@ def set_navigator_overrides(
 
 def set_page_scale_factor(
     page_scale_factor: float,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets a specified page scale factor.
 
@@ -963,7 +964,7 @@ def set_page_scale_factor(
 
 def set_script_execution_disabled(
     value: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Switches script execution in the page.
 
@@ -980,8 +981,8 @@ def set_script_execution_disabled(
 
 def set_touch_emulation_enabled(
     enabled: bool,
-    max_touch_points: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    max_touch_points: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables touch on platforms which do not support them.
 
@@ -1001,10 +1002,10 @@ def set_touch_emulation_enabled(
 
 def set_virtual_time_policy(
     policy: VirtualTimePolicy,
-    budget: typing.Optional[float] = None,
-    max_virtual_time_task_starvation_count: typing.Optional[int] = None,
-    initial_virtual_time: typing.Optional[network.TimeSinceEpoch] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, float]:
+    budget: float | None = None,
+    max_virtual_time_task_starvation_count: int | None = None,
+    initial_virtual_time: network.TimeSinceEpoch | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, float]:
     """
     Turns on virtual time for all frames (replacing real-time with a synthetic time source) and sets
     the current virtual time policy.  Note this supersedes any previous time budget.
@@ -1034,8 +1035,8 @@ def set_virtual_time_policy(
 
 
 def set_locale_override(
-    locale: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    locale: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides default host system locale with the specified one.
 
@@ -1055,7 +1056,7 @@ def set_locale_override(
 
 def set_timezone_override(
     timezone_id: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides default host system timezone with the specified one.
 
@@ -1073,7 +1074,7 @@ def set_timezone_override(
 def set_visible_size(
     width: int,
     height: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Resizes the frame/viewport of the page. Note that this does not affect the frame's container
     (e.g. browser window). Can be used to produce screenshots of the specified size. Not supported
@@ -1095,8 +1096,8 @@ def set_visible_size(
 
 
 def set_disabled_image_types(
-    image_types: typing.List[DisabledImageType],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    image_types: list[DisabledImageType],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -1115,7 +1116,7 @@ def set_disabled_image_types(
 
 def set_hardware_concurrency_override(
     hardware_concurrency: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -1134,10 +1135,10 @@ def set_hardware_concurrency_override(
 
 def set_user_agent_override(
     user_agent: str,
-    accept_language: typing.Optional[str] = None,
-    platform: typing.Optional[str] = None,
-    user_agent_metadata: typing.Optional[UserAgentMetadata] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    accept_language: str | None = None,
+    platform: str | None = None,
+    user_agent_metadata: UserAgentMetadata | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Allows overriding user agent with the given string.
     ``userAgentMetadata`` must be set for Client Hint headers to be sent.
@@ -1164,7 +1165,7 @@ def set_user_agent_override(
 
 def set_automation_override(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Allows overriding the automation flag.
 

--- a/src/streamlink/webbrowser/cdp/devtools/fetch.py
+++ b/src/streamlink/webbrowser/cdp/devtools/fetch.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.io as io
 import streamlink.webbrowser.cdp.devtools.network as network
@@ -54,13 +55,13 @@ class RequestStage(enum.Enum):
 class RequestPattern:
     #: Wildcards (``'*'`` -> zero or more, ``'?'`` -> exactly one) are allowed. Escape character is
     #: backslash. Omitting is equivalent to ``"*"``.
-    url_pattern: typing.Optional[str] = None
+    url_pattern: str | None = None
 
     #: If set, only requests for matching resource types will be intercepted.
-    resource_type: typing.Optional[network.ResourceType] = None
+    resource_type: network.ResourceType | None = None
 
     #: Stage at which to begin intercepting requests. Default is Request.
-    request_stage: typing.Optional[RequestStage] = None
+    request_stage: RequestStage | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -119,7 +120,7 @@ class AuthChallenge:
     realm: str
 
     #: Source of the authentication challenge.
-    source: typing.Optional[str] = None
+    source: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -152,11 +153,11 @@ class AuthChallengeResponse:
 
     #: The username to provide, possibly empty. Should only be set if response is
     #: ProvideCredentials.
-    username: typing.Optional[str] = None
+    username: str | None = None
 
     #: The password to provide, possibly empty. Should only be set if response is
     #: ProvideCredentials.
-    password: typing.Optional[str] = None
+    password: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -176,7 +177,7 @@ class AuthChallengeResponse:
         )
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables the fetch domain.
     """
@@ -187,9 +188,9 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 
 def enable(
-    patterns: typing.Optional[typing.List[RequestPattern]] = None,
-    handle_auth_requests: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    patterns: list[RequestPattern] | None = None,
+    handle_auth_requests: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables issuing of requestPaused events. A request will be paused until client
     calls one of failRequest, fulfillRequest or continueRequest/continueWithAuth.
@@ -212,7 +213,7 @@ def enable(
 def fail_request(
     request_id: RequestId,
     error_reason: network.ErrorReason,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Causes the request to fail with specified reason.
 
@@ -232,11 +233,11 @@ def fail_request(
 def fulfill_request(
     request_id: RequestId,
     response_code: int,
-    response_headers: typing.Optional[typing.List[HeaderEntry]] = None,
-    binary_response_headers: typing.Optional[str] = None,
-    body: typing.Optional[str] = None,
-    response_phrase: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    response_headers: list[HeaderEntry] | None = None,
+    binary_response_headers: str | None = None,
+    body: str | None = None,
+    response_phrase: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Provides response to the request.
 
@@ -267,12 +268,12 @@ def fulfill_request(
 
 def continue_request(
     request_id: RequestId,
-    url: typing.Optional[str] = None,
-    method: typing.Optional[str] = None,
-    post_data: typing.Optional[str] = None,
-    headers: typing.Optional[typing.List[HeaderEntry]] = None,
-    intercept_response: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    url: str | None = None,
+    method: str | None = None,
+    post_data: str | None = None,
+    headers: list[HeaderEntry] | None = None,
+    intercept_response: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Continues the request, optionally modifying some of its parameters.
 
@@ -305,7 +306,7 @@ def continue_request(
 def continue_with_auth(
     request_id: RequestId,
     auth_challenge_response: AuthChallengeResponse,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Continues a request supplying authChallengeResponse following authRequired event.
 
@@ -324,11 +325,11 @@ def continue_with_auth(
 
 def continue_response(
     request_id: RequestId,
-    response_code: typing.Optional[int] = None,
-    response_phrase: typing.Optional[str] = None,
-    response_headers: typing.Optional[typing.List[HeaderEntry]] = None,
-    binary_response_headers: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    response_code: int | None = None,
+    response_phrase: str | None = None,
+    response_headers: list[HeaderEntry] | None = None,
+    binary_response_headers: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Continues loading of the paused response, optionally modifying the
     response headers. If either responseCode or headers are modified, all of them
@@ -361,7 +362,7 @@ def continue_response(
 
 def get_response_body(
     request_id: RequestId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, bool]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, bool]]:
     """
     Causes the body of the response to be received from the server and
     returned as a single string. May only be issued for a request that
@@ -395,7 +396,7 @@ def get_response_body(
 
 def take_response_body_as_stream(
     request_id: RequestId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, io.StreamHandle]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, io.StreamHandle]:
     """
     Returns a handle to the stream representing the response body.
     The request must be paused in the HeadersReceived stage.
@@ -446,19 +447,19 @@ class RequestPaused:
     #: How the requested resource will be used.
     resource_type: network.ResourceType
     #: Response error if intercepted at response stage.
-    response_error_reason: typing.Optional[network.ErrorReason]
+    response_error_reason: network.ErrorReason | None
     #: Response code if intercepted at response stage.
-    response_status_code: typing.Optional[int]
+    response_status_code: int | None
     #: Response status text if intercepted at response stage.
-    response_status_text: typing.Optional[str]
+    response_status_text: str | None
     #: Response headers if intercepted at the response stage.
-    response_headers: typing.Optional[typing.List[HeaderEntry]]
+    response_headers: list[HeaderEntry] | None
     #: If the intercepted request had a corresponding Network.requestWillBeSent event fired for it,
     #: then this networkId will be the same as the requestId present in the requestWillBeSent event.
-    network_id: typing.Optional[network.RequestId]
+    network_id: network.RequestId | None
     #: If the request is due to a redirect response from the server, the id of the request that
     #: has caused the redirect.
-    redirected_request_id: typing.Optional[RequestId]
+    redirected_request_id: RequestId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> RequestPaused:

--- a/src/streamlink/webbrowser/cdp/devtools/input_.py
+++ b/src/streamlink/webbrowser/cdp/devtools/input_.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
@@ -25,31 +26,31 @@ class TouchPoint:
     y: float
 
     #: X radius of the touch area (default: 1.0).
-    radius_x: typing.Optional[float] = None
+    radius_x: float | None = None
 
     #: Y radius of the touch area (default: 1.0).
-    radius_y: typing.Optional[float] = None
+    radius_y: float | None = None
 
     #: Rotation angle (default: 0.0).
-    rotation_angle: typing.Optional[float] = None
+    rotation_angle: float | None = None
 
     #: Force (default: 1.0).
-    force: typing.Optional[float] = None
+    force: float | None = None
 
     #: The normalized tangential pressure, which has a range of [-1,1] (default: 0).
-    tangential_pressure: typing.Optional[float] = None
+    tangential_pressure: float | None = None
 
     #: The plane angle between the Y-Z plane and the plane containing both the stylus axis and the Y axis, in degrees of the range [-90,90], a positive tiltX is to the right (default: 0)
-    tilt_x: typing.Optional[float] = None
+    tilt_x: float | None = None
 
     #: The plane angle between the X-Z plane and the plane containing both the stylus axis and the X axis, in degrees of the range [-90,90], a positive tiltY is towards the user (default: 0).
-    tilt_y: typing.Optional[float] = None
+    tilt_y: float | None = None
 
     #: The clockwise rotation of a pen stylus around its own major axis, in degrees in the range [0,359] (default: 0).
-    twist: typing.Optional[int] = None
+    twist: int | None = None
 
     #: Identifier used to track touch sources between events, must be unique within an event.
-    id_: typing.Optional[float] = None
+    id_: float | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -146,11 +147,11 @@ class DragDataItem:
     data: str
 
     #: Title associated with a link. Only valid when ``mimeType`` == "text/uri-list".
-    title: typing.Optional[str] = None
+    title: str | None = None
 
     #: Stores the base URL for the contained markup. Only valid when ``mimeType``
     #: == "text/html".
-    base_url: typing.Optional[str] = None
+    base_url: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -174,13 +175,13 @@ class DragDataItem:
 
 @dataclass
 class DragData:
-    items: typing.List[DragDataItem]
+    items: list[DragDataItem]
 
     #: Bit field representing allowed drag operations. Copy = 1, Link = 2, Move = 16
     drag_operations_mask: int
 
     #: List of filenames that should be included when dropping
-    files: typing.Optional[typing.List[str]] = None
+    files: list[str] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -204,8 +205,8 @@ def dispatch_drag_event(
     x: float,
     y: float,
     data: DragData,
-    modifiers: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    modifiers: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Dispatches a drag event into the page.
 
@@ -233,21 +234,21 @@ def dispatch_drag_event(
 
 def dispatch_key_event(
     type_: str,
-    modifiers: typing.Optional[int] = None,
-    timestamp: typing.Optional[TimeSinceEpoch] = None,
-    text: typing.Optional[str] = None,
-    unmodified_text: typing.Optional[str] = None,
-    key_identifier: typing.Optional[str] = None,
-    code: typing.Optional[str] = None,
-    key: typing.Optional[str] = None,
-    windows_virtual_key_code: typing.Optional[int] = None,
-    native_virtual_key_code: typing.Optional[int] = None,
-    auto_repeat: typing.Optional[bool] = None,
-    is_keypad: typing.Optional[bool] = None,
-    is_system_key: typing.Optional[bool] = None,
-    location: typing.Optional[int] = None,
-    commands: typing.Optional[typing.List[str]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    modifiers: int | None = None,
+    timestamp: TimeSinceEpoch | None = None,
+    text: str | None = None,
+    unmodified_text: str | None = None,
+    key_identifier: str | None = None,
+    code: str | None = None,
+    key: str | None = None,
+    windows_virtual_key_code: int | None = None,
+    native_virtual_key_code: int | None = None,
+    auto_repeat: bool | None = None,
+    is_keypad: bool | None = None,
+    is_system_key: bool | None = None,
+    location: int | None = None,
+    commands: list[str] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Dispatches a key event to the page.
 
@@ -306,7 +307,7 @@ def dispatch_key_event(
 
 def insert_text(
     text: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     This method emulates inserting text that doesn't come from a key press,
     for example an emoji keyboard or an IME.
@@ -328,9 +329,9 @@ def ime_set_composition(
     text: str,
     selection_start: int,
     selection_end: int,
-    replacement_start: typing.Optional[int] = None,
-    replacement_end: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    replacement_start: int | None = None,
+    replacement_end: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     This method sets the current candidate text for IME.
     Use imeCommitComposition to commit the final text.
@@ -363,20 +364,20 @@ def dispatch_mouse_event(
     type_: str,
     x: float,
     y: float,
-    modifiers: typing.Optional[int] = None,
-    timestamp: typing.Optional[TimeSinceEpoch] = None,
-    button: typing.Optional[MouseButton] = None,
-    buttons: typing.Optional[int] = None,
-    click_count: typing.Optional[int] = None,
-    force: typing.Optional[float] = None,
-    tangential_pressure: typing.Optional[float] = None,
-    tilt_x: typing.Optional[float] = None,
-    tilt_y: typing.Optional[float] = None,
-    twist: typing.Optional[int] = None,
-    delta_x: typing.Optional[float] = None,
-    delta_y: typing.Optional[float] = None,
-    pointer_type: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    modifiers: int | None = None,
+    timestamp: TimeSinceEpoch | None = None,
+    button: MouseButton | None = None,
+    buttons: int | None = None,
+    click_count: int | None = None,
+    force: float | None = None,
+    tangential_pressure: float | None = None,
+    tilt_x: float | None = None,
+    tilt_y: float | None = None,
+    twist: int | None = None,
+    delta_x: float | None = None,
+    delta_y: float | None = None,
+    pointer_type: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Dispatches a mouse event to the page.
 
@@ -436,10 +437,10 @@ def dispatch_mouse_event(
 
 def dispatch_touch_event(
     type_: str,
-    touch_points: typing.List[TouchPoint],
-    modifiers: typing.Optional[int] = None,
-    timestamp: typing.Optional[TimeSinceEpoch] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    touch_points: list[TouchPoint],
+    modifiers: int | None = None,
+    timestamp: TimeSinceEpoch | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Dispatches a touch event to the page.
 
@@ -462,7 +463,7 @@ def dispatch_touch_event(
     yield cmd_dict
 
 
-def cancel_dragging() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def cancel_dragging() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Cancels any active dragging in the page.
     """
@@ -477,12 +478,12 @@ def emulate_touch_from_mouse_event(
     x: int,
     y: int,
     button: MouseButton,
-    timestamp: typing.Optional[TimeSinceEpoch] = None,
-    delta_x: typing.Optional[float] = None,
-    delta_y: typing.Optional[float] = None,
-    modifiers: typing.Optional[int] = None,
-    click_count: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    timestamp: TimeSinceEpoch | None = None,
+    delta_x: float | None = None,
+    delta_y: float | None = None,
+    modifiers: int | None = None,
+    click_count: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Emulates touch event from the mouse event parameters.
 
@@ -522,7 +523,7 @@ def emulate_touch_from_mouse_event(
 
 def set_ignore_input_events(
     ignore: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Ignores input events (useful while auditing page).
 
@@ -539,7 +540,7 @@ def set_ignore_input_events(
 
 def set_intercept_drags(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Prevents default drag and drop behavior and instead emits ``Input.dragIntercepted`` events.
     Drag and drop behavior can be directly controlled via ``Input.dispatchDragEvent``.
@@ -561,9 +562,9 @@ def synthesize_pinch_gesture(
     x: float,
     y: float,
     scale_factor: float,
-    relative_speed: typing.Optional[int] = None,
-    gesture_source_type: typing.Optional[GestureSourceType] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    relative_speed: int | None = None,
+    gesture_source_type: GestureSourceType | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Synthesizes a pinch gesture over a time period by issuing appropriate touch events.
 
@@ -593,17 +594,17 @@ def synthesize_pinch_gesture(
 def synthesize_scroll_gesture(
     x: float,
     y: float,
-    x_distance: typing.Optional[float] = None,
-    y_distance: typing.Optional[float] = None,
-    x_overscroll: typing.Optional[float] = None,
-    y_overscroll: typing.Optional[float] = None,
-    prevent_fling: typing.Optional[bool] = None,
-    speed: typing.Optional[int] = None,
-    gesture_source_type: typing.Optional[GestureSourceType] = None,
-    repeat_count: typing.Optional[int] = None,
-    repeat_delay_ms: typing.Optional[int] = None,
-    interaction_marker_name: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    x_distance: float | None = None,
+    y_distance: float | None = None,
+    x_overscroll: float | None = None,
+    y_overscroll: float | None = None,
+    prevent_fling: bool | None = None,
+    speed: int | None = None,
+    gesture_source_type: GestureSourceType | None = None,
+    repeat_count: int | None = None,
+    repeat_delay_ms: int | None = None,
+    interaction_marker_name: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Synthesizes a scroll gesture over a time period by issuing appropriate touch events.
 
@@ -655,10 +656,10 @@ def synthesize_scroll_gesture(
 def synthesize_tap_gesture(
     x: float,
     y: float,
-    duration: typing.Optional[int] = None,
-    tap_count: typing.Optional[int] = None,
-    gesture_source_type: typing.Optional[GestureSourceType] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    duration: int | None = None,
+    tap_count: int | None = None,
+    gesture_source_type: GestureSourceType | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Synthesizes a tap gesture over a time period by issuing appropriate touch events.
 

--- a/src/streamlink/webbrowser/cdp/devtools/inspector.py
+++ b/src/streamlink/webbrowser/cdp/devtools/inspector.py
@@ -9,13 +9,14 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables inspector domain notifications.
     """
@@ -25,7 +26,7 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def enable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables inspector domain notifications.
     """

--- a/src/streamlink/webbrowser/cdp/devtools/io.py
+++ b/src/streamlink/webbrowser/cdp/devtools/io.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.runtime as runtime
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
@@ -34,7 +35,7 @@ class StreamHandle(str):
 
 def close(
     handle: StreamHandle,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Close the stream, discard any temporary backing storage.
 
@@ -51,9 +52,9 @@ def close(
 
 def read(
     handle: StreamHandle,
-    offset: typing.Optional[int] = None,
-    size: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.Optional[bool], str, bool]]:
+    offset: int | None = None,
+    size: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[bool | None, str, bool]]:
     """
     Read a chunk of the stream
 
@@ -86,7 +87,7 @@ def read(
 
 def resolve_blob(
     object_id: runtime.RemoteObjectId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Return UUID of Blob object specified by a remote object id.
 

--- a/src/streamlink/webbrowser/cdp/devtools/network.py
+++ b/src/streamlink/webbrowser/cdp/devtools/network.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.debugger as debugger
 import streamlink.webbrowser.cdp.devtools.emulation as emulation
@@ -307,10 +308,10 @@ class ResourceTiming:
     receive_headers_end: float
 
     #: Started ServiceWorker static routing source evaluation.
-    worker_router_evaluation_start: typing.Optional[float] = None
+    worker_router_evaluation_start: float | None = None
 
     #: Started cache lookup when the source was evaluated to ``cache``.
-    worker_cache_lookup_start: typing.Optional[float] = None
+    worker_cache_lookup_start: float | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -389,7 +390,7 @@ class PostDataEntry:
     """
     Post data entry for HTTP request
     """
-    bytes_: typing.Optional[str] = None
+    bytes_: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -425,31 +426,31 @@ class Request:
     referrer_policy: str
 
     #: Fragment of the requested URL starting with hash, if present.
-    url_fragment: typing.Optional[str] = None
+    url_fragment: str | None = None
 
     #: HTTP POST request data.
     #: Use postDataEntries instead.
-    post_data: typing.Optional[str] = None
+    post_data: str | None = None
 
     #: True when the request has POST data. Note that postData might still be omitted when this flag is true when the data is too long.
-    has_post_data: typing.Optional[bool] = None
+    has_post_data: bool | None = None
 
     #: Request body elements (post data broken into individual entries).
-    post_data_entries: typing.Optional[typing.List[PostDataEntry]] = None
+    post_data_entries: list[PostDataEntry] | None = None
 
     #: The mixed content type of the request.
-    mixed_content_type: typing.Optional[security.MixedContentType] = None
+    mixed_content_type: security.MixedContentType | None = None
 
     #: Whether is loaded via link preload.
-    is_link_preload: typing.Optional[bool] = None
+    is_link_preload: bool | None = None
 
     #: Set for requests when the TrustToken API is used. Contains the parameters
     #: passed by the developer (e.g. via "fetch") as understood by the backend.
-    trust_token_params: typing.Optional[TrustTokenParams] = None
+    trust_token_params: TrustTokenParams | None = None
 
     #: True if this resource request is considered to be the 'same site' as the
     #: request corresponding to the main frame.
-    is_same_site: typing.Optional[bool] = None
+    is_same_site: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -572,7 +573,7 @@ class SecurityDetails:
     subject_name: str
 
     #: Subject Alternative Name (SAN) DNS names and IP addresses.
-    san_list: typing.List[str]
+    san_list: list[str]
 
     #: Name of the issuing CA.
     issuer: str
@@ -584,7 +585,7 @@ class SecurityDetails:
     valid_to: TimeSinceEpoch
 
     #: List of signed certificate timestamps (SCTs).
-    signed_certificate_timestamp_list: typing.List[SignedCertificateTimestamp]
+    signed_certificate_timestamp_list: list[SignedCertificateTimestamp]
 
     #: Whether the request complied with Certificate Transparency policy
     certificate_transparency_compliance: CertificateTransparencyCompliance
@@ -593,15 +594,15 @@ class SecurityDetails:
     encrypted_client_hello: bool
 
     #: (EC)DH group used by the connection, if applicable.
-    key_exchange_group: typing.Optional[str] = None
+    key_exchange_group: str | None = None
 
     #: TLS MAC. Note that AEAD ciphers do not have separate MACs.
-    mac: typing.Optional[str] = None
+    mac: str | None = None
 
     #: The signature algorithm used by the server in the TLS server signature,
     #: represented as a TLS SignatureScheme code point. Omitted if not
     #: applicable or not known.
-    server_signature_algorithm: typing.Optional[int] = None
+    server_signature_algorithm: int | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -788,7 +789,7 @@ class TrustTokenParams:
 
     #: Origins of issuers from whom to request tokens or redemption
     #: records.
-    issuers: typing.Optional[typing.List[str]] = None
+    issuers: list[str] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -862,14 +863,14 @@ class ServiceWorkerRouterSource(enum.Enum):
 class ServiceWorkerRouterInfo:
     #: ID of the rule matched. If there is a matched rule, this field will
     #: be set, otherwiser no value will be set.
-    rule_id_matched: typing.Optional[int] = None
+    rule_id_matched: int | None = None
 
     #: The router source of the matched rule. If there is a matched rule, this
     #: field will be set, otherwise no value will be set.
-    matched_source_type: typing.Optional[ServiceWorkerRouterSource] = None
+    matched_source_type: ServiceWorkerRouterSource | None = None
 
     #: The actual router source used.
-    actual_source_type: typing.Optional[ServiceWorkerRouterSource] = None
+    actual_source_type: ServiceWorkerRouterSource | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -926,58 +927,58 @@ class Response:
     security_state: security.SecurityState
 
     #: HTTP response headers text. This has been replaced by the headers in Network.responseReceivedExtraInfo.
-    headers_text: typing.Optional[str] = None
+    headers_text: str | None = None
 
     #: Refined HTTP request headers that were actually transmitted over the network.
-    request_headers: typing.Optional[Headers] = None
+    request_headers: Headers | None = None
 
     #: HTTP request headers text. This has been replaced by the headers in Network.requestWillBeSentExtraInfo.
-    request_headers_text: typing.Optional[str] = None
+    request_headers_text: str | None = None
 
     #: Remote IP address.
-    remote_ip_address: typing.Optional[str] = None
+    remote_ip_address: str | None = None
 
     #: Remote port.
-    remote_port: typing.Optional[int] = None
+    remote_port: int | None = None
 
     #: Specifies that the request was served from the disk cache.
-    from_disk_cache: typing.Optional[bool] = None
+    from_disk_cache: bool | None = None
 
     #: Specifies that the request was served from the ServiceWorker.
-    from_service_worker: typing.Optional[bool] = None
+    from_service_worker: bool | None = None
 
     #: Specifies that the request was served from the prefetch cache.
-    from_prefetch_cache: typing.Optional[bool] = None
+    from_prefetch_cache: bool | None = None
 
     #: Specifies that the request was served from the prefetch cache.
-    from_early_hints: typing.Optional[bool] = None
+    from_early_hints: bool | None = None
 
     #: Information about how ServiceWorker Static Router API was used. If this
     #: field is set with ``matchedSourceType`` field, a matching rule is found.
     #: If this field is set without ``matchedSource``, no matching rule is found.
     #: Otherwise, the API is not used.
-    service_worker_router_info: typing.Optional[ServiceWorkerRouterInfo] = None
+    service_worker_router_info: ServiceWorkerRouterInfo | None = None
 
     #: Timing information for the given request.
-    timing: typing.Optional[ResourceTiming] = None
+    timing: ResourceTiming | None = None
 
     #: Response source of response from ServiceWorker.
-    service_worker_response_source: typing.Optional[ServiceWorkerResponseSource] = None
+    service_worker_response_source: ServiceWorkerResponseSource | None = None
 
     #: The time at which the returned response was generated.
-    response_time: typing.Optional[TimeSinceEpoch] = None
+    response_time: TimeSinceEpoch | None = None
 
     #: Cache Storage Cache Name.
-    cache_storage_cache_name: typing.Optional[str] = None
+    cache_storage_cache_name: str | None = None
 
     #: Protocol used to fetch this request.
-    protocol: typing.Optional[str] = None
+    protocol: str | None = None
 
     #: The reason why Chrome uses a specific transport protocol for HTTP semantics.
-    alternate_protocol_usage: typing.Optional[AlternateProtocolUsage] = None
+    alternate_protocol_usage: AlternateProtocolUsage | None = None
 
     #: Security details for the request.
-    security_details: typing.Optional[SecurityDetails] = None
+    security_details: SecurityDetails | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1095,13 +1096,13 @@ class WebSocketResponse:
     headers: Headers
 
     #: HTTP response headers text.
-    headers_text: typing.Optional[str] = None
+    headers_text: str | None = None
 
     #: HTTP request headers.
-    request_headers: typing.Optional[Headers] = None
+    request_headers: Headers | None = None
 
     #: HTTP request headers text.
-    request_headers_text: typing.Optional[str] = None
+    request_headers_text: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1175,7 +1176,7 @@ class CachedResource:
     body_size: float
 
     #: Cached response data.
-    response: typing.Optional[Response] = None
+    response: Response | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1205,21 +1206,21 @@ class Initiator:
     type_: str
 
     #: Initiator JavaScript stack trace, set for Script only.
-    stack: typing.Optional[runtime.StackTrace] = None
+    stack: runtime.StackTrace | None = None
 
     #: Initiator URL, set for Parser type or for Script type (when script is importing module) or for SignedExchange type.
-    url: typing.Optional[str] = None
+    url: str | None = None
 
     #: Initiator line number, set for Parser type or for Script type (when script is importing
     #: module) (0-based).
-    line_number: typing.Optional[float] = None
+    line_number: float | None = None
 
     #: Initiator column number, set for Parser type or for Script type (when script is importing
     #: module) (0-based).
-    column_number: typing.Optional[float] = None
+    column_number: float | None = None
 
     #: Set if another request triggered this request (e.g. preflight).
-    request_id: typing.Optional[RequestId] = None
+    request_id: RequestId | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1322,13 +1323,13 @@ class Cookie:
     source_port: int
 
     #: Cookie SameSite type.
-    same_site: typing.Optional[CookieSameSite] = None
+    same_site: CookieSameSite | None = None
 
     #: Cookie partition key.
-    partition_key: typing.Optional[CookiePartitionKey] = None
+    partition_key: CookiePartitionKey | None = None
 
     #: True if cookie partition key is opaque.
-    partition_key_opaque: typing.Optional[bool] = None
+    partition_key_opaque: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1468,7 +1469,7 @@ class BlockedSetCookieWithReason:
     A cookie which was not stored from a response with the corresponding reason.
     """
     #: The reason(s) this cookie was blocked.
-    blocked_reasons: typing.List[SetCookieBlockedReason]
+    blocked_reasons: list[SetCookieBlockedReason]
 
     #: The string representing this individual cookie as it would appear in the header.
     #: This is not the entire "cookie" or "set-cookie" header which could have multiple cookies.
@@ -1477,7 +1478,7 @@ class BlockedSetCookieWithReason:
     #: The cookie object which represents the cookie which was not stored. It is optional because
     #: sometimes complete cookie information is not available, such as in the case of parsing
     #: errors.
-    cookie: typing.Optional[Cookie] = None
+    cookie: Cookie | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1537,11 +1538,11 @@ class AssociatedCookie:
     cookie: Cookie
 
     #: The reason(s) the cookie was blocked. If empty means the cookie is included.
-    blocked_reasons: typing.List[CookieBlockedReason]
+    blocked_reasons: list[CookieBlockedReason]
 
     #: The reason the cookie should have been blocked by 3PCD but is exempted. A cookie could
     #: only have at most one exemption reason.
-    exemption_reason: typing.Optional[CookieExemptionReason] = None
+    exemption_reason: CookieExemptionReason | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1573,42 +1574,42 @@ class CookieParam:
 
     #: The request-URI to associate with the setting of the cookie. This value can affect the
     #: default domain, path, source port, and source scheme values of the created cookie.
-    url: typing.Optional[str] = None
+    url: str | None = None
 
     #: Cookie domain.
-    domain: typing.Optional[str] = None
+    domain: str | None = None
 
     #: Cookie path.
-    path: typing.Optional[str] = None
+    path: str | None = None
 
     #: True if cookie is secure.
-    secure: typing.Optional[bool] = None
+    secure: bool | None = None
 
     #: True if cookie is http-only.
-    http_only: typing.Optional[bool] = None
+    http_only: bool | None = None
 
     #: Cookie SameSite type.
-    same_site: typing.Optional[CookieSameSite] = None
+    same_site: CookieSameSite | None = None
 
     #: Cookie expiration date, session cookie if not set
-    expires: typing.Optional[TimeSinceEpoch] = None
+    expires: TimeSinceEpoch | None = None
 
     #: Cookie Priority.
-    priority: typing.Optional[CookiePriority] = None
+    priority: CookiePriority | None = None
 
     #: True if cookie is SameParty.
-    same_party: typing.Optional[bool] = None
+    same_party: bool | None = None
 
     #: Cookie source scheme type.
-    source_scheme: typing.Optional[CookieSourceScheme] = None
+    source_scheme: CookieSourceScheme | None = None
 
     #: Cookie source port. Valid values are {-1, [1, 65535]}, -1 indicates an unspecified port.
     #: An unspecified port value allows protocol clients to emulate legacy cookie scope for the port.
     #: This is a temporary ability and it will be removed in the future.
-    source_port: typing.Optional[int] = None
+    source_port: int | None = None
 
     #: Cookie partition key. If not set, the cookie will be set as not partitioned.
-    partition_key: typing.Optional[CookiePartitionKey] = None
+    partition_key: CookiePartitionKey | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1675,7 +1676,7 @@ class AuthChallenge:
     realm: str
 
     #: Source of the authentication challenge.
-    source: typing.Optional[str] = None
+    source: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1708,11 +1709,11 @@ class AuthChallengeResponse:
 
     #: The username to provide, possibly empty. Should only be set if response is
     #: ProvideCredentials.
-    username: typing.Optional[str] = None
+    username: str | None = None
 
     #: The password to provide, possibly empty. Should only be set if response is
     #: ProvideCredentials.
-    password: typing.Optional[str] = None
+    password: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1755,13 +1756,13 @@ class RequestPattern:
     """
     #: Wildcards (``'*'`` -> zero or more, ``'?'`` -> exactly one) are allowed. Escape character is
     #: backslash. Omitting is equivalent to ``"*"``.
-    url_pattern: typing.Optional[str] = None
+    url_pattern: str | None = None
 
     #: If set, only requests for matching resource types will be intercepted.
-    resource_type: typing.Optional[ResourceType] = None
+    resource_type: ResourceType | None = None
 
     #: Stage at which to begin intercepting requests. Default is Request.
-    interception_stage: typing.Optional[InterceptionStage] = None
+    interception_stage: InterceptionStage | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1807,13 +1808,13 @@ class SignedExchangeSignature:
     expires: int
 
     #: Signed exchange signature cert Url.
-    cert_url: typing.Optional[str] = None
+    cert_url: str | None = None
 
     #: The hex string of signed exchange signature cert sha256.
-    cert_sha256: typing.Optional[str] = None
+    cert_sha256: str | None = None
 
     #: The encoded certificates.
-    certificates: typing.Optional[typing.List[str]] = None
+    certificates: list[str] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1862,7 +1863,7 @@ class SignedExchangeHeader:
     response_headers: Headers
 
     #: Signed exchange response signature.
-    signatures: typing.List[SignedExchangeSignature]
+    signatures: list[SignedExchangeSignature]
 
     #: Signed exchange header integrity hash in the form of ``sha256-<base64-hash-value>``.
     header_integrity: str
@@ -1915,10 +1916,10 @@ class SignedExchangeError:
     message: str
 
     #: The index of the signature which caused the error.
-    signature_index: typing.Optional[int] = None
+    signature_index: int | None = None
 
     #: The field which caused the error.
-    error_field: typing.Optional[SignedExchangeErrorField] = None
+    error_field: SignedExchangeErrorField | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1947,13 +1948,13 @@ class SignedExchangeInfo:
     outer_response: Response
 
     #: Information about the signed exchange header.
-    header: typing.Optional[SignedExchangeHeader] = None
+    header: SignedExchangeHeader | None = None
 
     #: Security details for the signed exchange header.
-    security_details: typing.Optional[SecurityDetails] = None
+    security_details: SecurityDetails | None = None
 
     #: Errors occurred while handling the signed exchange.
-    errors: typing.Optional[typing.List[SignedExchangeError]] = None
+    errors: list[SignedExchangeError] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -2088,9 +2089,9 @@ class CrossOriginOpenerPolicyStatus:
 
     report_only_value: CrossOriginOpenerPolicyValue
 
-    reporting_endpoint: typing.Optional[str] = None
+    reporting_endpoint: str | None = None
 
-    report_only_reporting_endpoint: typing.Optional[str] = None
+    report_only_reporting_endpoint: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -2131,9 +2132,9 @@ class CrossOriginEmbedderPolicyStatus:
 
     report_only_value: CrossOriginEmbedderPolicyValue
 
-    reporting_endpoint: typing.Optional[str] = None
+    reporting_endpoint: str | None = None
 
-    report_only_reporting_endpoint: typing.Optional[str] = None
+    report_only_reporting_endpoint: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -2193,11 +2194,11 @@ class ContentSecurityPolicyStatus:
 
 @dataclass
 class SecurityIsolationStatus:
-    coop: typing.Optional[CrossOriginOpenerPolicyStatus] = None
+    coop: CrossOriginOpenerPolicyStatus | None = None
 
-    coep: typing.Optional[CrossOriginEmbedderPolicyStatus] = None
+    coep: CrossOriginEmbedderPolicyStatus | None = None
 
-    csp: typing.Optional[typing.List[ContentSecurityPolicyStatus]] = None
+    csp: list[ContentSecurityPolicyStatus] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -2334,17 +2335,17 @@ class LoadNetworkResourcePageResult:
     success: bool
 
     #: Optional values used for error reporting.
-    net_error: typing.Optional[float] = None
+    net_error: float | None = None
 
-    net_error_name: typing.Optional[str] = None
+    net_error_name: str | None = None
 
-    http_status_code: typing.Optional[float] = None
+    http_status_code: float | None = None
 
     #: If successful, one of the following two fields holds the result.
-    stream: typing.Optional[io.StreamHandle] = None
+    stream: io.StreamHandle | None = None
 
     #: Response headers.
-    headers: typing.Optional[Headers] = None
+    headers: Headers | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -2398,8 +2399,8 @@ class LoadNetworkResourceOptions:
 
 
 def set_accepted_encodings(
-    encodings: typing.List[ContentEncoding],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    encodings: list[ContentEncoding],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets a list of content encodings that will be accepted. Empty list means no encoding is accepted.
 
@@ -2416,7 +2417,7 @@ def set_accepted_encodings(
     yield cmd_dict
 
 
-def clear_accepted_encodings_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_accepted_encodings_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears accepted encodings set by setAcceptedEncodings
 
@@ -2428,7 +2429,7 @@ def clear_accepted_encodings_override() -> typing.Generator[T_JSON_DICT, T_JSON_
     yield cmd_dict
 
 
-def can_clear_browser_cache() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
+def can_clear_browser_cache() -> Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     """
     Tells whether clearing browser cache is supported.
 
@@ -2441,7 +2442,7 @@ def can_clear_browser_cache() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool
     return bool(json["result"])
 
 
-def can_clear_browser_cookies() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
+def can_clear_browser_cookies() -> Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     """
     Tells whether clearing browser cookies is supported.
 
@@ -2454,7 +2455,7 @@ def can_clear_browser_cookies() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bo
     return bool(json["result"])
 
 
-def can_emulate_network_conditions() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
+def can_emulate_network_conditions() -> Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     """
     Tells whether emulation of network conditions is supported.
 
@@ -2467,7 +2468,7 @@ def can_emulate_network_conditions() -> typing.Generator[T_JSON_DICT, T_JSON_DIC
     return bool(json["result"])
 
 
-def clear_browser_cache() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_browser_cache() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears browser cache.
     """
@@ -2477,7 +2478,7 @@ def clear_browser_cache() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def clear_browser_cookies() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_browser_cookies() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears browser cookies.
     """
@@ -2489,14 +2490,14 @@ def clear_browser_cookies() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def continue_intercepted_request(
     interception_id: InterceptionId,
-    error_reason: typing.Optional[ErrorReason] = None,
-    raw_response: typing.Optional[str] = None,
-    url: typing.Optional[str] = None,
-    method: typing.Optional[str] = None,
-    post_data: typing.Optional[str] = None,
-    headers: typing.Optional[Headers] = None,
-    auth_challenge_response: typing.Optional[AuthChallengeResponse] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    error_reason: ErrorReason | None = None,
+    raw_response: str | None = None,
+    url: str | None = None,
+    method: str | None = None,
+    post_data: str | None = None,
+    headers: Headers | None = None,
+    auth_challenge_response: AuthChallengeResponse | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Response to Network.requestIntercepted which either modifies the request to continue with any
     modifications, or blocks it, or completes it with the provided response bytes. If a network
@@ -2540,11 +2541,11 @@ def continue_intercepted_request(
 
 def delete_cookies(
     name: str,
-    url: typing.Optional[str] = None,
-    domain: typing.Optional[str] = None,
-    path: typing.Optional[str] = None,
-    partition_key: typing.Optional[CookiePartitionKey] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    url: str | None = None,
+    domain: str | None = None,
+    path: str | None = None,
+    partition_key: CookiePartitionKey | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Deletes browser cookies with matching name and url or domain/path/partitionKey pair.
 
@@ -2571,7 +2572,7 @@ def delete_cookies(
     yield cmd_dict
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables network tracking, prevents network events from being sent to the client.
     """
@@ -2586,11 +2587,11 @@ def emulate_network_conditions(
     latency: float,
     download_throughput: float,
     upload_throughput: float,
-    connection_type: typing.Optional[ConnectionType] = None,
-    packet_loss: typing.Optional[float] = None,
-    packet_queue_length: typing.Optional[int] = None,
-    packet_reordering: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    connection_type: ConnectionType | None = None,
+    packet_loss: float | None = None,
+    packet_queue_length: int | None = None,
+    packet_reordering: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Activates emulation of network conditions.
 
@@ -2624,10 +2625,10 @@ def emulate_network_conditions(
 
 
 def enable(
-    max_total_buffer_size: typing.Optional[int] = None,
-    max_resource_buffer_size: typing.Optional[int] = None,
-    max_post_data_size: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    max_total_buffer_size: int | None = None,
+    max_resource_buffer_size: int | None = None,
+    max_post_data_size: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables network tracking, network events will now be delivered to the client.
 
@@ -2649,7 +2650,7 @@ def enable(
     yield cmd_dict
 
 
-def get_all_cookies() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[Cookie]]:
+def get_all_cookies() -> Generator[T_JSON_DICT, T_JSON_DICT, list[Cookie]]:
     """
     Returns all browser cookies. Depending on the backend support, will return detailed cookie
     information in the ``cookies`` field.
@@ -2666,7 +2667,7 @@ def get_all_cookies() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[
 
 def get_certificate(
     origin: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[str]]:
     """
     Returns the DER-encoded certificate.
 
@@ -2686,8 +2687,8 @@ def get_certificate(
 
 
 def get_cookies(
-    urls: typing.Optional[typing.List[str]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[Cookie]]:
+    urls: list[str] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[Cookie]]:
     """
     Returns all browser cookies for the current URL. Depending on the backend support, will return
     detailed cookie information in the ``cookies`` field.
@@ -2708,7 +2709,7 @@ def get_cookies(
 
 def get_response_body(
     request_id: RequestId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, bool]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, bool]]:
     """
     Returns content served for the given request.
 
@@ -2733,7 +2734,7 @@ def get_response_body(
 
 def get_request_post_data(
     request_id: RequestId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Returns post data sent with the request. Returns an error when no data was sent with the request.
 
@@ -2752,7 +2753,7 @@ def get_request_post_data(
 
 def get_response_body_for_interception(
     interception_id: InterceptionId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, bool]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, bool]]:
     """
     Returns content served for the given currently intercepted request.
 
@@ -2779,7 +2780,7 @@ def get_response_body_for_interception(
 
 def take_response_body_for_interception_as_stream(
     interception_id: InterceptionId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, io.StreamHandle]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, io.StreamHandle]:
     """
     Returns a handle to the stream representing the response body. Note that after this command,
     the intercepted request can't be continued as is -- you either need to cancel it or to provide
@@ -2803,7 +2804,7 @@ def take_response_body_for_interception_as_stream(
 
 def replay_xhr(
     request_id: RequestId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     This method sends a new XMLHttpRequest which is identical to the original one. The following
     parameters should be identical: method, url, async, request body, extra headers, withCredentials
@@ -2825,9 +2826,9 @@ def replay_xhr(
 def search_in_response_body(
     request_id: RequestId,
     query: str,
-    case_sensitive: typing.Optional[bool] = None,
-    is_regex: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[debugger.SearchMatch]]:
+    case_sensitive: bool | None = None,
+    is_regex: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[debugger.SearchMatch]]:
     """
     Searches for given string in response content.
 
@@ -2855,8 +2856,8 @@ def search_in_response_body(
 
 
 def set_blocked_ur_ls(
-    urls: typing.List[str],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    urls: list[str],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Blocks URLs from loading.
 
@@ -2875,7 +2876,7 @@ def set_blocked_ur_ls(
 
 def set_bypass_service_worker(
     bypass: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Toggles ignoring of service worker for each request.
 
@@ -2892,7 +2893,7 @@ def set_bypass_service_worker(
 
 def set_cache_disabled(
     cache_disabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Toggles ignoring cache for each request. If ``true``, cache will not be used.
 
@@ -2910,19 +2911,19 @@ def set_cache_disabled(
 def set_cookie(
     name: str,
     value: str,
-    url: typing.Optional[str] = None,
-    domain: typing.Optional[str] = None,
-    path: typing.Optional[str] = None,
-    secure: typing.Optional[bool] = None,
-    http_only: typing.Optional[bool] = None,
-    same_site: typing.Optional[CookieSameSite] = None,
-    expires: typing.Optional[TimeSinceEpoch] = None,
-    priority: typing.Optional[CookiePriority] = None,
-    same_party: typing.Optional[bool] = None,
-    source_scheme: typing.Optional[CookieSourceScheme] = None,
-    source_port: typing.Optional[int] = None,
-    partition_key: typing.Optional[CookiePartitionKey] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
+    url: str | None = None,
+    domain: str | None = None,
+    path: str | None = None,
+    secure: bool | None = None,
+    http_only: bool | None = None,
+    same_site: CookieSameSite | None = None,
+    expires: TimeSinceEpoch | None = None,
+    priority: CookiePriority | None = None,
+    same_party: bool | None = None,
+    source_scheme: CookieSourceScheme | None = None,
+    source_port: int | None = None,
+    partition_key: CookiePartitionKey | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     """
     Sets a cookie with the given cookie data; may overwrite equivalent cookies if they exist.
 
@@ -2978,8 +2979,8 @@ def set_cookie(
 
 
 def set_cookies(
-    cookies: typing.List[CookieParam],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    cookies: list[CookieParam],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets given cookies.
 
@@ -2996,7 +2997,7 @@ def set_cookies(
 
 def set_extra_http_headers(
     headers: Headers,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Specifies whether to always send extra HTTP headers with the requests from this page.
 
@@ -3013,7 +3014,7 @@ def set_extra_http_headers(
 
 def set_attach_debug_stack(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Specifies whether to attach a page script stack id in requests
 
@@ -3031,8 +3032,8 @@ def set_attach_debug_stack(
 
 
 def set_request_interception(
-    patterns: typing.List[RequestPattern],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    patterns: list[RequestPattern],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets the requests to intercept that match the provided patterns and optionally resource types.
     Deprecated, please use Fetch.enable instead.
@@ -3052,10 +3053,10 @@ def set_request_interception(
 
 def set_user_agent_override(
     user_agent: str,
-    accept_language: typing.Optional[str] = None,
-    platform: typing.Optional[str] = None,
-    user_agent_metadata: typing.Optional[emulation.UserAgentMetadata] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    accept_language: str | None = None,
+    platform: str | None = None,
+    user_agent_metadata: emulation.UserAgentMetadata | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Allows overriding user agent with the given string.
 
@@ -3081,7 +3082,7 @@ def set_user_agent_override(
 
 def stream_resource_content(
     request_id: RequestId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Enables streaming of the response for the given requestId.
     If enabled, the dataReceived event contains the data that was received during streaming.
@@ -3102,8 +3103,8 @@ def stream_resource_content(
 
 
 def get_security_isolation_status(
-    frame_id: typing.Optional[page.FrameId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, SecurityIsolationStatus]:
+    frame_id: page.FrameId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, SecurityIsolationStatus]:
     """
     Returns information about the COEP/COOP isolation status.
 
@@ -3125,7 +3126,7 @@ def get_security_isolation_status(
 
 def enable_reporting_api(
     enable: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables tracking for the Reporting API, events generated by the Reporting API will now be delivered to the client.
     Enabling triggers 'reportingApiReportAdded' for all existing reports.
@@ -3146,8 +3147,8 @@ def enable_reporting_api(
 def load_network_resource(
     url: str,
     options: LoadNetworkResourceOptions,
-    frame_id: typing.Optional[page.FrameId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, LoadNetworkResourcePageResult]:
+    frame_id: page.FrameId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, LoadNetworkResourcePageResult]:
     """
     Fetches the resource and returns the content.
 
@@ -3186,7 +3187,7 @@ class DataReceived:
     #: Actual bytes received (might be less than dataLength for compressed encodings).
     encoded_data_length: int
     #: Data that was received. (Encoded as a base64 string when passed over JSON)
-    data: typing.Optional[str]
+    data: str | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> DataReceived:
@@ -3242,11 +3243,11 @@ class LoadingFailed:
     #: Error message. List of network errors: https://cs.chromium.org/chromium/src/net/base/net_error_list.h
     error_text: str
     #: True if loading was canceled.
-    canceled: typing.Optional[bool]
+    canceled: bool | None
     #: The reason why loading was blocked, if any.
-    blocked_reason: typing.Optional[BlockedReason]
+    blocked_reason: BlockedReason | None
     #: The reason why loading was blocked by CORS, if any.
-    cors_error_status: typing.Optional[CorsErrorStatus]
+    cors_error_status: CorsErrorStatus | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> LoadingFailed:
@@ -3306,24 +3307,24 @@ class RequestIntercepted:
     is_navigation_request: bool
     #: Set if the request is a navigation that will result in a download.
     #: Only present after response is received from the server (i.e. HeadersReceived stage).
-    is_download: typing.Optional[bool]
+    is_download: bool | None
     #: Redirect location, only sent if a redirect was intercepted.
-    redirect_url: typing.Optional[str]
+    redirect_url: str | None
     #: Details of the Authorization Challenge encountered. If this is set then
     #: continueInterceptedRequest must contain an authChallengeResponse.
-    auth_challenge: typing.Optional[AuthChallenge]
+    auth_challenge: AuthChallenge | None
     #: Response error if intercepted at response stage or if redirect occurred while intercepting
     #: request.
-    response_error_reason: typing.Optional[ErrorReason]
+    response_error_reason: ErrorReason | None
     #: Response code if intercepted at response stage or if redirect occurred while intercepting
     #: request or auth retry occurred.
-    response_status_code: typing.Optional[int]
+    response_status_code: int | None
     #: Response headers if intercepted at the response stage or if redirect occurred while
     #: intercepting request or auth retry occurred.
-    response_headers: typing.Optional[Headers]
+    response_headers: Headers | None
     #: If the intercepted request had a corresponding requestWillBeSent event fired for it, then
     #: this requestId will be the same as the requestId present in the requestWillBeSent event.
-    request_id: typing.Optional[RequestId]
+    request_id: RequestId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> RequestIntercepted:
@@ -3384,13 +3385,13 @@ class RequestWillBeSent:
     #: for the request which was just redirected.
     redirect_has_extra_info: bool
     #: Redirect response data.
-    redirect_response: typing.Optional[Response]
+    redirect_response: Response | None
     #: Type of this resource.
-    type_: typing.Optional[ResourceType]
+    type_: ResourceType | None
     #: Frame identifier.
-    frame_id: typing.Optional[page.FrameId]
+    frame_id: page.FrameId | None
     #: Whether the request is initiated by a user gesture. Defaults to false.
-    has_user_gesture: typing.Optional[bool]
+    has_user_gesture: bool | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> RequestWillBeSent:
@@ -3475,7 +3476,7 @@ class ResponseReceived:
     #: or were emitted for this request.
     has_extra_info: bool
     #: Frame identifier.
-    frame_id: typing.Optional[page.FrameId]
+    frame_id: page.FrameId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ResponseReceived:
@@ -3520,7 +3521,7 @@ class WebSocketCreated:
     #: WebSocket request URL.
     url: str
     #: Request initiator.
-    initiator: typing.Optional[Initiator]
+    initiator: Initiator | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> WebSocketCreated:
@@ -3657,7 +3658,7 @@ class WebTransportCreated:
     #: Timestamp.
     timestamp: MonotonicTime
     #: Request initiator.
-    initiator: typing.Optional[Initiator]
+    initiator: Initiator | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> WebTransportCreated:
@@ -3722,15 +3723,15 @@ class RequestWillBeSentExtraInfo:
     request_id: RequestId
     #: A list of cookies potentially associated to the requested URL. This includes both cookies sent with
     #: the request and the ones not sent; the latter are distinguished by having blockedReasons field set.
-    associated_cookies: typing.List[AssociatedCookie]
+    associated_cookies: list[AssociatedCookie]
     #: Raw request headers as they will be sent over the wire.
     headers: Headers
     #: Connection timing information for the request.
     connect_timing: ConnectTiming
     #: The client security state set for the request.
-    client_security_state: typing.Optional[ClientSecurityState]
+    client_security_state: ClientSecurityState | None
     #: Whether the site has partitioned cookies stored in a partition different than the current one.
-    site_has_cookie_in_other_partition: typing.Optional[bool]
+    site_has_cookie_in_other_partition: bool | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> RequestWillBeSentExtraInfo:
@@ -3759,7 +3760,7 @@ class ResponseReceivedExtraInfo:
     #: A list of cookies which were not stored from the response along with the corresponding
     #: reasons for blocking. The cookies here may not be valid due to syntax errors, which
     #: are represented by the invalid cookie line string instead of a proper cookie.
-    blocked_cookies: typing.List[BlockedSetCookieWithReason]
+    blocked_cookies: list[BlockedSetCookieWithReason]
     #: Raw response headers as they were received over the wire.
     headers: Headers
     #: The IP address space of the resource. The address space can only be determined once the transport
@@ -3771,15 +3772,15 @@ class ResponseReceivedExtraInfo:
     status_code: int
     #: Raw response header text as it was received over the wire. The raw text may not always be
     #: available, such as in the case of HTTP/2 or QUIC.
-    headers_text: typing.Optional[str]
+    headers_text: str | None
     #: The cookie partition key that will be used to store partitioned cookies set in this response.
     #: Only sent when partitioned cookies are enabled.
-    cookie_partition_key: typing.Optional[CookiePartitionKey]
+    cookie_partition_key: CookiePartitionKey | None
     #: True if partitioned cookies are enabled, but the partition key is not serializable to string.
-    cookie_partition_key_opaque: typing.Optional[bool]
+    cookie_partition_key_opaque: bool | None
     #: A list of cookies which should have been blocked by 3PCD but are exempted and stored from
     #: the response with the corresponding reason.
-    exempted_cookies: typing.Optional[typing.List[ExemptedSetCookieWithReason]]
+    exempted_cookies: list[ExemptedSetCookieWithReason] | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ResponseReceivedExtraInfo:
@@ -3838,11 +3839,11 @@ class TrustTokenOperationDone:
     type_: TrustTokenOperationType
     request_id: RequestId
     #: Top level origin. The context in which the operation was attempted.
-    top_level_origin: typing.Optional[str]
+    top_level_origin: str | None
     #: Origin of the issuer in case of a "Issuance" or "Redemption" operation.
-    issuer_origin: typing.Optional[str]
+    issuer_origin: str | None
     #: The number of obtained Trust Tokens on a successful "Issuance" operation.
-    issued_token_count: typing.Optional[int]
+    issued_token_count: int | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> TrustTokenOperationDone:
@@ -3885,7 +3886,7 @@ class SubresourceWebBundleMetadataReceived:
     #: Request identifier. Used to match this information to another event.
     request_id: RequestId
     #: A list of URLs of resources in the subresource Web Bundle.
-    urls: typing.List[str]
+    urls: list[str]
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> SubresourceWebBundleMetadataReceived:
@@ -3932,7 +3933,7 @@ class SubresourceWebBundleInnerResponseParsed:
     #: Bundle request identifier. Used to match this information to another event.
     #: This made be absent in case when the instrumentation was enabled only
     #: after webbundle was parsed.
-    bundle_request_id: typing.Optional[RequestId]
+    bundle_request_id: RequestId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> SubresourceWebBundleInnerResponseParsed:
@@ -3960,7 +3961,7 @@ class SubresourceWebBundleInnerResponseError:
     #: Bundle request identifier. Used to match this information to another event.
     #: This made be absent in case when the instrumentation was enabled only
     #: after webbundle was parsed.
-    bundle_request_id: typing.Optional[RequestId]
+    bundle_request_id: RequestId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> SubresourceWebBundleInnerResponseError:
@@ -4017,7 +4018,7 @@ class ReportingApiEndpointsChangedForOrigin:
     """
     #: Origin of the document(s) which configured the endpoints.
     origin: str
-    endpoints: typing.List[ReportingApiEndpoint]
+    endpoints: list[ReportingApiEndpoint]
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ReportingApiEndpointsChangedForOrigin:

--- a/src/streamlink/webbrowser/cdp/devtools/page.py
+++ b/src/streamlink/webbrowser/cdp/devtools/page.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.debugger as debugger
 import streamlink.webbrowser.cdp.devtools.dom as dom
@@ -72,7 +73,7 @@ class AdFrameStatus:
     """
     ad_frame_type: AdFrameType
 
-    explanations: typing.Optional[typing.List[AdFrameExplanation]] = None
+    explanations: list[AdFrameExplanation] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -312,7 +313,7 @@ class PermissionsPolicyFeatureState:
 
     allowed: bool
 
-    locator: typing.Optional[PermissionsPolicyBlockLocator] = None
+    locator: PermissionsPolicyBlockLocator | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -430,7 +431,7 @@ class OriginTrialTokenWithStatus:
 
     #: ``parsedToken`` is present only when the token is extractable and
     #: parsable.
-    parsed_token: typing.Optional[OriginTrialToken] = None
+    parsed_token: OriginTrialToken | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -455,7 +456,7 @@ class OriginTrial:
 
     status: OriginTrialStatus
 
-    tokens_with_status: typing.List[OriginTrialTokenWithStatus]
+    tokens_with_status: list[OriginTrialTokenWithStatus]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -506,22 +507,22 @@ class Frame:
     cross_origin_isolated_context_type: CrossOriginIsolatedContextType
 
     #: Indicated which gated APIs / features are available.
-    gated_api_features: typing.List[GatedAPIFeatures]
+    gated_api_features: list[GatedAPIFeatures]
 
     #: Parent frame identifier.
-    parent_id: typing.Optional[FrameId] = None
+    parent_id: FrameId | None = None
 
     #: Frame's name as specified in the tag.
-    name: typing.Optional[str] = None
+    name: str | None = None
 
     #: Frame document's URL fragment including the '#'.
-    url_fragment: typing.Optional[str] = None
+    url_fragment: str | None = None
 
     #: If the frame failed to load, this contains the URL that could not be loaded. Note that unlike url above, this URL may contain a fragment.
-    unreachable_url: typing.Optional[str] = None
+    unreachable_url: str | None = None
 
     #: Indicates whether this frame was tagged as an ad and why.
-    ad_frame_status: typing.Optional[AdFrameStatus] = None
+    ad_frame_status: AdFrameStatus | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -581,16 +582,16 @@ class FrameResource:
     mime_type: str
 
     #: last-modified timestamp as reported by server.
-    last_modified: typing.Optional[network.TimeSinceEpoch] = None
+    last_modified: network.TimeSinceEpoch | None = None
 
     #: Resource content size.
-    content_size: typing.Optional[float] = None
+    content_size: float | None = None
 
     #: True if the resource failed to load.
-    failed: typing.Optional[bool] = None
+    failed: bool | None = None
 
     #: True if the resource was canceled during loading.
-    canceled: typing.Optional[bool] = None
+    canceled: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -629,10 +630,10 @@ class FrameResourceTree:
     frame: Frame
 
     #: Information about frame resources.
-    resources: typing.List[FrameResource]
+    resources: list[FrameResource]
 
     #: Child frames.
-    child_frames: typing.Optional[typing.List[FrameResourceTree]] = None
+    child_frames: list[FrameResourceTree] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -660,7 +661,7 @@ class FrameTree:
     frame: Frame
 
     #: Child frames.
-    child_frames: typing.Optional[typing.List[FrameTree]] = None
+    child_frames: list[FrameTree] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -782,7 +783,7 @@ class ScreencastFrameMetadata:
     scroll_offset_y: float
 
     #: Frame swap timestamp.
-    timestamp: typing.Optional[network.TimeSinceEpoch] = None
+    timestamp: network.TimeSinceEpoch | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -943,7 +944,7 @@ class VisualViewport:
     scale: float
 
     #: Page zoom factor (CSS to device independent pixels ratio).
-    zoom: typing.Optional[float] = None
+    zoom: float | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1018,25 +1019,25 @@ class FontFamilies:
     Generic font families collection.
     """
     #: The standard font-family.
-    standard: typing.Optional[str] = None
+    standard: str | None = None
 
     #: The fixed font-family.
-    fixed: typing.Optional[str] = None
+    fixed: str | None = None
 
     #: The serif font-family.
-    serif: typing.Optional[str] = None
+    serif: str | None = None
 
     #: The sansSerif font-family.
-    sans_serif: typing.Optional[str] = None
+    sans_serif: str | None = None
 
     #: The cursive font-family.
-    cursive: typing.Optional[str] = None
+    cursive: str | None = None
 
     #: The fantasy font-family.
-    fantasy: typing.Optional[str] = None
+    fantasy: str | None = None
 
     #: The math font-family.
-    math: typing.Optional[str] = None
+    math: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1100,10 +1101,10 @@ class FontSizes:
     Default font sizes.
     """
     #: Default standard font size.
-    standard: typing.Optional[int] = None
+    standard: int | None = None
 
     #: Default fixed font size.
-    fixed: typing.Optional[int] = None
+    fixed: int | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1186,7 +1187,7 @@ class InstallabilityError:
     error_id: str
 
     #: The list of error arguments (e.g. {name:'minimum-icon-size-in-pixels', value:'64'}).
-    error_arguments: typing.List[InstallabilityErrorArgument]
+    error_arguments: list[InstallabilityErrorArgument]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1233,7 +1234,7 @@ class CompilationCacheParams:
 
     #: A hint to the backend whether eager compilation is recommended.
     #: (the actual compilation mode used is upon backend discretion).
-    eager: typing.Optional[bool] = None
+    eager: bool | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1252,9 +1253,9 @@ class CompilationCacheParams:
 
 @dataclass
 class FileFilter:
-    name: typing.Optional[str] = None
+    name: str | None = None
 
-    accepts: typing.Optional[typing.List[str]] = None
+    accepts: list[str] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1282,10 +1283,10 @@ class FileHandler:
     #: other enums below.
     launch_type: str
 
-    icons: typing.Optional[typing.List[ImageResource]] = None
+    icons: list[ImageResource] | None = None
 
     #: Mimic a map, name is the key, accepts is the value.
-    accepts: typing.Optional[typing.List[FileFilter]] = None
+    accepts: list[FileFilter] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1318,9 +1319,9 @@ class ImageResource:
     #: consistency.
     url: str
 
-    sizes: typing.Optional[str] = None
+    sizes: str | None = None
 
-    type_: typing.Optional[str] = None
+    type_: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1380,7 +1381,7 @@ class ProtocolHandler:
 class RelatedApplication:
     url: str
 
-    id_: typing.Optional[str] = None
+    id_: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1425,7 +1426,7 @@ class Screenshot:
 
     form_factor: str
 
-    label: typing.Optional[str] = None
+    label: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1453,13 +1454,13 @@ class ShareTarget:
     enctype: str
 
     #: Embed the ShareTargetParams
-    title: typing.Optional[str] = None
+    title: str | None = None
 
-    text: typing.Optional[str] = None
+    text: str | None = None
 
-    url: typing.Optional[str] = None
+    url: str | None = None
 
-    files: typing.Optional[typing.List[FileFilter]] = None
+    files: list[FileFilter] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1511,61 +1512,61 @@ class Shortcut:
 
 @dataclass
 class WebAppManifest:
-    background_color: typing.Optional[str] = None
+    background_color: str | None = None
 
     #: The extra description provided by the manifest.
-    description: typing.Optional[str] = None
+    description: str | None = None
 
-    dir_: typing.Optional[str] = None
+    dir_: str | None = None
 
-    display: typing.Optional[str] = None
+    display: str | None = None
 
     #: The overrided display mode controlled by the user.
-    display_overrides: typing.Optional[typing.List[str]] = None
+    display_overrides: list[str] | None = None
 
     #: The handlers to open files.
-    file_handlers: typing.Optional[typing.List[FileHandler]] = None
+    file_handlers: list[FileHandler] | None = None
 
-    icons: typing.Optional[typing.List[ImageResource]] = None
+    icons: list[ImageResource] | None = None
 
-    id_: typing.Optional[str] = None
+    id_: str | None = None
 
-    lang: typing.Optional[str] = None
+    lang: str | None = None
 
     #: TODO(crbug.com/1231886): This field is non-standard and part of a Chrome
     #: experiment. See:
     #: https://github.com/WICG/web-app-launch/blob/main/launch_handler.md
-    launch_handler: typing.Optional[LaunchHandler] = None
+    launch_handler: LaunchHandler | None = None
 
-    name: typing.Optional[str] = None
+    name: str | None = None
 
-    orientation: typing.Optional[str] = None
+    orientation: str | None = None
 
-    prefer_related_applications: typing.Optional[bool] = None
+    prefer_related_applications: bool | None = None
 
     #: The handlers to open protocols.
-    protocol_handlers: typing.Optional[typing.List[ProtocolHandler]] = None
+    protocol_handlers: list[ProtocolHandler] | None = None
 
-    related_applications: typing.Optional[typing.List[RelatedApplication]] = None
+    related_applications: list[RelatedApplication] | None = None
 
-    scope: typing.Optional[str] = None
+    scope: str | None = None
 
     #: Non-standard, see
     #: https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md
-    scope_extensions: typing.Optional[typing.List[ScopeExtension]] = None
+    scope_extensions: list[ScopeExtension] | None = None
 
     #: The screenshots used by chromium.
-    screenshots: typing.Optional[typing.List[Screenshot]] = None
+    screenshots: list[Screenshot] | None = None
 
-    share_target: typing.Optional[ShareTarget] = None
+    share_target: ShareTarget | None = None
 
-    short_name: typing.Optional[str] = None
+    short_name: str | None = None
 
-    shortcuts: typing.Optional[typing.List[Shortcut]] = None
+    shortcuts: list[Shortcut] | None = None
 
-    start_url: typing.Optional[str] = None
+    start_url: str | None = None
 
-    theme_color: typing.Optional[str] = None
+    theme_color: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1854,10 +1855,10 @@ class BackForwardCacheBlockingDetails:
     column_number: int
 
     #: Url of the file where blockage happened. Optional because of tests.
-    url: typing.Optional[str] = None
+    url: str | None = None
 
     #: Function name where blockage happened. Optional because of anonymous functions and tests.
-    function: typing.Optional[str] = None
+    function: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1890,9 +1891,9 @@ class BackForwardCacheNotRestoredExplanation:
     #: Context associated with the reason. The meaning of this context is
     #: dependent on the reason:
     #: - EmbedderExtensionSentMessageToCachedFrame: the extension ID.
-    context: typing.Optional[str] = None
+    context: str | None = None
 
-    details: typing.Optional[typing.List[BackForwardCacheBlockingDetails]] = None
+    details: list[BackForwardCacheBlockingDetails] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1920,10 +1921,10 @@ class BackForwardCacheNotRestoredExplanationTree:
     url: str
 
     #: Not restored reasons of each frame
-    explanations: typing.List[BackForwardCacheNotRestoredExplanation]
+    explanations: list[BackForwardCacheNotRestoredExplanation]
 
     #: Array of children frame
-    children: typing.List[BackForwardCacheNotRestoredExplanationTree]
+    children: list[BackForwardCacheNotRestoredExplanationTree]
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -1943,7 +1944,7 @@ class BackForwardCacheNotRestoredExplanationTree:
 
 def add_script_to_evaluate_on_load(
     script_source: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, ScriptIdentifier]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, ScriptIdentifier]:
     """
     Deprecated, please use addScriptToEvaluateOnNewDocument instead.
 
@@ -1964,10 +1965,10 @@ def add_script_to_evaluate_on_load(
 
 def add_script_to_evaluate_on_new_document(
     source: str,
-    world_name: typing.Optional[str] = None,
-    include_command_line_api: typing.Optional[bool] = None,
-    run_immediately: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, ScriptIdentifier]:
+    world_name: str | None = None,
+    include_command_line_api: bool | None = None,
+    run_immediately: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, ScriptIdentifier]:
     """
     Evaluates given script in every frame upon creation (before loading frame's scripts).
 
@@ -1993,7 +1994,7 @@ def add_script_to_evaluate_on_new_document(
     return ScriptIdentifier.from_json(json["identifier"])
 
 
-def bring_to_front() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def bring_to_front() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Brings page to front (activates tab).
     """
@@ -2004,13 +2005,13 @@ def bring_to_front() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 
 def capture_screenshot(
-    format_: typing.Optional[str] = None,
-    quality: typing.Optional[int] = None,
-    clip: typing.Optional[Viewport] = None,
-    from_surface: typing.Optional[bool] = None,
-    capture_beyond_viewport: typing.Optional[bool] = None,
-    optimize_for_speed: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+    format_: str | None = None,
+    quality: int | None = None,
+    clip: Viewport | None = None,
+    from_surface: bool | None = None,
+    capture_beyond_viewport: bool | None = None,
+    optimize_for_speed: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Capture page screenshot.
 
@@ -2044,8 +2045,8 @@ def capture_screenshot(
 
 
 def capture_snapshot(
-    format_: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+    format_: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Returns a snapshot of the page as a string. For MHTML format, the serialization includes
     iframes, shadow DOM, external resources, and element-inline styles.
@@ -2066,7 +2067,7 @@ def capture_snapshot(
     return str(json["data"])
 
 
-def clear_device_metrics_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_device_metrics_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears the overridden device metrics.
 
@@ -2078,7 +2079,7 @@ def clear_device_metrics_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT
     yield cmd_dict
 
 
-def clear_device_orientation_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_device_orientation_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears the overridden Device Orientation.
 
@@ -2090,7 +2091,7 @@ def clear_device_orientation_override() -> typing.Generator[T_JSON_DICT, T_JSON_
     yield cmd_dict
 
 
-def clear_geolocation_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_geolocation_override() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears the overridden Geolocation Position and Error.
     """
@@ -2102,9 +2103,9 @@ def clear_geolocation_override() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, N
 
 def create_isolated_world(
     frame_id: FrameId,
-    world_name: typing.Optional[str] = None,
-    grant_univeral_access: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, runtime.ExecutionContextId]:
+    world_name: str | None = None,
+    grant_univeral_access: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, runtime.ExecutionContextId]:
     """
     Creates an isolated world for the given frame.
 
@@ -2130,7 +2131,7 @@ def create_isolated_world(
 def delete_cookie(
     cookie_name: str,
     url: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Deletes browser cookie with given name, domain and path.
 
@@ -2149,7 +2150,7 @@ def delete_cookie(
     yield cmd_dict
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables page domain notifications.
     """
@@ -2159,7 +2160,7 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def enable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables page domain notifications.
     """
@@ -2170,8 +2171,8 @@ def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 
 def get_app_manifest(
-    manifest_id: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, typing.List[AppManifestError], typing.Optional[str], typing.Optional[AppManifestParsedProperties], WebAppManifest]]:
+    manifest_id: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, list[AppManifestError], str | None, AppManifestParsedProperties | None, WebAppManifest]]:
     """
     Gets the processed manifest for this current document.
       This API always waits for the manifest to be loaded.
@@ -2205,7 +2206,7 @@ def get_app_manifest(
     )
 
 
-def get_installability_errors() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[InstallabilityError]]:
+def get_installability_errors() -> Generator[T_JSON_DICT, T_JSON_DICT, list[InstallabilityError]]:
     """
 
 
@@ -2220,7 +2221,7 @@ def get_installability_errors() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, ty
     return [InstallabilityError.from_json(i) for i in json["installabilityErrors"]]
 
 
-def get_manifest_icons() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Optional[str]]:
+def get_manifest_icons() -> Generator[T_JSON_DICT, T_JSON_DICT, str | None]:
     """
     Deprecated because it's not guaranteed that the returned icon is in fact the one used for PWA installation.
 
@@ -2235,7 +2236,7 @@ def get_manifest_icons() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Op
     return str(json["primaryIcon"]) if "primaryIcon" in json else None
 
 
-def get_app_id() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.Optional[str], typing.Optional[str]]]:
+def get_app_id() -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str | None, str | None]]:
     """
     Returns the unique (PWA) app id.
     Only returns values if the feature flag 'WebAppEnableManifestId' is enabled
@@ -2259,7 +2260,7 @@ def get_app_id() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typi
 
 def get_ad_script_id(
     frame_id: FrameId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Optional[AdScriptId]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, AdScriptId | None]:
     """
 
 
@@ -2278,7 +2279,7 @@ def get_ad_script_id(
     return AdScriptId.from_json(json["adScriptId"]) if "adScriptId" in json else None
 
 
-def get_frame_tree() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, FrameTree]:
+def get_frame_tree() -> Generator[T_JSON_DICT, T_JSON_DICT, FrameTree]:
     """
     Returns present frame tree structure.
 
@@ -2291,7 +2292,7 @@ def get_frame_tree() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, FrameTree]:
     return FrameTree.from_json(json["frameTree"])
 
 
-def get_layout_metrics() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[LayoutViewport, VisualViewport, dom.Rect, LayoutViewport, VisualViewport, dom.Rect]]:
+def get_layout_metrics() -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[LayoutViewport, VisualViewport, dom.Rect, LayoutViewport, VisualViewport, dom.Rect]]:
     """
     Returns metrics relating to the layouting of the page, such as viewport bounds/scale.
 
@@ -2318,7 +2319,7 @@ def get_layout_metrics() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tu
     )
 
 
-def get_navigation_history() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[int, typing.List[NavigationEntry]]]:
+def get_navigation_history() -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[int, list[NavigationEntry]]]:
     """
     Returns navigation history for the current page.
 
@@ -2337,7 +2338,7 @@ def get_navigation_history() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typin
     )
 
 
-def reset_navigation_history() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def reset_navigation_history() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Resets navigation history for the current page.
     """
@@ -2350,7 +2351,7 @@ def reset_navigation_history() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, Non
 def get_resource_content(
     frame_id: FrameId,
     url: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, bool]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, bool]]:
     """
     Returns content of the given resource.
 
@@ -2377,7 +2378,7 @@ def get_resource_content(
     )
 
 
-def get_resource_tree() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, FrameResourceTree]:
+def get_resource_tree() -> Generator[T_JSON_DICT, T_JSON_DICT, FrameResourceTree]:
     """
     Returns present frame / resource tree structure.
 
@@ -2394,8 +2395,8 @@ def get_resource_tree() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, FrameResou
 
 def handle_java_script_dialog(
     accept: bool,
-    prompt_text: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    prompt_text: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).
 
@@ -2415,11 +2416,11 @@ def handle_java_script_dialog(
 
 def navigate(
     url: str,
-    referrer: typing.Optional[str] = None,
-    transition_type: typing.Optional[TransitionType] = None,
-    frame_id: typing.Optional[FrameId] = None,
-    referrer_policy: typing.Optional[ReferrerPolicy] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[FrameId, typing.Optional[network.LoaderId], typing.Optional[str]]]:
+    referrer: str | None = None,
+    transition_type: TransitionType | None = None,
+    frame_id: FrameId | None = None,
+    referrer_policy: ReferrerPolicy | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[FrameId, network.LoaderId | None, str | None]]:
     """
     Navigates current page to the given URL.
 
@@ -2458,7 +2459,7 @@ def navigate(
 
 def navigate_to_history_entry(
     entry_id: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Navigates current page to the given history entry.
 
@@ -2474,24 +2475,24 @@ def navigate_to_history_entry(
 
 
 def print_to_pdf(
-    landscape: typing.Optional[bool] = None,
-    display_header_footer: typing.Optional[bool] = None,
-    print_background: typing.Optional[bool] = None,
-    scale: typing.Optional[float] = None,
-    paper_width: typing.Optional[float] = None,
-    paper_height: typing.Optional[float] = None,
-    margin_top: typing.Optional[float] = None,
-    margin_bottom: typing.Optional[float] = None,
-    margin_left: typing.Optional[float] = None,
-    margin_right: typing.Optional[float] = None,
-    page_ranges: typing.Optional[str] = None,
-    header_template: typing.Optional[str] = None,
-    footer_template: typing.Optional[str] = None,
-    prefer_css_page_size: typing.Optional[bool] = None,
-    transfer_mode: typing.Optional[str] = None,
-    generate_tagged_pdf: typing.Optional[bool] = None,
-    generate_document_outline: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[str, typing.Optional[io.StreamHandle]]]:
+    landscape: bool | None = None,
+    display_header_footer: bool | None = None,
+    print_background: bool | None = None,
+    scale: float | None = None,
+    paper_width: float | None = None,
+    paper_height: float | None = None,
+    margin_top: float | None = None,
+    margin_bottom: float | None = None,
+    margin_left: float | None = None,
+    margin_right: float | None = None,
+    page_ranges: str | None = None,
+    header_template: str | None = None,
+    footer_template: str | None = None,
+    prefer_css_page_size: bool | None = None,
+    transfer_mode: str | None = None,
+    generate_tagged_pdf: bool | None = None,
+    generate_document_outline: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[str, io.StreamHandle | None]]:
     """
     Print page as PDF.
 
@@ -2564,10 +2565,10 @@ def print_to_pdf(
 
 
 def reload(
-    ignore_cache: typing.Optional[bool] = None,
-    script_to_evaluate_on_load: typing.Optional[str] = None,
-    loader_id: typing.Optional[network.LoaderId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    ignore_cache: bool | None = None,
+    script_to_evaluate_on_load: str | None = None,
+    loader_id: network.LoaderId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Reloads given page optionally ignoring the cache.
 
@@ -2591,7 +2592,7 @@ def reload(
 
 def remove_script_to_evaluate_on_load(
     identifier: ScriptIdentifier,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Deprecated, please use removeScriptToEvaluateOnNewDocument instead.
 
@@ -2610,7 +2611,7 @@ def remove_script_to_evaluate_on_load(
 
 def remove_script_to_evaluate_on_new_document(
     identifier: ScriptIdentifier,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Removes given script from the list.
 
@@ -2627,7 +2628,7 @@ def remove_script_to_evaluate_on_new_document(
 
 def screencast_frame_ack(
     session_id: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Acknowledges that a screencast frame has been received by the frontend.
 
@@ -2648,9 +2649,9 @@ def search_in_resource(
     frame_id: FrameId,
     url: str,
     query: str,
-    case_sensitive: typing.Optional[bool] = None,
-    is_regex: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[debugger.SearchMatch]]:
+    case_sensitive: bool | None = None,
+    is_regex: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[debugger.SearchMatch]]:
     """
     Searches for given string in resource content.
 
@@ -2681,7 +2682,7 @@ def search_in_resource(
 
 def set_ad_blocking_enabled(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enable Chrome's experimental ad filter on all sites.
 
@@ -2700,7 +2701,7 @@ def set_ad_blocking_enabled(
 
 def set_bypass_csp(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enable page Content Security Policy by-passing.
 
@@ -2717,7 +2718,7 @@ def set_bypass_csp(
 
 def get_permissions_policy_state(
     frame_id: FrameId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[PermissionsPolicyFeatureState]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[PermissionsPolicyFeatureState]]:
     """
     Get Permissions Policy state on given frame.
 
@@ -2738,7 +2739,7 @@ def get_permissions_policy_state(
 
 def get_origin_trials(
     frame_id: FrameId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[OriginTrial]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[OriginTrial]]:
     """
     Get Origin Trials on given frame.
 
@@ -2762,15 +2763,15 @@ def set_device_metrics_override(
     height: int,
     device_scale_factor: float,
     mobile: bool,
-    scale: typing.Optional[float] = None,
-    screen_width: typing.Optional[int] = None,
-    screen_height: typing.Optional[int] = None,
-    position_x: typing.Optional[int] = None,
-    position_y: typing.Optional[int] = None,
-    dont_set_visible_size: typing.Optional[bool] = None,
-    screen_orientation: typing.Optional[emulation.ScreenOrientation] = None,
-    viewport: typing.Optional[Viewport] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    scale: float | None = None,
+    screen_width: int | None = None,
+    screen_height: int | None = None,
+    position_x: int | None = None,
+    position_y: int | None = None,
+    dont_set_visible_size: bool | None = None,
+    screen_orientation: emulation.ScreenOrientation | None = None,
+    viewport: Viewport | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides the values of device screen dimensions (window.screen.width, window.screen.height,
     window.innerWidth, window.innerHeight, and "device-width"/"device-height"-related CSS media
@@ -2823,7 +2824,7 @@ def set_device_orientation_override(
     alpha: float,
     beta: float,
     gamma: float,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides the Device Orientation.
 
@@ -2846,8 +2847,8 @@ def set_device_orientation_override(
 
 def set_font_families(
     font_families: FontFamilies,
-    for_scripts: typing.Optional[typing.List[ScriptFontFamilies]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    for_scripts: list[ScriptFontFamilies] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set generic font families.
 
@@ -2869,7 +2870,7 @@ def set_font_families(
 
 def set_font_sizes(
     font_sizes: FontSizes,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set default font sizes.
 
@@ -2889,7 +2890,7 @@ def set_font_sizes(
 def set_document_content(
     frame_id: FrameId,
     html: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets given markup as the document's HTML.
 
@@ -2908,8 +2909,8 @@ def set_document_content(
 
 def set_download_behavior(
     behavior: str,
-    download_path: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    download_path: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Set the behavior when downloading a file.
 
@@ -2930,10 +2931,10 @@ def set_download_behavior(
 
 
 def set_geolocation_override(
-    latitude: typing.Optional[float] = None,
-    longitude: typing.Optional[float] = None,
-    accuracy: typing.Optional[float] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    latitude: float | None = None,
+    longitude: float | None = None,
+    accuracy: float | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Overrides the Geolocation Position or Error. Omitting any of the parameters emulates position
     unavailable.
@@ -2958,7 +2959,7 @@ def set_geolocation_override(
 
 def set_lifecycle_events_enabled(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Controls whether page will emit lifecycle events.
 
@@ -2975,8 +2976,8 @@ def set_lifecycle_events_enabled(
 
 def set_touch_emulation_enabled(
     enabled: bool,
-    configuration: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    configuration: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Toggles mouse event-based touch event emulation.
 
@@ -2997,12 +2998,12 @@ def set_touch_emulation_enabled(
 
 
 def start_screencast(
-    format_: typing.Optional[str] = None,
-    quality: typing.Optional[int] = None,
-    max_width: typing.Optional[int] = None,
-    max_height: typing.Optional[int] = None,
-    every_nth_frame: typing.Optional[int] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    format_: str | None = None,
+    quality: int | None = None,
+    max_width: int | None = None,
+    max_height: int | None = None,
+    every_nth_frame: int | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Starts sending each frame using the ``screencastFrame`` event.
 
@@ -3032,7 +3033,7 @@ def start_screencast(
     yield cmd_dict
 
 
-def stop_loading() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def stop_loading() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Force the page stop all navigations and pending resource fetches.
     """
@@ -3042,7 +3043,7 @@ def stop_loading() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def crash() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def crash() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Crashes renderer on the IO thread, generates minidumps.
 
@@ -3054,7 +3055,7 @@ def crash() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def close() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def close() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Tries to close page, running its beforeunload hooks, if any.
     """
@@ -3066,7 +3067,7 @@ def close() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def set_web_lifecycle_state(
     state: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Tries to update the web lifecycle state of the page.
     It will transition the page to the given state according to:
@@ -3085,7 +3086,7 @@ def set_web_lifecycle_state(
     yield cmd_dict
 
 
-def stop_screencast() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def stop_screencast() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Stops sending each frame in the ``screencastFrame``.
 
@@ -3098,8 +3099,8 @@ def stop_screencast() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 
 def produce_compilation_cache(
-    scripts: typing.List[CompilationCacheParams],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    scripts: list[CompilationCacheParams],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Requests backend to produce compilation cache for the specified scripts.
     ``scripts`` are appended to the list of scripts for which the cache
@@ -3124,7 +3125,7 @@ def produce_compilation_cache(
 def add_compilation_cache(
     url: str,
     data: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Seeds compilation cache for given url. Compilation cache does not survive
     cross-process navigation.
@@ -3144,7 +3145,7 @@ def add_compilation_cache(
     yield cmd_dict
 
 
-def clear_compilation_cache() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def clear_compilation_cache() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Clears seeded compilation cache.
 
@@ -3158,7 +3159,7 @@ def clear_compilation_cache() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None
 
 def set_spc_transaction_mode(
     mode: AutoResponseMode,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sets the Secure Payment Confirmation transaction mode.
     https://w3c.github.io/secure-payment-confirmation/#sctn-automation-set-spc-transaction-mode
@@ -3178,7 +3179,7 @@ def set_spc_transaction_mode(
 
 def set_rph_registration_mode(
     mode: AutoResponseMode,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Extensions for Custom Handlers API:
     https://html.spec.whatwg.org/multipage/system-state.html#rph-automation
@@ -3198,8 +3199,8 @@ def set_rph_registration_mode(
 
 def generate_test_report(
     message: str,
-    group: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    group: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Generates a report for testing.
 
@@ -3219,7 +3220,7 @@ def generate_test_report(
     yield cmd_dict
 
 
-def wait_for_debugger() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def wait_for_debugger() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Pauses page execution. Can be resumed using generic Runtime.runIfWaitingForDebugger.
 
@@ -3233,7 +3234,7 @@ def wait_for_debugger() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def set_intercept_file_chooser_dialog(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Intercept file chooser requests and transfer control to protocol clients.
     When file chooser interception is enabled, native file chooser dialog is not shown.
@@ -3252,7 +3253,7 @@ def set_intercept_file_chooser_dialog(
 
 def set_prerendering_allowed(
     is_allowed: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enable/disable prerendering manually.
 
@@ -3298,7 +3299,7 @@ class FileChooserOpened:
     #: Input mode.
     mode: str
     #: Input node id. Only present for file choosers opened via an ``<input type="file">`` element.
-    backend_node_id: typing.Optional[dom.BackendNodeId]
+    backend_node_id: dom.BackendNodeId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> FileChooserOpened:
@@ -3320,7 +3321,7 @@ class FrameAttached:
     #: Parent frame identifier.
     parent_frame_id: FrameId
     #: JavaScript stack trace of when frame was attached, only set if frame initiated from script.
-    stack: typing.Optional[runtime.StackTrace]
+    stack: runtime.StackTrace | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> FrameAttached:
@@ -3651,7 +3652,7 @@ class JavascriptDialogOpening:
     #: the page execution. Execution can be resumed via calling Page.handleJavaScriptDialog.
     has_browser_handler: bool
     #: Default dialog prompt.
-    default_prompt: typing.Optional[str]
+    default_prompt: str | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> JavascriptDialogOpening:
@@ -3703,9 +3704,9 @@ class BackForwardCacheNotUsed:
     #: The frame id of the associated frame.
     frame_id: FrameId
     #: Array of reasons why the page could not be cached. This must not be empty.
-    not_restored_explanations: typing.List[BackForwardCacheNotRestoredExplanation]
+    not_restored_explanations: list[BackForwardCacheNotRestoredExplanation]
     #: Tree structure of reasons why the page could not be cached for each frame.
-    not_restored_explanations_tree: typing.Optional[BackForwardCacheNotRestoredExplanationTree]
+    not_restored_explanations_tree: BackForwardCacheNotRestoredExplanationTree | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> BackForwardCacheNotUsed:
@@ -3807,7 +3808,7 @@ class WindowOpen:
     #: Window name.
     window_name: str
     #: An array of enabled window features.
-    window_features: typing.List[str]
+    window_features: list[str]
     #: Whether or not it was triggered by user gesture.
     user_gesture: bool
 

--- a/src/streamlink/webbrowser/cdp/devtools/runtime.py
+++ b/src/streamlink/webbrowser/cdp/devtools/runtime.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
 
@@ -38,12 +39,12 @@ class SerializationOptions:
     serialization: str
 
     #: Deep serialization depth. Default is full depth. Respected only in ``deep`` serialization mode.
-    max_depth: typing.Optional[int] = None
+    max_depth: int | None = None
 
     #: Embedder-specific parameters. For example if connected to V8 in Chrome these control DOM
     #: serialization via ``maxNodeDepth: integer`` and ``includeShadowTree: "none" `` "open" `` "all"``.
     #: Values can be only of type string or integer.
-    additional_parameters: typing.Optional[dict] = None
+    additional_parameters: dict | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -70,14 +71,14 @@ class DeepSerializedValue:
     """
     type_: str
 
-    value: typing.Optional[typing.Any] = None
+    value: Any | None = None
 
-    object_id: typing.Optional[str] = None
+    object_id: str | None = None
 
     #: Set if value reference met more then once during serialization. In such
     #: case, value is provided only to one of the serialized values. Unique
     #: per value in the scope of one CDP call.
-    weak_local_object_reference: typing.Optional[int] = None
+    weak_local_object_reference: int | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -142,31 +143,31 @@ class RemoteObject:
     #: Object subtype hint. Specified for ``object`` type values only.
     #: NOTE: If you change anything here, make sure to also update
     #: ``subtype`` in ``ObjectPreview`` and ``PropertyPreview`` below.
-    subtype: typing.Optional[str] = None
+    subtype: str | None = None
 
     #: Object class (constructor) name. Specified for ``object`` type values only.
-    class_name: typing.Optional[str] = None
+    class_name: str | None = None
 
     #: Remote object value in case of primitive values or JSON values (if it was requested).
-    value: typing.Optional[typing.Any] = None
+    value: Any | None = None
 
     #: Primitive value which can not be JSON-stringified does not have ``value``, but gets this
     #: property.
-    unserializable_value: typing.Optional[UnserializableValue] = None
+    unserializable_value: UnserializableValue | None = None
 
     #: String representation of the object.
-    description: typing.Optional[str] = None
+    description: str | None = None
 
     #: Deep serialized value.
-    deep_serialized_value: typing.Optional[DeepSerializedValue] = None
+    deep_serialized_value: DeepSerializedValue | None = None
 
     #: Unique object identifier (for non-primitive values).
-    object_id: typing.Optional[RemoteObjectId] = None
+    object_id: RemoteObjectId | None = None
 
     #: Preview containing abbreviated property values. Specified for ``object`` type values only.
-    preview: typing.Optional[ObjectPreview] = None
+    preview: ObjectPreview | None = None
 
-    custom_preview: typing.Optional[CustomPreview] = None
+    custom_preview: CustomPreview | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -216,7 +217,7 @@ class CustomPreview:
     #: If formatter returns true as a result of formatter.hasBody call then bodyGetterId will
     #: contain RemoteObjectId for the function that returns result of formatter.body(object, config) call.
     #: The result value is json ML array.
-    body_getter_id: typing.Optional[RemoteObjectId] = None
+    body_getter_id: RemoteObjectId | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -245,16 +246,16 @@ class ObjectPreview:
     overflow: bool
 
     #: List of the properties.
-    properties: typing.List[PropertyPreview]
+    properties: list[PropertyPreview]
 
     #: Object subtype hint. Specified for ``object`` type values only.
-    subtype: typing.Optional[str] = None
+    subtype: str | None = None
 
     #: String representation of the object.
-    description: typing.Optional[str] = None
+    description: str | None = None
 
     #: List of the entries. Specified for ``map`` and ``set`` subtype values only.
-    entries: typing.Optional[typing.List[EntryPreview]] = None
+    entries: list[EntryPreview] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -290,13 +291,13 @@ class PropertyPreview:
     type_: str
 
     #: User-friendly property value string.
-    value: typing.Optional[str] = None
+    value: str | None = None
 
     #: Nested value preview.
-    value_preview: typing.Optional[ObjectPreview] = None
+    value_preview: ObjectPreview | None = None
 
     #: Object subtype hint. Specified for ``object`` type values only.
-    subtype: typing.Optional[str] = None
+    subtype: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -327,7 +328,7 @@ class EntryPreview:
     value: ObjectPreview
 
     #: Preview of the key. Specified for map-like collection entries.
-    key: typing.Optional[ObjectPreview] = None
+    key: ObjectPreview | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -361,27 +362,27 @@ class PropertyDescriptor:
     enumerable: bool
 
     #: The value associated with the property.
-    value: typing.Optional[RemoteObject] = None
+    value: RemoteObject | None = None
 
     #: True if the value associated with the property may be changed (data descriptors only).
-    writable: typing.Optional[bool] = None
+    writable: bool | None = None
 
     #: A function which serves as a getter for the property, or ``undefined`` if there is no getter
     #: (accessor descriptors only).
-    get: typing.Optional[RemoteObject] = None
+    get: RemoteObject | None = None
 
     #: A function which serves as a setter for the property, or ``undefined`` if there is no setter
     #: (accessor descriptors only).
-    set_: typing.Optional[RemoteObject] = None
+    set_: RemoteObject | None = None
 
     #: True if the result was thrown during the evaluation.
-    was_thrown: typing.Optional[bool] = None
+    was_thrown: bool | None = None
 
     #: True if the property is owned for the object.
-    is_own: typing.Optional[bool] = None
+    is_own: bool | None = None
 
     #: Property symbol object, if the property is of the ``symbol`` type.
-    symbol: typing.Optional[RemoteObject] = None
+    symbol: RemoteObject | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -429,7 +430,7 @@ class InternalPropertyDescriptor:
     name: str
 
     #: The value associated with the property.
-    value: typing.Optional[RemoteObject] = None
+    value: RemoteObject | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -455,15 +456,15 @@ class PrivatePropertyDescriptor:
     name: str
 
     #: The value associated with the private property.
-    value: typing.Optional[RemoteObject] = None
+    value: RemoteObject | None = None
 
     #: A function which serves as a getter for the private property,
     #: or ``undefined`` if there is no getter (accessor descriptors only).
-    get: typing.Optional[RemoteObject] = None
+    get: RemoteObject | None = None
 
     #: A function which serves as a setter for the private property,
     #: or ``undefined`` if there is no setter (accessor descriptors only).
-    set_: typing.Optional[RemoteObject] = None
+    set_: RemoteObject | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -493,13 +494,13 @@ class CallArgument:
     unserializable primitive value or neither of (for undefined) them should be specified.
     """
     #: Primitive value or serializable javascript object.
-    value: typing.Optional[typing.Any] = None
+    value: Any | None = None
 
     #: Primitive value which can not be JSON-stringified.
-    unserializable_value: typing.Optional[UnserializableValue] = None
+    unserializable_value: UnserializableValue | None = None
 
     #: Remote object handle.
-    object_id: typing.Optional[RemoteObjectId] = None
+    object_id: RemoteObjectId | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -556,7 +557,7 @@ class ExecutionContextDescription:
     unique_id: str
 
     #: Embedder-specific auxiliary data likely matching {isDefault: boolean, type: 'default'``'isolated'``'worker', frameId: string}
-    aux_data: typing.Optional[dict] = None
+    aux_data: dict | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -598,24 +599,24 @@ class ExceptionDetails:
     column_number: int
 
     #: Script ID of the exception location.
-    script_id: typing.Optional[ScriptId] = None
+    script_id: ScriptId | None = None
 
     #: URL of the exception location, to be used when the script was not reported.
-    url: typing.Optional[str] = None
+    url: str | None = None
 
     #: JavaScript stack trace if available.
-    stack_trace: typing.Optional[StackTrace] = None
+    stack_trace: StackTrace | None = None
 
     #: Exception object if available.
-    exception: typing.Optional[RemoteObject] = None
+    exception: RemoteObject | None = None
 
     #: Identifier of the context where exception happened.
-    execution_context_id: typing.Optional[ExecutionContextId] = None
+    execution_context_id: ExecutionContextId | None = None
 
     #: Dictionary with entries of meta data that the client associated
     #: with this exception, such as information about associated network
     #: requests, etc.
-    exception_meta_data: typing.Optional[dict] = None
+    exception_meta_data: dict | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -729,17 +730,17 @@ class StackTrace:
     Call frames for assertions or error messages.
     """
     #: JavaScript function name.
-    call_frames: typing.List[CallFrame]
+    call_frames: list[CallFrame]
 
     #: String label of this stack trace. For async traces this may be a name of the function that
     #: initiated the async call.
-    description: typing.Optional[str] = None
+    description: str | None = None
 
     #: Asynchronous JavaScript stack trace that preceded this stack, if available.
-    parent: typing.Optional[StackTrace] = None
+    parent: StackTrace | None = None
 
     #: Asynchronous JavaScript stack trace that preceded this stack, if available.
-    parent_id: typing.Optional[StackTraceId] = None
+    parent_id: StackTraceId | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -785,7 +786,7 @@ class StackTraceId:
     """
     id_: str
 
-    debugger_id: typing.Optional[UniqueDebuggerId] = None
+    debugger_id: UniqueDebuggerId | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -804,9 +805,9 @@ class StackTraceId:
 
 def await_promise(
     promise_object_id: RemoteObjectId,
-    return_by_value: typing.Optional[bool] = None,
-    generate_preview: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[RemoteObject, typing.Optional[ExceptionDetails]]]:
+    return_by_value: bool | None = None,
+    generate_preview: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[RemoteObject, ExceptionDetails | None]]:
     """
     Add handler to promise with given promise object id.
 
@@ -837,19 +838,19 @@ def await_promise(
 
 def call_function_on(
     function_declaration: str,
-    object_id: typing.Optional[RemoteObjectId] = None,
-    arguments: typing.Optional[typing.List[CallArgument]] = None,
-    silent: typing.Optional[bool] = None,
-    return_by_value: typing.Optional[bool] = None,
-    generate_preview: typing.Optional[bool] = None,
-    user_gesture: typing.Optional[bool] = None,
-    await_promise: typing.Optional[bool] = None,
-    execution_context_id: typing.Optional[ExecutionContextId] = None,
-    object_group: typing.Optional[str] = None,
-    throw_on_side_effect: typing.Optional[bool] = None,
-    unique_context_id: typing.Optional[str] = None,
-    serialization_options: typing.Optional[SerializationOptions] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[RemoteObject, typing.Optional[ExceptionDetails]]]:
+    object_id: RemoteObjectId | None = None,
+    arguments: list[CallArgument] | None = None,
+    silent: bool | None = None,
+    return_by_value: bool | None = None,
+    generate_preview: bool | None = None,
+    user_gesture: bool | None = None,
+    await_promise: bool | None = None,
+    execution_context_id: ExecutionContextId | None = None,
+    object_group: str | None = None,
+    throw_on_side_effect: bool | None = None,
+    unique_context_id: str | None = None,
+    serialization_options: SerializationOptions | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[RemoteObject, ExceptionDetails | None]]:
     """
     Calls function with given declaration on the given object. Object group of the result is
     inherited from the target object.
@@ -913,8 +914,8 @@ def compile_script(
     expression: str,
     source_url: str,
     persist_script: bool,
-    execution_context_id: typing.Optional[ExecutionContextId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.Optional[ScriptId], typing.Optional[ExceptionDetails]]]:
+    execution_context_id: ExecutionContextId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[ScriptId | None, ExceptionDetails | None]]:
     """
     Compiles expression.
 
@@ -944,7 +945,7 @@ def compile_script(
     )
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables reporting of execution contexts creation.
     """
@@ -954,7 +955,7 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def discard_console_entries() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def discard_console_entries() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Discards collected exceptions and console API calls.
     """
@@ -964,7 +965,7 @@ def discard_console_entries() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None
     yield cmd_dict
 
 
-def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def enable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables reporting of execution contexts creation by means of ``executionContextCreated`` event.
     When the reporting gets enabled the event will be sent immediately for each existing execution
@@ -978,22 +979,22 @@ def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def evaluate(
     expression: str,
-    object_group: typing.Optional[str] = None,
-    include_command_line_api: typing.Optional[bool] = None,
-    silent: typing.Optional[bool] = None,
-    context_id: typing.Optional[ExecutionContextId] = None,
-    return_by_value: typing.Optional[bool] = None,
-    generate_preview: typing.Optional[bool] = None,
-    user_gesture: typing.Optional[bool] = None,
-    await_promise: typing.Optional[bool] = None,
-    throw_on_side_effect: typing.Optional[bool] = None,
-    timeout: typing.Optional[TimeDelta] = None,
-    disable_breaks: typing.Optional[bool] = None,
-    repl_mode: typing.Optional[bool] = None,
-    allow_unsafe_eval_blocked_by_csp: typing.Optional[bool] = None,
-    unique_context_id: typing.Optional[str] = None,
-    serialization_options: typing.Optional[SerializationOptions] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[RemoteObject, typing.Optional[ExceptionDetails]]]:
+    object_group: str | None = None,
+    include_command_line_api: bool | None = None,
+    silent: bool | None = None,
+    context_id: ExecutionContextId | None = None,
+    return_by_value: bool | None = None,
+    generate_preview: bool | None = None,
+    user_gesture: bool | None = None,
+    await_promise: bool | None = None,
+    throw_on_side_effect: bool | None = None,
+    timeout: TimeDelta | None = None,
+    disable_breaks: bool | None = None,
+    repl_mode: bool | None = None,
+    allow_unsafe_eval_blocked_by_csp: bool | None = None,
+    unique_context_id: str | None = None,
+    serialization_options: SerializationOptions | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[RemoteObject, ExceptionDetails | None]]:
     """
     Evaluates expression on global object.
 
@@ -1061,7 +1062,7 @@ def evaluate(
     )
 
 
-def get_isolate_id() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
+def get_isolate_id() -> Generator[T_JSON_DICT, T_JSON_DICT, str]:
     """
     Returns the isolate id.
 
@@ -1076,7 +1077,7 @@ def get_isolate_id() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, str]:
     return str(json["id"])
 
 
-def get_heap_usage() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[float, float]]:
+def get_heap_usage() -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[float, float]]:
     """
     Returns the JavaScript heap usage.
     It is the total usage of the corresponding isolate not scoped to a particular Runtime.
@@ -1100,11 +1101,11 @@ def get_heap_usage() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[
 
 def get_properties(
     object_id: RemoteObjectId,
-    own_properties: typing.Optional[bool] = None,
-    accessor_properties_only: typing.Optional[bool] = None,
-    generate_preview: typing.Optional[bool] = None,
-    non_indexed_properties_only: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[typing.List[PropertyDescriptor], typing.Optional[typing.List[InternalPropertyDescriptor]], typing.Optional[typing.List[PrivatePropertyDescriptor]], typing.Optional[ExceptionDetails]]]:
+    own_properties: bool | None = None,
+    accessor_properties_only: bool | None = None,
+    generate_preview: bool | None = None,
+    non_indexed_properties_only: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[list[PropertyDescriptor], list[InternalPropertyDescriptor] | None, list[PrivatePropertyDescriptor] | None, ExceptionDetails | None]]:
     """
     Returns properties of a given object. Object group of the result is inherited from the target
     object.
@@ -1145,8 +1146,8 @@ def get_properties(
 
 
 def global_lexical_scope_names(
-    execution_context_id: typing.Optional[ExecutionContextId] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[str]]:
+    execution_context_id: ExecutionContextId | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[str]]:
     """
     Returns all let, const and class variables from global scope.
 
@@ -1166,8 +1167,8 @@ def global_lexical_scope_names(
 
 def query_objects(
     prototype_object_id: RemoteObjectId,
-    object_group: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, RemoteObject]:
+    object_group: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, RemoteObject]:
     """
     :param prototype_object_id: Identifier of the prototype to return objects for.
     :param object_group: *(Optional)* Symbolic group name that can be used to release the results.
@@ -1187,7 +1188,7 @@ def query_objects(
 
 def release_object(
     object_id: RemoteObjectId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Releases remote object with given id.
 
@@ -1204,7 +1205,7 @@ def release_object(
 
 def release_object_group(
     object_group: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Releases all remote objects that belong to a given group.
 
@@ -1219,7 +1220,7 @@ def release_object_group(
     yield cmd_dict
 
 
-def run_if_waiting_for_debugger() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def run_if_waiting_for_debugger() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Tells inspected instance to run if it was waiting for debugger to attach.
     """
@@ -1231,14 +1232,14 @@ def run_if_waiting_for_debugger() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, 
 
 def run_script(
     script_id: ScriptId,
-    execution_context_id: typing.Optional[ExecutionContextId] = None,
-    object_group: typing.Optional[str] = None,
-    silent: typing.Optional[bool] = None,
-    include_command_line_api: typing.Optional[bool] = None,
-    return_by_value: typing.Optional[bool] = None,
-    generate_preview: typing.Optional[bool] = None,
-    await_promise: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Tuple[RemoteObject, typing.Optional[ExceptionDetails]]]:
+    execution_context_id: ExecutionContextId | None = None,
+    object_group: str | None = None,
+    silent: bool | None = None,
+    include_command_line_api: bool | None = None,
+    return_by_value: bool | None = None,
+    generate_preview: bool | None = None,
+    await_promise: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, tuple[RemoteObject, ExceptionDetails | None]]:
     """
     Runs script with given id in a given context.
 
@@ -1284,7 +1285,7 @@ def run_script(
 
 def set_async_call_stack_depth(
     max_depth: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables or disables async call stacks tracking.
 
@@ -1301,7 +1302,7 @@ def set_async_call_stack_depth(
 
 def set_custom_object_formatter_enabled(
     enabled: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -1320,7 +1321,7 @@ def set_custom_object_formatter_enabled(
 
 def set_max_call_stack_size_to_capture(
     size: int,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
 
 
@@ -1337,7 +1338,7 @@ def set_max_call_stack_size_to_capture(
     yield cmd_dict
 
 
-def terminate_execution() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def terminate_execution() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Terminate current or next JavaScript execution.
     Will cancel the termination when the outer-most script execution ends.
@@ -1352,9 +1353,9 @@ def terminate_execution() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def add_binding(
     name: str,
-    execution_context_id: typing.Optional[ExecutionContextId] = None,
-    execution_context_name: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    execution_context_id: ExecutionContextId | None = None,
+    execution_context_name: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     If executionContextId is empty, adds binding with the given name on the
     global objects of all inspected contexts, including those created later,
@@ -1382,7 +1383,7 @@ def add_binding(
 
 def remove_binding(
     name: str,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     This method does not remove binding function from global object but
     unsubscribes current runtime agent from Runtime.bindingCalled notifications.
@@ -1400,7 +1401,7 @@ def remove_binding(
 
 def get_exception_details(
     error_object_id: RemoteObjectId,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.Optional[ExceptionDetails]]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, ExceptionDetails | None]:
     """
     This method tries to lookup and populate exception details for a
     JavaScript Error object.
@@ -1454,7 +1455,7 @@ class ConsoleAPICalled:
     #: Type of the call.
     type_: str
     #: Call arguments.
-    args: typing.List[RemoteObject]
+    args: list[RemoteObject]
     #: Identifier of the context where the call was made.
     execution_context_id: ExecutionContextId
     #: Call timestamp.
@@ -1462,11 +1463,11 @@ class ConsoleAPICalled:
     #: Stack trace captured when the call was made. The async stack chain is automatically reported for
     #: the following call types: ``assert``, ``error``, ``trace``, ``warning``. For other types the async call
     #: chain can be retrieved using ``Debugger.getStackTrace`` and ``stackTrace.parentId`` field.
-    stack_trace: typing.Optional[StackTrace]
+    stack_trace: StackTrace | None
     #: Console context descriptor for calls on non-default console context (not console.*):
     #: 'anonymous#unique-logger-id' for call on unnamed context, 'name#unique-logger-id' for call
     #: on named context.
-    context: typing.Optional[str]
+    context: str | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ConsoleAPICalled:
@@ -1577,7 +1578,7 @@ class InspectRequested:
     object_: RemoteObject
     hints: dict
     #: Identifier of the context where the call was made.
-    execution_context_id: typing.Optional[ExecutionContextId]
+    execution_context_id: ExecutionContextId | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> InspectRequested:

--- a/src/streamlink/webbrowser/cdp/devtools/security.py
+++ b/src/streamlink/webbrowser/cdp/devtools/security.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.network as network
 from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT, event_class
@@ -82,7 +83,7 @@ class CertificateSecurityState:
     cipher: str
 
     #: Page certificate.
-    certificate: typing.List[str]
+    certificate: list[str]
 
     #: Certificate subject name.
     subject_name: str
@@ -118,13 +119,13 @@ class CertificateSecurityState:
     obsolete_ssl_signature: bool
 
     #: (EC)DH group used by the connection, if applicable.
-    key_exchange_group: typing.Optional[str] = None
+    key_exchange_group: str | None = None
 
     #: TLS MAC. Note that AEAD ciphers do not have separate MACs.
-    mac: typing.Optional[str] = None
+    mac: str | None = None
 
     #: The highest priority network error code, if the certificate has an error.
-    certificate_network_error: typing.Optional[str] = None
+    certificate_network_error: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -193,7 +194,7 @@ class SafetyTipInfo:
     safety_tip_status: SafetyTipStatus
 
     #: The URL the safety tip suggested ("Did you mean?"). Only filled in for lookalike matches.
-    safe_url: typing.Optional[str] = None
+    safe_url: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -219,13 +220,13 @@ class VisibleSecurityState:
     security_state: SecurityState
 
     #: Array of security state issues ids.
-    security_state_issue_ids: typing.List[str]
+    security_state_issue_ids: list[str]
 
     #: Security state details about the page certificate.
-    certificate_security_state: typing.Optional[CertificateSecurityState] = None
+    certificate_security_state: CertificateSecurityState | None = None
 
     #: The type of Safety Tip triggered on the page. Note that this field will be set even if the Safety Tip UI was not actually shown.
-    safety_tip_info: typing.Optional[SafetyTipInfo] = None
+    safety_tip_info: SafetyTipInfo | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -268,10 +269,10 @@ class SecurityStateExplanation:
     mixed_content_type: MixedContentType
 
     #: Page certificate.
-    certificate: typing.List[str]
+    certificate: list[str]
 
     #: Recommendations to fix any issues.
-    recommendations: typing.Optional[typing.List[str]] = None
+    recommendations: list[str] | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -364,7 +365,7 @@ class CertificateErrorAction(enum.Enum):
         return cls(json)
 
 
-def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def disable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Disables tracking security state changes.
     """
@@ -374,7 +375,7 @@ def disable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
     yield cmd_dict
 
 
-def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+def enable() -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables tracking security state changes.
     """
@@ -386,7 +387,7 @@ def enable() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
 
 def set_ignore_certificate_errors(
     ignore: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enable/disable whether all certificate errors should be ignored.
 
@@ -404,7 +405,7 @@ def set_ignore_certificate_errors(
 def handle_certificate_error(
     event_id: int,
     action: CertificateErrorAction,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Handles a certificate error that fired a certificateError event.
 
@@ -423,7 +424,7 @@ def handle_certificate_error(
 
 def set_override_certificate_errors(
     override: bool,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enable/disable overriding certificate errors. If enabled, all certificate error events need to
     be handled by the DevTools client and should be answered with ``handleCertificateError`` commands.
@@ -494,11 +495,11 @@ class SecurityStateChanged:
     scheme_is_cryptographic: bool
     #: Previously a list of explanations for the security state. Now always
     #: empty.
-    explanations: typing.List[SecurityStateExplanation]
+    explanations: list[SecurityStateExplanation]
     #: Information about insecure content on the page.
     insecure_content_status: InsecureContentStatus
     #: Overrides user-visible description of the state. Always omitted.
-    summary: typing.Optional[str]
+    summary: str | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> SecurityStateChanged:

--- a/src/streamlink/webbrowser/cdp/devtools/target.py
+++ b/src/streamlink/webbrowser/cdp/devtools/target.py
@@ -9,8 +9,9 @@
 from __future__ import annotations
 
 import enum
-import typing
+from collections.abc import Generator
 from dataclasses import dataclass
+from typing import Any
 
 import streamlink.webbrowser.cdp.devtools.browser as browser
 import streamlink.webbrowser.cdp.devtools.page as page
@@ -62,16 +63,16 @@ class TargetInfo:
     can_access_opener: bool
 
     #: Opener target Id
-    opener_id: typing.Optional[TargetID] = None
+    opener_id: TargetID | None = None
 
     #: Frame id of originating window (is only set if target has an opener).
-    opener_frame_id: typing.Optional[page.FrameId] = None
+    opener_frame_id: page.FrameId | None = None
 
-    browser_context_id: typing.Optional[browser.BrowserContextID] = None
+    browser_context_id: browser.BrowserContextID | None = None
 
     #: Provides additional details for specific target types. For example, for
     #: the type of "page", this may be set to "prerender".
-    subtype: typing.Optional[str] = None
+    subtype: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -113,10 +114,10 @@ class FilterEntry:
     A filter used by target query/discovery/auto-attach operations.
     """
     #: If set, causes exclusion of matching targets from the list.
-    exclude: typing.Optional[bool] = None
+    exclude: bool | None = None
 
     #: If not present, matches any type.
-    type_: typing.Optional[str] = None
+    type_: str | None = None
 
     def to_json(self) -> T_JSON_DICT:
         json: T_JSON_DICT = {}
@@ -143,11 +144,11 @@ class TargetFilter(list):
     [{type: "browser", exclude: true}, {type: "tab", exclude: true}, {}]
     (i.e. include everything but ``browser`` and ``tab``).
     """
-    def to_json(self) -> typing.List[FilterEntry]:
+    def to_json(self) -> list[FilterEntry]:
         return self
 
     @classmethod
-    def from_json(cls, json: typing.List[FilterEntry]) -> TargetFilter:
+    def from_json(cls, json: list[FilterEntry]) -> TargetFilter:
         return cls(json)
 
     def __repr__(self):
@@ -176,7 +177,7 @@ class RemoteLocation:
 
 def activate_target(
     target_id: TargetID,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Activates (focuses) the target.
 
@@ -193,8 +194,8 @@ def activate_target(
 
 def attach_to_target(
     target_id: TargetID,
-    flatten: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, SessionID]:
+    flatten: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, SessionID]:
     """
     Attaches to the target with given id.
 
@@ -214,7 +215,7 @@ def attach_to_target(
     return SessionID.from_json(json["sessionId"])
 
 
-def attach_to_browser_target() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, SessionID]:
+def attach_to_browser_target() -> Generator[T_JSON_DICT, T_JSON_DICT, SessionID]:
     """
     Attaches to the browser target, only uses flat sessionId mode.
 
@@ -231,7 +232,7 @@ def attach_to_browser_target() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, Ses
 
 def close_target(
     target_id: TargetID,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, bool]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, bool]:
     """
     Closes the target. If the target is a page that gets closed too.
 
@@ -250,8 +251,8 @@ def close_target(
 
 def expose_dev_tools_protocol(
     target_id: TargetID,
-    binding_name: typing.Optional[str] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    binding_name: str | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Inject object to the target's main frame that provides a communication
     channel with browser target.
@@ -279,11 +280,11 @@ def expose_dev_tools_protocol(
 
 
 def create_browser_context(
-    dispose_on_detach: typing.Optional[bool] = None,
-    proxy_server: typing.Optional[str] = None,
-    proxy_bypass_list: typing.Optional[str] = None,
-    origins_with_universal_network_access: typing.Optional[typing.List[str]] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, browser.BrowserContextID]:
+    dispose_on_detach: bool | None = None,
+    proxy_server: str | None = None,
+    proxy_bypass_list: str | None = None,
+    origins_with_universal_network_access: list[str] | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, browser.BrowserContextID]:
     """
     Creates a new empty BrowserContext. Similar to an incognito profile but you can have more than
     one.
@@ -311,7 +312,7 @@ def create_browser_context(
     return browser.BrowserContextID.from_json(json["browserContextId"])
 
 
-def get_browser_contexts() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[browser.BrowserContextID]]:
+def get_browser_contexts() -> Generator[T_JSON_DICT, T_JSON_DICT, list[browser.BrowserContextID]]:
     """
     Returns all browser contexts created with ``Target.createBrowserContext`` method.
 
@@ -326,14 +327,14 @@ def get_browser_contexts() -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.
 
 def create_target(
     url: str,
-    width: typing.Optional[int] = None,
-    height: typing.Optional[int] = None,
-    browser_context_id: typing.Optional[browser.BrowserContextID] = None,
-    enable_begin_frame_control: typing.Optional[bool] = None,
-    new_window: typing.Optional[bool] = None,
-    background: typing.Optional[bool] = None,
-    for_tab: typing.Optional[bool] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, TargetID]:
+    width: int | None = None,
+    height: int | None = None,
+    browser_context_id: browser.BrowserContextID | None = None,
+    enable_begin_frame_control: bool | None = None,
+    new_window: bool | None = None,
+    background: bool | None = None,
+    for_tab: bool | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, TargetID]:
     """
     Creates a new page.
 
@@ -372,9 +373,9 @@ def create_target(
 
 
 def detach_from_target(
-    session_id: typing.Optional[SessionID] = None,
-    target_id: typing.Optional[TargetID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    session_id: SessionID | None = None,
+    target_id: TargetID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Detaches session with given id.
 
@@ -395,7 +396,7 @@ def detach_from_target(
 
 def dispose_browser_context(
     browser_context_id: browser.BrowserContextID,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Deletes a BrowserContext. All the belonging pages will be closed without calling their
     beforeunload hooks.
@@ -412,8 +413,8 @@ def dispose_browser_context(
 
 
 def get_target_info(
-    target_id: typing.Optional[TargetID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, TargetInfo]:
+    target_id: TargetID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, TargetInfo]:
     """
     Returns information about a target.
 
@@ -434,8 +435,8 @@ def get_target_info(
 
 
 def get_targets(
-    filter_: typing.Optional[TargetFilter] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, typing.List[TargetInfo]]:
+    filter_: TargetFilter | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, list[TargetInfo]]:
     """
     Retrieves a list of available targets.
 
@@ -455,9 +456,9 @@ def get_targets(
 
 def send_message_to_target(
     message: str,
-    session_id: typing.Optional[SessionID] = None,
-    target_id: typing.Optional[TargetID] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    session_id: SessionID | None = None,
+    target_id: TargetID | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Sends protocol message over session with given id.
     Consider using flat mode instead; see commands attachToTarget, setAutoAttach,
@@ -483,9 +484,9 @@ def send_message_to_target(
 def set_auto_attach(
     auto_attach: bool,
     wait_for_debugger_on_start: bool,
-    flatten: typing.Optional[bool] = None,
-    filter_: typing.Optional[TargetFilter] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    flatten: bool | None = None,
+    filter_: TargetFilter | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Controls whether to automatically attach to new targets which are considered to be related to
     this one. When turned on, attaches to all existing related targets as well. When turned off,
@@ -515,8 +516,8 @@ def set_auto_attach(
 def auto_attach_related(
     target_id: TargetID,
     wait_for_debugger_on_start: bool,
-    filter_: typing.Optional[TargetFilter] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    filter_: TargetFilter | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Adds the specified target to the list of targets that will be monitored for any related target
     creation (such as child frames, child workers and new versions of service worker) and reported
@@ -544,8 +545,8 @@ def auto_attach_related(
 
 def set_discover_targets(
     discover: bool,
-    filter_: typing.Optional[TargetFilter] = None,
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    filter_: TargetFilter | None = None,
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Controls whether to discover available targets and notify via
     ``targetCreated/targetInfoChanged/targetDestroyed`` events.
@@ -565,8 +566,8 @@ def set_discover_targets(
 
 
 def set_remote_locations(
-    locations: typing.List[RemoteLocation],
-) -> typing.Generator[T_JSON_DICT, T_JSON_DICT, None]:
+    locations: list[RemoteLocation],
+) -> Generator[T_JSON_DICT, T_JSON_DICT, None]:
     """
     Enables target discovery for the specified locations, when ``setDiscoverTargets`` was set to
     ``true``.
@@ -618,7 +619,7 @@ class DetachedFromTarget:
     #: Detached session identifier.
     session_id: SessionID
     #: Deprecated.
-    target_id: typing.Optional[TargetID]
+    target_id: TargetID | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> DetachedFromTarget:
@@ -639,7 +640,7 @@ class ReceivedMessageFromTarget:
     session_id: SessionID
     message: str
     #: Deprecated.
-    target_id: typing.Optional[TargetID]
+    target_id: TargetID | None
 
     @classmethod
     def from_json(cls, json: T_JSON_DICT) -> ReceivedMessageFromTarget:

--- a/src/streamlink/webbrowser/cdp/devtools/util.py
+++ b/src/streamlink/webbrowser/cdp/devtools/util.py
@@ -5,21 +5,29 @@
 #
 # CDP version: v0.0.1359167
 
-import typing
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 
-T_JSON_DICT = typing.Dict[str, typing.Any]
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+
+T_JSON_DICT: TypeAlias = "dict[str, Any]"
 _event_parsers = {}
 
 
 def event_class(method):
     """A decorator that registers a class as an event class."""
+
     def decorate(cls):
         _event_parsers[method] = cls
         return cls
+
     return decorate
 
 
-def parse_json_event(json: T_JSON_DICT) -> typing.Any:
+def parse_json_event(json: T_JSON_DICT) -> Any:
     """Parse a JSON dictionary into a CDP event."""
     return _event_parsers[json["method"]].from_json(json["params"])

--- a/src/streamlink/webbrowser/chromium.py
+++ b/src/streamlink/webbrowser/chromium.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import os
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator, List, Optional, Union
 
 import trio
 
@@ -16,7 +18,7 @@ class ChromiumWebbrowser(Webbrowser):
     ERROR_RESOLVE = "Could not find Chromium-based web browser executable"
 
     @classmethod
-    def names(cls) -> List[str]:
+    def names(cls) -> list[str]:
         return [
             "chromium",
             "chromium-browser",
@@ -26,9 +28,9 @@ class ChromiumWebbrowser(Webbrowser):
         ]
 
     @classmethod
-    def fallback_paths(cls) -> List[Union[str, Path]]:
+    def fallback_paths(cls) -> list[str | Path]:
         if is_win32:
-            ms_edge: List[Union[str, Path]] = [
+            ms_edge: list[str | Path] = [
                 str(Path(base) / sub / "msedge.exe")
                 for sub in (
                     "Microsoft\\Edge\\Application",
@@ -41,7 +43,7 @@ class ChromiumWebbrowser(Webbrowser):
                 )]
                 if base is not None
             ]
-            google_chrome: List[Union[str, Path]] = [
+            google_chrome: list[str | Path] = [
                 str(Path(base) / sub / "chrome.exe")
                 for sub in (
                     "Google\\Chrome\\Application",
@@ -68,7 +70,7 @@ class ChromiumWebbrowser(Webbrowser):
         return []
 
     @classmethod
-    def launch_args(cls) -> List[str]:
+    def launch_args(cls) -> list[str]:
         # https://docs.google.com/spreadsheets/d/1n-vw_PCPS45jX3Jt9jQaAhFqBY6Ge1vWF_Pa0k7dCk4
         # https://peter.sh/experiments/chromium-command-line-switches/
         return [
@@ -141,8 +143,8 @@ class ChromiumWebbrowser(Webbrowser):
     def __init__(
         self,
         *args,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
+        host: str | None = None,
+        port: int | None = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -150,7 +152,7 @@ class ChromiumWebbrowser(Webbrowser):
         self.port = port
 
     @asynccontextmanager
-    async def launch(self, headless: bool = False, timeout: Optional[float] = None) -> AsyncGenerator[trio.Nursery, None]:
+    async def launch(self, headless: bool = False, timeout: float | None = None) -> AsyncGenerator[trio.Nursery, None]:
         if self.port is None:
             if ":" in self.host:
                 self.port = await find_free_port_ipv6(self.host)

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1,10 +1,13 @@
+from __future__ import annotations
+
 import argparse
 import numbers
 import re
+from collections.abc import Callable
 from pathlib import Path
 from string import printable
 from textwrap import dedent
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
 from streamlink import __version__ as streamlink_version, logger
 from streamlink.session import Streamlink
@@ -17,7 +20,7 @@ from streamlink_cli.utils import find_default_player
 
 class ArgumentParser(argparse.ArgumentParser):
     # noinspection PyUnresolvedReferences,PyProtectedMember
-    NESTED_ARGUMENT_GROUPS: Dict[Optional[argparse._ArgumentGroup], List[argparse._ArgumentGroup]]
+    NESTED_ARGUMENT_GROUPS: dict[argparse._ArgumentGroup | None, list[argparse._ArgumentGroup]]
 
     _RE_PRINTABLE = re.compile(fr"[{re.escape(printable)}]")
     _RE_OPTION = re.compile(r"^(?P<name>[A-Za-z0-9-]+)(?:(?P<op>\s*=\s*|\s+)(?P<value>.*))?$")
@@ -30,7 +33,7 @@ class ArgumentParser(argparse.ArgumentParser):
     def add_argument_group(
         self,
         *args,
-        parent: Optional[argparse._ArgumentGroup] = None,
+        parent: argparse._ArgumentGroup | None = None,
         **kwargs,
     ) -> argparse._ArgumentGroup:
         group = super().add_argument_group(*args, **kwargs)
@@ -1398,7 +1401,7 @@ def build_parser():
 
 # The order of arguments determines if options get overridden by `Streamlink.set_option()`
 # NOTE: arguments with `action=store_{true,false}` must set `default=None`
-_ARGUMENT_TO_SESSIONOPTION: List[Tuple[str, str, Optional[Callable[[Any], Any]]]] = [
+_ARGUMENT_TO_SESSIONOPTION: list[tuple[str, str, Callable[[Any], Any] | None]] = [
     # generic arguments
     ("locale", "locale", None),
 

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import sys
 from getpass import getpass
 from json import dumps
-from typing import Any, Dict, List, Optional, TextIO, Union
+from typing import Any, TextIO
 
 from streamlink.user_input import UserInputRequester
 from streamlink_cli.utils import JSONEncoder
@@ -30,7 +32,7 @@ class ConsoleOutput:
         self.json = json
         self.output = output
 
-    def ask(self, prompt: str) -> Optional[str]:
+    def ask(self, prompt: str) -> str | None:
         if not sys.stdin.isatty():
             return None
 
@@ -42,7 +44,7 @@ class ConsoleOutput:
         except Exception:
             return None
 
-    def askpass(self, prompt: str) -> Optional[str]:
+    def askpass(self, prompt: str) -> str | None:
         if not sys.stdin.isatty():
             return None
 
@@ -57,7 +59,7 @@ class ConsoleOutput:
         if not self.json:
             return
 
-        out: Union[List, Dict]
+        out: list | dict
         if objs and isinstance(objs[0], list):
             out = []
             for obj in objs:

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import os
 import tempfile
 from pathlib import Path
-from typing import List
 
 from streamlink.compat import is_darwin, is_win32
 from streamlink_cli.compat import DeprecatedPath
@@ -15,8 +16,8 @@ DEFAULT_STREAM_METADATA = {
     "game": "No Game/Category",
 }
 
-CONFIG_FILES: List[Path]
-PLUGIN_DIRS: List[Path]
+CONFIG_FILES: list[Path]
+PLUGIN_DIRS: list[Path]
 LOG_DIR: Path
 
 if is_win32:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import importlib.metadata
 import logging
@@ -8,11 +10,12 @@ import signal
 import ssl
 import sys
 import warnings
+from collections.abc import Mapping
 from contextlib import closing, suppress
 from gettext import gettext
 from pathlib import Path
 from time import sleep
-from typing import Any, List, Mapping, Optional, Type, Union
+from typing import Any
 
 import streamlink.logger as logger
 from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __version__ as streamlink_version
@@ -38,7 +41,7 @@ QUIET_OPTIONS = ("json", "stream_url", "quiet")
 
 args: Any = None  # type: ignore[assignment]
 console: ConsoleOutput = None  # type: ignore[assignment]
-output: Union[FileOutput, PlayerOutput] = None  # type: ignore[assignment]
+output: FileOutput | PlayerOutput = None  # type: ignore[assignment]
 stream_fd: StreamIO = None  # type: ignore[assignment]
 streamlink: Streamlink = None  # type: ignore[assignment]
 
@@ -88,7 +91,7 @@ def check_file_output(path: Path, force: bool) -> Path:
     return realpath
 
 
-def create_output(formatter: Formatter) -> Union[FileOutput, PlayerOutput]:
+def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
     """Decides where to write the stream.
 
     Depending on arguments it can be one of these:
@@ -170,7 +173,7 @@ def create_output(formatter: Formatter) -> Union[FileOutput, PlayerOutput]:
     )
 
 
-def create_http_server(host: Optional[str] = None, port: int = 0) -> HTTPOutput:
+def create_http_server(host: str | None = None, port: int = 0) -> HTTPOutput:
     """
     Create an HTTP server listening on a given host and port.
     If host is None, listen on all available interfaces.
@@ -471,7 +474,7 @@ def fetch_streams(plugin: Plugin) -> Mapping[str, Stream]:
                           sorting_excludes=args.stream_sorting_excludes)
 
 
-def fetch_streams_with_retry(plugin: Plugin, interval: float, count: int) -> Optional[Mapping[str, Stream]]:
+def fetch_streams_with_retry(plugin: Plugin, interval: float, count: int) -> Mapping[str, Stream] | None:
     """Attempts to fetch streams repeatedly
        until some are returned or limit hit."""
 
@@ -677,7 +680,7 @@ def can_handle_url() -> int:
         return 128 + signal.SIGINT
 
 
-def load_plugins(dirs: List[Path], showwarning: bool = True):
+def load_plugins(dirs: list[Path], showwarning: bool = True):
     """Attempts to load plugins from a list of directories."""
     for directory in dirs:
         if directory.is_dir():
@@ -694,7 +697,7 @@ def load_plugins(dirs: List[Path], showwarning: bool = True):
 
 def setup_args(
     parser: argparse.ArgumentParser,
-    config_files: Optional[List[Path]] = None,
+    config_files: list[Path] | None = None,
     ignore_unknown: bool = False,
 ):
     """Parses arguments."""
@@ -797,7 +800,7 @@ def setup_plugin_args(session: Streamlink, parser: ArgumentParser):
             group.add_argument(parg.argument_name(pname), **parg.options)
 
 
-def setup_plugin_options(pluginname: str, pluginclass: Type[Plugin]) -> Options:
+def setup_plugin_options(pluginname: str, pluginclass: type[Plugin]) -> Options:
     """Initializes plugin options from argument values."""
 
     if not pluginclass.arguments:
@@ -908,9 +911,9 @@ def log_current_arguments(session: Streamlink, parser: argparse.ArgumentParser):
 def setup_logger_and_console(
     stream=sys.stdout,
     level: str = "info",
-    fmt: Optional[str] = None,
-    datefmt: Optional[str] = None,
-    file: Optional[str] = None,
+    fmt: str | None = None,
+    datefmt: str | None = None,
+    file: str | None = None,
     json=False,
 ):
     global console

--- a/src/streamlink_cli/output/file.py
+++ b/src/streamlink_cli/output/file.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import BinaryIO, Optional
+from typing import BinaryIO
 
 from streamlink.compat import is_win32
 from streamlink_cli.compat import stdout
@@ -14,9 +16,9 @@ if is_win32:
 class FileOutput(Output):
     def __init__(
         self,
-        filename: Optional[Path] = None,
-        fd: Optional[BinaryIO] = None,
-        record: Optional["FileOutput"] = None,
+        filename: Path | None = None,
+        fd: BinaryIO | None = None,
+        record: FileOutput | None = None,
     ):
         super().__init__()
         self.filename = filename

--- a/src/streamlink_cli/output/http.py
+++ b/src/streamlink_cli/output/http.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import socket
 from contextlib import suppress
 from http.server import BaseHTTPRequestHandler
 from io import BytesIO
-from typing import Optional
 
 from streamlink_cli.output.abc import Output
 
@@ -23,11 +24,11 @@ class HTTPRequest(BaseHTTPRequestHandler):
 class HTTPOutput(Output):
     socket: socket.socket
 
-    def __init__(self, host: Optional[str] = "127.0.0.1", port: int = 0) -> None:
+    def __init__(self, host: str | None = "127.0.0.1", port: int = 0) -> None:
         super().__init__()
         self.host = host
         self.port = port
-        self.conn: Optional[socket.socket] = None
+        self.conn: socket.socket | None = None
 
     @property
     def addresses(self):

--- a/src/streamlink_cli/output/player.py
+++ b/src/streamlink_cli/output/player.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
@@ -5,11 +7,12 @@ import shlex
 import subprocess
 import sys
 import warnings
+from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from pathlib import Path
 from shutil import which
 from time import sleep
-from typing import ClassVar, Dict, List, Mapping, Optional, Sequence, TextIO, Tuple, Type, Union
+from typing import ClassVar, TextIO
 
 from streamlink.compat import is_win32
 from streamlink.exceptions import StreamlinkWarning
@@ -24,16 +27,16 @@ log = logging.getLogger("streamlink.cli.output")
 
 
 class PlayerArgs:
-    EXECUTABLES: ClassVar[List[re.Pattern]] = []
+    EXECUTABLES: ClassVar[list[re.Pattern]] = []
 
     def __init__(
         self,
         path: Path,
         args: str = "",
-        title: Optional[str] = None,
-        filename: Optional[str] = None,
-        namedpipe: Optional[NamedPipeBase] = None,
-        http: Optional[HTTPOutput] = None,
+        title: str | None = None,
+        filename: str | None = None,
+        namedpipe: NamedPipeBase | None = None,
+        http: HTTPOutput | None = None,
     ):
         self.path = path
         self.args = args
@@ -51,7 +54,7 @@ class PlayerArgs:
         else:
             self._input = self.get_stdin()
 
-    def build(self) -> List[str]:
+    def build(self) -> list[str]:
         args_title = []
         if self.title is not None:
             args_title.extend(self.get_title(self.title))
@@ -86,12 +89,12 @@ class PlayerArgs:
     def get_http(self, http: HTTPOutput) -> str:
         return http.url
 
-    def get_title(self, title: str) -> List[str]:
+    def get_title(self, title: str) -> list[str]:
         return []
 
 
 class PlayerArgsVLC(PlayerArgs):
-    EXECUTABLES: ClassVar[List[re.Pattern]] = [
+    EXECUTABLES: ClassVar[list[re.Pattern]] = [
         re.compile(r"^vlc$", re.IGNORECASE),
     ]
 
@@ -101,7 +104,7 @@ class PlayerArgsVLC(PlayerArgs):
 
         return super().get_namedpipe(namedpipe)
 
-    def get_title(self, title) -> List[str]:
+    def get_title(self, title) -> list[str]:
         # allow escaping with \$: see https://wiki.videolan.org/Documentation:Format_String/
         # TODO: remove this feature
         title = title.replace("$", "$$").replace(r"\$$", "$")
@@ -110,7 +113,7 @@ class PlayerArgsVLC(PlayerArgs):
 
 
 class PlayerArgsMPV(PlayerArgs):
-    EXECUTABLES: ClassVar[List[re.Pattern]] = [
+    EXECUTABLES: ClassVar[list[re.Pattern]] = [
         re.compile(r"^mpv$", re.IGNORECASE),
     ]
 
@@ -120,16 +123,16 @@ class PlayerArgsMPV(PlayerArgs):
 
         return super().get_namedpipe(namedpipe)
 
-    def get_title(self, title: str) -> List[str]:
+    def get_title(self, title: str) -> list[str]:
         return [f"--force-media-title={title}"]
 
 
 class PlayerArgsPotplayer(PlayerArgs):
-    EXECUTABLES: ClassVar[List[re.Pattern]] = [
+    EXECUTABLES: ClassVar[list[re.Pattern]] = [
         re.compile(r"^potplayer(?:mini(?:64)?)?$", re.IGNORECASE),
     ]
 
-    def get_title(self, title: str) -> List[str]:
+    def get_title(self, title: str) -> list[str]:
         if self._input != "-":
             # PotPlayer CLI help:
             # "You can specify titles for URLs by separating them with a backslash (\) at the end of URLs."
@@ -144,30 +147,30 @@ class PlayerOutput(Output):
     PLAYER_ARGS_INPUT = "playerinput"
     PLAYER_ARGS_TITLE = "playertitleargs"
 
-    PLAYERS: ClassVar[Dict[str, Type[PlayerArgs]]] = {
+    PLAYERS: ClassVar[Mapping[str, type[PlayerArgs]]] = {
         "vlc": PlayerArgsVLC,
         "mpv": PlayerArgsMPV,
         "potplayer": PlayerArgsPotplayer,
     }
 
     player: subprocess.Popen
-    stdin: Union[int, TextIO]
-    stdout: Union[int, TextIO]
-    stderr: Union[int, TextIO]
+    stdin: int | TextIO
+    stdout: int | TextIO
+    stderr: int | TextIO
 
     def __init__(
         self,
         path: Path,
         args: str = "",
-        env: Optional[Sequence[Tuple[str, str]]] = None,
+        env: Sequence[tuple[str, str]] | None = None,
         quiet: bool = True,
         kill: bool = True,
         call: bool = False,
-        filename: Optional[str] = None,
-        namedpipe: Optional[NamedPipeBase] = None,
-        http: Optional[HTTPOutput] = None,
-        record: Optional[FileOutput] = None,
-        title: Optional[str] = None,
+        filename: str | None = None,
+        namedpipe: NamedPipeBase | None = None,
+        http: HTTPOutput | None = None,
+        record: FileOutput | None = None,
+        title: str | None = None,
     ):
         super().__init__()
 
@@ -254,7 +257,7 @@ class PlayerOutput(Output):
         else:
             self._open_subprocess(args)
 
-    def _open_call(self, args: List[str]):
+    def _open_call(self, args: list[str]):
         log.debug(f"Calling: {args!r}{f', env: {self.env!r}' if self.env else ''}")
 
         environ = dict(os.environ)
@@ -267,7 +270,7 @@ class PlayerOutput(Output):
             stderr=self.stderr,
         )
 
-    def _open_subprocess(self, args: List[str]):
+    def _open_subprocess(self, args: list[str]):
         log.debug(f"Opening subprocess: {args!r}{f', env: {self.env!r}' if self.env else ''}")
 
         environ = dict(os.environ)

--- a/src/streamlink_cli/streamrunner.py
+++ b/src/streamlink_cli/streamrunner.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import errno
 import logging
 import sys
 from contextlib import suppress
 from pathlib import Path
 from threading import Event, Lock, Thread
-from typing import Optional
 
 from streamlink.stream.stream import StreamIO
 from streamlink_cli.output import FileOutput, HTTPOutput, Output, PlayerOutput
@@ -71,8 +72,8 @@ class PlayerPollThread(Thread):
 class StreamRunner:
     """Read data from a stream and write it to the output."""
 
-    playerpoller: Optional[PlayerPollThread] = None
-    progress: Optional[Progress] = None
+    playerpoller: PlayerPollThread | None = None
+    progress: Progress | None = None
 
     def __init__(
         self,
@@ -84,7 +85,7 @@ class StreamRunner:
         self.output = output
         self.is_http = isinstance(output, HTTPOutput)
 
-        filename: Optional[Path] = None
+        filename: Path | None = None
 
         if isinstance(output, PlayerOutput):
             self.playerpoller = PlayerPollThread(stream, output)

--- a/src/streamlink_cli/utils/formatter.py
+++ b/src/streamlink_cli/utils/formatter.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
 
 from streamlink.utils.formatter import Formatter as _BaseFormatter
 from streamlink_cli.utils.path import replace_chars, replace_path, truncate_path
@@ -8,7 +9,7 @@ from streamlink_cli.utils.path import replace_chars, replace_path, truncate_path
 class Formatter(_BaseFormatter):
     title = _BaseFormatter.format
 
-    def path(self, pathlike: str, charmap: Optional[str] = None, max_filename_length: int = 255) -> Path:
+    def path(self, pathlike: str, charmap: str | None = None, max_filename_length: int = 255) -> Path:
         def mapper(s):
             return replace_chars(s, charmap)
 

--- a/src/streamlink_cli/utils/path.py
+++ b/src/streamlink_cli/utils/path.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import re
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Optional, Union
 
 from streamlink.compat import is_win32
 
@@ -20,7 +22,7 @@ else:
     RE_CHARS = RE_CHARS_POSIX
 
 
-def replace_chars(path: str, charmap: Optional[str] = None, replacement: str = REPLACEMENT) -> str:
+def replace_chars(path: str, charmap: str | None = None, replacement: str = REPLACEMENT) -> str:
     if charmap is None:
         pattern = RE_CHARS
     else:
@@ -54,7 +56,7 @@ def truncate_path(path: str, length: int = 255, keep_extension: bool = True) -> 
     return f"{decoded}.{parts[1]}"
 
 
-def replace_path(pathlike: Union[str, Path], mapper: Callable[[str, bool], str]) -> Path:
+def replace_path(pathlike: str | Path, mapper: Callable[[str, bool], str]) -> Path:
     def get_part(part: str, isfile: bool) -> str:
         newpart = mapper(part, isfile)
         return REPLACEMENT if part != newpart and newpart in SPECIAL_PATH_PARTS else newpart

--- a/src/streamlink_cli/utils/player.py
+++ b/src/streamlink_cli/utils/player.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
 from os import environ
 from pathlib import Path
 from shutil import which
-from typing import Iterable, Optional
 
 from streamlink.compat import is_darwin, is_win32
 
 
-def _resolve_executable(paths: Iterable[Path], *exes: str) -> Optional[Path]:
+def _resolve_executable(paths: Iterable[Path], *exes: str) -> Path | None:
     for exe in exes:
         resolved = which(exe)
         if resolved:
@@ -26,7 +28,7 @@ def _resolve_executable(paths: Iterable[Path], *exes: str) -> Optional[Path]:
     return None
 
 
-def _find_default_player_win32() -> Optional[Path]:
+def _find_default_player_win32() -> Path | None:
     envvars = "PROGRAMFILES", "PROGRAMFILES(X86)", "PROGRAMW6432"
     subpath = Path() / "VideoLAN" / "VLC"
 
@@ -40,7 +42,7 @@ def _find_default_player_win32() -> Optional[Path]:
     )
 
 
-def _find_default_player_darwin() -> Optional[Path]:
+def _find_default_player_darwin() -> Path | None:
     subpath = Path() / "Applications" / "VLC.app" / "Contents" / "MacOS"
 
     return _resolve_executable(
@@ -53,14 +55,14 @@ def _find_default_player_darwin() -> Optional[Path]:
     )
 
 
-def _find_default_player_other() -> Optional[Path]:
+def _find_default_player_other() -> Path | None:
     return _resolve_executable(
         [],
         "vlc",
     )
 
 
-def find_default_player() -> Optional[Path]:
+def find_default_player() -> Path | None:
     if is_win32:
         return _find_default_player_win32()
     elif is_darwin:

--- a/src/streamlink_cli/utils/progress.py
+++ b/src/streamlink_cli/utils/progress.py
@@ -1,18 +1,25 @@
+from __future__ import annotations
+
 import os
 from collections import deque
+from collections.abc import Callable, Iterable, Mapping
 from math import floor
 from pathlib import PurePath
 from shutil import get_terminal_size
 from string import Formatter as StringFormatter
 from threading import Event, RLock, Thread
 from time import time
-from typing import Callable, Deque, Dict, Iterable, List, Optional, TextIO, Tuple, Union
+from typing import TYPE_CHECKING, TextIO
 
 from streamlink.compat import is_win32
 
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+
 _stringformatter = StringFormatter()
-_TFormat = Iterable[Iterable[Tuple[str, Optional[str], Optional[str], Optional[str]]]]
+_TFormat: TypeAlias = "Iterable[Iterable[tuple[str, str | None, str | None, str | None]]]"
 
 
 class ProgressFormatter:
@@ -39,7 +46,7 @@ class ProgressFormatter:
     # widths generated from
     # https://www.unicode.org/Public/4.0-Update/EastAsianWidth-4.0.0.txt
     # See https://github.com/streamlink/streamlink/pull/2032
-    WIDTHS: Iterable[Tuple[int, int]] = (
+    WIDTHS: Iterable[tuple[int, int]] = (
         (13, 1),
         (15, 0),
         (126, 1),
@@ -110,10 +117,10 @@ class ProgressFormatter:
         return current
 
     @classmethod
-    def format(cls, formats: _TFormat, params: Dict[str, Union[str, Callable[[int], str]]]) -> str:
+    def format(cls, formats: _TFormat, params: Mapping[str, str | Callable[[int], str]]) -> str:
         term_width = cls.term_width()
-        static: List[str] = []
-        variable: List[Tuple[int, Callable[[int], str], int]] = []
+        static: list[str] = []
+        variable: list[tuple[int, Callable[[int], str], int]] = []
 
         for fmt in formats:
             static.clear()
@@ -232,7 +239,7 @@ class Progress(Thread):
         self.stream: TextIO = stream
         self.path: PurePath = path
         self.interval: float = interval
-        self.history: Deque[Tuple[float, int]] = deque(maxlen=int(history / interval))
+        self.history: deque[tuple[float, int]] = deque(maxlen=int(history / interval))
         self.threshold: int = int(threshold / interval)
 
         self.started: float = 0.0

--- a/src/streamlink_cli/utils/versioncheck.py
+++ b/src/streamlink_cli/utils/versioncheck.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import re
-from typing import Tuple
 
 import requests
 
@@ -11,7 +12,7 @@ from streamlink.cache import Cache
 log = logging.getLogger("streamlink.cli")
 
 
-def _parse_version(version: str) -> Tuple[int, int, int, int]:
+def _parse_version(version: str) -> tuple[int, int, int, int]:
     m = re.match(r"(\d+)\.(\d+)\.(\d+)(?:[+-](\d+))?", version)
     if not m:
         raise ValueError(f"Invalid version string: '{version}'")

--- a/tests/cli/main/test_handle_url.py
+++ b/tests/cli/main/test_handle_url.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import json
 import re
-from typing import Dict, Optional, Union
 from unittest.mock import Mock
 
 import pytest
@@ -25,7 +26,7 @@ STREAMS_MULTIVARIANT = "mock://stream"
 class FakeStream(Stream):
     __shortname__ = "fake"
 
-    def __init__(self, session: Streamlink, url: Optional[str], manifest_url: Optional[str]):
+    def __init__(self, session: Streamlink, url: str | None, manifest_url: str | None):
         super().__init__(session)
         self.url = url
         self.manifest_url = manifest_url
@@ -76,7 +77,7 @@ def streams(request: pytest.FixtureRequest, session: Streamlink):
 
 
 @pytest.fixture(autouse=True)
-def plugin(session: Streamlink, streams: Union[BaseException, Dict[str, FakeStream]]):
+def plugin(session: Streamlink, streams: BaseException | dict[str, FakeStream]):
     @pluginmatcher(re.compile("https?://plugin"))
     class FakePlugin(Plugin):
         __module__ = "plugin"

--- a/tests/cli/main/test_resolve_stream_name.py
+++ b/tests/cli/main/test_resolve_stream_name.py
@@ -1,4 +1,6 @@
-from typing import Mapping
+from __future__ import annotations
+
+from collections.abc import Mapping
 from unittest.mock import Mock
 
 import pytest

--- a/tests/cli/output/test_file.py
+++ b/tests/cli/output/test_file.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
 from contextlib import contextmanager
 from io import BufferedRandom, BufferedWriter
 from pathlib import Path
-from typing import Iterator
 
 import pytest
 

--- a/tests/cli/output/test_player.py
+++ b/tests/cli/output/test_player.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import subprocess
-from contextlib import nullcontext
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
-from typing import ContextManager, Dict, Mapping, Sequence, Type
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -171,7 +173,7 @@ class TestPlayerArgs:
             id="Potplayer (potplayermini64)",
         ),
     ])
-    def test_knownplayer(self, playerpath: str, playerargsclass: Type[PlayerArgs]):
+    def test_knownplayer(self, playerpath: str, playerargsclass: type[PlayerArgs]):
         assert isinstance(PlayerOutput.playerargsfactory(path=Path(playerpath)), playerargsclass)
 
     # noinspection PyTestParametrized
@@ -251,7 +253,7 @@ class TestPlayerArgs:
 # TODO: refactor PlayerOutput and write proper tests
 class TestPlayerOutput:
     @pytest.fixture(autouse=True)
-    def _os_environ(self, os_environ: Dict[str, str]):
+    def _os_environ(self, os_environ: dict[str, str]):
         os_environ["FAKE"] = "ENVIRONMENT"
         yield
         assert sorted(os_environ.keys()) == ["FAKE"], "Doesn't pollute the os.environ dict with custom env vars"
@@ -354,7 +356,7 @@ class TestPlayerOutput:
         playeroutput: PlayerOutput,
         mock_which: Mock,
         mock_popen: Mock,
-        expected: ContextManager,
+        expected: AbstractContextManager,
         warns: bool,
     ):
         with expected:

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import gettext
 from argparse import Namespace
 from pathlib import Path
-from typing import Any, List
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -192,7 +194,7 @@ class TestMatchArgumentOverride:
         id="Deprecated argument with override",
     ),
 ])
-def test_setup_session_options(parser: ArgumentParser, session: Streamlink, argv: List, option: str, expected: Any):
+def test_setup_session_options(parser: ArgumentParser, session: Streamlink, argv: list, option: str, expected: Any):
     args = parser.parse_args(argv)
     setup_session_options(session, args)
     assert session.get_option(option) == expected

--- a/tests/cli/test_plugin_args_and_options.py
+++ b/tests/cli/test_plugin_args_and_options.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import argparse
-from typing import Type
 from unittest.mock import Mock, call
 
 import pytest
@@ -52,7 +53,7 @@ def plugin():
 
 
 @pytest.fixture(autouse=True)
-def session(session: Streamlink, parser: ArgumentParser, plugin: Type[Plugin]):
+def session(session: Streamlink, parser: ArgumentParser, plugin: type[Plugin]):
     session.plugins["mock"] = plugin
 
     setup_plugin_args(session, parser)
@@ -68,7 +69,7 @@ def console(monkeypatch: pytest.MonkeyPatch):
 
 
 class TestPluginArgs:
-    def test_arguments(self, parser: ArgumentParser, plugin: Type[Plugin]):
+    def test_arguments(self, parser: ArgumentParser, plugin: type[Plugin]):
         group_plugins = next((grp for grp in parser._action_groups if grp.title == "Plugin options"), None)  # pragma: no branch
         assert group_plugins is not None, "Adds the 'Plugin options' arguments group"
         assert group_plugins in parser.NESTED_ARGUMENT_GROUPS[None], "Adds the 'Plugin options' arguments group"
@@ -100,7 +101,7 @@ class TestPluginOptions:
         assert not console.ask.called
         assert not console.askpass.called
 
-    def test_options(self, plugin: Type[Plugin], console: Mock):
+    def test_options(self, plugin: type[Plugin], console: Mock):
         options = setup_plugin_options("mock", plugin)
 
         assert console.ask.call_args_list == [call("CAPTCHA code: ")]

--- a/tests/cli/test_streamrunner.py
+++ b/tests/cli/test_streamrunner.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import errno
 import sys
 from collections import deque
+from collections.abc import Callable
 from pathlib import Path
 from threading import Thread
-from typing import Callable, Deque, List, Union
 from unittest.mock import Mock, patch
 
 import pytest
@@ -43,7 +45,7 @@ class FakeStream(_TestableWithHandshake, StreamIO):
 
     def __init__(self) -> None:
         super().__init__()
-        self.data: Deque[Union[bytes, Callable]] = deque()
+        self.data: deque[bytes | Callable] = deque()
 
     # noinspection PyUnusedLocal
     def read(self, *args):
@@ -59,7 +61,7 @@ class FakeOutput(_TestableWithHandshake):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.data: List[bytes] = []
+        self.data: list[bytes] = []
 
     def write(self, data):
         with self.handshake():
@@ -577,7 +579,7 @@ class TestHasProgress:
     def test_no_progress(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        output: Union[FakePlayerOutput, FakeFileOutput, FakeHTTPOutput],
+        output: FakePlayerOutput | FakeFileOutput | FakeHTTPOutput,
         stderr: bool,
     ):
         if not stderr:
@@ -612,7 +614,7 @@ class TestHasProgress:
     )
     def test_has_progress(
         self,
-        output: Union[FakePlayerOutput, FakeFileOutput],
+        output: FakePlayerOutput | FakeFileOutput,
         expected: Path,
     ):
         stream_runner = FakeStreamRunner(StreamIO(), output, show_progress=True)

--- a/tests/cli/utils/test_path.py
+++ b/tests/cli/utils/test_path.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
 from string import ascii_lowercase as alphabet
-from typing import Tuple
 
 import pytest
 
@@ -186,7 +187,7 @@ bear = "🐻"  # Unicode character: "Bear Face" (U+1F43B)
         id="bear+ext2 - truncate at 50",
     ),
 ])
-def test_truncate_path(args: Tuple[str, int, bool], expected: str):
+def test_truncate_path(args: tuple[str, int, bool], expected: str):
     path, length, keep_extension = args
     result = truncate_path(path, length, keep_extension)
     assert len(result.encode("utf-8")) <= length

--- a/tests/cli/utils/test_player.py
+++ b/tests/cli/utils/test_player.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List, Optional
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -31,8 +32,8 @@ class TestFindDefaultPlayer:
         request: pytest.FixtureRequest,
         monkeypatch: pytest.MonkeyPatch,
         which: Mock,
-        lookups: List[str],
-        expected: Optional[str],
+        lookups: list[str],
+        expected: str | None,
     ):
         monkeypatch.setattr("streamlink_cli.utils.player.is_win32", "win32" in request.function.__name__)
         monkeypatch.setattr("streamlink_cli.utils.player.is_darwin", "darwin" in request.function.__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import os
 import sys
+from collections.abc import Callable, Mapping
 from functools import partial
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any
 
 import pytest
 import requests_mock as rm
@@ -9,7 +12,7 @@ import requests_mock as rm
 from streamlink.session import Streamlink
 
 
-_TEST_CONDITION_MARKERS: Dict[str, Union[Tuple[bool, str], Callable[[Any], Tuple[bool, str]]]] = {
+_TEST_CONDITION_MARKERS: Mapping[str, tuple[bool, str] | Callable[[Any], tuple[bool, str]]] = {
     "posix_only": (os.name == "posix", "only applicable on a POSIX OS"),
     "windows_only": (os.name == "nt", "only applicable on Windows"),
     "python": lambda *ver, **_: (  # pragma: no cover
@@ -42,7 +45,7 @@ def pytest_runtest_setup(item: pytest.Item):
     _check_test_condition(item)
 
 
-def pytest_collection_modifyitems(items: List[pytest.Item]):  # pragma: no cover
+def pytest_collection_modifyitems(items: list[pytest.Item]):  # pragma: no cover
     default = next((idx for idx, string in enumerate(_TEST_PRIORITIES) if string is None), sys.maxsize)
     priorities = {
         item: next(
@@ -106,7 +109,7 @@ def requests_mock(requests_mock: rm.Mocker) -> rm.Mocker:
 
 
 @pytest.fixture()
-def os_environ(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Dict[str, str]:
+def os_environ(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     class FakeEnviron(dict):
         def __setitem__(self, key, value):
             if key == "PYTEST_CURRENT_TEST":

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import unittest
 from binascii import hexlify
 from functools import partial
 from threading import Event, Thread
-from typing import List
 from unittest.mock import patch
 
 import requests_mock
@@ -144,7 +145,7 @@ class HLSStreamReadThread(Thread):
         self.read_once = Event()
         self.handshake = Handshake()
         self.read_all = False
-        self.data: List[bytes] = []
+        self.data: list[bytes] = []
 
         self.session = session
         self.stream = stream

--- a/tests/plugins/__init__.py
+++ b/tests/plugins/__init__.py
@@ -1,8 +1,16 @@
-from typing import Dict, List, Match, Optional, Sequence, Set, Tuple, Type, Union
+from __future__ import annotations
+
+from collections.abc import Sequence
+from re import Match
+from typing import TYPE_CHECKING
 
 import pytest
 
 from streamlink.plugin.plugin import Matcher, Plugin
+
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 
 generic_negative_matches = [
@@ -12,21 +20,20 @@ generic_negative_matches = [
 ]
 
 
-# TODO: use proper type aliases
-TUrl = str
-TName = str
-TUrlNamed = Tuple[TName, TUrl]
-TUrlOrNamedUrl = Union[TUrl, TUrlNamed]
-TMatchGroup = Union[Dict[str, str], Sequence[Optional[str]]]
+TUrl: TypeAlias = str
+TName: TypeAlias = str
+TUrlNamed: TypeAlias = "tuple[TName, TUrl]"
+TUrlOrNamedUrl: TypeAlias = "TUrl | TUrlNamed"
+TMatchGroup: TypeAlias = "dict[str, str] | Sequence[str | None]"
 
 
-_plugin_can_handle_url_classnames: Set[str] = set()
+_plugin_can_handle_url_classnames: set[str] = set()
 
 
 class PluginCanHandleUrl:
-    __plugin__: Type[Plugin]
+    __plugin__: type[Plugin]
 
-    should_match: List[TUrlOrNamedUrl] = []
+    should_match: list[TUrlOrNamedUrl] = []
     """
     A list of URLs that should match any of the plugin's URL regexes.
     URL can be a tuple of a matcher name and the URL itself.
@@ -38,7 +45,7 @@ class PluginCanHandleUrl:
     ]
     """
 
-    should_match_groups: List[Tuple[TUrlOrNamedUrl, TMatchGroup]] = []
+    should_match_groups: list[tuple[TUrlOrNamedUrl, TMatchGroup]] = []
     """
     A list of URL+capturegroup tuples, where capturegroup can be a dict (re.Match.groupdict()) or a tuple (re.Match.groups()).
     URL can be a tuple of a matcher name and the URL itself.
@@ -55,7 +62,7 @@ class PluginCanHandleUrl:
     ]
     """
 
-    should_not_match: List[TUrl] = []
+    should_not_match: list[TUrl] = []
     """
     A list of URLs that should not match any of the plugin's URL regexes.
     Generic negative URL matches are appended to this list automatically and must not be defined.
@@ -69,36 +76,36 @@ class PluginCanHandleUrl:
     # ---- test utils
 
     @classmethod
-    def matchers(cls) -> List[Matcher]:
-        empty: List[Matcher] = []
+    def matchers(cls) -> list[Matcher]:
+        empty: list[Matcher] = []
         return cls.__plugin__.matchers or empty
 
     @classmethod
-    def urls_all(cls) -> List[TUrlOrNamedUrl]:
+    def urls_all(cls) -> list[TUrlOrNamedUrl]:
         return cls.should_match + [item for item, groups in cls.should_match_groups]
 
     @classmethod
-    def urls_unnamed(cls) -> List[TUrl]:
+    def urls_unnamed(cls) -> list[TUrl]:
         return [item for item in cls.urls_all() if type(item) is str]
 
     @classmethod
-    def urls_named(cls) -> List[TUrlNamed]:
+    def urls_named(cls) -> list[TUrlNamed]:
         return [item for item in cls.urls_all() if type(item) is tuple]
 
     @classmethod
-    def urlgroups_unnamed(cls) -> List[Tuple[TUrl, TMatchGroup]]:
+    def urlgroups_unnamed(cls) -> list[tuple[TUrl, TMatchGroup]]:
         return [(item, groups) for item, groups in cls.should_match_groups if type(item) is str]
 
     @classmethod
-    def urlgroups_named(cls) -> List[Tuple[TName, TUrl, TMatchGroup]]:
+    def urlgroups_named(cls) -> list[tuple[TName, TUrl, TMatchGroup]]:
         return [(item[0], item[1], groups) for item, groups in cls.should_match_groups if type(item) is tuple]
 
     @classmethod
-    def urls_negative(cls) -> List[TUrl]:
+    def urls_negative(cls) -> list[TUrl]:
         return cls.should_not_match + generic_negative_matches
 
     @staticmethod
-    def _get_match_groups(match: Match, grouptype: Type[TMatchGroup]) -> TMatchGroup:
+    def _get_match_groups(match: Match, grouptype: type[TMatchGroup]) -> TMatchGroup:
         return (
             # ignore None values in capture group dicts
             {k: v for k, v in match.groupdict().items() if v is not None}
@@ -121,7 +128,7 @@ class PluginCanHandleUrl:
         assert issubclass(self.__plugin__, Plugin), "Test has a __plugin__ that is a subclass of the Plugin class"
         assert self.should_match or self.should_match_groups, "Test has at least one positive URL"
 
-    def test_class_name(self, classnames: Set[str]):
+    def test_class_name(self, classnames: set[str]):
         assert self.__class__.__name__ not in classnames
 
     # ---- all tests below are parametrized dynamically via conftest.py

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,4 +1,6 @@
-from typing import Callable, List, Optional, Tuple
+from __future__ import annotations
+
+from collections.abc import Callable
 
 import pytest
 
@@ -6,7 +8,7 @@ from streamlink.plugin.plugin import Matcher
 from tests.plugins import PluginCanHandleUrl
 
 
-def pytest_collection_modifyitems(items: List[pytest.Item]):  # pragma: no cover
+def pytest_collection_modifyitems(items: list[pytest.Item]):  # pragma: no cover
     # remove empty parametrized tests
     items[:] = [
         item
@@ -21,13 +23,13 @@ def pytest_collection_modifyitems(items: List[pytest.Item]):  # pragma: no cover
 def pytest_generate_tests(metafunc: pytest.Metafunc):
     if metafunc.cls is not None and issubclass(metafunc.cls, PluginCanHandleUrl):
         name: str = f"_parametrize_plugincanhandleurl_{metafunc.function.__name__}"
-        parametrizer: Optional[Callable[[pytest.Metafunc], None]] = globals().get(name)
+        parametrizer: Callable[[pytest.Metafunc], None] | None = globals().get(name)
         if parametrizer:
             parametrizer(metafunc)
 
 
 def _parametrize_plugincanhandleurl_test_all_matchers_match(metafunc: pytest.Metafunc):
-    matchers: List[Tuple[int, Matcher]] = list(enumerate(metafunc.cls.matchers()))
+    matchers: list[tuple[int, Matcher]] = list(enumerate(metafunc.cls.matchers()))
     metafunc.parametrize(
         "matcher",
         [m for i, m in matchers],
@@ -36,7 +38,7 @@ def _parametrize_plugincanhandleurl_test_all_matchers_match(metafunc: pytest.Met
 
 
 def _parametrize_plugincanhandleurl_test_all_named_matchers_have_tests(metafunc: pytest.Metafunc):
-    matchers: List[Matcher] = [m for m in metafunc.cls.matchers() if m.name is not None]
+    matchers: list[Matcher] = [m for m in metafunc.cls.matchers() if m.name is not None]
     metafunc.parametrize(
         "matcher",
         matchers,

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import json
 import unittest
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 from unittest.mock import MagicMock, Mock, call, patch
 from urllib.parse import parse_qsl, urlparse
 
@@ -856,9 +857,9 @@ class TestTwitchHLSMultivariantResponse:
         monkeypatch: pytest.MonkeyPatch,
         caplog: pytest.LogCaptureFixture,
         plugin: Twitch,
-        streamid: Optional[str],
+        streamid: str | None,
         raises: nullcontext,
-        streams: Optional[dict],
+        streams: dict | None,
         log: list,
     ):
         caplog.set_level("error", "streamlink.plugins.twitch")

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import ssl
 from ssl import SSLContext
-from typing import Optional
 from unittest.mock import Mock, PropertyMock, call
 
 import pytest
@@ -89,7 +90,7 @@ class TestHTTPSession:
         ("utf-8", "utf-8"),
         ("cp949", "cp949"),
     ])
-    def test_json(self, monkeypatch: pytest.MonkeyPatch, encoding: str, override: Optional[str]):
+    def test_json(self, monkeypatch: pytest.MonkeyPatch, encoding: str, override: str | None):
         mock_content = PropertyMock(return_value="{\"test\": \"Α and Ω\"}".encode(encoding))  # noqa: RUF001
         monkeypatch.setattr("requests.Response.content", mock_content)
 

--- a/tests/session/test_options.py
+++ b/tests/session/test_options.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import re
 from socket import AF_INET, AF_INET6
-from typing import Dict
 from unittest.mock import Mock
 
 import pytest
@@ -85,7 +86,7 @@ class TestOptionsInterface:
 
         return adapters
 
-    def test_options_interface(self, adapters: Dict[str, Mock], session: Streamlink):
+    def test_options_interface(self, adapters: dict[str, Mock], session: Streamlink):
         assert session.get_option("interface") is None
 
         session.set_option("interface", "my-interface")

--- a/tests/session/test_plugins.py
+++ b/tests/session/test_plugins.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import hashlib
 import re
@@ -5,7 +7,7 @@ import re
 # noinspection PyProtectedMember
 from importlib.metadata import FileHash, PackagePath
 from pathlib import Path
-from typing import Optional, Type, cast
+from typing import cast
 from unittest.mock import Mock, call
 
 import pytest
@@ -64,7 +66,7 @@ def test_empty(caplog: pytest.LogCaptureFixture, session: Streamlink):
     assert caplog.record_tuples == []
 
 
-def test_set_get_del(session: Streamlink, fake_plugin: Type[Plugin]):
+def test_set_get_del(session: Streamlink, fake_plugin: type[Plugin]):
     assert "fake" not in session.plugins
 
     session.plugins["fake"] = fake_plugin
@@ -80,7 +82,7 @@ def test_set_get_del(session: Streamlink, fake_plugin: Type[Plugin]):
     assert session.plugins.get_loaded() == {}
 
 
-def test_update_clear(session: Streamlink, fake_plugin: Type[Plugin]):
+def test_update_clear(session: Streamlink, fake_plugin: type[Plugin]):
     assert "fake" not in session.plugins
 
     session.plugins.update({"fake": fake_plugin})
@@ -95,7 +97,7 @@ def test_update_clear(session: Streamlink, fake_plugin: Type[Plugin]):
     assert session.plugins.get_loaded() == {}
 
 
-def test_iter_arguments(session: Streamlink, fake_plugin: Type[Plugin]):
+def test_iter_arguments(session: Streamlink, fake_plugin: type[Plugin]):
     session.plugins.update({"fake": fake_plugin})
     assert [(name, [arg.argument_name(name) for arg in args]) for name, args in session.plugins.iter_arguments()] == [
         ("fake", ["--fake-foo", "--fake-bar"]),
@@ -103,7 +105,7 @@ def test_iter_arguments(session: Streamlink, fake_plugin: Type[Plugin]):
 
 
 class TestLoad:
-    def test_load_builtin(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, fake_plugin: Type[Plugin]):
+    def test_load_builtin(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, fake_plugin: type[Plugin]):
         mock = Mock(return_value={"fake": fake_plugin})
         monkeypatch.setattr(StreamlinkPlugins, "_load_plugins_from_path", mock)
         session = Streamlink(plugins_builtin=True, plugins_lazy=False)
@@ -207,7 +209,7 @@ class TestLoad:
 
 class TestLoadPluginsData:
     @pytest.fixture()
-    def session(self, monkeypatch: pytest.MonkeyPatch, fake_plugin: Type[Plugin], metadata_files: Mock):
+    def session(self, monkeypatch: pytest.MonkeyPatch, fake_plugin: type[Plugin], metadata_files: Mock):
         class MockStreamlinkPlugins(StreamlinkPlugins):
             def load_builtin(self):
                 self._plugins.update({"fake": fake_plugin})
@@ -218,7 +220,7 @@ class TestLoadPluginsData:
         return Streamlink(plugins_builtin=True, plugins_lazy=True)
 
     @pytest.fixture(autouse=True)
-    def metadata_files(self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, pluginsdata: Optional[str]):
+    def metadata_files(self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, pluginsdata: str | None):
         options = getattr(request, "param", {})
         package_record = options.get("package-record", True)
         mode = options.get("package-record-hash-mode", "sha256")

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
-from typing import List
 from unittest.mock import ANY, Mock, call
 
 import freezegun
@@ -117,7 +118,7 @@ class TestDASHStreamParseManifest:
         mpd: Mock,
         with_video_only: bool,
         with_audio_only: bool,
-        expected: List[str],
+        expected: list[str],
     ):
         adaptationset = Mock(
             contentProtections=None,
@@ -370,7 +371,7 @@ class TestDASHStreamWorker:
         return mock
 
     @pytest.fixture()
-    def segments(self) -> List[Mock]:
+    def segments(self) -> list[Mock]:
         return [
             Mock(url="init_segment"),
             Mock(url="first_segment"),
@@ -427,7 +428,7 @@ class TestDASHStreamWorker:
         timestamp: datetime,
         worker: DASHStreamWorker,
         representation: Mock,
-        segments: List[Mock],
+        segments: list[Mock],
         mpd: Mock,
     ):
         mpd.dynamic = True
@@ -452,7 +453,7 @@ class TestDASHStreamWorker:
         worker: DASHStreamWorker,
         timestamp: datetime,
         representation: Mock,
-        segments: List[Mock],
+        segments: list[Mock],
         mpd: Mock,
     ):
         mpd.dynamic = False
@@ -475,7 +476,7 @@ class TestDASHStreamWorker:
         mock_time: Mock,
         worker: DASHStreamWorker,
         representation: Mock,
-        segments: List[Mock],
+        segments: list[Mock],
         mpd: Mock,
         duration: float,
     ):

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import itertools
 import os
-import typing
 import unittest
 from datetime import datetime, timedelta, timezone
 from threading import Event
-from typing import Dict
+from typing import NamedTuple
 from unittest.mock import Mock, call, patch
 
 import freezegun
@@ -109,7 +110,7 @@ class TestHLSVariantPlaylist:
         return HLSStream.parse_variant_playlist(session, url)
 
     @pytest.mark.parametrize("streams", ["hls/test_master.m3u8"], indirect=True)
-    def test_variant_playlist(self, request: pytest.FixtureRequest, streams: Dict[str, HLSStream]):
+    def test_variant_playlist(self, request: pytest.FixtureRequest, streams: dict[str, HLSStream]):
         assert list(streams.keys()) == ["720p", "720p_alt", "480p", "360p", "160p", "1080p (source)", "90k"]
         assert all(isinstance(stream, HLSStream) for stream in streams.values())
         assert all(stream.multivariant is not None and stream.multivariant.is_master for stream in streams.values())
@@ -961,7 +962,7 @@ class TestHlsPlaylistReloadTime(TestMixinStreamHLS, unittest.TestCase):
 class TestHlsPlaylistParseErrors(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = EventedWriterHLSStream
 
-    class FakePlaylist(typing.NamedTuple):
+    class FakePlaylist(NamedTuple):
         is_master: bool = False
         iframes_only: bool = False
 

--- a/tests/stream/hls/test_m3u8.py
+++ b/tests/stream/hls/test_m3u8.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
-from typing import Optional, Tuple, Union
 
 import pytest
 
@@ -62,7 +63,7 @@ def test_parse_tag_mapping():
     ("#TAG:ATTRIBUTES", ("TAG", "ATTRIBUTES")),
     ("#TAG:    ATTRIBUTES    ", ("TAG", "ATTRIBUTES")),
 ])
-def test_split_tag(string: str, expected: Union[Tuple[str, str], Tuple[None, None]]):
+def test_split_tag(string: str, expected: tuple[str, str] | tuple[None, None]):
     assert M3U8Parser.split_tag(string) == expected
 
 
@@ -149,7 +150,7 @@ def test_parse_bool(string: str, expected: bool):
     ("1234", ByteRange(1234, None)),
     ("1234@5678", ByteRange(1234, 5678)),
 ])
-def test_parse_byterange(string: str, expected: Optional[ByteRange]):
+def test_parse_byterange(string: str, expected: ByteRange | None):
     assert M3U8Parser.parse_byterange(string) == expected
 
 
@@ -173,7 +174,7 @@ def test_parse_extinf(string: str, expected: ExtInf):
     ("0XDEADBEEF", False, b"\xde\xad\xbe\xef"),
     ("0xdeadbee", False, b"\x0d\xea\xdb\xee"),
 ])
-def test_parse_hex(caplog: pytest.LogCaptureFixture, string: Optional[str], log: bool, expected: Optional[bytes]):
+def test_parse_hex(caplog: pytest.LogCaptureFixture, string: str | None, log: bool, expected: bytes | None):
     assert M3U8Parser.parse_hex(string) == expected
     assert [(record.name, record.levelname, record.message) for record in caplog.records] == ([
         ("streamlink.stream.hls.m3u8", "warning", "Discarded invalid hexadecimal-sequence attribute value"),
@@ -187,7 +188,7 @@ def test_parse_hex(caplog: pytest.LogCaptureFixture, string: Optional[str], log:
     ("2000-99-99T99:99:99.999Z", True, None),
     ("2000-01-01T00:00:00.000Z", False, datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=UTC)),
 ])
-def test_parse_iso8601(caplog: pytest.LogCaptureFixture, string: Optional[str], log: bool, expected: Optional[datetime]):
+def test_parse_iso8601(caplog: pytest.LogCaptureFixture, string: str | None, log: bool, expected: datetime | None):
     assert M3U8Parser.parse_iso8601(string) == expected
     assert [(record.name, record.levelname, record.message) for record in caplog.records] == ([
         ("streamlink.stream.hls.m3u8", "warning", "Discarded invalid ISO8601 attribute value"),
@@ -200,7 +201,7 @@ def test_parse_iso8601(caplog: pytest.LogCaptureFixture, string: Optional[str], 
     ("123.456", timedelta(seconds=123.456)),
     ("-123.456", timedelta(seconds=-123.456)),
 ])
-def test_parse_timedelta(string: Optional[str], expected: Optional[timedelta]):
+def test_parse_timedelta(string: str | None, expected: timedelta | None):
     assert M3U8Parser.parse_timedelta(string) == expected
 
 

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import subprocess
-from typing import Dict, List, Optional, Type
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -45,7 +46,7 @@ class TestCommand:
         pytest.param("custom", {"ffmpeg": "ffmpeg"}, None, id="custom-negative"),
         pytest.param("custom", {"ffmpeg": "ffmpeg", "custom": "custom"}, "custom", id="custom-positive"),
     ])
-    def test_no_cache(self, session: Streamlink, command: Optional[str], which: Dict, expected: Optional[str]):
+    def test_no_cache(self, session: Streamlink, command: str | None, which: dict, expected: str | None):
         session.options.update({"ffmpeg-ffmpeg": command})
         with patch("streamlink.stream.ffmpegmux.which", side_effect=which.get):
             assert FFMPEGMuxer.command(session) == expected
@@ -54,7 +55,7 @@ class TestCommand:
         pytest.param(None, False, id="negative"),
         pytest.param("ffmpeg", True, id="positive"),
     ])
-    def test_is_usable(self, session: Streamlink, resolved: Optional[str], expected: bool):
+    def test_is_usable(self, session: Streamlink, resolved: str | None, expected: bool):
         with patch("streamlink.stream.ffmpegmux.which", return_value=resolved):
             assert FFMPEGMuxer.is_usable(session) is expected
 
@@ -497,9 +498,9 @@ class TestOpen:
         self,
         session: Streamlink,
         popen: Mock,
-        options: Dict,
-        muxer_args: Dict,
-        expected: List,
+        options: dict,
+        muxer_args: dict,
+        expected: list,
     ):
         session.options.update(options)
         streamio = FFMPEGMuxer(session, **muxer_args)
@@ -530,7 +531,7 @@ class TestOpen:
         pytest.param({"ffmpeg-verbose-path": "foo", "ffmpeg-verbose": True}, None, id="verbose-path priority"),
         pytest.param({"ffmpeg-verbose-path": "foo"}, OSError, id="OSError on close"),
     ])
-    def test_stderr_path(self, session: Streamlink, popen: Mock, options: dict, side_effect: Optional[Type[Exception]]):
+    def test_stderr_path(self, session: Streamlink, popen: Mock, options: dict, side_effect: type[Exception] | None):
         session.options.update(options)
         with patch("streamlink.stream.ffmpegmux.Path") as mock_path:
             file: Mock = mock_path("foo").expanduser().open("w")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 from json import JSONDecodeError
 from pathlib import Path
-from typing import Type, Union
 from unittest.mock import Mock, patch
 
 import freezegun
@@ -35,7 +36,7 @@ class TestPathlibAndStr:
         pytest.param("foo", id="str"),
         pytest.param(Path("foo"), id="Path"),
     ])
-    def test_constructor(self, cache_dir: Path, filename: Union[str, Path]):
+    def test_constructor(self, cache_dir: Path, filename: str | Path):
         cache = Cache(filename)
         assert cache.filename == cache_dir / Path(filename)
 
@@ -116,7 +117,7 @@ class TestIO:
         ("pathlib.Path.open", OSError),
         ("json.load", JSONDecodeError),
     ])
-    def test_load_fail(self, cache: Cache, mockpath: str, side_effect: Type[Exception]):
+    def test_load_fail(self, cache: Cache, mockpath: str, side_effect: type[Exception]):
         with patch("pathlib.Path.exists", return_value=True):
             with patch(mockpath, side_effect=side_effect):
                 cache._load()
@@ -127,7 +128,7 @@ class TestIO:
         TypeError,
         ValueError,
     ])
-    def test_save_fail_jsondump(self, cache: Cache, side_effect: Type[Exception]):
+    def test_save_fail_jsondump(self, cache: Cache, side_effect: type[Exception]):
         with patch("json.dump", side_effect=side_effect):
             with pytest.raises(side_effect):
                 cache.set("key", "value")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
 import warnings
+from collections.abc import Iterable
 from datetime import timezone
 from errno import EINVAL, EPIPE
 from inspect import currentframe, getframeinfo
 from io import BytesIO, TextIOWrapper
 from pathlib import Path
-from typing import Iterable, Optional, Tuple, Type
 
 import freezegun
 import pytest
@@ -45,7 +47,7 @@ def log(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, output:
     if "logfile" in request.fixturenames:
         params["filename"] = request.getfixturevalue("logfile")
 
-    stream: Optional[TextIOWrapper] = output
+    stream: TextIOWrapper | None = output
     if not params.pop("stdout", True):
         stream = None
     if not params.pop("stderr", True):
@@ -312,7 +314,7 @@ class TestLogging:
 
 class TestCaptureWarnings:
     @staticmethod
-    def _warn(messages: Iterable[Tuple[str, Type[Warning]]], filterwarnings=None):
+    def _warn(messages: Iterable[tuple[str, type[Warning]]], filterwarnings=None):
         frame = currentframe()
         assert frame
         assert frame.f_back
@@ -343,7 +345,7 @@ class TestCaptureWarnings:
         recwarn: pytest.WarningsRecorder,
         log: logging.Logger,
         output: TextIOWrapper,
-        warning: Tuple[str, Type[Warning]],
+        warning: tuple[str, type[Warning]],
         expected: str,
         origin: bool,
     ):
@@ -402,7 +404,7 @@ class TestCaptureWarnings:
         recwarn: pytest.WarningsRecorder,
         log: logging.Logger,
         output: TextIOWrapper,
-        warning: Tuple[str, Type[Warning]],
+        warning: tuple[str, type[Warning]],
     ):
         self._warn([warning], filterwarnings="ignore")
         assert recwarn.list == []

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import re
 import time
 from contextlib import nullcontext
 from operator import eq, gt, lt
-from typing import Any, Type
+from typing import Any
 from unittest.mock import Mock, call, patch
 
 import freezegun
@@ -60,7 +62,7 @@ class TestPlugin:
         (CustomConstructorOnePlugin, "test_plugin", "tests.test_plugin"),
         (CustomConstructorTwoPlugin, "test_plugin", "tests.test_plugin"),
     ])
-    def test_constructor(self, caplog: pytest.LogCaptureFixture, pluginclass: Type[Plugin], module: str, logger: str):
+    def test_constructor(self, caplog: pytest.LogCaptureFixture, pluginclass: type[Plugin], module: str, logger: str):
         session = Mock()
         with patch("streamlink.plugin.plugin.Cache") as mock_cache, \
              patch.object(pluginclass, "load_cookies") as mock_load_cookies:
@@ -372,12 +374,12 @@ class TestCookies:
             yield cache
 
     @pytest.fixture()
-    def logger(self, pluginclass: Type[Plugin]):
+    def logger(self, pluginclass: type[Plugin]):
         with patch("streamlink.plugin.plugin.logging") as mock_logging:
             yield mock_logging.getLogger(pluginclass.__module__)
 
     @pytest.fixture()
-    def plugin(self, pluginclass: Type[Plugin], session: Streamlink, plugincache: Mock, logger: Mock):
+    def plugin(self, pluginclass: type[Plugin], session: Streamlink, plugincache: Mock, logger: Mock):
         plugin = pluginclass(session, "http://test.se")
         assert plugin.cache is plugincache
         assert plugin.logger is logger

--- a/tests/testutils/handshake.py
+++ b/tests/testutils/handshake.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
 from threading import Event
-from typing import Awaitable, Callable, Generator, Optional, Type
 
 
 @dataclass
 class _HandshakeContext:
-    error: Optional[Exception] = None
+    error: Exception | None = None
 
 
 class Handshake:
@@ -23,7 +25,7 @@ class Handshake:
         self._context = _HandshakeContext()
 
     @contextmanager
-    def __call__(self, exception: Optional[Type[Exception]] = None) -> Generator[_HandshakeContext, None, None]:
+    def __call__(self, exception: type[Exception] | None = None) -> Generator[_HandshakeContext, None, None]:
         """Execute application logic in this context manager and optionally capture exceptions."""
         try:
             self.ready()
@@ -52,11 +54,11 @@ class Handshake:
         """Allow producer thread to run."""
         self._go.set()
 
-    def wait_ready(self, timeout: Optional[float] = None) -> bool:
+    def wait_ready(self, timeout: float | None = None) -> bool:
         """Wait for producer thread to be ready and return whether it is ready or not."""
         return self._ready.wait(timeout=timeout)
 
-    def wait_done(self, timeout: Optional[float] = None) -> bool:
+    def wait_done(self, timeout: float | None = None) -> bool:
         """Wait for producer thread to be done and return whether it is done or not. If an exception was captured, raise it."""
         result = self._done.wait(timeout=timeout)
         self._done.clear()
@@ -68,14 +70,14 @@ class Handshake:
 
         return result
 
-    def step(self, timeout: Optional[float] = None) -> bool:
+    def step(self, timeout: float | None = None) -> bool:
         """Allow producer thread to run, wait for it to complete and return whether it has finished or not."""
         self.go()
         return self.wait_done(timeout=timeout)
 
-    is_ready: Callable[[Optional[float]], Awaitable[bool]]
-    is_done: Callable[[Optional[float]], Awaitable[bool]]
-    asyncstep: Callable[[Optional[float]], Awaitable[bool]]
+    is_ready: Callable[[float | None], Awaitable[bool]]
+    is_done: Callable[[float | None], Awaitable[bool]]
+    asyncstep: Callable[[float | None], Awaitable[bool]]
 
 
 def _sync2async(obj, name, method):

--- a/tests/utils/test_args.py
+++ b/tests/utils/test_args.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import List, Sequence, Type
 
 import pytest
 
@@ -34,7 +36,7 @@ def test_boolean(value: str, expected: bool, raises: nullcontext):
     pytest.param("/var/run/foo,/var/run/bar", ["/var/run/foo", "/var/run/bar"], id="paths"),
     pytest.param("foo bar,baz", ["foo bar", "baz"], id="whitespace"),
 ])
-def test_comma_list(value: str, expected: List[str]):
+def test_comma_list(value: str, expected: list[str]):
     assert comma_list(value) == expected
 
 
@@ -58,7 +60,7 @@ def test_comma_list(value: str, expected: List[str]):
         id="unique",
     ),
 ])
-def test_comma_list_filter(options: dict, value: str, expected: List[str]):
+def test_comma_list_filter(options: dict, value: str, expected: list[str]):
     func = comma_list_filter(**options)
     assert func(value) == expected
 
@@ -156,7 +158,7 @@ class TestNum:
         (float, "-", None, pytest.raises(ValueError, match=r"^could not convert string to float:")),
         (float, "foo", None, pytest.raises(ValueError, match=r"^could not convert string to float:")),
     ])
-    def test_numtype(self, numtype: Type[float], value: float, expected: float, raises: nullcontext):
+    def test_numtype(self, numtype: type[float], value: float, expected: float, raises: nullcontext):
         func = num(numtype)
         assert func.__name__ == numtype.__name__
         with raises:

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import List, Optional, Union
 
 import pytest
 
@@ -94,9 +95,9 @@ RESOLVE_EXECUTABLE_LOOKUPS = {
 ])
 def test_resolve_executable(
     monkeypatch: pytest.MonkeyPatch,
-    custom: Optional[str],
-    names: Optional[List[str]],
-    fallbacks: Optional[List[Union[str, Path]]],
+    custom: str | None,
+    names: list[str] | None,
+    fallbacks: list[str | Path] | None,
     expected: str,
 ):
     monkeypatch.setattr("streamlink.utils.path.which", RESOLVE_EXECUTABLE_LOOKUPS.get)

--- a/tests/utils/test_processoutput.py
+++ b/tests/utils/test_processoutput.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import sys
-from typing import Awaitable, Callable, Optional, Tuple
+from collections.abc import Awaitable, Callable
 from unittest.mock import Mock, call
 
 import pytest
@@ -34,8 +36,8 @@ class FakeProcessOutput(ProcessOutput):
     onstdout: Mock
     onstderr: Mock
 
-    onoutput_sender: trio.MemorySendChannel[Tuple[str, str]]
-    onoutput_receiver: trio.MemoryReceiveChannel[Tuple[str, str]]
+    onoutput_sender: trio.MemorySendChannel[tuple[str, str]]
+    onoutput_receiver: trio.MemoryReceiveChannel[tuple[str, str]]
 
     def __init__(self, *args, ignoresigterm: bool = False, **kwargs):
         command = [sys.executable, "-c", CODE]
@@ -251,7 +253,7 @@ async def test_output_exception(get_process: Callable[[], Awaitable[trio.Process
 
     po = CustomFakeProcessOutput(timeout=4)
     # noinspection PyUnusedLocal
-    process: Optional[trio.Process] = None
+    process: trio.Process | None = None
 
     with pytest.raises(ExceptionGroup) as exc_info:  # noqa: PT012
         async with trio.open_nursery() as nursery:

--- a/tests/utils/test_random.py
+++ b/tests/utils/test_random.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections import defaultdict
+from collections.abc import Iterator, Sequence
 from itertools import count
-from typing import Dict, Iterator, Sequence
 
 import pytest
 
@@ -18,7 +20,7 @@ from streamlink.utils.random import (
 
 @pytest.fixture()
 def _iterated_choice(monkeypatch: pytest.MonkeyPatch):
-    choices: Dict[Sequence, Iterator[int]] = defaultdict(count)
+    choices: dict[Sequence, Iterator[int]] = defaultdict(count)
 
     def fake_choice(seq):
         return seq[next(choices[seq]) % len(seq)]

--- a/tests/webbrowser/cdp/__init__.py
+++ b/tests/webbrowser/cdp/__init__.py
@@ -1,7 +1,4 @@
-# TODO: trio>0.22 release: remove __future__ import (generic memorychannels)
 from __future__ import annotations
-
-from typing import List
 
 import trio
 from trio_websocket import CloseReason, ConnectionClosed  # type: ignore[import]
@@ -13,7 +10,7 @@ class FakeWebsocketConnection:
 
     def __init__(self) -> None:
         self.sender, self.receiver = trio.open_memory_channel(10)
-        self.sent: List[str] = []
+        self.sent: list[str] = []
         self.closed: bool = False
 
     async def send_message(self, message: str):

--- a/tests/webbrowser/cdp/test_client.py
+++ b/tests/webbrowser/cdp/test_client.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
 from contextlib import nullcontext
-from typing import Awaitable, Callable, Union, cast
+from typing import TYPE_CHECKING, cast
 from unittest.mock import ANY, AsyncMock, Mock, call
 
 import pytest
@@ -16,8 +19,15 @@ from streamlink.webbrowser.cdp.exceptions import CDPError
 from tests.webbrowser.cdp import FakeWebsocketConnection
 
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+
+TAsyncHandler: TypeAlias = "AsyncMock | Callable[[CDPClientSession, RequestPaused], Awaitable]"
+
+
 def async_handler(*args, **kwargs):
-    return cast(Union[AsyncMock, Callable[[CDPClientSession, RequestPaused], Awaitable]], AsyncMock(*args, **kwargs))
+    return cast(TAsyncHandler, AsyncMock(*args, **kwargs))
 
 
 @pytest.fixture()

--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import contextlib
+from collections.abc import Generator
 from contextlib import nullcontext
 from dataclasses import dataclass
 from functools import partial
-from typing import Dict, Generator, Optional, Type
 from unittest.mock import AsyncMock
 
 import pytest
@@ -89,7 +91,7 @@ class TestCreateConnection:
         pytest.param(0, 2, id="No timeout uses default value"),
         pytest.param(3, 3, id="Custom timeout value"),
     ])
-    async def test_timeout(self, websocket_connection: FakeWebsocketConnection, timeout: Optional[int], expected: int):
+    async def test_timeout(self, websocket_connection: FakeWebsocketConnection, timeout: int | None, expected: int):
         async with CDPConnection.create("ws://localhost:1234/fake", timeout=timeout) as cdp_conn:
             pass
         assert cdp_conn.cmd_timeout == expected
@@ -172,7 +174,7 @@ class TestSend:
         cdp_connection: CDPConnection,
         websocket_connection: FakeWebsocketConnection,
         autojump_clock: MockClock,
-        timeout: Optional[float],
+        timeout: float | None,
         jump: float,
         raises: nullcontext,
     ):
@@ -578,7 +580,7 @@ class TestSession:
 class TestHandleEvent:
     @pytest.fixture(autouse=True)
     def event_parsers(self, monkeypatch: pytest.MonkeyPatch):
-        event_parsers: Dict[str, Type] = {
+        event_parsers: dict[str, type] = {
             "Fake.fakeEvent": FakeEvent,
         }
         monkeypatch.setattr("streamlink.webbrowser.cdp.devtools.util._event_parsers", event_parsers)

--- a/tests/webbrowser/conftest.py
+++ b/tests/webbrowser/conftest.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import sys
 from contextlib import asynccontextmanager
 from subprocess import PIPE
-from typing import Optional
 from unittest.mock import Mock
 
 import pytest
@@ -49,7 +50,7 @@ def webbrowser_launch(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCapture
     monkeypatch.setattr("trio.run_process", fake_trio_run_process)
 
     @asynccontextmanager
-    async def webbrowser_launch(*args, webbrowser: Optional[Webbrowser] = None, **kwargs):
+    async def webbrowser_launch(*args, webbrowser: Webbrowser | None = None, **kwargs):
         # dummy web browser process, which idles until stdin receives input with an exit code
         webbrowser = webbrowser or Webbrowser()
         webbrowser.executable = sys.executable

--- a/tests/webbrowser/test_chromium.py
+++ b/tests/webbrowser/test_chromium.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from contextlib import nullcontext
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from signal import SIGTERM
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import pytest
 import requests_mock as rm
@@ -42,7 +44,7 @@ class TestInit:
             id="Success with custom path",
         ),
     ], indirect=["resolve_executable"])
-    def test_resolve_executable(self, resolve_executable, executable: Optional[str], raises: nullcontext):
+    def test_resolve_executable(self, resolve_executable, executable: str | None, raises: nullcontext):
         with raises:
             ChromiumWebbrowser(executable=executable)
 
@@ -112,7 +114,7 @@ async def test_launch(
     mock_clock,
     webbrowser_launch,
     host: str,
-    port: Optional[int],
+    port: int | None,
     headless: bool,
 ):
     async def fake_find_free_port(_):
@@ -191,7 +193,7 @@ def test_get_websocket_address(
         "webSocketDebuggerUrl": f"ws://{_host}:{port}/devtools/browser/some-uuid4",
     }
 
-    responses: List[Dict[str, Any]] = [{"exc": Timeout()} for _ in range(num)]
+    responses: list[dict[str, Any]] = [{"exc": Timeout()} for _ in range(num)]
     responses.append({"json": payload})
     mock = requests_mock.register_uri("GET", address, responses)
 

--- a/tests/webbrowser/test_webbrowser.py
+++ b/tests/webbrowser/test_webbrowser.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from signal import SIGTERM
-from typing import List, Optional
 
 import pytest
 import trio
@@ -15,7 +14,7 @@ from streamlink.webbrowser.webbrowser import Webbrowser
 
 class _FakeWebbrowser(Webbrowser):
     @classmethod
-    def launch_args(cls) -> List[str]:
+    def launch_args(cls) -> list[str]:
         return ["foo", "bar"]
 
 
@@ -46,7 +45,7 @@ class TestInit:
             id="Success with custom path",
         ),
     ], indirect=["resolve_executable"])
-    def test_resolve_executable(self, resolve_executable, executable: Optional[str], raises: nullcontext):
+    def test_resolve_executable(self, resolve_executable, executable: str | None, raises: nullcontext):
         with raises:
             Webbrowser(executable=executable)
 


### PR DESCRIPTION
In preparation for the upcoming py38 removal, this updates all typing annotations to modern syntax.

Before I'm going to merge this, I will have to double and triple check everything first, which I haven't done yet. I will have a look at this on the weekend. The changes were all done manually, and I tried to translate everything 1-to-1, but some minor things were also changed and fixed in the process. Not everything though, but this wasn't the goal here. The goal is to not introduce any new typing bugs.

```
$ git diff master --shortstat
 123 files changed, 2286 insertions(+), 2080 deletions(-)
```

----

As a requirement, currently, without dropping py38 just yet, [PEP 563](https://peps.python.org/pep-0563/) is required with its `from __future__ import annotations`, to postpone evaluation of annotations. This could've been done a long time ago already, but never was, because it didn't really matter. Now we have one giant commit that updates everything and will need to be added to `.git-blame-ignore-revs`.

There are three commits. Commit two and three don't belong into one, so they had to be split up.

1. 1. Add [PEP 563](https://peps.python.org/pep-0563/) imports: `from __future__ import annotations`  
      This can be removed again (where possible) when dropping py38 at the end of October. Union types ([PEP 604](https://peps.python.org/pep-0604/)) still require it, as it's a py310 feature and requires dropping py39 support.
   2. Remove all previously quoted forward-references in type annotations (due to PEP 563).
   3. Switch to [PEP 585](https://peps.python.org/pep-0585/)  
      This replaces generics of the builtin base classes like `type`, `list`, `tuple`, `set`, `dict`, etc., which previously had to be done by imported their respective aliases from `typing`. This also imports stuff like `Callable`, `Mapping`, `Iterable`, etc. from `collections.abc` or `deque` from `collections` or `Pattern` from `re`, rather than their deprecated aliases from `typing`.
      https://docs.python.org/3/library/typing.html#deprecated-aliases
   4. Switch to [PEP 604](https://peps.python.org/pep-0604/)  
      This replaces `typing.Union`/`typing.Optional` with union types and their `a | b` syntax. `a | None` should always come last, as a suffix rather than prefix or somewhere in-between a chain of union types.
   5. Add remaining missing [`TypeAlias`](https://docs.python.org/3/library/typing.html#typing.TypeAlias) annotations ([PEP 613](https://peps.python.org/pep-0613/)), and always import from `typing_extensions` in `TYPE_CHECKING` mode, as `TypeAlias` is a py310 feature which requires this compat import. Use annotation strings, to allow modern syntax via postponed evaluation (PEP 563).
   6. Fix and use non-invariant types in places where it was previously an obvious mistake to use the invariant type (only did this for `Mapping`/`dict`).
   7. Fix some other minor stuff (one of those minor changes was an incorrect import, which always caused typing issues in PyCharm and its mypy plugin).
2. Add the `scripts` directory to the mypy config and fix typing issues. Both the GH release script and CDP generator script required some further changes which didn't belong into commit one, as well as the config update.
3. Regenerate the CDP modules using the same parameters from their previous update.

Two exceptions which currently can't be updated yet are [`streamlink.plugin.plugin._MCollection(list[MType])`](https://github.com/streamlink/streamlink/blob/6.11.0/src/streamlink/plugin/plugin.py#L198-L234), because it's a runtime typing requirement and can't be evaluated on py38, and [`streamlink.plugin.plugin.Matches(_MCollection[re.Match | None])`](https://github.com/streamlink/streamlink/blob/6.11.0/src/streamlink/plugin/plugin.py#L198-L234), which requires py310 due to the union type.

----

```
$ git grep 'from typing' | column -ts: -Nfile,import -H-
file                                                 import
build_backend/__init__.py                            from typing import Any
build_backend/onbuild.py                             from typing import Any, Generic, TypeVar
build_backend/plugins_json.py                        from typing import TYPE_CHECKING, Any, ClassVar, Generic, TextIO, TypeVar
build_backend/plugins_json.py                            from typing_extensions import TypeAlias
build_backend/test_plugins_json.py                   from typing import Any
docs/ext_html_template_vars.py                       from typing import Any
docs/ext_plugins.py                                  from typing import Any
script/generate-cdp.py                               from typing import cast
script/generate-cdp.py                               from typing import Any
script/generate-cdp.py                               from typing import TYPE_CHECKING, Any
script/generate-cdp.py                                   from typing_extensions import TypeAlias
script/github-release.py                             from typing import IO, Any, Literal, NewType
script/update-user-agents.py                         from typing import Any
src/streamlink/cache.py                              from typing import Any
src/streamlink/compat.py                             from typing import Any
src/streamlink/logger.py                             from typing import IO, TYPE_CHECKING, Literal
src/streamlink/options.py                            from typing import Any, ClassVar, Literal, TypeVar
src/streamlink/plugin/api/validate/_schemas.py       from typing import Any, Literal
src/streamlink/plugin/api/validate/_validate.py      from typing import Any
src/streamlink/plugin/api/validate/_validators.py    from typing import Any, Literal
src/streamlink/plugin/api/websocket.py               from typing import Any
src/streamlink/plugin/plugin.py                      from typing import TYPE_CHECKING, Any, ClassVar, List, Literal, NamedTuple, Type, TypeVar, Union
src/streamlink/plugins/twitch.py                     from typing import ClassVar
src/streamlink/plugins/ustreamtv.py                  from typing import Any
src/streamlink/session/http.py                       from typing import Any
src/streamlink/session/http.pyi                      from typing import Any
src/streamlink/session/http.pyi                      from typing_extensions import TypeAlias
src/streamlink/session/options.py                    from typing import TYPE_CHECKING, Any, ClassVar
src/streamlink/session/plugins.py                    from typing import TYPE_CHECKING, Literal
src/streamlink/session/plugins.py                        from typing import TypeAlias, TypedDict  # type
src/streamlink/session/plugins.py                        from typing_extensions import TypeAlias, TypedDict
src/streamlink/session/session.py                    from typing import Any
src/streamlink/stream/dash/dash.py                   from typing import Any
src/streamlink/stream/dash/manifest.py               from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, overload
src/streamlink/stream/dash/manifest.py                   from typing_extensions import TypeAlias
src/streamlink/stream/ffmpegmux.py                   from typing import Any, ClassVar, Generic, TextIO, TypeVar
src/streamlink/stream/hls/hls.py                     from typing import Any, ClassVar
src/streamlink/stream/hls/m3u8.py                    from typing import ClassVar, Generic, TypeVar
src/streamlink/stream/hls/m3u8.py                        from typing import Self  # type
src/streamlink/stream/hls/m3u8.py                        from typing_extensions import Self
src/streamlink/stream/hls/segment.py                 from typing import NamedTuple
src/streamlink/stream/segmented/segmented.py         from typing import ClassVar, Generic, TypeVar
src/streamlink/stream/segmented/segmented.py             from typing import TypeAlias  # type
src/streamlink/stream/segmented/segmented.py             from typing_extensions import TypeAlias
src/streamlink/utils/args.py                         from typing import Any, Generic, TypeVar
src/streamlink/utils/cache.py                        from typing import Generic, TypeVar
src/streamlink/utils/data.py                         from typing import Any
src/streamlink/utils/formatter.py                    from typing import Any
src/streamlink/utils/module.py                       from typing import TYPE_CHECKING
src/streamlink/utils/processoutput.py                from typing import BinaryIO
src/streamlink/utils/times.py                        from typing import Generic, TypeVar
src/streamlink/webbrowser/cdp/client.py              from typing import Any
src/streamlink/webbrowser/cdp/client.py                  from typing import Self, TypeAlias  # type
src/streamlink/webbrowser/cdp/client.py                  from typing_extensions import Self, TypeAlias
src/streamlink/webbrowser/cdp/connection.py          from typing import Generic, TypeVar, cast
src/streamlink/webbrowser/cdp/connection.py              from typing import Self, TypeAlias  # type
src/streamlink/webbrowser/cdp/connection.py              from typing_extensions import Self, TypeAlias
src/streamlink/webbrowser/cdp/devtools/browser.py    from typing import Any
src/streamlink/webbrowser/cdp/devtools/debugger.py   from typing import Any
src/streamlink/webbrowser/cdp/devtools/dom.py        from typing import Any
src/streamlink/webbrowser/cdp/devtools/emulation.py  from typing import Any
src/streamlink/webbrowser/cdp/devtools/fetch.py      from typing import Any
src/streamlink/webbrowser/cdp/devtools/input_.py     from typing import Any
src/streamlink/webbrowser/cdp/devtools/inspector.py  from typing import Any
src/streamlink/webbrowser/cdp/devtools/io.py         from typing import Any
src/streamlink/webbrowser/cdp/devtools/network.py    from typing import Any
src/streamlink/webbrowser/cdp/devtools/page.py       from typing import Any
src/streamlink/webbrowser/cdp/devtools/runtime.py    from typing import Any
src/streamlink/webbrowser/cdp/devtools/security.py   from typing import Any
src/streamlink/webbrowser/cdp/devtools/target.py     from typing import Any
src/streamlink/webbrowser/cdp/devtools/util.py       from typing import TYPE_CHECKING, Any
src/streamlink/webbrowser/cdp/devtools/util.py           from typing_extensions import TypeAlias
src/streamlink_cli/argparser.py                      from typing import Any
src/streamlink_cli/compat.py                         from typing import TYPE_CHECKING, BinaryIO
src/streamlink_cli/console.py                        from typing import Any, TextIO
src/streamlink_cli/main.py                           from typing import Any
src/streamlink_cli/output/file.py                    from typing import BinaryIO
src/streamlink_cli/output/player.py                  from typing import ClassVar, TextIO
src/streamlink_cli/utils/progress.py                 from typing import TYPE_CHECKING, TextIO
src/streamlink_cli/utils/progress.py                     from typing_extensions import TypeAlias
tests/cli/main/test_check_file_output.py             from typing import TYPE_CHECKING
tests/cli/test_argparser.py                          from typing import Any
tests/conftest.py                                    from typing import Any
tests/plugins/__init__.py                            from typing import TYPE_CHECKING
tests/plugins/__init__.py                                from typing_extensions import TypeAlias
tests/session/test_plugins.py                        from typing import cast
tests/stream/hls/test_hls.py                         from typing import NamedTuple
tests/test_plugin.py                                 from typing import Any
tests/webbrowser/cdp/test_client.py                  from typing import TYPE_CHECKING, cast
tests/webbrowser/cdp/test_client.py                      from typing_extensions import TypeAlias
tests/webbrowser/test_chromium.py                    from typing import Any
```