### PR TITLE
ci.readthedocs: update fetch depth with tags

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,11 @@ build:
   jobs:
     post_checkout:
       - "[ ${READTHEDOCS_VERSION_TYPE} = external ] || exit 183"
-      - "git fetch --depth=300 origin +refs/tags/*:refs/tags/*"
+      - git ls-remote --tags --sort=version:refname 2>&- | awk "END{printf \"+%s:%s\",\$2,\$2}" | git fetch origin --depth=300
+      - git fetch origin --depth=300 --update-shallow
+      - git describe --tags --long --dirty
     post_install:
-      - "python -m pip install --upgrade --upgrade-strategy=eager -e ."
+      - python -m pip install --upgrade --upgrade-strategy=eager -e .
 
 python:
   install:


### PR DESCRIPTION
The version strings in the PR preview builds on RTD are currently not working
https://app.readthedocs.org/projects/streamlink/builds/26084325/#248769245--66

because RTD creates a shallow clone with a fetch depth of 50, which is hardcoded:
https://github.com/readthedocs/readthedocs.org/blame/727da6e216f0fd0d08f7921b72de92a9c26fb25a/readthedocs/vcs_support/backends/git.py#L34

The current "fetch tags" command doesn't unshallow, so the latest tag can't be reached from any PR, resulting in a failure when running `git describe --tags`. It also fetches every tag, which is not what we want either.
https://github.com/streamlink/streamlink/blob/47d8e1d1b78362b5320788dd643b80a30ade6104/.readthedocs.yml#L10

----

This PR therefore updates the fetch tags logic, only targets the latest tag after querying the remote repo, and then fetches and deepens the shallow clone up to a depth of 300 commits.

Alternatively, the entire repo clone could be unshallowed, but we always want to avoid that, as FFmpeg and RTMPdump Windows binaries were committed in the past (~35 MiB), bloating up the repo forever.

I'll probably have a look at updating the GH actions workflows accordingly as well with the correct fetch tags commands. But let's see first if this here is working correctly.