### PR TITLE
cli: fix duplicate dependency logging

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -777,8 +777,7 @@ def log_root_warning():
             log.info("streamlink is running as root! Be careful!")
 
 
-def log_current_versions():
-    """Show current installed versions"""
+def log_current_versions() -> None:
     if not logger.root.isEnabledFor(logging.DEBUG):
         return
 
@@ -797,14 +796,17 @@ def log_current_versions():
     log.debug(f"OpenSSL:    {ssl.OPENSSL_VERSION}")
     log.debug(f"Streamlink: {streamlink_version}")
 
+    log.debug("Dependencies:")
     # https://peps.python.org/pep-0508/#names
     re_name = re.compile(r"[A-Z\d](?:[A-Z\d._-]*[A-Z\d])?", re.IGNORECASE)
-    log.debug("Dependencies:")
-    for name in [
-        match.group(0)
-        for match in map(re_name.match, importlib.metadata.requires("streamlink"))
+    dependencies: list[str] = importlib.metadata.requires("streamlink") or []
+    dependency_names: set[str] = {
+        match[0]
+        for match in [re_name.match(item) for item in dependencies]
         if match is not None
-    ]:  # fmt: skip
+    }  # fmt: skip
+    # noinspection PyTypeChecker
+    for name in sorted(dependency_names, key=str.lower):
         try:
             version = importlib.metadata.version(name)
         except importlib.metadata.PackageNotFoundError:

--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -225,8 +225,8 @@ class TestInfos:
                     ("cli", "debug", "OpenSSL:    OPENSSL_VERSION"),
                     ("cli", "debug", "Streamlink: STREAMLINK_VERSION"),
                     ("cli", "debug", "Dependencies:"),
-                    ("cli", "debug", " foo: 1.2.3"),
                     ("cli", "debug", " bar-baz: 2.0.0"),
+                    ("cli", "debug", " foo: 1.2.3"),
                 ],
                 id="darwin",
             ),
@@ -239,8 +239,8 @@ class TestInfos:
                     ("cli", "debug", "OpenSSL:    OPENSSL_VERSION"),
                     ("cli", "debug", "Streamlink: STREAMLINK_VERSION"),
                     ("cli", "debug", "Dependencies:"),
-                    ("cli", "debug", " foo: 1.2.3"),
                     ("cli", "debug", " bar-baz: 2.0.0"),
+                    ("cli", "debug", " foo: 1.2.3"),
                 ],
                 id="win32",
             ),
@@ -253,8 +253,8 @@ class TestInfos:
                     ("cli", "debug", "OpenSSL:    OPENSSL_VERSION"),
                     ("cli", "debug", "Streamlink: STREAMLINK_VERSION"),
                     ("cli", "debug", "Dependencies:"),
-                    ("cli", "debug", " foo: 1.2.3"),
                     ("cli", "debug", " bar-baz: 2.0.0"),
+                    ("cli", "debug", " foo: 1.2.3"),
                 ],
                 id="linux",
             ),
@@ -282,7 +282,12 @@ class TestInfos:
 
         mock_importlib_metadata = Mock()
         mock_importlib_metadata.PackageNotFoundError = FakePackageNotFoundError
-        mock_importlib_metadata.requires.return_value = ["foo>1", "bar-baz==2", "qux~=3"]
+        mock_importlib_metadata.requires.return_value = [
+            "foo>1 ; python_version>='3.13'",
+            "foo<=1 ; python_version<'3.13'",
+            "bar-baz==2",
+            "qux~=3",
+        ]
         mock_importlib_metadata.version.side_effect = version
 
         monkeypatch.setattr("importlib.metadata", mock_importlib_metadata)


### PR DESCRIPTION
This also sorts the dependency names alphabetically...

master
```
$ streamlink -l debug
[cli][debug] OS:         Linux-6.11.5-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.13.0
[cli][debug] OpenSSL:    OpenSSL 3.4.0 22 Oct 2024
[cli][debug] Streamlink: 6.11.0+67.g4af4a88a
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug]  trio: 0.27.0
[cli][debug]  trio: 0.27.0
[cli][debug] Arguments:
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```

pr
```
$ streamlink -l debug
[cli][debug] OS:         Linux-6.11.5-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.13.0
[cli][debug] OpenSSL:    OpenSSL 3.4.0 22 Oct 2024
[cli][debug] Streamlink: 6.11.0+68.g82b6f523
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.27.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  typing-extensions: 4.12.2
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```