### PR TITLE
cli.output: remove VLC stream metadata variables

### DIFF
--- a/src/streamlink_cli/output/player.py
+++ b/src/streamlink_cli/output/player.py
@@ -105,9 +105,7 @@ class PlayerArgsVLC(PlayerArgs):
         return super().get_namedpipe(namedpipe)
 
     def get_title(self, title) -> list[str]:
-        # allow escaping with \$: see https://wiki.videolan.org/Documentation:Format_String/
-        # TODO: remove this feature
-        title = title.replace("$", "$$").replace(r"\$$", "$")
+        title = title.replace("$", "$$")
 
         return ["--input-title-format", title]
 

--- a/tests/cli/output/test_player.py
+++ b/tests/cli/output/test_player.py
@@ -216,8 +216,8 @@ class TestPlayerArgs:
             id="No title on unknown player",
         ),
         pytest.param(
-            dict(path=Path("vlc"), title="foo bar"),
-            ["vlc", "--input-title-format", "foo bar", "-"],
+            dict(path=Path("vlc"), title="foo bar: $a - $t"),
+            ["vlc", "--input-title-format", "foo bar: $$a - $$t", "-"],
             id="VLC title",
         ),
         pytest.param(


### PR DESCRIPTION
VLC allows having custom variables in its --input-title-format parameter value for displaying certain **stream metadata**, for example `$a` for the stream author metadata or `$t` for the stream title metadata.

To avoid unintended variable substitution, `$` characters need to be escaped by replacing `$` with `$$`.

https://wiki.videolan.org/Documentation:Format_String/

When Streamlink's --title argument was implemented in 5c3cf57, a workaround was added for VLC, so users could escape a dollar sign with a leading backslash in the --title value, so the resulting `\$$` sequence would be turned back into a regular `$`, allowing VLC to interpret stream metadata variables.

However, the title value that's passed to `PlayerOutput` is already formatted by the CLI's `Formatter` instance, which means that it can include arbitrary **plugin metadata**, like stream IDs, author names, category names, stream titles, etc.

This means that if the user has for example set `--title` to `{title}` and the plugin's `title` metadata includes the `\$` sequence, then this will be turned into a single `$` character, making VLC interpret it and its following character as a stream metadata variable.

Fix this by removing the flawed dollar sign escape logic.

----

resolves #4205