### PR TITLE
session: fix --interface on custom HTTPAdapters

### DIFF
--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -384,8 +384,8 @@ class StreamlinkOptions(Options):
     # ---- setters
 
     def _set_interface(self, key, value):
-        for scheme, adapter in self.session.http.adapters.items():
-            if scheme not in ("http://", "https://"):
+        for adapter in self.session.http.adapters.values():
+            if not isinstance(adapter, HTTPAdapter):
                 continue
             if not value:
                 adapter.poolmanager.connection_pool_kw.pop("source_address", None)


### PR DESCRIPTION
Noticed that bug while updating the typing annotations.

The `--interface` CLI argument (and its respective session option `interface`) currently only affects the `HTTPAdapter`s mounted at `http://` and `https://` (the default configuration). Some plugins however not only override the default adapters, but extend the adapter mapping with custom schemes or additional hostnames that must match:
- https://github.com/streamlink/streamlink/blob/20a58b9c88e1348f453cc4bb3567e0a937ed74a2/src/streamlink/plugins/abematv.py#L261-L263
- https://github.com/streamlink/streamlink/blob/20a58b9c88e1348f453cc4bb3567e0a937ed74a2/src/streamlink/plugins/kick.py#L48
- https://github.com/streamlink/streamlink/blob/20a58b9c88e1348f453cc4bb3567e0a937ed74a2/src/streamlink/plugins/filmon.py#L184-L186