### PR TITLE
cli: add --show-matchers argument

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -270,6 +270,13 @@ def build_parser():
         """,
     )
     general.add_argument(
+        "--show-matchers",
+        metavar="PLUGIN",
+        help="""
+            Show the list of matchers of a specific plugin (URL regex pattern with opt. priority and opt. name).
+        """,
+    )
+    general.add_argument(
         "--can-handle-url",
         metavar="URL",
         help="""

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -36,6 +36,7 @@ from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.exceptions import StreamlinkCLIError
 from streamlink_cli.output import FileOutput, HTTPOutput, PlayerOutput
+from streamlink_cli.show_matchers import show_matchers
 from streamlink_cli.streamrunner import StreamRunner
 from streamlink_cli.utils import Formatter, datetime
 from streamlink_cli.utils.versioncheck import check_version
@@ -950,6 +951,8 @@ def run(parser: ArgumentParser) -> int:
         console.msg(helptext)
     elif args.plugins:
         print_plugins()
+    elif args.show_matchers:
+        show_matchers(streamlink, console, args.show_matchers)
     elif args.can_handle_url or args.can_handle_url_no_redirect:
         exit_code = can_handle_url()
     elif args.url:

--- a/src/streamlink_cli/show_matchers.py
+++ b/src/streamlink_cli/show_matchers.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import re
+from textwrap import dedent, indent
+
+from streamlink.plugin import HIGH_PRIORITY, LOW_PRIORITY, NO_PRIORITY, NORMAL_PRIORITY, Plugin
+from streamlink.session import Streamlink
+from streamlink_cli.console import ConsoleOutput
+from streamlink_cli.exceptions import StreamlinkCLIError
+
+
+PRIORITY_NAMES = {
+    NO_PRIORITY: "NONE",
+    LOW_PRIORITY: "LOW",
+    HIGH_PRIORITY: "HIGH",
+}
+
+# noinspection PyTypeChecker
+PATTERN_FLAG_NAMES: dict[int, str] = {
+    flag.value: flag.name
+    for flag in (re.IGNORECASE, re.VERBOSE)
+    if flag.name
+}  # fmt: skip
+
+
+def show_matchers(session: Streamlink, console: ConsoleOutput, pluginname: str):
+    if pluginname not in session.plugins:
+        raise StreamlinkCLIError("Plugin not found", code=1)
+
+    plugin = session.plugins[pluginname]
+
+    if console.json:
+        console.msg_json(show_matchers_json(plugin))
+    else:
+        console.msg(show_matchers_text(plugin))
+
+
+def show_matchers_text(plugin: type[Plugin]) -> str:
+    output = []
+    indentation = "  "
+    for matcher in plugin.matchers or []:
+        data = []
+        flags = [name for val, name in PATTERN_FLAG_NAMES.items() if matcher.pattern.flags & val]
+        if matcher.name:
+            data.append(f"name: {matcher.name}")
+        if matcher.priority != NORMAL_PRIORITY:
+            data.append(f"priority: {PRIORITY_NAMES.get(matcher.priority, matcher.priority)}")
+        if flags:
+            data.append(f"flags: {' & '.join(flags)}")
+        if matcher.pattern.flags & re.VERBOSE:
+            data.append(f"pattern:\n{indent(dedent(matcher.pattern.pattern).strip(), indentation)}")
+        else:
+            data.append(f"pattern: {matcher.pattern.pattern}")
+        item = indent("\n".join(data), indentation)
+        output.append(f"- {item[2:]}")
+
+    return "\n".join(output)
+
+
+def show_matchers_json(plugin: type[Plugin]) -> list[dict]:
+    return [
+        {
+            "name": matcher.name,
+            "priority": matcher.priority,
+            "flags": matcher.pattern.flags & ~re.UNICODE,
+            "pattern": (
+                dedent(matcher.pattern.pattern).strip()
+                if matcher.pattern.flags & re.VERBOSE
+                else matcher.pattern.pattern
+            ),
+        }
+        for matcher in plugin.matchers or []
+    ]  # fmt: skip

--- a/tests/cli/main/test_show_matchers.py
+++ b/tests/cli/main/test_show_matchers.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import re
+from textwrap import dedent
+
+import pytest
+
+import streamlink_cli.main
+from streamlink.plugin import HIGH_PRIORITY, NORMAL_PRIORITY, Plugin, pluginmatcher
+from streamlink.session import Streamlink
+
+
+@pytest.fixture(autouse=True)
+def session(session: Streamlink):
+    @pluginmatcher(re.compile("foo", re.IGNORECASE))
+    @pluginmatcher(name="asdf", pattern=re.compile("bar"), priority=HIGH_PRIORITY)
+    @pluginmatcher(re.compile("baz\nqux", re.IGNORECASE + re.VERBOSE), priority=100)
+    class MyPlugin(Plugin):
+        def _get_streams(self):  # pragma: no cover
+            pass
+
+    session.plugins.update({"plugin": MyPlugin})
+
+    return session
+
+
+@pytest.mark.parametrize(
+    ("argv", "output"),
+    [
+        pytest.param(
+            ["--show-matchers", "doesnotexist"],
+            "error: Plugin not found\n",
+            id="no-json",
+        ),
+        pytest.param(
+            ["--show-matchers", "doesnotexist", "--json"],
+            """{\n  "error": "Plugin not found"\n}\n""",
+            id="json",
+        ),
+    ],
+    indirect=["argv"],
+)
+def test_plugin_not_found(capsys: pytest.CaptureFixture[str], argv: list[str], output: str):
+    with pytest.raises(SystemExit) as exc_info:
+        streamlink_cli.main.main()
+    assert exc_info.value.code == 1
+    stdout, stderr = capsys.readouterr()
+    assert stdout == output
+    assert stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("argv", "output"),
+    [
+        pytest.param(
+            ["--show-matchers", "plugin"],
+            dedent("""
+                - flags: IGNORECASE
+                  pattern: foo
+                - name: asdf
+                  priority: HIGH
+                  pattern: bar
+                - priority: 100
+                  flags: IGNORECASE & VERBOSE
+                  pattern:
+                    baz
+                    qux
+            """).lstrip(),
+            id="no-json",
+        ),
+        pytest.param(
+            ["--show-matchers", "plugin", "--json"],
+            dedent(f"""
+                [
+                  {{
+                    "name": null,
+                    "priority": {NORMAL_PRIORITY},
+                    "flags": {int(re.IGNORECASE)},
+                    "pattern": "foo"
+                  }},
+                  {{
+                    "name": "asdf",
+                    "priority": {HIGH_PRIORITY},
+                    "flags": 0,
+                    "pattern": "bar"
+                  }},
+                  {{
+                    "name": null,
+                    "priority": 100,
+                    "flags": {int(re.IGNORECASE + re.VERBOSE)},
+                    "pattern": "baz\\nqux"
+                  }}
+                ]
+            """).lstrip(),
+            id="json",
+        ),
+    ],
+    indirect=["argv"],
+)
+def test_show_matchers(capsys: pytest.CaptureFixture[str], argv: list[str], output: str):
+    with pytest.raises(SystemExit) as exc_info:
+        streamlink_cli.main.main()
+    assert exc_info.value.code == 0
+    stdout, stderr = capsys.readouterr()
+    assert stdout == output
+    assert stderr == ""


### PR DESCRIPTION
This adds the `--show-matchers` CLI argument for listing a plugin's matchers. Regular text and JSON output is supported.

While the JSON output contains all data (excluding the redundant `re.UNICODE` flag), the regular text output uses **yaml-like** syntax, skips missing matcher names and default priorities/flags, uses text for priority constants and flags (human readable), and it puts verbose regex patterns on the next line with a secondary indentation level. As said, it's not valid yaml, as it would require quoting+escaping the single-line regex patterns or adding yaml block-style indicators, which would make reading more difficult.

Plugin sideloading is of course supported.

Examples

```
$ streamlink --show-matchers twitch
- name: player
  pattern: https?://player\.twitch\.tv/\?.+
- name: clip
  pattern: https?://(?:clips\.twitch\.tv|(?:[\w-]+\.)?twitch\.tv/(?:[\w-]+/)?clip)/(?P<clip_id>[^/?]+)
- name: vod
  pattern: https?://(?:[\w-]+\.)?twitch\.tv/(?:[\w-]+/)?v(?:ideos?)?/(?P<video_id>\d+)
- name: live
  pattern: https?://(?:(?!clips\.)[\w-]+\.)?twitch\.tv/(?P<channel>(?!v(?:ideos?)?/|clip/)[^/?]+)/?(?:\?|$)
```

```
$ streamlink --show-matchers twitch --json
[
  {
    "name": "player",
    "priority": 20,
    "flags": 0,
    "pattern": "https?://player\\.twitch\\.tv/\\?.+"
  },
  {
    "name": "clip",
    "priority": 20,
    "flags": 0,
    "pattern": "https?://(?:clips\\.twitch\\.tv|(?:[\\w-]+\\.)?twitch\\.tv/(?:[\\w-]+/)?clip)/(?P<clip_id>[^/?]+)"
  },
  {
    "name": "vod",
    "priority": 20,
    "flags": 0,
    "pattern": "https?://(?:[\\w-]+\\.)?twitch\\.tv/(?:[\\w-]+/)?v(?:ideos?)?/(?P<video_id>\\d+)"
  },
  {
    "name": "live",
    "priority": 20,
    "flags": 0,
    "pattern": "https?://(?:(?!clips\\.)[\\w-]+\\.)?twitch\\.tv/(?P<channel>(?!v(?:ideos?)?/|clip/)[^/?]+)/?(?:\\?|$)"
  }
]
```

```
$ streamlink --show-matchers hls
- pattern: hls(?:variant)?://(?P<url>\S+)(?:\s(?P<params>.+))?$
- priority: LOW
  flags: IGNORECASE
  pattern: (?P<url>[^/]+/\S+\.m3u8(?:\?\S*)?)(?:\s(?P<params>.+))?$
```

```
$ streamlink --show-matchers steam
- pattern: https?://steamcommunity\.com/broadcast/watch/(\d+)
- pattern: https?://steam\.tv/(\w+)
```

```
$ streamlink --show-matchers ustreamtv
- flags: VERBOSE
  pattern:
    https?://(?:(?:www\.)?ustream\.tv|video\.ibm\.com)
    (?:
        /combined-embed
        /(?P<combined_channel_id>\d+)
        (?:/video/(?P<combined_video_id>\d+))?
        |
        (?:(?:/embed/|/channel/(?:id/)?)(?P<channel_id>\d+))?
        (?:(?:/embed)?/recorded/(?P<video_id>\d+))?
    )
```

```
$ streamlink --show-matchers ustreamtv --json
[
  {
    "name": null,
    "priority": 20,
    "flags": 64,
    "pattern": "https?://(?:(?:www\\.)?ustream\\.tv|video\\.ibm\\.com)\n(?:\n    /combined-embed\n    /(?P<combined_channel_id>\\d+)\n    (?:/video/(?P<combined_video_id>\\d+))?\n    |\n    (?:(?:/embed/|/channel/(?:id/)?)(?P<channel_id>\\d+))?\n    (?:(?:/embed)?/recorded/(?P<video_id>\\d+))?\n)"
  }
]
```

```
$ streamlink --show-matchers doesnotexist; echo $?
error: Plugin not found
1

$ streamlink --show-matchers doesnotexist --json; echo $?
{
  "error": "Plugin not found"
}
1
```