### PR TITLE
cli: warn when deprecated plugin argument is set

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -185,6 +185,14 @@ class Argument:
         self.sensitive = sensitive
         self._argument_name = self._normalize_name(argument_name) if argument_name else None
 
+        # special cases for storing the default value to check whether a plugin argument was set or not
+        if action == "store_true":
+            self.const = True
+            self._default = False if default is None else default
+        elif action == "store_false":
+            self.const = False
+            self._default = True if default is None else default
+
     @staticmethod
     def _normalize_name(name: str) -> str:
         return name.replace("_", "-").strip("-")
@@ -229,7 +237,11 @@ class Argument:
             name: getattr(self, attr)
             for name, attr in self._ARGPARSE_ARGUMENT_KEYWORDS.items()
             # don't pass keywords with ``None`` values to ``ArgumentParser.add_argument()``
-            if getattr(self, attr) is not None
+            if (
+                getattr(self, attr) is not None
+                # don't include the const option value if the action is store_true or store_false
+                and not (name == "const" and self.action in ("store_true", "store_false"))
+            )
         }
 
     def __hash__(self):

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import numbers
 import re
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 from string import printable
@@ -11,6 +12,7 @@ from textwrap import dedent
 from typing import Any
 
 from streamlink import __version__ as streamlink_version, logger
+from streamlink.exceptions import StreamlinkDeprecationWarning
 from streamlink.options import Options
 from streamlink.plugin import Plugin
 from streamlink.session import Streamlink
@@ -1517,11 +1519,16 @@ def setup_plugin_options(
 
     for parg in pluginclass.arguments:
         defaults[parg.dest] = parg.default
+        value = getattr(args, parg.namespace_dest(pluginname))
 
         if parg.help == argparse.SUPPRESS:
+            if value != parg.default:
+                warnings.warn(
+                    f"The {parg.argument_name(pluginname)} plugin argument has been disabled and will be removed in the future",
+                    StreamlinkDeprecationWarning,
+                    stacklevel=1,
+                )
             continue
-
-        value = getattr(args, parg.namespace_dest(pluginname))
 
         values[parg.dest] = value
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 
 import pytest
@@ -188,6 +190,12 @@ class TestArgument:
             "const": 123,
         }
 
+        # doesn't include the const keyword if action is store_true or store_false
+        assert Argument("test", action="store_true").options == {"action": "store_true", "default": False}
+        assert Argument("test", action="store_true", default=123).options == {"action": "store_true", "default": 123}
+        assert Argument("test", action="store_false").options == {"action": "store_false", "default": True}
+        assert Argument("test", action="store_false", default=123).options == {"action": "store_false", "default": 123}
+
     def test_equality(self):
         a1 = Argument(
             "test",
@@ -226,6 +234,20 @@ class TestArgument:
         assert a1 == a2
         assert a1 != a3
         assert a2 != a3
+
+    @pytest.mark.parametrize(
+        ("action", "default", "expected_const", "expected_default"),
+        [
+            pytest.param("store_true", None, True, False, id="store_true-no-default"),
+            pytest.param("store_true", "default", True, "default", id="store_true-with-default"),
+            pytest.param("store_false", None, False, True, id="store_false-no-default"),
+            pytest.param("store_false", "default", False, "default", id="store_false-with-default"),
+        ],
+    )
+    def test_store_true_false(self, action: str, default: str | None, expected_const: bool, expected_default: str | None):
+        arg = Argument("foo", action=action, default=default)
+        assert arg.const is expected_const
+        assert arg.default is expected_default
 
 
 class TestArguments:


### PR DESCRIPTION
```
$ streamlink twitch.tv/CHANNEL
[cli][info] Found matching plugin twitch for URL twitch.tv/CHANNEL
error: No playable streams found on this URL: twitch.tv/CHANNEL
```
```
$ streamlink twitch.tv/CHANNEL --twitch-disable-hosting --twitch-disable-reruns
[warnings][streamlinkdeprecation] The --twitch-disable-hosting plugin argument has been disabled and will be removed in the future
[warnings][streamlinkdeprecation] The --twitch-disable-reruns plugin argument has been disabled and will be removed in the future
[cli][info] Found matching plugin twitch for URL twitch.tv/CHANNEL
error: No playable streams found on this URL: twitch.tv/CHANNEL
```
```
$ echo -e 'twitch-disable-hosting\ntwitch-disable-reruns' > /tmp/config
$ streamlink --config /tmp/config twitch.tv/CHANNEL
[warnings][streamlinkdeprecation] The --twitch-disable-hosting plugin argument has been disabled and will be removed in the future
[warnings][streamlinkdeprecation] The --twitch-disable-reruns plugin argument has been disabled and will be removed in the future
[cli][info] Found matching plugin twitch for URL twitch.tv/CHANNEL
error: No playable streams found on this URL: twitch.tv/CHANNEL
```