### PR TITLE
session: remove deprecated stream-type options

### DIFF
--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -200,42 +200,6 @@ class StreamlinkOptions(Options):
           - ``int``
           - ``3``
           - Max number of DASH manifest reload attempts before giving up
-        * - hls-segment-attempts *(deprecated)*
-          - ``int``
-          - ``3``
-          - See ``stream-segment-attempts``
-        * - hls-segment-threads *(deprecated)*
-          - ``int``
-          - ``3``
-          - See ``stream-segment-threads``
-        * - hls-segment-timeout *(deprecated)*
-          - ``float``
-          - ``10.00``
-          - See ``stream-segment-timeout``
-        * - hls-timeout *(deprecated)*
-          - ``float``
-          - ``60.00``
-          - See ``stream-timeout``
-        * - dash-segment-attempts *(deprecated)*
-          - ``int``
-          - ``3``
-          - See ``stream-segment-attempts``
-        * - dash-segment-threads *(deprecated)*
-          - ``int``
-          - ``3``
-          - See ``stream-segment-threads``
-        * - dash-segment-timeout *(deprecated)*
-          - ``float``
-          - ``10.00``
-          - See ``stream-segment-timeout``
-        * - dash-timeout *(deprecated)*
-          - ``float``
-          - ``60.00``
-          - See ``stream-timeout``
-        * - http-stream-timeout *(deprecated)*
-          - ``float``
-          - ``60.00``
-          - See ``stream-timeout``
         * - ffmpeg-ffmpeg
           - ``str | None``
           - ``None``
@@ -486,13 +450,4 @@ class StreamlinkOptions(Options):
         "http-ssl-verify": _set_http_attr,
         "http-trust-env": _set_http_attr,
         "http-timeout": _set_http_attr,
-        "dash-segment-attempts": _factory_set_deprecated("stream-segment-attempts", int),
-        "hls-segment-attempts": _factory_set_deprecated("stream-segment-attempts", int),
-        "dash-segment-threads": _factory_set_deprecated("stream-segment-threads", int),
-        "hls-segment-threads": _factory_set_deprecated("stream-segment-threads", int),
-        "dash-segment-timeout": _factory_set_deprecated("stream-segment-timeout", float),
-        "hls-segment-timeout": _factory_set_deprecated("stream-segment-timeout", float),
-        "dash-timeout": _factory_set_deprecated("stream-timeout", float),
-        "hls-timeout": _factory_set_deprecated("stream-timeout", float),
-        "http-stream-timeout": _factory_set_deprecated("stream-timeout", float),
     }

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1123,12 +1123,6 @@ def build_parser():
         """,
     )
 
-    transport_hls.add_argument("--hls-segment-attempts", help=argparse.SUPPRESS)
-    transport_hls.add_argument("--hls-segment-threads", help=argparse.SUPPRESS)
-    transport_hls.add_argument("--hls-segment-timeout", help=argparse.SUPPRESS)
-    transport_hls.add_argument("--hls-timeout", help=argparse.SUPPRESS)
-    transport.add_argument("--http-stream-timeout", help=argparse.SUPPRESS)
-
     transport_ffmpeg.add_argument(
         "--ffmpeg-ffmpeg",
         metavar="FILENAME",
@@ -1439,13 +1433,6 @@ _ARGUMENT_TO_SESSIONOPTION: list[tuple[str, str, Callable[[Any], Any] | None]] =
     ("http_ssl_cert", "http-ssl-cert", None),
     ("http_ssl_cert_crt_key", "http-ssl-cert", tuple),
     ("http_timeout", "http-timeout", None),
-
-    # deprecated stream transport arguments (need to be defined first, so following ones can override values)
-    ("hls_segment_attempts", "hls-segment-attempts", None),
-    ("hls_segment_threads", "hls-segment-threads", None),
-    ("hls_segment_timeout", "hls-segment-timeout", None),
-    ("hls_timeout", "hls-timeout", None),
-    ("http_stream_timeout", "http-stream-timeout", None),
 
     # stream transport arguments
     ("ringbuffer_size", "ringbuffer-size", None),

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -213,6 +213,26 @@ def test_setup_session_options_override(monkeypatch: pytest.MonkeyPatch, session
     assert session.get_option(key) == expected
 
 
+@pytest.mark.parametrize(
+    ("namespace", "expected"),
+    [
+        pytest.param(Namespace(deprecated=None, new=123), 123, id="new-only"),
+        pytest.param(Namespace(deprecated=123, new=None), 123, id="deprecated-only"),
+        pytest.param(Namespace(deprecated=123, new=456), 456, id="new-overrides-deprecated"),
+    ],
+)
+def test_setup_session_options_deprecation_override(
+    monkeypatch: pytest.MonkeyPatch,
+    session: Streamlink,
+    namespace: Namespace,
+    expected: int,
+):
+    arg_to_sessopt = [("deprecated", "option", None), ("new", "option", None)]
+    monkeypatch.setattr("streamlink_cli.argparser._ARGUMENT_TO_SESSIONOPTION", arg_to_sessopt)
+    setup_session_options(session, namespace)
+    assert session.options.get_explicit("option") == expected
+
+
 def test_cli_main_setup_session_options(monkeypatch: pytest.MonkeyPatch, parser: ArgumentParser, session: Streamlink):
     class StopTest(Exception):
         pass

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -149,7 +149,6 @@ class TestMatchArgumentOverride:
         assert capsys.readouterr().err.endswith(errormsg)
 
 
-@pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize(("argv", "option", "expected"), [
     pytest.param(
         ["--locale", "xx_XX"],
@@ -180,18 +179,6 @@ class TestMatchArgumentOverride:
         "http-ssl-cert",
         ("foo.crt", "bar.key"),
         id="Arg+value with tuple mapper",
-    ),
-    pytest.param(
-        ["--hls-timeout", "123"],
-        "stream-timeout",
-        123.0,
-        id="Deprecated argument",
-    ),
-    pytest.param(
-        ["--hls-timeout", "123", "--stream-timeout", "456"],
-        "stream-timeout",
-        456.0,
-        id="Deprecated argument with override",
     ),
 ])
 def test_setup_session_options(parser: ArgumentParser, session: Streamlink, argv: list, option: str, expected: Any):

--- a/tests/session/test_options.py
+++ b/tests/session/test_options.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from inspect import currentframe, getframeinfo
 from operator import itemgetter
 from socket import AF_INET, AF_INET6
 from unittest.mock import Mock
@@ -12,6 +13,7 @@ from requests.adapters import HTTPAdapter
 from streamlink.exceptions import StreamlinkDeprecationWarning
 from streamlink.session import Streamlink
 from streamlink.session.http import TLSNoDHAdapter
+from streamlink.session.options import StreamlinkOptions
 
 
 _original_allowed_gai_family = urllib3.util.connection.allowed_gai_family  # type: ignore[attr-defined]
@@ -50,6 +52,31 @@ def test_session_wrapper_methods(session: Streamlink):
     session.set_option("test_option", "option")
     assert session.get_option("test_option") == "option"
     assert session.get_option("non_existing") is None
+
+
+def test_session_option_set_deprecated(recwarn: pytest.WarningsRecorder, session: Streamlink):
+    def get_lineno():
+        frame = currentframe()
+        assert frame
+        assert frame.f_back
+        return getframeinfo(frame.f_back).lineno
+
+    class FakeStreamlinkOptions(StreamlinkOptions):
+        _MAP_SETTERS = {
+            "deprecated": StreamlinkOptions._factory_set_deprecated("new", int),
+        }
+
+    session.options = FakeStreamlinkOptions(session)
+    assert session.get_option("new") is None
+    assert recwarn.list == []
+
+    session.set_option("deprecated", 123)
+    lineno = get_lineno() - 1
+
+    assert session.get_option("new") == 123
+    assert [(item.filename, item.lineno, item.category, str(item.message)) for item in recwarn.list] == [
+        (__file__, lineno, StreamlinkDeprecationWarning, "`deprecated` has been deprecated in favor of the `new` option"),
+    ]
 
 
 def test_options_locale(monkeypatch: pytest.MonkeyPatch, session: Streamlink):


### PR DESCRIPTION
Remove the following deprecated session options:
- `hls-segment-attempts`
- `hls-segment-threads`
- `hls-segment-timeout`
- `hls-timeout`
- `dash-segment-attempts`
- `dash-segment-threads`
- `dash-segment-timeout`
- `dash-timeout`
- `http-stream-timeout`

and their respective CLI arguments (DASH CLI args didn't exist):
- `--hls-segment-attempts`
- `--hls-segment-threads`
- `--hls-segment-timeout`
- `--hls-timeout`
- `--http-stream-timeout`
