### PR TITLE
cli: remove now unused DeprecatedPath

### DIFF
--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,7 +1,6 @@
 import sys
 from os import devnull
-from pathlib import Path
-from typing import TYPE_CHECKING, BinaryIO
+from typing import BinaryIO
 
 
 try:
@@ -14,17 +13,6 @@ except AttributeError:  # pragma: no cover
     del _atexit_register
 
 
-if TYPE_CHECKING:  # pragma: no cover
-    _BasePath = Path
-else:
-    _BasePath = type(Path())
-
-
-class DeprecatedPath(_BasePath):
-    pass
-
-
 __all__ = [
-    "DeprecatedPath",
     "stdout",
 ]

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -5,7 +5,6 @@ import tempfile
 from pathlib import Path
 
 from streamlink.compat import is_darwin, is_win32
-from streamlink_cli.compat import DeprecatedPath
 
 
 DEFAULT_STREAM_METADATA = {
@@ -37,7 +36,7 @@ elif is_darwin:
     PLUGIN_DIRS = [
         Path.home() / "Library" / "Application Support" / "streamlink" / "plugins",
     ]
-    LOG_DIR = DeprecatedPath(Path.home() / "Library" / "Logs" / "streamlink")
+    LOG_DIR = Path.home() / "Library" / "Logs" / "streamlink"
 else:
     XDG_CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME", "~/.config")).expanduser()
     XDG_DATA_HOME = Path(os.environ.get("XDG_DATA_HOME", "~/.local/share")).expanduser()

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -26,7 +26,7 @@ from streamlink.stream.stream import Stream, StreamIO
 from streamlink.utils.named_pipe import NamedPipe
 from streamlink.utils.times import LOCAL as LOCALTIMEZONE
 from streamlink_cli.argparser import ArgumentParser, build_parser, setup_session_options
-from streamlink_cli.compat import DeprecatedPath, stdout
+from streamlink_cli.compat import stdout
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.exceptions import StreamlinkCLIError


### PR DESCRIPTION
For some reason, `LOG_DIR` was set as a `DeprecatedPath` on macOS. This didn't have any effect, but it's weird that it was set here...