### PR TITLE
stream.dash: fix missing FFMPEGMuxer.is_usable()

### DIFF
--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -391,16 +391,18 @@ class DASHStream(Stream):
         if rep_video:
             video = DASHStreamReader(self, rep_video, timestamp)
             log.debug(f"Opening DASH reader for: {rep_video.ident!r} - {rep_video.mimeType}")
-            video.open()
 
         if rep_audio:
             audio = DASHStreamReader(self, rep_audio, timestamp)
             log.debug(f"Opening DASH reader for: {rep_audio.ident!r} - {rep_audio.mimeType}")
-            audio.open()
 
-        if video and audio:
+        if video and audio and FFMPEGMuxer.is_usable(self.session):
+            video.open()
+            audio.open()
             return FFMPEGMuxer(self.session, video, audio, copyts=True).open()
         elif video:
+            video.open()
             return video
         elif audio:
+            audio.open()
             return audio

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -164,13 +164,14 @@ class FFMPEGMuxer(StreamIO):
             pipe.close()
 
     def __init__(self, session, *streams, **options):
-        if not self.is_usable(session):
-            raise StreamError("cannot use FFMPEG")
-
         self.session = session
         self.process = None
-        self.streams = streams
+        self.errorlog = subprocess.DEVNULL
 
+        if not self.is_usable(session):
+            raise StreamError("Cannot use FFmpeg")
+
+        self.streams = streams
         self.pipes = [NamedPipe() for _ in self.streams]
         self.pipe_threads = [
             threading.Thread(
@@ -224,8 +225,6 @@ class FFMPEGMuxer(StreamIO):
             self.errorlog = Path(session.options.get("ffmpeg-verbose-path")).expanduser().open("w")
         elif session.options.get("ffmpeg-verbose"):
             self.errorlog = sys.stderr
-        else:
-            self.errorlog = subprocess.DEVNULL
 
     def open(self):
         for t in self.pipe_threads:

--- a/src/streamlink/stream/segmented/segmented.py
+++ b/src/streamlink/stream/segmented/segmented.py
@@ -254,9 +254,9 @@ class SegmentedStreamReader(StreamIO, Generic[TSegment, TResult]):
         self.buffer.close()
 
         current = current_thread()
-        if current is not self.worker:  # pragma: no branch
+        if current is not self.worker and self.worker.is_alive():  # pragma: no branch
             self.worker.join(timeout=self.timeout)
-        if current is not self.writer:  # pragma: no branch
+        if current is not self.writer and self.writer.is_alive():  # pragma: no branch
             self.writer.join(timeout=self.timeout)
 
         super().close()

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -336,6 +336,7 @@ class TestDASHStreamOpen:
     @pytest.fixture()
     def muxer(self, monkeypatch: pytest.MonkeyPatch):
         muxer = Mock()
+        muxer.is_usable.return_value = True
         monkeypatch.setattr("streamlink.stream.dash.dash.FFMPEGMuxer", muxer)
         return muxer
 


### PR DESCRIPTION
DASH streams currently fail with an ugly error traceback if FFmpeg is unavailable or can't be used.

This is because the `FFMPEGMuxer` instance which is created in `DASHStream.open()` checks for `FFMPEGMuxer.is_usable()` itself in its constructor and raises a `StreamError` if FFmpeg is unavailable. This is bad for multiple reasons, because the substreams were already opened and don't get closed properly in this case, and their respective worker threads still try to enqueue new segments, leading to the error. On top of that, some class attributes are uninitialized and another thread-join call fails too.

As a simple solution for now, check for the FFmpeg availabilty in `DASHStream.open()` before opening any substreams. This fix also has the side-effect of falling through to video-only or audio-only streams if FFmpeg is unavailable, which the warning message from the availability check already implies, so this is actually preferred.

This is all far from ideal though and the entire FFMPEGMuxer implementation needs to be rewritten from scratch. I've explained that in the stream selection overhaul thread.

Going to have another look at the changes later before merging...

----

master
```
$ streamlink --ffmpeg-ffmpeg /dev/null -o /dev/null https://steamcommunity.com/broadcast/watch/76561199803546468 best
[cli][info] Found matching plugin steam for URL https://steamcommunity.com/broadcast/watch/76561199803546468
[cli][info] Available streams: 1080p (worst, best)
[cli][info] Opening stream: 1080p (dash)
[cli][info] Writing output to
/dev/null
[stream.ffmpegmux][warning] No valid FFmpeg binary was found. See the --ffmpeg-ffmpeg option.
[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
[cli][error] Try 1/1: Could not open stream <DASHStream ['dash', 'https://cache9-ams1.steamcontent.com/broadcast/76561199803546468/7906216281721504142/manifest/0/cache9-ams1.steamcontent.com/?broadcast_origin=ext3-fra1.steamserver.net']> (Could not open stream: cannot use FFMPEG)
Exception ignored in: <streamlink.stream.ffmpegmux.FFMPEGMuxer object at 0x7f09f3b482b0>
Traceback (most recent call last):
  File "/home/basti/repos/streamlink/src/streamlink/stream/ffmpegmux.py", line 246, in close
    if self.process:
AttributeError: 'FFMPEGMuxer' object has no attribute 'process'
error: Could not open stream <DASHStream ['dash', 'https://cache9-ams1.steamcontent.com/broadcast/76561199803546468/7906216281721504142/manifest/0/cache9-ams1.steamcontent.com/?broadcast_origin=ext3-fra1.steamserver.net']>, tried 1 times, exiting
Exception in thread Thread-DASHStreamWorker:
Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/segmented/segmented.py", line 218, in run
    self.writer.put(segment)
    ~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/segmented/segmented.py", line 104, in put
    future = self.executor.submit(self.fetch, segment)
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 172, in submit
    raise RuntimeError('cannot schedule new futures after '
                       'interpreter shutdown')
RuntimeError: cannot schedule new futures after interpreter shutdown
Exception in thread Thread-DASHStreamWorker:
Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1041, in _bootstrap_inner
    self.run()
    ~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/segmented/segmented.py", line 218, in run
    self.writer.put(segment)
    ~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/segmented/segmented.py", line 104, in put
    future = self.executor.submit(self.fetch, segment)
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 172, in submit
    raise RuntimeError('cannot schedule new futures after '
                       'interpreter shutdown')
RuntimeError: cannot schedule new futures after interpreter shutdown
^CException ignored on threading shutdown:
Traceback (most recent call last):
  File "/usr/lib/python3.13/threading.py", line 1534, in _shutdown
    atexit_call()
  File "/usr/lib/python3.13/threading.py", line 1505, in <lambda>
    _threading_atexits.append(lambda: func(*arg, **kwargs))
  File "/usr/lib/python3.13/concurrent/futures/thread.py", line 31, in _python_exit
    t.join()
  File "/usr/lib/python3.13/threading.py", line 1092, in join
    self._handle.join(timeout)
KeyboardInterrupt:
```

PR (video-only stream output)
```
$ streamlink --ffmpeg-ffmpeg /dev/null -o /dev/null https://steamcommunity.com/broadcast/watch/76561199803546468 best
[cli][info] Found matching plugin steam for URL https://steamcommunity.com/broadcast/watch/76561199803546468
[cli][info] Available streams: 1080p (worst, best)
[cli][info] Opening stream: 1080p (dash)
[cli][info] Writing output to
/dev/null
[stream.ffmpegmux][warning] No valid FFmpeg binary was found. See the --ffmpeg-ffmpeg option.
[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
[download] Written 8.49 MiB to /dev/null (2s @ 3.39 MiB/s)                                                                                      [download] Written 8.49 MiB to /dev/null (2s @ 3.39 MiB/s)                                                                                      
[cli][info] Stream ended
Interrupted! Exiting...
[cli][info] Closing currently open stream...
```