### PR TITLE
plugins.kick: fix 403 error and VOD URL matcher

### DIFF
--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -31,7 +31,7 @@ class KickAdapter(SSLContextAdapter):
 )
 @pluginmatcher(
     name="vod",
-    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/video/(?P<vod>[^/?]+)"),
+    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/(?:video/|[^/]+/videos/)(?P<vod>[^/?]+)"),
 )
 @pluginmatcher(
     name="clip",
@@ -46,6 +46,7 @@ class Kick(Plugin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.session.http.mount("https://kick.com/", KickAdapter())
+        self.session.http.headers.update({"Sec-Fetch-User": "?1"})
 
     def _get_token(self):
         res = self.session.http.get(self._URL_TOKEN, raise_for_status=False)

--- a/tests/plugins/test_kick.py
+++ b/tests/plugins/test_kick.py
@@ -8,5 +8,6 @@ class TestPluginCanHandleUrlKick(PluginCanHandleUrl):
     should_match_groups = [
         (("live", "https://kick.com/LIVE_CHANNEL"), {"channel": "LIVE_CHANNEL"}),
         (("vod", "https://kick.com/video/VIDEO_ID"), {"vod": "VIDEO_ID"}),
+        (("vod", "https://kick.com/VIDEO_CHANNEL/videos/VIDEO_ID"), {"vod": "VIDEO_ID"}),
         (("clip", "https://kick.com/CLIP_CHANNEL?clip=CLIP_ID"), {"channel": "CLIP_CHANNEL", "clip": "CLIP_ID"}),
     ]


### PR DESCRIPTION
Closes #6325

See https://github.com/streamlink/streamlink/pull/6325#issuecomment-2543143217 (credits to @Hakkin)

This seems to fix the 403 response just fine, so let's add the header to the entire HTTP session when initializing the plugin. Alternatively, the header could be added by the custom `KickAdapter`, but then the adapter would also need to be mounted on other (sub-)domains where the HLS stream data is accessed from. Or it could be set on all API requests and HLSStream instances, but that would be a bit redundant and therefore unnecessary.

In addition to fixing the 403 responses, this PR also fixes the VOD URL matcher. Surprisingly though, some VODs I checked still returned 403 when accessing the HLS playlist, which made me believe that the header didn't work. Turns out that those VODs are not accessible on their site either.