### PR TITLE
cli: fix errors on missing stdin fd

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -18,6 +18,7 @@ from streamlink.user_input import UserInputRequester
 from streamlink.utils.args import boolean, comma_list, comma_list_filter, filesize, keyvalue, num
 from streamlink.utils.times import hours_minutes_seconds_float
 from streamlink_cli.constants import STREAM_PASSTHROUGH
+from streamlink_cli.exceptions import StreamlinkCLIError
 from streamlink_cli.output.player import PlayerOutput
 from streamlink_cli.utils import find_default_player
 
@@ -1538,10 +1539,13 @@ def setup_plugin_options(
     for req in required.values():
         if not values.get(req.dest):
             prompt = f"{req.prompt or f'Enter {pluginname} {req.name}'}"
-            if req.sensitive:
-                value = user_input_requester.ask_password(prompt)
-            else:
-                value = user_input_requester.ask(prompt)
+            try:
+                if req.sensitive:
+                    value = user_input_requester.ask_password(prompt)
+                else:
+                    value = user_input_requester.ask(prompt)
+            except OSError as err:
+                raise StreamlinkCLIError from err
             values[req.dest] = value
 
     options = Options(defaults)

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -13,16 +13,17 @@ class ConsoleUserInputRequester(UserInputRequester):
     """
     Request input from the user on the console using the standard ask/askpass methods
     """
+
     def __init__(self, console):
         self.console = console
 
     def ask(self, prompt: str) -> str:
-        if not sys.stdin.isatty():
+        if not sys.stdin or not sys.stdin.isatty():
             raise OSError("no TTY available")
         return self.console.ask(f"{prompt.strip()}: ")
 
     def ask_password(self, prompt: str) -> str:
-        if not sys.stdin.isatty():
+        if not sys.stdin or not sys.stdin.isatty():
             raise OSError("no TTY available")
         return self.console.askpass(f"{prompt.strip()}: ")
 
@@ -33,7 +34,7 @@ class ConsoleOutput:
         self.output = output
 
     def ask(self, prompt: str) -> str | None:
-        if not sys.stdin.isatty():
+        if not sys.stdin or not sys.stdin.isatty():
             return None
 
         self.output.write(prompt)
@@ -45,7 +46,7 @@ class ConsoleOutput:
             return None
 
     def askpass(self, prompt: str) -> str | None:
-        if not sys.stdin.isatty():
+        if not sys.stdin or not sys.stdin.isatty():
             return None
 
         return getpass(prompt, self.output)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -85,7 +85,7 @@ def check_file_output(path: Path, force: bool) -> Path:
     log.debug("Checking file output")
 
     if realpath.is_file() and not force:
-        if sys.stdin.isatty():
+        if sys.stdin and sys.stdin.isatty():
             answer = console.ask(f"File {path} already exists! Overwrite it? [y/N] ")
             if not answer or answer.lower() != "y":
                 raise StreamlinkCLIError()

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -129,6 +129,13 @@ class TestConsoleOutput:
         assert getvalue(output) == ""
         assert mock_input.call_args_list == []
 
+    def test_ask_no_stdin(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
+        monkeypatch.setattr("sys.stdin", None)
+
+        console = ConsoleOutput(output)
+        assert console.ask("test: ") is None
+        assert getvalue(output) == ""
+
     def test_ask_input_exception(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
         monkeypatch.setattr("builtins.input", Mock(side_effect=ValueError))
 
@@ -150,3 +157,11 @@ class TestConsoleOutput:
     def test_askpass_no_tty(self, output: TextIOWrapper):
         console = ConsoleOutput(output)
         assert console.askpass("test: ") is None
+        assert getvalue(output) == ""
+
+    def test_askpass_no_stdin(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
+        monkeypatch.setattr("sys.stdin", None)
+
+        console = ConsoleOutput(output)
+        assert console.askpass("test: ") is None
+        assert getvalue(output) == ""


### PR DESCRIPTION
Follow-up of c587485

- Fix `AttributeError` when asking for input for required plugin args
- Fix `AttributeError` when confirming file output path

----

master - file output
```
$ streamlink httpstream://file:///dev/zero best -o /tmp/recording </dev/null
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/recording
[cli][error] File /tmp/recording already exists, use --force to overwrite it.
```
```
$ streamlink httpstream://file:///dev/zero best -o /tmp/recording 0>&-
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/recording
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-313/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 967, in main
    exit_code = run(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 947, in run
    exit_code = handle_url_wrapper()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 550, in handle_url_wrapper
    handle_url()
    ~~~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 614, in handle_url
    handle_stream(plugin, streams, stream_name)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 462, in handle_stream
    success = output_stream(stream, formatter)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 364, in output_stream
    output = create_output(formatter)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 119, in create_output
    filename = check_file_output(formatter.path(args.output, args.fs_safe_rules), args.force)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 88, in check_file_output
    if sys.stdin.isatty():
       ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isatty'
```

master - required plugin args
```
$ streamlink clubbingtv.com </dev/null
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-313/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 967, in main
    exit_code = run(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 947, in run
    exit_code = handle_url_wrapper()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 550, in handle_url_wrapper
    handle_url()
    ~~~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 584, in handle_url
    options = setup_plugin_options(streamlink, args, pluginname, pluginclass)
  File "/home/basti/repos/streamlink/src/streamlink_cli/argparser.py", line 1544, in setup_plugin_options
    value = user_input_requester.ask(prompt)
  File "/home/basti/repos/streamlink/src/streamlink_cli/console.py", line 21, in ask
    raise OSError("no TTY available")
OSError: no TTY available
```
```
$ streamlink clubbingtv.com 0>&-
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-313/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 967, in main
    exit_code = run(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 947, in run
    exit_code = handle_url_wrapper()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 550, in handle_url_wrapper
    handle_url()
    ~~~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 584, in handle_url
    options = setup_plugin_options(streamlink, args, pluginname, pluginclass)
  File "/home/basti/repos/streamlink/src/streamlink_cli/argparser.py", line 1544, in setup_plugin_options
    value = user_input_requester.ask(prompt)
  File "/home/basti/repos/streamlink/src/streamlink_cli/console.py", line 20, in ask
    if not sys.stdin.isatty():
           ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'isatty'
```

PR - file output
```
$ streamlink httpstream://file:///dev/zero best -o /tmp/recording </dev/null
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/recording
[cli][error] File /tmp/recording already exists, use --force to overwrite it.
```
```
$ streamlink httpstream://file:///dev/zero best -o /tmp/recording 0>&-
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/recording
[cli][error] File /tmp/recording already exists, use --force to overwrite it.
```

PR - required plugin args
```
$ streamlink clubbingtv.com </dev/null
error: no TTY available
```
```
$ streamlink clubbingtv.com 0>&-
error: no TTY available
```