### PR TITLE
Introducing Streamlink Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/streamlink/streamlink/issues"><img alt="Open issues" src="https://img.shields.io/github/issues/streamlink/streamlink.svg?style=flat-square&maxAge=86400"></a>
   <a href="https://github.com/streamlink/streamlink/actions?query=event%3Apush"><img alt="Build status" src="https://img.shields.io/github/actions/workflow/status/streamlink/streamlink/test.yml?branch=master&event=push&style=flat-square&maxAge=86400"></a>
   <a href="https://codecov.io/github/streamlink/streamlink?branch=master"><img alt="Overall code coverage" src="https://img.shields.io/codecov/c/github/streamlink/streamlink.svg?branch=master&style=flat-square&maxAge=86400"></a>
+  <a href="https://gurubase.io/g/streamlink"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Streamlink%20Guru-006BFF?style=flat-square&maxAge=86400"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Streamlink Guru](https://gurubase.io/g/streamlink) to Gurubase. Streamlink Guru uses the data from this repo and data from the [docs](https://streamlink.github.io/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Streamlink Guru", which highlights that Streamlink now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Streamlink Guru in Gurubase, just let me know that's totally fine.
