### PR TITLE
plugins.welt: fix schema

### DIFF
--- a/src/streamlink/plugins/welt.py
+++ b/src/streamlink/plugins/welt.py
@@ -28,7 +28,6 @@ class Welt(Plugin):
                 validate.parse_html(),
                 validate.xml_xpath_string("""
                     .//script
-                    [@type='application/json']
                     [starts-with(@data-internal-ref,'WeltVideoPlayer-') or @data-content='VideoPlayer.Config']
                     /text()
                 """),


### PR DESCRIPTION
```
$ ./script/test-plugin-urls.py welt
:: https://welt.de/tv-programm-live-stream/
::  360p_alt, 360p, 432p_alt, 432p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
:: https://www.welt.de/mediathek/dokumentation/space/strip-the-cosmos/sendung192055593/Strip-the-Cosmos-Die-Megastuerme-der-Planeten.html
::  200k, 1000k, 1500k, 2000k, worst, best
:: https://www.welt.de/mediathek/magazin/gesellschaft/sendung247758214/Die-Welt-am-Wochenende-Auf-hoher-See-mit-der-Gorch-Fock.html
::  700k, 1200k, 2400k, 4800k, worst, best
:: https://www.welt.de/tv-programm-live-stream/
::  360p_alt, 360p, 432p_alt, 432p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
:: https://www.welt.de/tv-programm-n24-doku/
::  360p_alt, 360p, 432p_alt, 432p, 720p_alt, 720p, 1080p_alt, 1080p, worst, best
```