### PR TITLE
ci.github: ignore git fetch pipefail on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,10 @@ jobs:
       - name: Fetch tags
         shell: bash
         run: |
-          git ls-remote --tags --sort=version:refname 2>&- | awk 'END{printf "+%s:%s\n",$2,$2}' | git fetch origin --depth=300
+          git ls-remote --tags --sort=version:refname 2>&- \
+            | awk 'END{printf "+%s:%s\n",$2,$2}' \
+            | git fetch origin --depth=300 \
+            || { ec=$?; [ $ec -eq 141 ] && true || (exit $ec); }
           git fetch origin --depth=300 --update-shallow
           git describe --tags --long --dirty
       - uses: actions/setup-python@v5


### PR DESCRIPTION
See #6289

This ignores error 141 (pipefail) and preserves other exit codes. As mentioned, the tags are always fetched fine by `git fetch`, so this must be some kind of race condition in the Windows builds of `bash`, `git` or `awk`. I don't want to debug this further, because it's stupid. The piped commands should never fail with 141.

Going to restart the CI runs a couple of time before merging, just like in #6289... That PR didn't catch the error which occurred during the scheduled CI runs though.