### PR TITLE
plugins.bilibili: accept MPEG-TS HLS streams

### DIFF
--- a/src/streamlink/plugins/bilibili.py
+++ b/src/streamlink/plugins/bilibili.py
@@ -53,7 +53,7 @@ class Bilibili(Plugin):
                                 ),
                             },
                         ],
-                        validate.filter(lambda item: item["format_name"] == "fmp4"),
+                        validate.filter(lambda item: item["format_name"] in ("fmp4", "ts")),
                     ),
                 },
             ],


### PR DESCRIPTION
Resolves #6329 

The HLS stream however appears to be really slow or the connection is throttled. Their website doesn't use HLS and just progressively downloads a single FLV container. (see #5782 - still no feedback after almost a year now)

```
$ streamlink -l debug https://live.bilibili.com/32352415?hotRank=0&session_id=2f53f6b1e46116ea00151dcda767571a_7ACB95EC-467D-4EBE-94AB-EE4491304448&launch_id=1000338&live_from=77002 best
[cli][debug] OS:         Linux-6.12.1-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.13.0
[cli][debug] OpenSSL:    OpenSSL 3.4.0 22 Oct 2024
[cli][debug] Streamlink: 7.0.0+29.gcae99032
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.8.30
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.27.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.2.3
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://live.bilibili.com/32352415?hotRank=0&session_id=2f53f6b1e46116ea00151dcda767571a_7ACB95EC-467D-4EBE-94AB-EE4491304448&launch_id=1000338&live_from=77002
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin bilibili for URL https://live.bilibili.com/32352415?hotRank=0&session_id=2f53f6b1e46116ea00151dcda767571a_7ACB95EC-467D-4EBE-94AB-EE4491304448&launch_id=1000338&live_from=77002
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 2; Last Sequence: 4
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 2; End Sequence: None
[stream.hls][debug] Adding segment 2 to queue
[stream.hls][debug] Adding segment 3 to queue
[stream.hls][debug] Adding segment 4 to queue
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 5 to queue
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 6 to queue
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 7 to queue
[stream.hls][debug] Writing segment 2 to output
[stream.hls][debug] Segment 2 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://live.bilibili.com/32352415?hotRank=0&session_id=2f53f6b1e46116ea00151dcda767571a_7ACB95EC-467D-4EBE-94AB-EE4491304448&launch_id=1000338&live_from=77002', '-']
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Adding segment 8 to queue
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```