### PR TITLE
chore: drop support for Python 3.8

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 12
+    after_n_builds: 10
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -444,7 +444,7 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
       - Notes
     * - python
       - `Python`_
-      - At least version **3.8**
+      - At least version **3.9**
     * - build
       - `setuptools`_
       - At least version **65.6.0** |br|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -54,7 +53,7 @@ dynamic = [
   "gui-scripts",
 ]
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
   "certifi",
   "exceptiongroup ; python_version<'3.11'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,7 @@ src = [
   "src",
   "tests",
 ]
-target-version = "py38"
+target-version = "py39"
 fix = false
 line-length = 128
 output-format = "full"
@@ -284,7 +284,7 @@ allow-multiline = false
 
 # https://mypy.readthedocs.io/en/stable/config_file.html
 [tool.mypy]
-python_version = 3.8
+python_version = 3.9
 show_error_codes = true
 show_error_context = true
 show_column_numbers = true

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def format_msg(text, *args, **kwargs):
 
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 8)
+REQUIRED_PYTHON = (3, 9)
 
 # This check and everything above must remain compatible with older Python versions
 if CURRENT_PYTHON < REQUIRED_PYTHON:


### PR DESCRIPTION
Resolves #6229 