### PR TITLE
stream.dash: refactor BaseURL.join()

### DIFF
--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from itertools import count, repeat
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, overload
-from urllib.parse import urljoin, urlparse, urlsplit, urlunparse, urlunsplit
+from urllib.parse import urljoin, urlparse, urlunparse
 
 from isodate import Duration, parse_datetime, parse_duration  # type: ignore[import]
 
@@ -267,7 +267,7 @@ class MPDNode:
     def base_url(self):
         base_url = self._base_url
         if hasattr(self, "baseURLs") and len(self.baseURLs):
-            base_url = BaseURL.join(base_url, self.baseURLs[0].url)
+            base_url = urljoin(base_url, self.baseURLs[0].url)
         return base_url
 
 
@@ -389,24 +389,6 @@ class BaseURL(MPDNode):
         super().__init__(*args, **kwargs)
 
         self.url = (self.text or "").strip()
-
-    @property
-    def is_absolute(self) -> bool:
-        return bool(urlparse(self.url).scheme)
-
-    @staticmethod
-    def join(url: str, other: str) -> str:
-        # if the other URL is an absolute url, then return that
-        if urlparse(other).scheme:
-            return other
-        elif url:
-            parts = list(urlsplit(url))
-            if not parts[2].endswith("/") and not parts[3]:
-                parts[2] += "/"
-            url = urlunsplit(parts)
-            return urljoin(url, other)
-        else:
-            return other
 
 
 class Location(MPDNode):
@@ -808,7 +790,7 @@ class SegmentList(_MultipleSegmentBaseType):
         return start
 
     def make_url(self, url: str | None) -> str:
-        return BaseURL.join(self.base_url, url) if url else self.base_url
+        return urljoin(self.base_url, url)
 
 
 class SegmentTemplate(_MultipleSegmentBaseType):
@@ -859,7 +841,7 @@ class SegmentTemplate(_MultipleSegmentBaseType):
 
     @staticmethod
     def make_url(base_url: str, url: str) -> str:
-        return BaseURL.join(base_url, url)
+        return urljoin(base_url, url)
 
     def segment_numbers(self, timestamp: datetime | None = None) -> Iterator[tuple[int, datetime]]:
         """

--- a/tests/resources/dash/test_baseurl_urljoin.mpd
+++ b/tests/resources/dash/test_baseurl_urljoin.mpd
@@ -10,44 +10,94 @@
   mediaPresentationDuration="PT0H0M6.00S"
   minBufferTime="PT6.0S"
 >
-  <Period id="0" start="PT12M34S">
-    <BaseURL>https://hostname/path</BaseURL>
-    <AdaptationSet id="0" mimeType="video/mp4">
+  <Period id="empty-baseurl" start="PT12M34S">
+    <BaseURL/>
+    <AdaptationSet id="absolute-segments" mimeType="video/mp4">
       <SegmentTemplate
-        presentationTimeOffset="0"
+        initialization="/absolute/init_$RepresentationID$.m4s"
+        media="/absolute/media_$RepresentationID$-$Number$.m4s"
+        startNumber="1"
         timescale="90000"
         duration="540000"
+      />
+      <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
+    </AdaptationSet>
+    <AdaptationSet id="relative-segments" mimeType="video/mp4">
+      <SegmentTemplate
+        initialization="relative/init_$RepresentationID$.m4s"
+        media="relative/media_$RepresentationID$-$Number$.m4s"
         startNumber="1"
-        media="media_$RepresentationID$-$Number$.m4s"
-        initialization="init_$RepresentationID$.m4s"
+        timescale="90000"
+        duration="540000"
       />
       <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
     </AdaptationSet>
   </Period>
-  <Period id="1" start="PT12M34S">
-    <BaseURL>https://hostname/path/manifest.mpd?query</BaseURL>
-    <AdaptationSet id="0" mimeType="video/mp4">
+  <Period id="baseurl-with-scheme" start="PT12M34S">
+    <BaseURL>https://host/path/subpath</BaseURL>
+    <AdaptationSet id="absolute-segments" mimeType="video/mp4">
       <SegmentTemplate
-        presentationTimeOffset="0"
+        initialization="/absolute/init_$RepresentationID$.m4s"
+        media="/absolute/media_$RepresentationID$-$Number$.m4s"
+        startNumber="1"
         timescale="90000"
         duration="540000"
+      />
+      <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
+    </AdaptationSet>
+    <AdaptationSet id="relative-segments" mimeType="video/mp4">
+      <SegmentTemplate
+        initialization="relative/init_$RepresentationID$.m4s"
+        media="relative/media_$RepresentationID$-$Number$.m4s"
         startNumber="1"
-        media="media_$RepresentationID$-$Number$.m4s"
-        initialization="init_$RepresentationID$.m4s"
+        timescale="90000"
+        duration="540000"
       />
       <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
     </AdaptationSet>
   </Period>
-  <Period id="2" start="PT12M34S">
-    <BaseURL>https://hostname/path/manifest.mpd</BaseURL>
-    <AdaptationSet id="0" mimeType="video/mp4">
+  <Period id="absolute-baseurl" start="PT12M34S">
+    <BaseURL>/path/subpath</BaseURL>
+    <AdaptationSet id="absolute-segments" mimeType="video/mp4">
       <SegmentTemplate
-        presentationTimeOffset="0"
+        initialization="/absolute/init_$RepresentationID$.m4s"
+        media="/absolute/media_$RepresentationID$-$Number$.m4s"
+        startNumber="1"
         timescale="90000"
         duration="540000"
+      />
+      <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
+    </AdaptationSet>
+    <AdaptationSet id="relative-segments" mimeType="video/mp4">
+      <SegmentTemplate
+        initialization="relative/init_$RepresentationID$.m4s"
+        media="relative/media_$RepresentationID$-$Number$.m4s"
         startNumber="1"
-        media="media_$RepresentationID$-$Number$.m4s"
-        initialization="init_$RepresentationID$.m4s"
+        timescale="90000"
+        duration="540000"
+      />
+      <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
+    </AdaptationSet>
+  </Period>
+  <Period id="relative-baseurl" start="PT12M34S">
+    <BaseURL>path/subpath</BaseURL>
+    <AdaptationSet id="absolute-segments" mimeType="video/mp4">
+      <SegmentTemplate
+        initialization="/absolute/init_$RepresentationID$.m4s"
+        media="/absolute/media_$RepresentationID$-$Number$.m4s"
+        startNumber="1"
+        timescale="90000"
+        duration="540000"
+      />
+      <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
+    </AdaptationSet>
+    <AdaptationSet id="relative-segments" mimeType="video/mp4">
+      <SegmentTemplate
+        initialization="relative/init_$RepresentationID$.m4s"
+        media="relative/media_$RepresentationID$-$Number$.m4s"
+        startNumber="1"
+        timescale="90000"
+        duration="540000"
       />
       <Representation id="video_5000kbps" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="5000000"/>
     </AdaptationSet>

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -554,26 +554,96 @@ class TestMPDParser:
 
     def test_baseurl_urljoin(self):
         with xml("dash/test_baseurl_urljoin.mpd") as mpd_xml:
-            mpd = MPD(mpd_xml, base_url="https://foo/", url="https://test/manifest.mpd")
+            mpd = MPD(mpd_xml, base_url="https://foo/bar/", url="https://test/manifest.mpd")
 
         segment_urls = [
-            [segment.uri for segment in itertools.islice(representation.segments(), 2)]
+            [
+                (period.id, adaptationset.id, segment.uri)
+                for segment in itertools.islice(representation.segments(), 2)
+            ]
             for period in mpd.periods
             for adaptationset in period.adaptationSets
             for representation in adaptationset.representations
-        ]
+        ]  # fmt: skip
         assert segment_urls == [
             [
-                "https://hostname/path/init_video_5000kbps.m4s",
-                "https://hostname/path/media_video_5000kbps-1.m4s",
+                ("empty-baseurl", "absolute-segments", "https://foo/absolute/init_video_5000kbps.m4s"),
+                ("empty-baseurl", "absolute-segments", "https://foo/absolute/media_video_5000kbps-1.m4s"),
             ],
             [
-                "https://hostname/path/init_video_5000kbps.m4s",
-                "https://hostname/path/media_video_5000kbps-1.m4s",
+                ("empty-baseurl", "relative-segments", "https://foo/bar/relative/init_video_5000kbps.m4s"),
+                ("empty-baseurl", "relative-segments", "https://foo/bar/relative/media_video_5000kbps-1.m4s"),
             ],
             [
-                "https://hostname/path/manifest.mpd/init_video_5000kbps.m4s",
-                "https://hostname/path/manifest.mpd/media_video_5000kbps-1.m4s",
+                ("baseurl-with-scheme", "absolute-segments", "https://host/absolute/init_video_5000kbps.m4s"),
+                ("baseurl-with-scheme", "absolute-segments", "https://host/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("baseurl-with-scheme", "relative-segments", "https://host/path/relative/init_video_5000kbps.m4s"),
+                ("baseurl-with-scheme", "relative-segments", "https://host/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("absolute-baseurl", "absolute-segments", "https://foo/absolute/init_video_5000kbps.m4s"),
+                ("absolute-baseurl", "absolute-segments", "https://foo/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("absolute-baseurl", "relative-segments", "https://foo/path/relative/init_video_5000kbps.m4s"),
+                ("absolute-baseurl", "relative-segments", "https://foo/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("relative-baseurl", "absolute-segments", "https://foo/absolute/init_video_5000kbps.m4s"),
+                ("relative-baseurl", "absolute-segments", "https://foo/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("relative-baseurl", "relative-segments", "https://foo/bar/path/relative/init_video_5000kbps.m4s"),
+                ("relative-baseurl", "relative-segments", "https://foo/bar/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+        ]
+
+        with xml("dash/test_baseurl_urljoin.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="", url="https://test/manifest.mpd")
+
+        segment_urls = [
+            [
+                (period.id, adaptationset.id, segment.uri)
+                for segment in itertools.islice(representation.segments(), 2)
+            ]
+            for period in mpd.periods
+            for adaptationset in period.adaptationSets
+            for representation in adaptationset.representations
+        ]  # fmt: skip
+        assert segment_urls == [
+            [
+                ("empty-baseurl", "absolute-segments", "/absolute/init_video_5000kbps.m4s"),
+                ("empty-baseurl", "absolute-segments", "/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("empty-baseurl", "relative-segments", "relative/init_video_5000kbps.m4s"),
+                ("empty-baseurl", "relative-segments", "relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("baseurl-with-scheme", "absolute-segments", "https://host/absolute/init_video_5000kbps.m4s"),
+                ("baseurl-with-scheme", "absolute-segments", "https://host/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("baseurl-with-scheme", "relative-segments", "https://host/path/relative/init_video_5000kbps.m4s"),
+                ("baseurl-with-scheme", "relative-segments", "https://host/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("absolute-baseurl", "absolute-segments", "/absolute/init_video_5000kbps.m4s"),
+                ("absolute-baseurl", "absolute-segments", "/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("absolute-baseurl", "relative-segments", "/path/relative/init_video_5000kbps.m4s"),
+                ("absolute-baseurl", "relative-segments", "/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("relative-baseurl", "absolute-segments", "/absolute/init_video_5000kbps.m4s"),
+                ("relative-baseurl", "absolute-segments", "/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("relative-baseurl", "relative-segments", "path/relative/init_video_5000kbps.m4s"),
+                ("relative-baseurl", "relative-segments", "path/relative/media_video_5000kbps-1.m4s"),
             ],
         ]
 


### PR DESCRIPTION
- Remove `BaseURL.join()` and replace it with simple `urllib.parse.urljoin()` calls:
  Appending a trailing path separator is incorrect, and checking for absolute and non-empty components is unnecessary
- Remove unused `BaseURL.is_absolute()` property

----

Fixes #6327 

As said in the linked issue, I have no idea why the weird `parts[2] += "/"` logic was added in the initial DASH implementation.

`urllib.parse.urljoin()` is IETF RFC 3986 compliant, which is what's required by ISO/IEC 23009-1:2022 5.6.4 (BaseURL processing section of the DASH standard).

----

@zhenyahacker please have a look and check if that's working for you. Thanks.