### PR TITLE
plugins: fix broken matcher capture groups

### DIFF
--- a/src/streamlink/plugins/abematv.py
+++ b/src/streamlink/plugins/abematv.py
@@ -222,9 +222,8 @@ class AbemaTV(Plugin):
         jsonres = self.session.http.json(res, schema=self._USER_SCHEMA)
         self.usertoken = jsonres["token"]  # for authorzation
 
-        matchresult = self.match
-        if matchresult.group("onair"):
-            onair = matchresult.group("onair")
+        if self.matches["onair"]:
+            onair = self.match["onair"]
             if onair == "news-global":
                 self._CHANNEL = update_qsd(self._CHANNEL, {"division": "1"})
             res = self.session.http.get(self._CHANNEL)
@@ -236,14 +235,14 @@ class AbemaTV(Plugin):
             else:
                 raise NoStreamsError
             playlisturl = channel["playback"]["hls"]
-        elif matchresult.group("episode"):
-            episode = matchresult.group("episode")
+        elif self.matches["episode"]:
+            episode = self.match["episode"]
             if not self._is_playable("episode", episode):
                 log.error("Premium stream is not playable")
                 return {}
             playlisturl = self._PRGM3U8.format(episode)
-        elif matchresult.group("slots"):
-            slots = matchresult.group("slots")
+        elif self.matches["slots"]:
+            slots = self.match["slots"]
             if not self._is_playable("slots", slots):
                 log.error("Premium stream is not playable")
                 return {}

--- a/src/streamlink/plugins/ard_mediathek.py
+++ b/src/streamlink/plugins/ard_mediathek.py
@@ -56,7 +56,7 @@ class ARDMediathek(Plugin):
         )
         if not data_json:
             data_json = self.session.http.get(
-                self._URL_API.format(item=self.match.group("id_live") or self.match.group("id_video")),
+                self._URL_API.format(item=self.match["id_live"] if self.matches["live"] else self.match["id_video"]),
                 params={
                     "devicetype": "pc",
                     "embedded": "false",

--- a/src/streamlink/plugins/bbciplayer.py
+++ b/src/streamlink/plugins/bbciplayer.py
@@ -205,10 +205,8 @@ class BBCiPlayer(Plugin):
             log.error("Could not authenticate, check your username and password")
             return
 
-        episode_id = self.match.group("episode_id")
-        channel_name = self.match.group("channel_name")
-
-        if episode_id:
+        if self.matches["episode"]:
+            episode_id = self.match["episode_id"]
             log.debug(f"Loading streams for episode: {episode_id}")
             vpid = self.find_vpid(self.url)
             if vpid:
@@ -216,7 +214,9 @@ class BBCiPlayer(Plugin):
                 yield from self.mediaselector(vpid)
             else:
                 log.error(f"Could not find VPID for episode {episode_id}")
-        elif channel_name:
+
+        elif self.matches["live"]:
+            channel_name = self.match["channel_name"]
             log.debug(f"Loading stream for live channel: {channel_name}")
             if self.get_option("hd"):
                 tvip = f"{self.find_tvip(self.url, master=True)}_hd"

--- a/src/streamlink/plugins/picarto.py
+++ b/src/streamlink/plugins/picarto.py
@@ -167,12 +167,12 @@ class Picarto(Plugin):
     def _get_streams(self):
         m = self.match.groupdict()
 
-        if m["po_vod_id"] or m["vod_id"]:
+        if m.get("po_vod_id") or m.get("vod_id"):
             log.debug("Type=VOD")
-            return self.get_vod(m["po_vod_id"] or m["vod_id"])
-        elif m["po_user"] or m["user"]:
+            return self.get_vod(m.get("po_vod_id") or m.get("vod_id"))
+        elif m.get("po_user") or m.get("user"):
             log.debug("Type=Live")
-            return self.get_live(m["po_user"] or m["user"])
+            return self.get_live(m.get("po_user") or m.get("user"))
 
 
 __plugin__ = Picarto

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -135,7 +135,7 @@ class Streann(Plugin):
         return data["token"]
 
     def _get_streams(self):
-        if not self.matches[0]:
+        if not self.matches["streann"]:
             self._domain = urlparse(self.url).netloc
             iframes = self.session.http.get(
                 self.url,


### PR DESCRIPTION
Verbose plugin matcher regexes of some plugins were split into multiple simple matchers in 742988f2d57f1807bea2210a1d721c632c1d7b75.

Some regex capture group references however were not updated, resulting in `IndexError` being raised.

----

Fixes #6366 
See #6363, #6364 

Here's the list of all updated plugins in 742988f2d57f1807bea2210a1d721c632c1d7b75 and their current number of `@pluginmatcher`s, with all `self.match`/`self.matches` references (for accessing matchers and their regex capture groups). 

```
$ for file in (git show --format="" --name-only 742988f2d57f1807bea2210a1d721c632c1d7b75 -- src/); echo $file; grep -c -F '@pluginmatcher' $file; grep -F 'self.match' $file; echo; end
src/streamlink/plugins/abematv.py
3
        if self.matches["onair"]:
            onair = self.match["onair"]
        elif self.matches["episode"]:
            episode = self.match["episode"]
        elif self.matches["slots"]:
            slots = self.match["slots"]

src/streamlink/plugins/adultswim.py
1
        url_type, show_name, episode_name = self.match.groups()

src/streamlink/plugins/albavision.py
13

src/streamlink/plugins/ard_mediathek.py
2
                self._URL_API.format(item=self.match["id_live"] if self.matches["live"] else self.match["id_video"]),

src/streamlink/plugins/bbciplayer.py
2
        if self.matches["episode"]:
            episode_id = self.match["episode_id"]
        elif self.matches["live"]:
            channel_name = self.match["channel_name"]

src/streamlink/plugins/cdnbg.py
8

src/streamlink/plugins/cinergroup.py
5

src/streamlink/plugins/dailymotion.py
2
        if self.matches["user"]:
            media_id = self._get_media_id(self.match["user"])
            media_id = self.match["media_id"]

src/streamlink/plugins/mediavitrina.py
4

src/streamlink/plugins/picarto.py
4
        m = self.match.groupdict()

src/streamlink/plugins/streann.py
6
        if not self.matches["streann"]:

src/streamlink/plugins/swisstxt.py
1
        site = self.match.group(1) or self.match.group(2)

src/streamlink/plugins/tf1.py
3
        if self.matches["live"]:
            channel = self.match["live"]
        elif self.matches["stream"]:
            channel = self.match["stream"]
        elif self.matches["lci"]:

src/streamlink/plugins/trovo.py
1
        url_data = self.match.groupdict()

src/streamlink/plugins/turkuvaz.py
9

src/streamlink/plugins/tv4play.py
2
            self.video_id = self.match.group("video_id")

```

Plugins with only one matcher, or plugins which don't look up regex capture groups could be ignored. Other ones had to be investigated.

- **abematv.py** (fixed via self.matches check)
- **adultswim.py** (single matcher)
- **albavision.py** (no capture groups)
- **ard_mediathek.py** (fixed via self.matches check)
- **bbciplayer.py** (fixed via self.matches check)
- **cdnbg.py** (no capture groups)
- **cinergroup.py** (no capture groups)
- **dailymotion.py** (fixed in earlier commit)
- **mediavitrina.py** (no capture groups)
- **picarto.py** (fixed by accessing dict.get())
- **streann.py** (fixed incorrect matcher id/name)
- **swisstxt.py** (single matcher)
- **tf1.py** (was already fixed)
- **trovo.py** (single matcher)
- **turkuvaz.py** (no capture groups)
- **tv4play.py** (both matcher regexes have the same group name)
