### PR TITLE
tools: bump ruff to 0.6.9 and mypy to 1.12.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,7 @@ coverage[toml]
 ruff ==0.6.9
 
 # typing
-mypy ==1.11.2
+mypy ==1.12.0
 lxml-stubs
 trio-typing
 types-freezegun

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,7 @@ pytest-cov
 coverage[toml]
 
 # code-linting
-ruff ==0.6.7
+ruff ==0.6.9
 
 # typing
 mypy ==1.11.2

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -417,7 +417,7 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         d = 0.0
         default = -1
 
-        segments_order = segments if duration >= 0 else reversed(segments)
+        segments_order = iter(segments) if duration >= 0 else reversed(segments)
 
         for segment in segments_order:
             if d >= abs(duration):


### PR DESCRIPTION
The mypy bump requires a fix since their 1.12.0 release includes a regression in regards to unions of iterators and iterables, so we need to explicitly turn the `list` object into an `Iterator`, so that it matches the type of `reversed(...)`

> `src/streamlink/stream/hls/hls.py:422:24: error: Item "list[HLSSegment]" of "Union[Iterator[HLSSegment], list[HLSSegment]]" has no attribute "__next__"  [union-attr]`