### PR TITLE
plugins.tv3cat: update plugin matchers

### DIFF
--- a/src/streamlink/plugins/tv3cat.py
+++ b/src/streamlink/plugins/tv3cat.py
@@ -1,5 +1,6 @@
 """
 $description Live TV channels and video on-demand service from CCMA, a Catalan public, state-owned broadcaster.
+$url 3cat.cat
 $url ccma.cat
 $type live, vod
 $region Spain
@@ -21,11 +22,11 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(
     name="live",
-    pattern=re.compile(r"https://(?:www)?\.ccma\.cat/3cat/directes/(?P<ident>[^/?]+)"),
+    pattern=re.compile(r"https://(?:www)?\.(?:3cat|ccma)\.cat/3cat/directes/(?P<ident>[^/?]+)"),
 )
 @pluginmatcher(
     name="vod",
-    pattern=re.compile(r"https://(?:www)?\.ccma\.cat/3cat/[^/]+/video/(?P<ident>\d+)"),
+    pattern=re.compile(r"https://(?:www)?\.(?:3cat|ccma)\.cat/3cat/[^/]+/video/(?P<ident>\d+)"),
 )
 class TV3Cat(Plugin):
     _URL_API_GEO = "https://dinamics.ccma.cat/geo.json"

--- a/tests/plugins/test_tv3cat.py
+++ b/tests/plugins/test_tv3cat.py
@@ -6,12 +6,17 @@ class TestPluginCanHandleUrlTV3Cat(PluginCanHandleUrl):
     __plugin__ = TV3Cat
 
     should_match_groups = [
+        (("live", "https://www.3cat.cat/3cat/directes/tv3/"), {"ident": "tv3"}),
         (("live", "https://www.ccma.cat/3cat/directes/tv3/"), {"ident": "tv3"}),
         (("live", "https://www.ccma.cat/3cat/directes/324/"), {"ident": "324"}),
         (("live", "https://www.ccma.cat/3cat/directes/esport3/"), {"ident": "esport3"}),
         (("live", "https://www.ccma.cat/3cat/directes/sx3/"), {"ident": "sx3"}),
         (("live", "https://www.ccma.cat/3cat/directes/catalunya-radio/"), {"ident": "catalunya-radio"}),
 
+        (
+            ("vod", "https://www.3cat.cat/3cat/t1xc1-arribada/video/6260741/"),
+            {"ident": "6260741"},
+        ),
         (
             ("vod", "https://www.ccma.cat/3cat/t1xc1-arribada/video/6260741/"),
             {"ident": "6260741"},


### PR DESCRIPTION
Resolves #6241 

That site apparently has changed its hostname while still supporting the old one, which redirects. Didn't check any changes to the site itself, since updating the matchers alone seemed to work.

```
$ ./script/test-plugin-urls.py tv3cat
:: https://www.3cat.cat/3cat/directes/tv3/
::  480p, 720p, 1080p, worst, best
:: https://www.3cat.cat/3cat/t1xc1-arribada/video/6260741/
::  720p_dash, 576p, 720p, 1080p, worst, best
:: https://www.ccma.cat/3cat/buscant-la-sostenibilitat-i-la-tecnologia-del-futur/video/6268863/
::  720p_dash, 576p, 720p, 1080p, worst, best
:: https://www.ccma.cat/3cat/directes/324/
::  480p, 720p, 1080p, worst, best
:: https://www.ccma.cat/3cat/directes/catalunya-radio/
::  96k, worst, best
:: https://www.ccma.cat/3cat/directes/esport3/
:::: The content is geo-blocked
!! No streams found
:: https://www.ccma.cat/3cat/directes/sx3/
:::: The content is geo-blocked
!! No streams found
:: https://www.ccma.cat/3cat/directes/tv3/
::  480p, 720p, 1080p, worst, best
:: https://www.ccma.cat/3cat/merli-els-peripatetics-capitol-1/video/5549976/
:::: The content is geo-blocked
!! No streams found
:: https://www.ccma.cat/3cat/t1xc1-arribada/video/6260741/
::  720p_dash, 576p, 720p, 1080p, worst, best
```