### PR TITLE
stream.dash: opt publishTime/availabilityStartTime

### DIFF
--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -310,13 +310,12 @@ class MPD(MPDNode):
         self.publishTime = self.attr(
             "publishTime",
             parser=MPDParsers.datetime,
-            required=self.type == "dynamic",
+            default=EPOCH_START,
         )
         self.availabilityStartTime = self.attr(
             "availabilityStartTime",
             parser=MPDParsers.datetime,
             default=EPOCH_START,
-            required=self.type == "dynamic",
         )
         self.availabilityEndTime = self.attr(
             "availabilityEndTime",
@@ -938,12 +937,11 @@ class SegmentTemplate(_MultipleSegmentBaseType):
             time = self.root.timelines[ident]
             is_initial = time == -1
 
-            publish_time = self.root.publishTime or EPOCH_START
-            threshold = publish_time - self.root.suggestedPresentationDelay
+            threshold = self.root.publishTime - self.root.suggestedPresentationDelay
 
             # transform the timeline into a segment list
             timeline = []
-            available_at = publish_time
+            available_at = self.root.publishTime
 
             # the last segment in the timeline is the most recent one
             # so, work backwards and calculate when each of the segments was

--- a/tests/resources/dash/test_dynamic_no_publish_time_timeline_with_start.mpd
+++ b/tests/resources/dash/test_dynamic_no_publish_time_timeline_with_start.mpd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  type="dynamic"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  minimumUpdatePeriod="PT6.00S"
+  minBufferTime="PT2S"
+  timeShiftBufferDepth="PT259200S"
+  maxSegmentDuration="PT6.0S"
+>
+  <Period id="period" start="PT0S">
+    <AdaptationSet frameRate="25" mimeType="video/mp4" startWithSAP="1" id="1" contentType="video" segmentAlignment="true">
+      <SegmentTemplate timescale="90000" media="$RepresentationID$-$Time$.m4s">
+        <SegmentTimeline>
+          <S d="540000" t="155994767894430"/>
+          <S d="540000" r="7"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        width="1920"
+        height="1080"
+        codecs="avc1.640028"
+        id="video_1920x1080_avc1"
+        bandwidth="14652634"
+      />
+    </AdaptationSet>
+  </Period>
+  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="2024-12-04T01:21:18.032097Z"/>
+</MPD>

--- a/tests/resources/dash/test_dynamic_no_publish_time_timeline_without_start.mpd
+++ b/tests/resources/dash/test_dynamic_no_publish_time_timeline_without_start.mpd
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  type="dynamic"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  minimumUpdatePeriod="PT6.00S"
+  minBufferTime="PT2S"
+  timeShiftBufferDepth="PT259200S"
+  maxSegmentDuration="PT6.0S"
+>
+  <Period id="period" start="PT0S">
+    <AdaptationSet frameRate="25" mimeType="video/mp4" startWithSAP="1" id="1" contentType="video" segmentAlignment="true">
+      <SegmentTemplate timescale="90000" media="$RepresentationID$-$Time$.m4s">
+        <SegmentTimeline>
+          <S d="540000"/>
+          <S d="540000" r="7"/>
+        </SegmentTimeline>
+      </SegmentTemplate>
+      <Representation
+        width="1920"
+        height="1080"
+        codecs="avc1.640028"
+        id="video_1920x1080_avc1"
+        bandwidth="14652634"
+      />
+    </AdaptationSet>
+  </Period>
+  <UTCTiming schemeIdUri="urn:mpeg:dash:utc:direct:2014" value="2024-12-04T01:21:18.032097Z"/>
+</MPD>


### PR DESCRIPTION
Remove requirement from `publishTime` and `availabilityStartTime` in dynamic DASH manifests and simply default to UNIX Epoch.

----

Resolves #6322 

According to ISO/IEC 23009-1:2022 section 5.3.1.2, `MPD@publishTime` is an optional attribute with a default value, and it "shall be present" in dynamic manifests, same as the `MPD@availabilityStartTime` attribute. For static manifests, we've already set these attributes to optional in the parser, as they are not important in this case.

For dynamic manifests however, defaulting to UNIX Epoch can be problematic, depending on whether segment timelines include at least one timestamp anchor or not. If they don't, as the `SegmentTimeline.S@t` attribute is optional (section 5.3.9.6.2), then their anchor is the manifest's publishTime. Defaulting to 1970-01-01T00:00:00Z in dynamic manifests and using that as the anchor doesn't make sense, hence why `MPD@publishTime` was previously set as a required attribute.

Parsers however should always be more lenient with data that's not 100% valid, so let's fix the attribute requirement.

The `MPD@availabilityStartTime` changes don't have any tests here, but that should be fine.