### PR TITLE
options: make Options inherit from dict

### DIFF
--- a/src/streamlink/options.py
+++ b/src/streamlink/options.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from typing import Any, ClassVar, Dict, Literal, TypeVar
 
 
-class Options:
+class Options(Dict[str, Any]):
     """
     For storing options to be used by the Streamlink session and plugins, with default values.
 
@@ -13,18 +13,16 @@ class Options:
           This means that the keys ``example_one`` and ``example-one`` are equivalent.
     """
 
+    #: Optional getter mapping for :class:`Options` subclasses
     _MAP_GETTERS: ClassVar[Mapping[str, Callable[[Any, str], Any]]] = {}
-    """Optional getter mapping for :class:`Options` subclasses"""
 
+    #: Optional setter mapping for :class:`Options` subclasses
     _MAP_SETTERS: ClassVar[Mapping[str, Callable[[Any, str, Any], None]]] = {}
-    """Optional setter mapping for :class:`Options` subclasses"""
 
     def __init__(self, defaults: Mapping[str, Any] | None = None):
-        if not defaults:
-            defaults = {}
-
-        self.defaults = self._normalize_dict(defaults)
-        self.options = self.defaults.copy()
+        super().__init__()
+        self._defaults = self._normalize_dict(defaults or {})
+        super().update(self._defaults)
 
     @staticmethod
     def _normalize_key(name: str) -> str:
@@ -35,13 +33,17 @@ class Options:
         normalize_key = cls._normalize_key
         return {normalize_key(key): value for key, value in src.items()}
 
+    @property
+    def defaults(self):
+        return self._defaults
+
     def clear(self) -> None:
         """Restore default options"""
 
-        self.options.clear()
-        self.options.update(self.defaults.copy())
+        super().clear()
+        self.update(self._defaults)
 
-    def get(self, key: str) -> Any:
+    def get(self, key: str) -> Any:  # type: ignore[override]
         """Get the stored value of a specific key"""
 
         normalized = self._normalize_key(key)
@@ -49,13 +51,13 @@ class Options:
         if method is not None:
             return method(self, normalized)
         else:
-            return self.options.get(normalized)
+            return super().get(normalized)
 
     def get_explicit(self, key: str) -> Any:
         """Get the stored value of a specific key and ignore any get-mappings"""
 
         normalized = self._normalize_key(key)
-        return self.options.get(normalized)
+        return super().get(normalized)
 
     def set(self, key: str, value: Any) -> None:
         """Set the value for a specific key"""
@@ -65,43 +67,26 @@ class Options:
         if method is not None:
             method(self, normalized, value)
         else:
-            self.options[normalized] = value
+            super().__setitem__(normalized, value)
 
     def set_explicit(self, key: str, value: Any) -> None:
         """Set the value for a specific key and ignore any set-mappings"""
 
         normalized = self._normalize_key(key)
-        self.options[normalized] = value
+        super().__setitem__(normalized, value)
 
-    def update(self, options: Mapping[str, Any]) -> None:
+    # noinspection PyMethodOverriding
+    def update(self, options: Mapping[str, Any]) -> None:  # type: ignore[override]
         """Merge options"""
 
         for key, value in options.items():
             self.set(key, value)
-
-    def keys(self):
-        return self.options.keys()
-
-    def values(self):
-        return self.options.values()
-
-    def items(self):
-        return self.options.items()
 
     def __getitem__(self, item):
         return self.get(item)
 
     def __setitem__(self, item, value):
         return self.set(item, value)
-
-    def __contains__(self, item):
-        return self.options.__contains__(item)
-
-    def __len__(self):
-        return self.options.__len__()
-
-    def __iter__(self):
-        return self.options.__iter__()
 
 
 _TChoices = TypeVar("_TChoices", bound=Iterable)

--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -294,7 +294,7 @@ class Plugin(metaclass=PluginMeta):
 
     _url: str = ""
 
-    def __init__(self, session: Streamlink, url: str, options: Options | None = None):
+    def __init__(self, session: Streamlink, url: str, options: Mapping[str, Any] | Options | None = None):
         """
         :param session: The Streamlink session instance
         :param url: The input URL used for finding and resolving streams
@@ -304,7 +304,9 @@ class Plugin(metaclass=PluginMeta):
         modulename = self.__class__.__module__
         self.module = modulename.split(".")[-1]
         self.logger = logging.getLogger(modulename)
-        self.options = Options() if options is None else options
+
+        self.options = Options(options)
+
         self.cache = Cache(
             filename="plugin-cache.json",
             key_prefix=self.module,

--- a/src/streamlink/session/session.py
+++ b/src/streamlink/session/session.py
@@ -31,7 +31,7 @@ class Streamlink:
 
     def __init__(
         self,
-        options: Mapping[str, Any] | None = None,
+        options: Mapping[str, Any] | Options | None = None,
         *,
         plugins_builtin: bool = True,
         plugins_lazy: bool = True,

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -223,7 +223,7 @@ def test_setup_session_options_default_values(monkeypatch: pytest.MonkeyPatch, p
     monkeypatch.setattr(session, "set_option", mock_set_option)
     args = parser.parse_args([])
     setup_session_options(session, args)
-    assert session.options.options == session.options.defaults
+    assert session.options == session.options.defaults
     assert not mock_set_option.called, "Value of unset session-option arg must be None and must not call set_option()"
 
 
@@ -367,8 +367,8 @@ class TestSetupPluginArgsAndOptions:
 
     def test_setup_options_no_plugin_arguments(self, session: Streamlink, console: Mock):
         options = setup_plugin_options(session, Namespace(), "mock", Plugin)
-        assert not options.defaults
-        assert not options.options
+        assert options == {}
+        assert options.defaults == {}
 
         assert not console.ask.called
         assert not console.askpass.called

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -12,41 +12,68 @@ class TestOptions:
     @pytest.fixture()
     def options(self):
         return Options({
-            "a_default": "default",
-            "another-default": "default2",
+            "foo-bar": "1",
+            "baz_qux": "2",
         })
 
-    def test_empty(self):
-        options = Options()
-        assert not options.defaults
-        assert not options.options
+    def test_defaults(self, options: Options):
+        empty = Options()
+        assert empty == {}
+        assert empty.defaults == {}
 
-    def test_set(self, options: Options):
-        assert options.get("a_default") == "default"
+        assert options.defaults == {
+            "foo-bar": "1",
+            "baz-qux": "2",
+        }
+        assert options == options.defaults
+
+    def test_get_set(self, options: Options):
+        assert options.get("foo-bar") == "1"
+        assert options["foo-bar"] == "1"
+        assert options.get("baz_qux") == "2"
+        assert options["baz_qux"] == "2"
+
         assert options.get("non_existing") is None
+        assert options["non_existing"] is None
 
-        options.set("an_option", "option")
-        assert options.get("an_option") == "option"
+        options.set("abc-def", 3.14)
+        assert options.get("abc-def") == 3.14
+        assert options.get("abc-def") == 3.14
+
+        obj = object()
+        options["foo_bar"] = obj
+        assert options.get("foo-bar") is obj
+        assert options.get("foo_bar") is obj
+
+        assert list(options.items()) == [
+            ("foo-bar", obj),
+            ("baz-qux", "2"),
+            ("abc-def", 3.14),
+        ]
 
     def test_update(self, options: Options):
-        assert options.get("a_default") == "default"
+        assert options.get("foo-bar") == "1"
         assert options.get("non_existing") is None
 
-        options.update({"an_option": "option"})
-        assert options.get("an_option") == "option"
+        options.update({"foo-bar": "value"})
+        assert options.get("foo-bar") == "value"
 
-    def test_name_normalised(self, options: Options):
-        assert options.get("a_default") == "default"
-        assert options.get("a-default") == "default"
-        assert options.get("another-default") == "default2"
-        assert options.get("another_default") == "default2"
+        other = Options({"foo-bar": "VALUE"})
+        other.set("abc", "def")
+        options.update(other)
+
+        assert list(options.items()) == [
+            ("foo-bar", "VALUE"),
+            ("baz-qux", "2"),
+            ("abc", "def"),
+        ]
 
     def test_clear(self, options: Options):
-        assert options.get("a_default") == "default"
-        options.set("a_default", "other")
-        assert options.get("a_default") == "other"
+        assert options.get("foo-bar") == "1"
+        options.set("foo-bar", "other")
+        assert options.get("foo-bar") == "other"
         options.clear()
-        assert options.get("a_default") == "default"
+        assert options.get("foo-bar") == "1"
 
 
 class TestMappedOptions:


### PR DESCRIPTION
This makes the `options` arguments of both the `Streamlink` session class and the `Plugin` class more consistent. The former currenly doesn't allow passing an `Options` object as the `options` argument, while the latter doesn't allow `dict`s and always requires an `Options` object.

The reason for these inconsistencies is that the `Streamlink` session defines a set of default values and key-value mappings, so passing an `Options` object didn't make sense when it was implemented. The `Plugin` options argument was implemented when the `Plugin.bind()` nonsense was removed and `Plugin.options` were turned from class attributes to instance attributes (5.0.0 - #5033), so regular `dict`s were never considered as plugin options arguments.

~~A side-effect of these changes however is that plugin options now don't have default values anymore, because the argument is always merged into an empty `Options` object. I'm not fully sure if this is actually relevant here in the plugin API. I'll have to think about it, because I don't want to break any downstream stuff. Opening this as a draft for now because of that.~~

Custom plugin options are now set as default values on the plugin's `options` object, copied from the passed `dict` or `Options` object.