### PR TITLE
ci.github: remove -dev suffix from py313 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
-          - "3.13-dev"  # TODO: remove -dev suffix once stable release has been published
+          - "3.13"
         # include:
         #   - runs-on: ubuntu-latest
         #     python-version: "3.14-dev"


### PR DESCRIPTION
CI won't pass until actions/python-versions#312 has been merged.

edit:
Merged an hour ago, restarting failed CI jobs, and then going to merge...