### PR TITLE
stream.hls: refactor playlist reload

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -168,11 +168,11 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
         self.logged_ads: deque[str] = deque(maxlen=10)
         super().__init__(reader, *args, **kwargs)
 
-    def _playlist_reload_time(self, playlist: TwitchM3U8):  # type: ignore[override]
+    def _get_reload_time(self, playlist: TwitchM3U8):  # type: ignore[override]
         if self.stream.low_latency and playlist.segments:
             return playlist.segments[-1].duration
 
-        return super()._playlist_reload_time(playlist)
+        return super()._get_reload_time(playlist)
 
     def process_segments(self, playlist: TwitchM3U8):  # type: ignore[override]
         # ignore prefetch segments if not LL streaming

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -304,10 +304,6 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         self.playlist_sequence_last: datetime = now()
         self.playlist_segments: list[HLSSegment] = []
 
-        self.playlist_reload_last: datetime = now()
-        self.playlist_reload_time: float = 6
-        self.playlist_reload_time_override = self.session.options.get("hls-playlist-reload-time")
-        self.playlist_reload_retries = self.session.options.get("hls-playlist-reload-attempts")
         self.segment_queue_timing_threshold_factor = self.session.options.get("hls-segment-queue-threshold")
         self.live_edge = self.session.options.get("hls-live-edge")
         self.duration_offset_start = int(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0))
@@ -316,23 +312,27 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         )
         self.hls_live_restart = self.stream.force_restart or self.session.options.get("hls-live-restart")
 
-        if str(self.playlist_reload_time_override).isnumeric() and float(self.playlist_reload_time_override) >= 2:
-            self.playlist_reload_time_override = float(self.playlist_reload_time_override)
-        elif self.playlist_reload_time_override not in ["segment", "live-edge"]:
-            self.playlist_reload_time_override = 0
+        self._reload_last: datetime = now()
+        self._reload_time: float = 6
+        self._reload_time_override = self.session.options.get("hls-playlist-reload-time")
+        self._reload_retries = self.session.options.get("hls-playlist-reload-attempts")
+        if str(self._reload_time_override).isnumeric() and float(self._reload_time_override) >= 2:
+            self._reload_time_override = float(self._reload_time_override)
+        elif self._reload_time_override not in ("segment", "live-edge"):
+            self._reload_time_override = 0
 
     def _fetch_playlist(self) -> Response:
         res = self.session.http.get(
             self.stream.url,
             exception=StreamError,
-            retries=self.playlist_reload_retries,
+            retries=self._reload_retries,
             **self.reader.request_params,
         )
         res.encoding = "utf-8"
 
         return res
 
-    def reload_playlist(self):
+    def reload(self):
         if self.closed:  # pragma: no cover
             return
 
@@ -353,24 +353,24 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             raise StreamError("Streams containing I-frames only are not playable")
 
         self.playlist_targetduration = playlist.targetduration or 0
-        self.playlist_reload_time = self._playlist_reload_time(playlist)
+        self._reload_time = self._get_reload_time(playlist)
 
         if playlist.segments:
             self.process_segments(playlist)
 
-    def _playlist_reload_time(self, playlist: M3U8[HLSSegment, HLSPlaylist]) -> float:
-        if self.playlist_reload_time_override == "segment" and playlist.segments:
+    def _get_reload_time(self, playlist: M3U8[HLSSegment, HLSPlaylist]) -> float:
+        if self._reload_time_override == "segment" and playlist.segments:
             return playlist.segments[-1].duration
-        if self.playlist_reload_time_override == "live-edge" and playlist.segments:
+        if self._reload_time_override == "live-edge" and playlist.segments:
             return sum(s.duration for s in playlist.segments[-max(1, self.live_edge - 1) :])
-        if type(self.playlist_reload_time_override) is float and self.playlist_reload_time_override > 0:
-            return self.playlist_reload_time_override
+        if type(self._reload_time_override) is float and self._reload_time_override > 0:
+            return self._reload_time_override
         if playlist.targetduration:
             return playlist.targetduration
         if playlist.segments:
             return sum(s.duration for s in playlist.segments[-max(1, self.live_edge - 1) :])
 
-        return self.playlist_reload_time
+        return self._reload_time
 
     def process_segments(self, playlist: M3U8[HLSSegment, HLSPlaylist]) -> None:
         segments = playlist.segments
@@ -383,7 +383,7 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         self.playlist_segments = segments
 
         if not self.playlist_changed:
-            self.playlist_reload_time = max(self.playlist_reload_time / 2, 1)
+            self._reload_time = max(self._reload_time / 2, 1)
 
         if playlist.is_endlist:
             self.playlist_end = last_segment.num
@@ -430,12 +430,12 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         return default
 
     def iter_segments(self):
-        self.playlist_reload_last \
+        self._reload_last \
             = self.playlist_sequence_last \
             = now()  # fmt: skip
 
         try:
-            self.reload_playlist()
+            self.reload()
         except StreamError as err:
             log.error(f"{err}")
             self.reader.close()
@@ -510,19 +510,19 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             # Exclude playlist fetch+processing time from the overall playlist reload time
             # and reload playlist in a strict time interval
             time_completed = now()
-            time_elapsed = max(0.0, (time_completed - self.playlist_reload_last).total_seconds())
-            time_wait = max(0.0, self.playlist_reload_time - time_elapsed)
+            time_elapsed = max(0.0, (time_completed - self._reload_last).total_seconds())
+            time_wait = max(0.0, self._reload_time - time_elapsed)
             if self.wait(time_wait):
                 if time_wait > 0:
                     # If we had to wait, then don't call now() twice and instead reference the timestamp from before
                     # the wait() call, to prevent a shifting time offset due to the execution time.
-                    self.playlist_reload_last = time_completed + timedelta(seconds=time_wait)
+                    self._reload_last = time_completed + timedelta(seconds=time_wait)
                 else:
                     # Otherwise, get the current time, as the reload interval already has shifted.
-                    self.playlist_reload_last = now()
+                    self._reload_last = now()
 
                 try:
-                    self.reload_playlist()
+                    self.reload()
                 except StreamError as err:
                     log.warning(f"Failed to reload playlist: {err}")
 

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -458,16 +458,7 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
                     continue
 
                 log.debug(f"Adding segment {segment.num} to queue")
-                offset = segment.num - self.playlist_sequence
-                if offset > 0:
-                    log.warning(
-                        (
-                            f"Skipped segments {self.playlist_sequence}-{segment.num - 1} after playlist reload. "
-                            if offset > 1
-                            else f"Skipped segment {self.playlist_sequence} after playlist reload. "
-                        )
-                        + "This is unsupported and will result in incoherent output data.",
-                    )
+                self.check_queue_gap(segment, self.playlist_sequence)
 
                 yield segment
                 queued = True

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -5,7 +5,6 @@ import re
 import struct
 from collections.abc import Mapping
 from concurrent.futures import Future
-from datetime import datetime, timedelta
 from typing import Any, ClassVar
 from urllib.parse import urlparse
 
@@ -292,8 +291,6 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
     writer: HLSStreamWriter
     stream: HLSStream
 
-    SEGMENT_QUEUE_TIMING_THRESHOLD_MIN = 5.0
-
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
@@ -301,10 +298,8 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
         self.playlist_end: int | None = None
         self.playlist_targetduration: float = 0
         self.playlist_sequence: int = -1
-        self.playlist_sequence_last: datetime = now()
         self.playlist_segments: list[HLSSegment] = []
 
-        self.segment_queue_timing_threshold_factor = self.session.options.get("hls-segment-queue-threshold")
         self.live_edge = self.session.options.get("hls-live-edge")
         self.duration_offset_start = int(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0))
         self.duration_limit = self.stream.duration or (
@@ -318,6 +313,8 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
             self._reload_time_override = float(self._reload_time_override)
         elif self._reload_time_override not in ("segment", "live-edge"):
             self._reload_time_override = 0
+
+        self._queue_deadline_factor = self.session.options.get("hls-segment-queue-threshold")
 
     def _fetch_playlist(self) -> Response:
         res = self.session.http.get(
@@ -355,6 +352,9 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
 
         if playlist.segments:
             self.process_segments(playlist)
+
+    def get_duration(self) -> float:
+        return self.playlist_targetduration
 
     def _get_reload_time(self, playlist: M3U8[HLSSegment, HLSPlaylist]) -> float:
         if self._reload_time_override == "segment" and playlist.segments:
@@ -397,20 +397,6 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
     def valid_segment(self, segment: HLSSegment) -> bool:
         return segment.num >= self.playlist_sequence
 
-    def _segment_queue_timing_threshold_reached(self) -> bool:
-        if self.segment_queue_timing_threshold_factor <= 0:
-            return False
-
-        threshold = max(
-            self.SEGMENT_QUEUE_TIMING_THRESHOLD_MIN,
-            self.playlist_targetduration * self.segment_queue_timing_threshold_factor,
-        )
-        if now() <= self.playlist_sequence_last + timedelta(seconds=threshold):
-            return False
-
-        log.warning(f"No new segments in playlist for more than {threshold:.2f}s. Stopping...")
-        return True
-
     @staticmethod
     def duration_to_sequence(duration: float, segments: list[HLSSegment]) -> int:
         d = 0.0
@@ -429,7 +415,7 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
 
     def iter_segments(self):
         self._reload_last \
-            = self.playlist_sequence_last \
+            = self._queue_last \
             = now()  # fmt: skip
 
         try:
@@ -496,13 +482,12 @@ class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
 
                 self.playlist_sequence = segment.num + 1
 
-            # End of stream
+            # Explicit end of stream
             if self.closed or self.playlist_end is not None and (not queued or self.playlist_sequence > self.playlist_end):
                 return
 
-            if queued:
-                self.playlist_sequence_last = now()
-            elif self._segment_queue_timing_threshold_reached():
+            # Implicit end of stream
+            if self.check_queue_deadline(queued):
                 return
 
             self.wait_and_reload()

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -20,7 +20,7 @@ from streamlink.stream.filtered import FilteredStream
 from streamlink.stream.hls.m3u8 import M3U8, M3U8Parser, parse_m3u8
 from streamlink.stream.hls.segment import ByteRange, HLSPlaylist, HLSSegment, Key, Map, Media
 from streamlink.stream.http import HTTPStream
-from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter
+from streamlink.stream.segmented import PollingSegmentedStreamWorker, SegmentedStreamReader, SegmentedStreamWriter
 from streamlink.utils.cache import LRUCache
 from streamlink.utils.crypto import AES, unpad
 from streamlink.utils.formatter import Formatter
@@ -287,7 +287,7 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
             log.debug(f"Segment {segment.num} complete")
 
 
-class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
+class HLSStreamWorker(PollingSegmentedStreamWorker[HLSSegment, Response]):
     reader: HLSStreamReader
     writer: HLSStreamWriter
     stream: HLSStream
@@ -312,8 +312,6 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         )
         self.hls_live_restart = self.stream.force_restart or self.session.options.get("hls-live-restart")
 
-        self._reload_last: datetime = now()
-        self._reload_time: float = 6
         self._reload_time_override = self.session.options.get("hls-playlist-reload-time")
         self._reload_retries = self.session.options.get("hls-playlist-reload-attempts")
         if str(self._reload_time_override).isnumeric() and float(self._reload_time_override) >= 2:
@@ -507,24 +505,7 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             elif self._segment_queue_timing_threshold_reached():
                 return
 
-            # Exclude playlist fetch+processing time from the overall playlist reload time
-            # and reload playlist in a strict time interval
-            time_completed = now()
-            time_elapsed = max(0.0, (time_completed - self._reload_last).total_seconds())
-            time_wait = max(0.0, self._reload_time - time_elapsed)
-            if self.wait(time_wait):
-                if time_wait > 0:
-                    # If we had to wait, then don't call now() twice and instead reference the timestamp from before
-                    # the wait() call, to prevent a shifting time offset due to the execution time.
-                    self._reload_last = time_completed + timedelta(seconds=time_wait)
-                else:
-                    # Otherwise, get the current time, as the reload interval already has shifted.
-                    self._reload_last = now()
-
-                try:
-                    self.reload()
-                except StreamError as err:
-                    log.warning(f"Failed to reload playlist: {err}")
+            self.wait_and_reload()
 
 
 class HLSStreamReader(FilteredStream, SegmentedStreamReader[HLSSegment, Response]):

--- a/src/streamlink/stream/segmented/__init__.py
+++ b/src/streamlink/stream/segmented/__init__.py
@@ -1,2 +1,3 @@
+from streamlink.stream.segmented.polling import PollingSegmentedStreamWorker
 from streamlink.stream.segmented.segment import Segment
 from streamlink.stream.segmented.segmented import SegmentedStreamReader, SegmentedStreamWorker, SegmentedStreamWriter

--- a/src/streamlink/stream/segmented/polling.py
+++ b/src/streamlink/stream/segmented/polling.py
@@ -15,6 +15,8 @@ log = logging.getLogger(__name__)
 class PollingSegmentedStreamWorker(SegmentedStreamWorker[TSegment, TResult], metaclass=abc.ABCMeta):
     """StreamWorker to be used in segmented streams where new data has to be fetched and processed periodically"""
 
+    QUEUE_DEADLINE_MIN = 5.0
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         dt_now = now()
@@ -22,9 +24,17 @@ class PollingSegmentedStreamWorker(SegmentedStreamWorker[TSegment, TResult], met
         self._reload_time: float = 6
         self._reload_last: datetime = dt_now
 
+        self._queue_deadline_factor = 3
+        self._queue_last: datetime = dt_now
+
     @abc.abstractmethod
     def reload(self) -> None:  # pragma: no cover
         """Fetch new data and process it"""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def get_duration(self) -> float:  # pragma: no cover
+        """Get the time in seconds until the next reload is necessary (HLS targetduration, DASH mediaPresentationDuration)"""
         raise NotImplementedError
 
     def wait_and_reload(self):
@@ -47,3 +57,23 @@ class PollingSegmentedStreamWorker(SegmentedStreamWorker[TSegment, TResult], met
                 self.reload()
             except StreamError as err:
                 log.warning(f"Reloading failed: {err}")
+
+    def check_queue_deadline(self, queued: bool) -> bool:
+        """Check whether new items were queued in a specific time frame, so the stream can be stopped early"""
+
+        if queued:
+            self._queue_last = now()
+            return False
+
+        if self._queue_deadline_factor <= 0:
+            return False
+
+        deadline = max(
+            self.QUEUE_DEADLINE_MIN,
+            self.get_duration() * self._queue_deadline_factor,
+        )
+        if now() <= self._queue_last + timedelta(seconds=deadline):
+            return False
+
+        log.warning(f"No new segments for more than {deadline:.2f}s. Stopping...")
+        return True

--- a/src/streamlink/stream/segmented/polling.py
+++ b/src/streamlink/stream/segmented/polling.py
@@ -77,3 +77,16 @@ class PollingSegmentedStreamWorker(SegmentedStreamWorker[TSegment, TResult], met
 
         log.warning(f"No new segments for more than {deadline:.2f}s. Stopping...")
         return True
+
+    # noinspection PyMethodMayBeStatic
+    def check_queue_gap(self, segment: TSegment, position: int) -> None:
+        offset = segment.num - position
+        if offset > 0:
+            log.warning(
+                (
+                    f"Skipped segments {position}-{segment.num - 1} after playlist reload. "
+                    if offset > 1
+                    else f"Skipped segment {position} after playlist reload. "
+                )
+                + "This is unsupported and will result in incoherent output data.",
+            )

--- a/src/streamlink/stream/segmented/polling.py
+++ b/src/streamlink/stream/segmented/polling.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import abc
+import logging
+from datetime import datetime, timedelta
+
+from streamlink.exceptions import StreamError
+from streamlink.stream.segmented.segmented import SegmentedStreamWorker, TResult, TSegment
+from streamlink.utils.times import now
+
+
+log = logging.getLogger(__name__)
+
+
+class PollingSegmentedStreamWorker(SegmentedStreamWorker[TSegment, TResult], metaclass=abc.ABCMeta):
+    """StreamWorker to be used in segmented streams where new data has to be fetched and processed periodically"""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        dt_now = now()
+
+        self._reload_time: float = 6
+        self._reload_last: datetime = dt_now
+
+    @abc.abstractmethod
+    def reload(self) -> None:  # pragma: no cover
+        """Fetch new data and process it"""
+        raise NotImplementedError
+
+    def wait_and_reload(self):
+        """Pause the worker until the next reload time interval has been reached, then call reload()"""
+
+        # Exclude fetch+processing time from the overall reload time and reload in a strict time interval
+        time_completed = now()
+        time_elapsed = max(0.0, (time_completed - self._reload_last).total_seconds())
+        time_wait = max(0.0, self._reload_time - time_elapsed)
+        if self.wait(time_wait):
+            if time_wait > 0:
+                # If we had to wait, then don't call now() twice and instead reference the timestamp from before
+                # the wait() call, to prevent a shifting time offset due to the execution time
+                self._reload_last = time_completed + timedelta(seconds=time_wait)
+            else:
+                # Otherwise, get the current time, as the reload interval already has shifted
+                self._reload_last = now()
+
+            try:
+                self.reload()
+            except StreamError as err:
+                log.warning(f"Reloading failed: {err}")

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -16,7 +16,7 @@ from tests.testutils.handshake import Handshake
 TIMEOUT_AWAIT_READ = 5
 TIMEOUT_AWAIT_READ_ONCE = 5
 TIMEOUT_AWAIT_WRITE = 60  # https://github.com/streamlink/streamlink/issues/3868
-TIMEOUT_AWAIT_PLAYLIST_RELOAD = 5
+TIMEOUT_AWAIT_RELOAD = 5
 TIMEOUT_AWAIT_PLAYLIST_WAIT = 5
 TIMEOUT_AWAIT_CLOSE = 5
 
@@ -100,9 +100,9 @@ class EventedHLSStreamWorker(_HLSStreamWorker):
         self.handshake_wait = Handshake()
         self.time_wait = None
 
-    def reload_playlist(self):
+    def reload(self):
         with self.handshake_reload():
-            return super().reload_playlist()
+            return super().reload()
 
     def wait(self, time):
         self.time_wait = time
@@ -251,7 +251,7 @@ class TestMixinStreamHLS(unittest.TestCase):
         thread.join(timeout)
         assert self.thread.reader.closed, "Stream reader is closed"
 
-    def await_playlist_reload(self, timeout=TIMEOUT_AWAIT_PLAYLIST_RELOAD) -> None:
+    def await_reload(self, timeout=TIMEOUT_AWAIT_RELOAD) -> None:
         worker: EventedHLSStreamWorker = self.thread.reader.worker  # type: ignore[assignment]
         assert worker.is_alive()
         assert worker.handshake_reload.step(timeout)

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -586,7 +586,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
         self.await_write(4)
         self.await_read(read_all=True)
-        assert self.thread.reader.worker.playlist_reload_time == pytest.approx(23 / 3)
+        assert self.thread.reader.worker._reload_time == pytest.approx(23 / 3)
 
     @patch("streamlink.stream.hls.hls.log")
     def test_hls_prefetch_after_discontinuity(self, mock_log):

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -1053,7 +1053,8 @@ class TestHlsPlaylistParseErrors(TestMixinStreamHLS, unittest.TestCase):
         assert mock_log.debug.mock_calls == [call("Reloading playlist")]
         assert mock_log.error.mock_calls == [call("Missing #EXTM3U header")]
 
-    def test_reload(self, mock_log):
+    @patch("streamlink.stream.segmented.polling.log")
+    def test_reload(self, mock_log, *_):
         segments = self.subject([
             Playlist(1, [Segment(0)]),
             self.InvalidPlaylist(),
@@ -1066,8 +1067,8 @@ class TestHlsPlaylistParseErrors(TestMixinStreamHLS, unittest.TestCase):
         self.close()
         self.await_close()
         assert mock_log.warning.mock_calls == [
-            call("Failed to reload playlist: Missing #EXTM3U header"),
-            call("Failed to reload playlist: Missing #EXTM3U header"),
+            call("Reloading failed: Missing #EXTM3U header"),
+            call("Reloading failed: Missing #EXTM3U header"),
         ]
 
     @patch("streamlink.stream.hls.hls.parse_m3u8", Mock(return_value=FakePlaylist(is_master=True)))

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -213,7 +213,7 @@ class TestHLSStream(TestMixinStreamHLS, unittest.TestCase):
 # TODO: finally rewrite the segmented/HLS test setup using pytest and replace redundant setups with parametrization
 @patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))
 class TestHLSStreamPlaylistReloadDiscontinuity(TestMixinStreamHLS, unittest.TestCase):
-    @patch("streamlink.stream.hls.hls.log")
+    @patch("streamlink.stream.segmented.polling.log")
     def test_no_discontinuity(self, mock_log: Mock):
         segments = self.subject([
             Playlist(0, [Segment(0), Segment(1)]),
@@ -226,7 +226,7 @@ class TestHLSStreamPlaylistReloadDiscontinuity(TestMixinStreamHLS, unittest.Test
         assert all(self.called(s) for s in segments.values())
         assert mock_log.warning.call_args_list == []
 
-    @patch("streamlink.stream.hls.hls.log")
+    @patch("streamlink.stream.segmented.polling.log")
     def test_discontinuity_single_segment(self, mock_log: Mock):
         segments = self.subject([
             Playlist(0, [Segment(0), Segment(1)]),
@@ -243,7 +243,7 @@ class TestHLSStreamPlaylistReloadDiscontinuity(TestMixinStreamHLS, unittest.Test
             call("Skipped segment 7 after playlist reload. This is unsupported and will result in incoherent output data."),
         ]
 
-    @patch("streamlink.stream.hls.hls.log")
+    @patch("streamlink.stream.segmented.polling.log")
     def test_discontinuity_multiple_segments(self, mock_log: Mock):
         segments = self.subject([
             Playlist(0, [Segment(0), Segment(1)]),

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -276,7 +276,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
     def get_session(self, options=None, *args, **kwargs):
         return super().get_session({**self.OPTIONS, **(options or {})}, *args, **kwargs)
 
-    def test_segment_queue_timing_threshold_reached(self) -> None:
+    def test_queue_deadline_reached(self) -> None:
         self.subject(
             start=False,
             playlists=[
@@ -290,13 +290,13 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
         with (
             freezegun.freeze_time(EPOCH) as frozen_time,
-            patch("streamlink.stream.hls.hls.log") as mock_log,
+            patch("streamlink.stream.segmented.polling.log") as mock_log,
         ):
             self.start()
 
             assert worker.handshake_reload.wait_ready(1), "Loads playlist for the first time"
             assert worker.playlist_sequence == -1, "Initial sequence number"
-            assert worker.playlist_sequence_last == EPOCH, "Sets the initial last queue time"
+            assert worker._queue_last == EPOCH, "Sets the initial last queue time"
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
@@ -304,8 +304,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #1"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
-            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Updates the last queue time"
-            assert worker.playlist_targetduration == 5.0
+            assert worker._queue_last == EPOCH + ONE_SECOND, "Updates the last queue time"
+            assert worker.get_duration() == 5.0
 
             # trigger next reload when the target duration has passed
             frozen_time.tick(targetduration)
@@ -314,8 +314,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #2"
             assert worker.playlist_sequence == 2, "Updates the sequence number again"
-            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND + targetduration, "Updates the last queue time again"
-            assert worker.playlist_targetduration == 5.0
+            assert worker._queue_last == EPOCH + ONE_SECOND + targetduration, "Updates the last queue time again"
+            assert worker.get_duration() == 5.0
 
             for num in range(3, 6):
                 # trigger next reload when the target duration has passed
@@ -325,8 +325,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() call #{num}"
                 assert worker.playlist_sequence == 2, "Sequence number is unchanged"
-                assert worker.playlist_sequence_last == EPOCH + ONE_SECOND + targetduration, "Last queue time is unchanged"
-                assert worker.playlist_targetduration == 5.0
+                assert worker._queue_last == EPOCH + ONE_SECOND + targetduration, "Last queue time is unchanged"
+                assert worker.get_duration() == 5.0
 
             assert mock_log.warning.call_args_list == []
 
@@ -338,9 +338,9 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.await_read(read_all=True)
             self.await_close(1)
 
-            assert mock_log.warning.call_args_list == [call("No new segments in playlist for more than 15.00s. Stopping...")]
+            assert mock_log.warning.call_args_list == [call("No new segments for more than 15.00s. Stopping...")]
 
-    def test_segment_queue_timing_threshold_reached_ignored(self) -> None:
+    def test_queue_deadline_reached_ignored(self) -> None:
         segments = self.subject(
             start=False,
             options={"hls-segment-queue-threshold": 0},
@@ -357,7 +357,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_reload.wait_ready(1), "Loads playlist for the first time"
             assert worker.playlist_sequence == -1, "Initial sequence number"
-            assert worker.playlist_sequence_last == EPOCH, "Sets the initial last queue time"
+            assert worker._queue_last == EPOCH, "Sets the initial last queue time"
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
@@ -365,8 +365,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at first wait() call"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
-            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Updates the last queue time"
-            assert worker.playlist_targetduration == 5.0
+            assert worker._queue_last == EPOCH + ONE_SECOND, "Updates the last queue time"
+            assert worker.get_duration() == 5.0
             assert self.await_read() == self.content(segments)
 
             # keep reloading a couple of times
@@ -377,7 +377,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() #{num + 1}"
                 assert worker.playlist_sequence == 1, "Sequence number is unchanged"
-                assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
+                assert worker._queue_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
 
         assert self.thread.data == [], "No new data"
         assert worker.is_alive()
@@ -385,7 +385,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
         # make stream end gracefully to avoid any unnecessary thread blocking
         self.thread.reader.writer.put(None)
 
-    def test_segment_queue_timing_threshold_reached_min(self) -> None:
+    def test_queue_deadline_reached_min(self) -> None:
         self.subject(
             start=False,
             playlists=[
@@ -398,13 +398,13 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
         with (
             freezegun.freeze_time(EPOCH) as frozen_time,
-            patch("streamlink.stream.hls.hls.log") as mock_log,
+            patch("streamlink.stream.segmented.polling.log") as mock_log,
         ):
             self.start()
 
             assert worker.handshake_reload.wait_ready(1), "Loads playlist for the first time"
             assert worker.playlist_sequence == -1, "Initial sequence number"
-            assert worker.playlist_sequence_last == EPOCH, "Sets the initial last queue time"
+            assert worker._queue_last == EPOCH, "Sets the initial last queue time"
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
@@ -412,8 +412,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #1"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
-            assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Updates the last queue time"
-            assert worker.playlist_targetduration == 1.0
+            assert worker._queue_last == EPOCH + ONE_SECOND, "Updates the last queue time"
+            assert worker.get_duration() == 1.0
 
             for num in range(2, 7):
                 # trigger next reload when the target duration has passed
@@ -423,8 +423,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() call #{num}"
                 assert worker.playlist_sequence == 1, "Sequence number is unchanged"
-                assert worker.playlist_sequence_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
-                assert worker.playlist_targetduration == 1.0
+                assert worker._queue_last == EPOCH + ONE_SECOND, "Last queue time is unchanged"
+                assert worker.get_duration() == 1.0
 
             assert mock_log.warning.call_args_list == []
 
@@ -433,7 +433,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.await_playlist_wait(1)
             self.await_reload(1)
 
-            assert mock_log.warning.call_args_list == [call("No new segments in playlist for more than 5.00s. Stopping...")]
+            assert mock_log.warning.call_args_list == [call("No new segments for more than 5.00s. Stopping...")]
 
     def test_playlist_reload_offset(self) -> None:
         segments = self.subject(
@@ -1033,7 +1033,7 @@ class TestHlsReloadTime(TestMixinStreamHLS, unittest.TestCase):
 
 @patch("streamlink.stream.hls.hls.log")
 @patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))
-@patch("streamlink.stream.hls.hls.HLSStreamWorker._segment_queue_timing_threshold_reached", Mock(return_value=False))
+@patch("streamlink.stream.hls.hls.HLSStreamWorker.check_queue_deadline", Mock(return_value=False))
 class TestHlsPlaylistParseErrors(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = EventedWriterHLSStream
 

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -300,7 +300,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
-            self.await_playlist_reload(1)
+            self.await_reload(1)
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #1"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
@@ -310,7 +310,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             # trigger next reload when the target duration has passed
             frozen_time.tick(targetduration)
             self.await_playlist_wait(1)
-            self.await_playlist_reload(1)
+            self.await_reload(1)
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #2"
             assert worker.playlist_sequence == 2, "Updates the sequence number again"
@@ -321,7 +321,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
                 # trigger next reload when the target duration has passed
                 frozen_time.tick(targetduration)
                 self.await_playlist_wait(1)
-                self.await_playlist_reload(1)
+                self.await_reload(1)
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() call #{num}"
                 assert worker.playlist_sequence == 2, "Sequence number is unchanged"
@@ -333,7 +333,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             # trigger next reload when the target duration has passed
             frozen_time.tick(targetduration)
             self.await_playlist_wait(1)
-            self.await_playlist_reload(1)
+            self.await_reload(1)
 
             self.await_read(read_all=True)
             self.await_close(1)
@@ -361,7 +361,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
-            self.await_playlist_reload(1)
+            self.await_reload(1)
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at first wait() call"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
@@ -373,7 +373,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             for num in range(10):
                 frozen_time.tick(targetduration)
                 self.await_playlist_wait(1)
-                self.await_playlist_reload(1)
+                self.await_reload(1)
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() #{num + 1}"
                 assert worker.playlist_sequence == 1, "Sequence number is unchanged"
@@ -408,7 +408,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
 
             # first playlist reload has taken one second
             frozen_time.tick(ONE_SECOND)
-            self.await_playlist_reload(1)
+            self.await_reload(1)
 
             assert worker.handshake_wait.wait_ready(1), "Arrives at wait() call #1"
             assert worker.playlist_sequence == 1, "Updates the sequence number"
@@ -419,7 +419,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
                 # trigger next reload when the target duration has passed
                 frozen_time.tick(targetduration)
                 self.await_playlist_wait(1)
-                self.await_playlist_reload(1)
+                self.await_reload(1)
 
                 assert worker.handshake_wait.wait_ready(1), f"Arrives at wait() call #{num}"
                 assert worker.playlist_sequence == 1, "Sequence number is unchanged"
@@ -431,7 +431,7 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             # trigger next reload when the target duration has passed
             frozen_time.tick(targetduration)
             self.await_playlist_wait(1)
-            self.await_playlist_reload(1)
+            self.await_reload(1)
 
             assert mock_log.warning.call_args_list == [call("No new segments in playlist for more than 5.00s. Stopping...")]
 
@@ -453,12 +453,12 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.start()
 
             assert worker.handshake_reload.wait_ready(1), "Arrives at initial playlist reload"
-            assert worker.playlist_reload_last == EPOCH, "Sets the initial value of the last reload time"
+            assert worker._reload_last == EPOCH, "Sets the initial value of the last reload time"
 
             # adjust clock and reload playlist: let it take one second
-            frozen_time.move_to(worker.playlist_reload_last + ONE_SECOND)
-            self.await_playlist_reload()
-            assert worker.playlist_reload_time == 5.0, "Uses the playlist's targetduration as reload time"
+            frozen_time.move_to(worker._reload_last + ONE_SECOND)
+            self.await_reload()
+            assert worker._reload_time == 5.0, "Uses the playlist's targetduration as reload time"
 
             # time_completed = 00:00:01; time_elapsed = 1s
             assert worker.handshake_wait.wait_ready(1), "Arrives at first wait() call"
@@ -468,13 +468,13 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.await_playlist_wait()
 
             assert worker.handshake_reload.wait_ready(1), "Arrives at second playlist reload"
-            assert worker.playlist_reload_last == EPOCH + targetduration, \
+            assert worker._reload_last == EPOCH + targetduration, \
                 "Last reload time is the sum of reload+wait time (=targetduration)"  # fmt: skip
 
             # adjust clock and reload playlist: let it exceed targetduration by two seconds
-            frozen_time.move_to(worker.playlist_reload_last + targetduration + ONE_SECOND * 2)
-            self.await_playlist_reload()
-            assert worker.playlist_reload_time == 5.0, "Uses the playlist's targetduration as reload time"
+            frozen_time.move_to(worker._reload_last + targetduration + ONE_SECOND * 2)
+            self.await_reload()
+            assert worker._reload_time == 5.0, "Uses the playlist's targetduration as reload time"
 
             # time_completed = 00:00:12; time_elapsed = 7s (exceeded 5s targetduration)
             assert worker.handshake_wait.wait_ready(1), "Arrives at second wait() call"
@@ -484,13 +484,13 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.await_playlist_wait()
 
             assert worker.handshake_reload.wait_ready(1), "Arrives at third playlist reload"
-            assert worker.playlist_reload_last == EPOCH + targetduration * 2 + ONE_SECOND * 2, \
+            assert worker._reload_last == EPOCH + targetduration * 2 + ONE_SECOND * 2, \
                 "Sets last reload time to current time when reloading took too long (changes the interval)"  # fmt: skip
 
             # adjust clock and reload playlist: let it take one second again
-            frozen_time.move_to(worker.playlist_reload_last + ONE_SECOND)
-            self.await_playlist_reload()
-            assert worker.playlist_reload_time == 5.0, "Uses the playlist's targetduration as reload time"
+            frozen_time.move_to(worker._reload_last + ONE_SECOND)
+            self.await_reload()
+            assert worker._reload_time == 5.0, "Uses the playlist's targetduration as reload time"
 
             # time_completed = 00:00:13; time_elapsed = 1s
             assert worker.handshake_wait.wait_ready(1), "Arrives at third wait() call"
@@ -500,13 +500,13 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.await_playlist_wait()
 
             assert worker.handshake_reload.wait_ready(1), "Arrives at fourth playlist reload"
-            assert worker.playlist_reload_last == EPOCH + targetduration * 3 + ONE_SECOND * 2, \
+            assert worker._reload_last == EPOCH + targetduration * 3 + ONE_SECOND * 2, \
                 "Last reload time is the sum of reload+wait time (=targetduration) of the changed interval"  # fmt: skip
 
             # adjust clock and reload playlist: simulate no fetch+processing delay
-            frozen_time.move_to(worker.playlist_reload_last)
-            self.await_playlist_reload()
-            assert worker.playlist_reload_time == 5.0, "Uses the playlist's targetduration as reload time"
+            frozen_time.move_to(worker._reload_last)
+            self.await_reload()
+            assert worker._reload_time == 5.0, "Uses the playlist's targetduration as reload time"
 
             # time_completed = 00:00:17; time_elapsed = 0s
             assert worker.handshake_wait.wait_ready(1), "Arrives at fourth wait() call"
@@ -516,11 +516,11 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             self.await_playlist_wait()
 
             assert worker.handshake_reload.wait_ready(1), "Arrives at fifth playlist reload"
-            assert worker.playlist_reload_last == EPOCH + targetduration * 4 + ONE_SECOND * 2, \
+            assert worker._reload_last == EPOCH + targetduration * 4 + ONE_SECOND * 2, \
                 "Last reload time is the sum of reload+wait time (no delay)"  # fmt: skip
 
             # adjusting the clock is not needed anymore
-            self.await_playlist_reload()
+            self.await_reload()
             assert self.await_read(read_all=True) == self.content(segments)
             self.await_close()
             assert worker.playlist_end == 4, "Stream has ended"
@@ -938,7 +938,7 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
 
 
 @patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))
-class TestHlsPlaylistReloadTime(TestMixinStreamHLS, unittest.TestCase):
+class TestHlsReloadTime(TestMixinStreamHLS, unittest.TestCase):
     segments = [
         Segment(0, duration=11),
         Segment(1, duration=7),
@@ -961,72 +961,72 @@ class TestHlsPlaylistReloadTime(TestMixinStreamHLS, unittest.TestCase):
         super().subject(*args, start=False, **kwargs)
 
         # mock the worker thread's _playlist_reload_time method, so that the main thread can wait on its call
-        playlist_reload_time_called = Event()
-        orig_playlist_reload_time = self.thread.reader.worker._playlist_reload_time
+        get_reload_time_called = Event()
+        orig_get_reload_time = self.thread.reader.worker._get_reload_time
 
-        def mocked_playlist_reload_time(*args, **kwargs):
-            playlist_reload_time_called.set()
-            return orig_playlist_reload_time(*args, **kwargs)
+        def mocked_get_reload_time(*args2, **kwargs2):
+            get_reload_time_called.set()
+            return orig_get_reload_time(*args2, **kwargs2)
 
         # immediately kill the writer thread as we don't need it and don't want to wait for its queue polling to end
         def mocked_queue_get():
             return None
 
         with (
-            patch.object(self.thread.reader.worker, "_playlist_reload_time", side_effect=mocked_playlist_reload_time),
+            patch.object(self.thread.reader.worker, "_get_reload_time", side_effect=mocked_get_reload_time),
             patch.object(self.thread.reader.writer, "_queue_get", side_effect=mocked_queue_get),
         ):
             self.start()
 
-            if not playlist_reload_time_called.wait(timeout=5):  # pragma: no cover
-                raise RuntimeError("Missing _playlist_reload_time() call")
+            if not get_reload_time_called.wait(timeout=5):  # pragma: no cover
+                raise RuntimeError("Missing _get_reload_time() call")
 
             # wait for the worker thread to terminate, so that deterministic assertions can be done about the reload time
             self.thread.reader.worker.join()
 
-            return self.thread.reader.worker.playlist_reload_time
+            return self.thread.reader.worker._reload_time
 
-    def test_hls_playlist_reload_time_default(self):
+    def test_default(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="default")
         assert time == 4, "default sets the reload time to the playlist's target duration"
 
-    def test_hls_playlist_reload_time_segment(self):
+    def test_segment(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="segment")
         assert time == 3, "segment sets the reload time to the playlist's last segment"
 
-    def test_hls_playlist_reload_time_segment_no_segments(self):
+    def test_segment_no_segments(self):
         time = self.subject([Playlist(0, [], end=True, targetduration=4)], reload_time="segment")
         assert time == 4, "segment sets the reload time to the targetduration if no segments are available"
 
-    def test_hls_playlist_reload_time_segment_no_segments_no_targetduration(self):
+    def test_segment_no_segments_no_targetduration(self):
         time = self.subject([Playlist(0, [], end=True, targetduration=0)], reload_time="segment")
         assert time == 6, "sets reload time to 6 seconds when no segments and no targetduration are available"
 
-    def test_hls_playlist_reload_time_live_edge(self):
+    def test_live_edge(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="live-edge")
         assert time == 8, "live-edge sets the reload time to the sum of the number of segments of the live-edge"
 
-    def test_hls_playlist_reload_time_live_edge_no_segments(self):
+    def test_live_edge_no_segments(self):
         time = self.subject([Playlist(0, [], end=True, targetduration=4)], reload_time="live-edge")
         assert time == 4, "live-edge sets the reload time to the targetduration if no segments are available"
 
-    def test_hls_playlist_reload_time_live_edge_no_segments_no_targetduration(self):
+    def test_live_edge_no_segments_no_targetduration(self):
         time = self.subject([Playlist(0, [], end=True, targetduration=0)], reload_time="live-edge")
         assert time == 6, "sets reload time to 6 seconds when no segments and no targetduration are available"
 
-    def test_hls_playlist_reload_time_number(self):
+    def test_number(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="2")
         assert time == 2, "number values override the reload time"
 
-    def test_hls_playlist_reload_time_number_invalid(self):
+    def test_number_invalid(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="0")
         assert time == 4, "invalid number values set the reload time to the playlist's targetduration"
 
-    def test_hls_playlist_reload_time_no_target_duration(self):
+    def test_no_target_duration(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=0)], reload_time="default")
         assert time == 8, "uses the live-edge sum if the playlist is missing the targetduration data"
 
-    def test_hls_playlist_reload_time_no_data(self):
+    def test_no_data(self):
         time = self.subject([Playlist(0, [], end=True, targetduration=0)], reload_time="default")
         assert time == 6, "sets reload time to 6 seconds when no data is available"
 


### PR DESCRIPTION
Resolves #6340

Opening this as a draft for now, as it's WIP and unfinished. This simply moves stuff into a new intermediate abstract base class, `PollingSegmentedStreamWorker`, and it simplifies attribute and method names.

I currently don't know if this requires further changes, as I haven't had a look at the `DASHStreamWorker` yet, which is supposed to utilize the shared code here in the future.

Another thing that's missing, but could be changed later, is renaming the `hls-segment-queue-threshold` session option and CLI argument, as it's now part of the shared base class. A good opportunity for choosing a better name, e.g. `segmented-queue-deadline` or something like that.