### PR TITLE
stream.dash: fix base_url input

### DIFF
--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -9,7 +9,6 @@ from contextlib import contextmanager, suppress
 from datetime import datetime
 from time import time
 from typing import Any
-from urllib.parse import urlparse, urlunparse
 
 from requests import Response
 
@@ -253,11 +252,7 @@ class DASHStream(Stream):
         manifest: str = res.text
         url: str = res.url
 
-        urlp = list(urlparse(url))
-        urlp[2], _ = urlp[2].rsplit("/", 1)
-        base_url: str = urlunparse(urlp)
-
-        return manifest, dict(url=url, base_url=base_url)
+        return manifest, dict(url=url, base_url=url)
 
     @staticmethod
     def parse_mpd(manifest: str, mpd_params: Mapping[str, Any]) -> MPD:

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -72,7 +72,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p"])
 
     def test_audio_only(self, session: Streamlink, mpd: Mock):
@@ -86,7 +86,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["a128k", "a256k"])
 
     @pytest.mark.parametrize(
@@ -143,7 +143,7 @@ class TestDASHStreamParseManifest:
             with_video_only=with_video_only,
             with_audio_only=with_audio_only,
         )
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert list(streams.keys()) == expected
 
     def test_audio_single(self, session: Streamlink, mpd: Mock):
@@ -158,7 +158,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p"])
 
     def test_audio_multi(self, session: Streamlink, mpd: Mock):
@@ -174,7 +174,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p+a128k", "1080p+a128k", "720p+a256k", "1080p+a256k"])
 
     def test_audio_multi_lang(self, session: Streamlink, mpd: Mock):
@@ -190,7 +190,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p"])
         assert getattr(streams["720p"].audio_representation, "lang", None) == "en"
         assert getattr(streams["1080p"].audio_representation, "lang", None) == "en"
@@ -208,7 +208,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p"])
         assert getattr(streams["720p"].audio_representation, "lang", None) == "eng"
         assert getattr(streams["1080p"].audio_representation, "lang", None) == "eng"
@@ -225,7 +225,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p"])
         assert getattr(streams["720p"].audio_representation, "lang", None) == "en_no_voice"
         assert getattr(streams["1080p"].audio_representation, "lang", None) == "en_no_voice"
@@ -245,7 +245,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p"])
         assert getattr(streams["720p"].audio_representation, "lang", None) == "es"
         assert getattr(streams["1080p"].audio_representation, "lang", None) == "es"
@@ -264,7 +264,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert sorted(streams.keys()) == sorted(["720p", "1080p", "1080p_alt", "1080p_alt2"])
 
     # Verify the fix for https://github.com/streamlink/streamlink/issues/4217
@@ -280,7 +280,7 @@ class TestDASHStreamParseManifest:
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert getattr(streams["1080p"].video_representation, "bandwidth", None) == pytest.approx(128.0)
         assert getattr(streams["1080p_alt"].video_representation, "bandwidth", None) == pytest.approx(64.0)
         assert getattr(streams["1080p_alt2"].video_representation, "bandwidth", None) == pytest.approx(32.0)
@@ -319,10 +319,10 @@ class TestDASHStreamParseManifest:
     #       This test currently achieves nothing... (manifest fixture added in 7aada92)
     def test_segments_number_time(self, session: Streamlink, mpd: Mock):
         with xml("dash/test_9.mpd") as mpd_xml:
-            mpd.return_value = MPD(mpd_xml, base_url="http://test", url="http://test/manifest.mpd")
+            mpd.return_value = MPD(mpd_xml, base_url="http://test/manifest.mpd", url="http://test/manifest.mpd")
 
         streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd")
-        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test")]
+        assert mpd.call_args_list == [call(ANY, url="http://test/manifest.mpd", base_url="http://test/manifest.mpd")]
         assert list(streams.keys()) == ["480p"]
 
 

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -552,7 +552,55 @@ class TestMPDParser:
             ],
         ]
 
-    def test_baseurl_urljoin(self):
+    def test_baseurl_urljoin_no_trailing_slash(self):
+        with xml("dash/test_baseurl_urljoin.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="https://foo/bar", url="https://test/manifest.mpd")
+
+        segment_urls = [
+            [
+                (period.id, adaptationset.id, segment.uri)
+                for segment in itertools.islice(representation.segments(), 2)
+            ]
+            for period in mpd.periods
+            for adaptationset in period.adaptationSets
+            for representation in adaptationset.representations
+        ]  # fmt: skip
+        assert segment_urls == [
+            [
+                ("empty-baseurl", "absolute-segments", "https://foo/absolute/init_video_5000kbps.m4s"),
+                ("empty-baseurl", "absolute-segments", "https://foo/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("empty-baseurl", "relative-segments", "https://foo/relative/init_video_5000kbps.m4s"),
+                ("empty-baseurl", "relative-segments", "https://foo/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("baseurl-with-scheme", "absolute-segments", "https://host/absolute/init_video_5000kbps.m4s"),
+                ("baseurl-with-scheme", "absolute-segments", "https://host/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("baseurl-with-scheme", "relative-segments", "https://host/path/relative/init_video_5000kbps.m4s"),
+                ("baseurl-with-scheme", "relative-segments", "https://host/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("absolute-baseurl", "absolute-segments", "https://foo/absolute/init_video_5000kbps.m4s"),
+                ("absolute-baseurl", "absolute-segments", "https://foo/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("absolute-baseurl", "relative-segments", "https://foo/path/relative/init_video_5000kbps.m4s"),
+                ("absolute-baseurl", "relative-segments", "https://foo/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("relative-baseurl", "absolute-segments", "https://foo/absolute/init_video_5000kbps.m4s"),
+                ("relative-baseurl", "absolute-segments", "https://foo/absolute/media_video_5000kbps-1.m4s"),
+            ],
+            [
+                ("relative-baseurl", "relative-segments", "https://foo/path/relative/init_video_5000kbps.m4s"),
+                ("relative-baseurl", "relative-segments", "https://foo/path/relative/media_video_5000kbps-1.m4s"),
+            ],
+        ]
+
+    def test_baseurl_urljoin_with_trailing_slash(self):
         with xml("dash/test_baseurl_urljoin.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="https://foo/bar/", url="https://test/manifest.mpd")
 
@@ -600,6 +648,7 @@ class TestMPDParser:
             ],
         ]
 
+    def test_baseurl_urljoin_empty(self):
         with xml("dash/test_baseurl_urljoin.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="", url="https://test/manifest.mpd")
 
@@ -647,7 +696,7 @@ class TestMPDParser:
             ],
         ]
 
-    def test_nested_baseurls(self):
+    def test_baseurl_nested(self):
         with xml("dash/test_baseurl_nested.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="https://foo/", url="https://test/manifest.mpd")
 


### PR DESCRIPTION
Follow-up of 53ac068

Simply pass the whole input URL as `base_url` value, since we're always joining all URLs using `urllib.parse.urljoin()`.

Add another test case which fails on 53ac068 due to the incorrect path splitting, and update all remaining tests.

----

Fixes #6337 
Introduced by #6328

@pzhlkj6612 please check. Thanks!
