### PR TITLE
ci.github: install opt deps on all Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
           -r dev-requirements.txt
         continue-on-error: ${{ matrix.continue || false }}
       - name: Install optional Python dependencies
-        if: ${{ ! startsWith(matrix['python-version'], '3.13') }}
         run: >
           python -m pip install -U
           brotli


### PR DESCRIPTION
Brotli has finally added the missing Python 3.13 wheels a couple of days ago:
https://pypi.org/project/Brotli/1.1.0/#files