### PR TITLE
logger: mark basicConfig kwargs as kw-only

### DIFF
--- a/src/streamlink/logger.py
+++ b/src/streamlink/logger.py
@@ -206,13 +206,14 @@ def capturewarnings(capture=False):
 
 # noinspection PyShadowingBuiltins,PyPep8Naming
 def basicConfig(
+    *,
     filename: str | Path | None = None,
     filemode: str = "a",
-    stream: IO | None = None,
-    level: str | None = None,
-    format: str = FORMAT_BASE,  # noqa: A002  # TODO: rename to "fmt" (breaking)
-    style: Literal["%", "{", "$"] = FORMAT_STYLE,
+    format: str = FORMAT_BASE,  # noqa: A002
     datefmt: str = FORMAT_DATE,
+    style: Literal["%", "{", "$"] = FORMAT_STYLE,
+    level: str | None = None,
+    stream: IO | None = None,
     remove_base: list[str] | None = None,
     capture_warnings: bool = False,
 ) -> logging.StreamHandler:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -875,12 +875,12 @@ def setup_logger_and_console(
 
     try:
         streamhandler = logger.basicConfig(
-            stream=stream,
             filename=filename,
-            level=level,
-            style="{",
             format=fmt,
             datefmt=datefmt,
+            style="{",
+            level=level,
+            stream=stream,
             capture_warnings=True,
         )
     except Exception as err:


### PR DESCRIPTION
- rearrange keywords based on `logging.basicConfig()`
- remove TODO note, as "format" is also used in `logging.basicConfig()`

----

I added the "rename to fmt" TODO note for the `format` keyword in 85ea235d139d5505307157643807d6f04b02f59c when I added ruff's "A" linting rules, as it shadows `builtins.format`, but since `logging.basicConfig()` uses the same keyword name and since `streamlink.logger.basicConfig()` is based on it, it doesn't make sense using a different name.
https://docs.python.org/3/library/logging.html#logging.basicConfig