### PR TITLE
plugins.twitch: update access token debug log msg

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -288,9 +288,11 @@ class UsherService:
                     "hide_ads": bool,
                     "server_ads": bool,
                     "show_ads": bool,
+                    "subscriber": bool,
+                    "turbo": bool,
                 },
             ).validate(extra_params)
-            log.debug(f"{extra_params_debug!r}")
+            log.debug(" ".join(f"{key}={value!r}" for key, value in extra_params_debug.items()))
 
         return self._create_url(f"/api/channel/hls/{channel.lower()}.m3u8", **extra_params)
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -646,16 +646,42 @@ class TestUsherService:
         args = param.get("args", ("twitch",))
 
         token = {
-            "expires": 9876543210,
-            "channel": "twitch",
-            "channel_id": 123,
-            "user_id": 456,
-            "user_ip": "127.0.0.1",
             "adblock": False,
+            "authorization": {
+                "forbidden": False,
+                "reason": "",
+            },
+            "blackout_enabled": False,
+            "channel": "CHANNEL",
+            "channel_id": 1234567890,
+            "chansub": {
+                "restricted_bitrates": [],
+                "view_until": 1924905600,
+            },
+            "ci_gb": False,
             "geoblock_reason": "",
+            "device_id": None,
+            "expires": 1736957801,
+            "extended_history_allowed": False,
+            "game": "",
             "hide_ads": False,
+            "https_required": True,
+            "mature": False,
+            "partner": False,
+            "platform": "web",
+            "player_type": "embed",
+            "private": {
+                "allowed_to_view": True,
+            },
+            "privileged": False,
+            "role": "",
             "server_ads": True,
             "show_ads": True,
+            "subscriber": False,
+            "turbo": False,
+            "user_id": 1234,
+            "user_ip": "127.0.0.1",
+            "version": 2,
         }
 
         return getattr(plugin.usher, service)(*args, token=json.dumps(token), sig="tokensignature")
@@ -670,7 +696,10 @@ class TestUsherService:
                     (
                         "streamlink.plugins.twitch",
                         "debug",
-                        "{'adblock': False, 'geoblock_reason': '', 'hide_ads': False, 'server_ads': True, 'show_ads': True}",
+                        (
+                            "adblock=False geoblock_reason='' hide_ads=False server_ads=True show_ads=True"
+                            + " subscriber=False turbo=False"
+                        ),
                     ),
                 ],
                 id="channel",


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/discussions/6400#discussioncomment-11844989

Since I don't have any channel or turbo subscriptions on Twitch, could someone else please quickly check this PR branch and see if the `subscriber` and `turbo` values are actually correct when authenticating?
https://streamlink.github.io/cli/plugins/twitch.html#authentication

This PR also changes the debug message format in order to keep it a bit shorter...

master
```
$ streamlink -l debug twitch.tv/gorgc | grep -F plugins.twitch
[plugins.twitch][debug] Getting live HLS streams for gorgc
[plugins.twitch][debug] {'adblock': False, 'geoblock_reason': '', 'hide_ads': False, 'server_ads': True, 'show_ads': True}
```

PR
```
$ streamlink -l debug twitch.tv/gorgc | grep -F plugins.twitch
[plugins.twitch][debug] Getting live HLS streams for gorgc
[plugins.twitch][debug] adblock=False geoblock_reason='' hide_ads=False server_ads=True show_ads=True subscriber=False turbo=False
```