### PR TITLE
plugin: fix shared matchers and arguments in inherited plugins

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -203,8 +203,8 @@ MType = TypeVar("MType")
 
 
 class _MCollection(List[MType]):
-    def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
         self._names: dict[str, MType] = {}
 
     def __getitem__(self, item):
@@ -212,8 +212,16 @@ class _MCollection(List[MType]):
 
 
 class Matchers(_MCollection[Matcher]):
-    def register(self, matcher: Matcher) -> None:
+    def __init__(self, *matchers):
+        super().__init__(matchers)
+        for matcher in matchers:
+            self._add_named_matcher(matcher)
+
+    def add(self, matcher: Matcher) -> None:
         super().insert(0, matcher)
+        self._add_named_matcher(matcher)
+
+    def _add_named_matcher(self, matcher: Matcher) -> None:
         if matcher.name:
             if matcher.name in self._names:
                 raise ValueError(f"A matcher named '{matcher.name}' has already been registered")
@@ -232,7 +240,13 @@ class Matches(_MCollection[Union[re.Match, None]]):
         return next(((matcher.pattern, match) for matcher, match in matches if match is not None), (None, None))
 
 
-class Plugin:
+class PluginMeta(type):
+    def __init__(cls, name, bases, namespace, **kwargs):
+        super().__init__(name, bases, namespace, **kwargs)
+        cls.matchers = Matchers(*getattr(cls, "matchers", []))
+
+
+class Plugin(metaclass=PluginMeta):
     """
     Plugin base class for retrieving streams and metadata from the URL specified.
     """
@@ -251,7 +265,7 @@ class Plugin:
     #: Supports matcher lookups by the matcher index or the optional matcher name.
     #:
     #: Use the :func:`pluginmatcher` decorator to initialize plugin matchers.
-    matchers: ClassVar[Matchers | None] = None
+    matchers: ClassVar[Matchers]
 
     #: The plugin's :class:`Arguments <streamlink.options.Arguments>` collection.
     #:
@@ -651,9 +665,7 @@ def pluginmatcher(
     def decorator(cls: type[Plugin]) -> type[Plugin]:
         if not issubclass(cls, Plugin):
             raise TypeError(f"{cls.__name__} is not a Plugin")
-        if cls.matchers is None:
-            cls.matchers = Matchers()
-        cls.matchers.register(matcher)
+        cls.matchers.add(matcher)
 
         return cls
 

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -244,6 +244,7 @@ class PluginMeta(type):
     def __init__(cls, name, bases, namespace, **kwargs):
         super().__init__(name, bases, namespace, **kwargs)
         cls.matchers = Matchers(*getattr(cls, "matchers", []))
+        cls.arguments = Arguments(*getattr(cls, "arguments", []))
 
 
 class Plugin(metaclass=PluginMeta):
@@ -270,7 +271,7 @@ class Plugin(metaclass=PluginMeta):
     #: The plugin's :class:`Arguments <streamlink.options.Arguments>` collection.
     #:
     #: Use the :func:`pluginargument` decorator to initialize plugin arguments.
-    arguments: ClassVar[Arguments | None] = None
+    arguments: ClassVar[Arguments]
 
     #: A list of optional :class:`re.Match` results of all defined matchers.
     #: Supports match lookups by the matcher index or the optional matcher name.
@@ -761,8 +762,6 @@ def pluginargument(
     def decorator(cls: Type[Plugin]) -> Type[Plugin]:
         if not issubclass(cls, Plugin):
             raise TypeError(f"{repr(cls)} is not a Plugin")  # noqa: RUF010  # builtins.repr gets monkeypatched in tests
-        if cls.arguments is None:
-            cls.arguments = Arguments()
         cls.arguments.add(arg)
 
         return cls

--- a/src/streamlink/session/plugins.py
+++ b/src/streamlink/session/plugins.py
@@ -307,7 +307,7 @@ class StreamlinkPluginsData:
             matchers = Matchers()
             for m in plugindata.get("matchers") or []:
                 matcher = cls._build_matcher(m)
-                matchers.register(matcher)
+                matchers.add(matcher)
 
             res[pluginname] = matchers
 

--- a/tests/session/test_plugins.py
+++ b/tests/session/test_plugins.py
@@ -360,10 +360,10 @@ class TestLoadPluginsData:
         assert [(record.name, record.levelname, record.message) for record in caplog.get_records(when="setup")] == []
 
         matchers_a = Matchers()
-        matchers_a.register(Matcher(pattern=re.compile(r"foo"), priority=NORMAL_PRIORITY, name=None))
-        matchers_a.register(Matcher(pattern=re.compile(r"bar", re.VERBOSE), priority=10, name="bar"))
+        matchers_a.add(Matcher(pattern=re.compile(r"foo"), priority=NORMAL_PRIORITY, name=None))
+        matchers_a.add(Matcher(pattern=re.compile(r"bar", re.VERBOSE), priority=10, name="bar"))
         matchers_b = Matchers()
-        matchers_b.register(Matcher(pattern=re.compile(r"baz"), priority=NORMAL_PRIORITY, name=None))
+        matchers_b.add(Matcher(pattern=re.compile(r"baz"), priority=NORMAL_PRIORITY, name=None))
         assert list(session.plugins.iter_matchers()) == [("testpluginA", matchers_a), ("testpluginB", matchers_b)]
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes accidentally shared `matchers` and `arguments` references in plugin classes which inherit from existing plugin classes.

It's not really a problematic issue, as it's very unlikely that the ancestor plugin class is used in a Streamlink session when it's already overridden by a plugin subclass in the same session, but it should still be fixed.

These changes unfortunately make the `Plugin` API docs look a bit weird.

----

Fixing this also made me realize that we never deprecated the old `arguments = Arguments(...)` definition style in plugin classes. The docs tell the user to always use the plugin decorators, but this is not enforced, hence why there's even a test case for the old plugin arguments definition. The matchers definition is theoretically also possible this way. This doesn't affect Streamlink's own plugins though, so it's probably not worth deprecating or directly removing this.

Another thing that should probably also be changed and cleaned up in the future is how the `Matchers` and `Arguments` are defined. `Argument` and `Arguments` are part of the `options` module, because they are tied to the `Options` class, while the `Matcher` and `Matchers` classes are part of the `plugin` module (and thus the `streamlink.plugin` package). Everything's actually only related to plugins, so the `options` module shouldn't be in its current place in the root `streamlink` package. `streamlink.plugin` already re-exports everything from the `options` module.