### PR TITLE
tell twitch.tv we can eat HEVC and AV1

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -264,12 +264,15 @@ class UsherService:
     def _create_url(self, endpoint, **extra_params):
         url = f"https://usher.ttvnw.net{endpoint}"
         params = {
-            "player": "twitchweb",
-            "p": int(random() * 999999),
-            "type": "any",
-            "allow_source": "true",
             "allow_audio_only": "true",
+            "allow_source": "true",
             "allow_spectre": "false",
+
+            "p": int(random() * 999999),
+            "player": "twitchweb",
+
+            "type": "any",
+            "supported_codecs": "av1,h265,h264,mp4a",
         }
         params.update(extra_params)
 
@@ -295,7 +298,7 @@ class UsherService:
         return self._create_url(f"/api/channel/hls/{channel.lower()}.m3u8", **extra_params)
 
     def video(self, video_id: str, **extra_params) -> str:
-        return self._create_url(f"/vod/{video_id}", **extra_params)
+        return self._create_url(f"/vod/{video_id}.m3u8", **extra_params)
 
 
 class TwitchAPI:


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink

If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
https://streamlink.github.io/latest/developing.html#validating-changes

Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.

Thank you very much!
-->

Example VOD:
https://www.twitch.tv/videos/2337242283

Before patch the best stream we are served was `720p60`
```m3u8
#EXTM3U
#EXT-X-TWITCH-INFO:ORIGIN="s3",B="false",REGION="NA",USER-IP="73.167.119.148",SERVING-ID="e08b71128c5f49548d01545ec44db219",CLUSTER="metro_vod",USER-COUNTRY="US",MANIFEST-CLUSTER="metro_vod"
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="720p60",NAME="720p60",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=3726985,CODECS="avc1.640020,mp4a.40.2",RESOLUTION=1280x720,VIDEO="720p60",FRAME-RATE=60.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/720p60/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="480p30",NAME="480p",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=1204429,CODECS="avc1.64001F,mp4a.40.2",RESOLUTION=852x480,VIDEO="480p30",FRAME-RATE=30.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/480p30/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="360p30",NAME="360p",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=704630,CODECS="avc1.64001E,mp4a.40.2",RESOLUTION=640x360,VIDEO="360p30",FRAME-RATE=30.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/360p30/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="audio_only",NAME="Audio Only",AUTOSELECT=NO,DEFAULT=NO
#EXT-X-STREAM-INF:BANDWIDTH=198788,CODECS="mp4a.40.2",VIDEO="audio_only"
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/audio_only/index-muted-FBQT3CBZHP.m3u8
```

After we are served an extra two higher resolution streams `1080p60` and `1440p60` that were encoded in HEVC (H.265)
```m3u8
#EXTM3U
#EXT-X-TWITCH-INFO:ORIGIN="s3",B="false",REGION="NA",USER-IP="73.167.119.148",SERVING-ID="952c33a0ed584ddfb2ad192779c260e7",CLUSTER="metro_vod",USER-COUNTRY="US",MANIFEST-CLUSTER="metro_vod"
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="chunked",NAME="1440p60",AUTOSELECT=NO,DEFAULT=NO
#EXT-X-STREAM-INF:BANDWIDTH=7229731,CODECS="hev1.1.2.L150.90.0.0.0.0.0,mp4a.40.2",RESOLUTION=2560x1440,VIDEO="chunked",FRAME-RATE=60.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/chunked/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="1080p60",NAME="1080p60",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=5229729,CODECS="hev1.1.2.L123.90.0.0.0.0.0,mp4a.40.2",RESOLUTION=1920x1080,VIDEO="1080p60",FRAME-RATE=60.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/1080p60/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="720p60",NAME="720p60",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=3726985,CODECS="avc1.640020,mp4a.40.2",RESOLUTION=1280x720,VIDEO="720p60",FRAME-RATE=60.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/720p60/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="480p30",NAME="480p",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=1204429,CODECS="avc1.64001F,mp4a.40.2",RESOLUTION=852x480,VIDEO="480p30",FRAME-RATE=30.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/480p30/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="360p30",NAME="360p",AUTOSELECT=YES,DEFAULT=YES
#EXT-X-STREAM-INF:BANDWIDTH=704630,CODECS="avc1.64001E,mp4a.40.2",RESOLUTION=640x360,VIDEO="360p30",FRAME-RATE=30.000
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/360p30/index-muted-FBQT3CBZHP.m3u8
#EXT-X-MEDIA:TYPE=VIDEO,GROUP-ID="audio_only",NAME="Audio Only",AUTOSELECT=NO,DEFAULT=NO
#EXT-X-STREAM-INF:BANDWIDTH=198788,CODECS="mp4a.40.2",VIDEO="audio_only"
https://dqrpb9wgowsf5.cloudfront.net/40ec7078b8966811c6fb_misterarther_45238830363_1735315234/audio_only/index-muted-FBQT3CBZHP.m3u8
```

