### PR TITLE
plugin: update and fix Plugin attr docstrings

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -237,48 +237,45 @@ class Plugin:
     Plugin base class for retrieving streams and metadata from the URL specified.
     """
 
-    matchers: ClassVar[Matchers | None] = None
-    """
-    The list of plugin matchers (URL pattern + priority + optional name).
-    This list supports matcher lookups both by matcher index, as well as matcher name, if defined.
+    #: The Streamlink session which this plugin instance belongs to,
+    #: with access to its :attr:`HTTPSession <streamlink.session.Streamlink.http>`.
+    session: Streamlink
 
-    Use the :func:`pluginmatcher` decorator to initialize plugin matchers.
-    """
-
-    arguments: ClassVar[Arguments | None] = None
-    """
-    The plugin's :class:`Arguments <streamlink.options.Arguments>` collection.
-
-    Use the :func:`pluginargument` decorator to initialize plugin arguments.
-    """
-
-    matches: Matches
-    """
-    A list of optional :class:`re.Match` results of all defined matchers.
-    This list supports match lookups both by the respective matcher index, as well as matcher name, if defined.
-    """
-
-    matcher: re.Pattern | None = None
-    """A reference to the compiled :class:`re.Pattern` of the first matching matcher"""
-
-    match: re.Match | None = None
-    """A reference to the :class:`re.Match` result of the first matching matcher"""
-
+    #: Plugin options, initialized with the user-set values of the plugin's arguments.
     options: Options
-    """Plugin options, initialized with the user-set values of the plugin's arguments"""
 
+    #: Plugin cache object, used to store plugin-specific data other than HTTP session cookies.
     cache: Cache
-    """Plugin cache object, used to store plugin-specific data other than HTTP session cookies"""
 
-    # plugin metadata attributes
+    #: The list of plugin matchers (URL pattern + priority + optional name).
+    #: Supports matcher lookups by the matcher index or the optional matcher name.
+    #:
+    #: Use the :func:`pluginmatcher` decorator to initialize plugin matchers.
+    matchers: ClassVar[Matchers | None] = None
+
+    #: The plugin's :class:`Arguments <streamlink.options.Arguments>` collection.
+    #:
+    #: Use the :func:`pluginargument` decorator to initialize plugin arguments.
+    arguments: ClassVar[Arguments | None] = None
+
+    #: A list of optional :class:`re.Match` results of all defined matchers.
+    #: Supports match lookups by the matcher index or the optional matcher name.
+    matches: Matches
+
+    #: A reference to the compiled :class:`re.Pattern` of the first matching matcher.
+    matcher: re.Pattern | None = None
+
+    #: A reference to the :class:`re.Match` result of the first matching matcher.
+    match: re.Match | None = None
+
+    #: Metadata 'id' attribute: unique stream ID, etc.
     id: str | None = None
-    """Metadata 'id' attribute: unique stream ID, etc."""
+    #: Metadata 'title' attribute: the stream's short descriptive title.
     title: str | None = None
-    """Metadata 'title' attribute: the stream's short descriptive title"""
+    #: Metadata 'author' attribute: the channel or broadcaster name, etc.
     author: str | None = None
-    """Metadata 'author' attribute: the channel or broadcaster name, etc."""
+    #: Metadata 'category' attribute: name of a game being played, a music genre, etc.
     category: str | None = None
-    """Metadata 'category' attribute: name of a game being played, a music genre, etc."""
 
     _url: str = ""
 


### PR DESCRIPTION
This fixes the missing `Plugin.session` attribute documentation, switches the used docstring format, and fixes some documentation issues.

The order of attributes is unfortunately not respected by Sphinx for some strange reason, despite `bysource` being set as `member-order` in Sphinx's autoclass directive. Must have something to do with some of the attrs being set in the constructor. Or it's a bug, don't know...
https://github.com/streamlink/streamlink/blame/e4fe1ed6acbbf72602ea65e7783f167edc10687b/docs/api/plugin.rst#L8