### PR TITLE
utils.module: add override parameter

### DIFF
--- a/src/streamlink/session/plugins.py
+++ b/src/streamlink/session/plugins.py
@@ -196,7 +196,7 @@ class StreamlinkPlugins:
     def _load_plugin_from_finder(name: str, finder: PathEntryFinderProtocol) -> Optional[Tuple[ModuleType, Type[Plugin]]]:
         try:
             # set the full plugin module name, even for sideloaded plugins
-            mod = exec_module(finder, f"streamlink.plugins.{name}")
+            mod = exec_module(finder, f"streamlink.plugins.{name}", override=True)
         except ImportError as err:
             log.exception(f"Failed to load plugin {name} from {err.path}\n")
             return None

--- a/src/streamlink/utils/module.py
+++ b/src/streamlink/utils/module.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from importlib.machinery import FileFinder
 from importlib.util import module_from_spec
 from pathlib import Path
@@ -21,13 +22,13 @@ def get_finder(path: Union[Path, str]) -> PathEntryFinderProtocol:
     return finder
 
 
-def load_module(name: str, path: Union[Path, str]) -> ModuleType:
+def load_module(name: str, path: Union[Path, str], override: bool = False) -> ModuleType:
     finder = get_finder(path)
 
-    return exec_module(finder, name)
+    return exec_module(finder, name, override)
 
 
-def exec_module(finder: PathEntryFinderProtocol, name: str) -> ModuleType:
+def exec_module(finder: PathEntryFinderProtocol, name: str, override: bool = False) -> ModuleType:
     spec = finder.find_spec(name)
     if not spec or not spec.loader:
         raise ImportError(
@@ -35,7 +36,12 @@ def exec_module(finder: PathEntryFinderProtocol, name: str) -> ModuleType:
             name=name,
             path=finder.path if isinstance(finder, FileFinder) else None,
         )
+
+    if not override and (mod := sys.modules.get(spec.name)):
+        return mod
+
     mod = module_from_spec(spec)
+    sys.modules[spec.name] = mod
     spec.loader.exec_module(mod)
 
     return mod

--- a/tests/utils/test_module.py
+++ b/tests/utils/test_module.py
@@ -42,7 +42,33 @@ def test_load_module_importerror(name: str, path: Path, expected: ImportError):
 
 
 def test_load_module():
-    mod = load_module(__name__.split(".")[-1], Path(__file__).parent)
-    assert "__test_marker__" in mod.__dict__
-    assert mod is not sys.modules[__name__]
-    assert mod.__test_marker__ == sys.modules[__name__].__test_marker__
+    name = __name__.split(".")[-1]
+
+    try:
+        assert __name__ in sys.modules
+        assert name not in sys.modules
+
+        prev = sys.modules[__name__]
+        mod1 = load_module(name, Path(__file__).parent)
+        assert name in sys.modules
+        assert mod1 is sys.modules[name]
+        assert prev is sys.modules[__name__]
+        assert mod1 is not sys.modules[__name__]
+
+        assert "__test_marker__" in mod1.__dict__
+        assert mod1.__test_marker__ == sys.modules[__name__].__test_marker__
+
+        mod2 = load_module(name, Path(__file__).parent)
+        assert mod2 is mod1
+
+        mod3 = load_module(name, Path(__file__).parent, override=True)
+        assert mod1 is not sys.modules[name]
+        assert mod3 is sys.modules[name]
+        assert prev is sys.modules[__name__]
+        assert mod3 is not sys.modules[__name__]
+
+        assert "__test_marker__" in mod3.__dict__
+        assert mod3.__test_marker__ == sys.modules[__name__].__test_marker__
+
+    finally:
+        sys.modules.pop(name, None)


### PR DESCRIPTION
Always look up and return already cached modules, but allow overriding cached modules if `override` is set to `True`.

Set `override=True` when calling `exec_module()` in `StreamlinkPlugins._load_plugin_from_finder()`.

----

See https://github.com/streamlink/streamlink/pull/6218#issuecomment-2395065369

The only other place where `load_module` and `exec_module` are currently used apart from `StreamlinkPlugins` (lazy plugins loader), is `tests/test_plugins.py`, where all plugin modules are loaded for the parametrization of plugin-module tests (has a test module? has plugin matchers defined? exports `__plugin__`? etc...).

Since we're now returning the already cached plugin modules from pytest's collector in `tests/plugins/test_*.py` rather than re-executing everything, this should also improve the overall testsuite runtime by a bit.