### PR TITLE
plugins.twitch: refactor Twitch._access_token()

### DIFF
--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -703,9 +703,7 @@ class TestTwitchAPIAccessToken:
 
     @pytest.fixture()
     def plugin(self, request: pytest.FixtureRequest, session: Streamlink):
-        options = Options()
-        for param in getattr(request, "param", {}):
-            options.set(*param)
+        options = Options(getattr(request, "param", {}))
 
         return Twitch(session, "https://twitch.tv/channelname", options)
 
@@ -750,7 +748,7 @@ class TestTwitchAPIAccessToken:
         ("plugin", "exp_headers", "exp_variables"),
         [
             (
-                [],
+                {},
                 {"Client-ID": TwitchAPI.CLIENT_ID},
                 {
                     "isLive": True,
@@ -761,22 +759,16 @@ class TestTwitchAPIAccessToken:
                 },
             ),
             (
-                [
-                    (
-                        "api-header",
-                        [
-                            ("Authorization", "invalid data"),
-                            ("Authorization", "OAuth 0123456789abcdefghijklmnopqrst"),
-                        ],
-                    ),
-                    (
-                        "access-token-param",
-                        [
-                            ("specialVariable", "specialValue"),
-                            ("playerType", "frontpage"),
-                        ],
-                    ),
-                ],
+                {
+                    "api-header": [
+                        ("Authorization", "invalid data"),
+                        ("Authorization", "OAuth 0123456789abcdefghijklmnopqrst"),
+                    ],
+                    "access-token-param": [
+                        ("specialVariable", "specialValue"),
+                        ("playerType", "frontpage"),
+                    ],
+                },
                 {
                     "Client-ID": TwitchAPI.CLIENT_ID,
                     "Authorization": "OAuth 0123456789abcdefghijklmnopqrst",
@@ -867,7 +859,9 @@ class TestTwitchAPIAccessToken:
         ("plugin", "mock"),
         [
             (
-                [("api-header", [("Authorization", "OAuth invalid-token")])],
+                {
+                    "api-header": [("Authorization", "OAuth invalid-token")],
+                },
                 {
                     "status_code": 401,
                     "json": {"error": "Unauthorized", "status": 401, "message": 'The "Authorization" token is invalid.'},
@@ -896,7 +890,9 @@ class TestTwitchAPIAccessToken:
         ("plugin", "mock"),
         [
             (
-                [("api-header", [("Authorization", "OAuth invalid-token")])],
+                {
+                    "api-header": [("Authorization", "OAuth invalid-token")],
+                },
                 {
                     "response_list": [
                         {

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -798,17 +798,33 @@ class TestTwitchAPIAccessToken:
 
     @pytest.mark.usefixtures("_assert_live")
     @pytest.mark.parametrize(
-        "mock",
+        ("plugin", "mock"),
         [
-            {
-                "json": {"data": {"streamPlaybackAccessToken": {"value": '{"channel":"foo"}', "signature": "sig"}}},
-            },
+            pytest.param(
+                {
+                    "force-client-integrity": False,
+                },
+                {
+                    "json": {"data": {"streamPlaybackAccessToken": {"value": '{"channel":"foo"}', "signature": "sig"}}},
+                },
+                id="no-force-client-integrity",
+            ),
+            pytest.param(
+                {
+                    "force-client-integrity": True,
+                },
+                {
+                    "json": {"data": {"streamPlaybackAccessToken": {"value": '{"channel":"foo"}', "signature": "sig"}}},
+                },
+                id="force-client-integrity",
+            ),
         ],
         indirect=True,
     )
     def test_live_success(self, plugin: Twitch, mock: rm.Mocker):
         data = plugin._access_token(True, "channelname")
         assert data == ("sig", '{"channel":"foo"}', [])
+        assert len(mock.request_history) == 1
 
     @pytest.mark.usefixtures("_assert_live")
     @pytest.mark.parametrize(
@@ -891,6 +907,7 @@ class TestTwitchAPIAccessToken:
         [
             (
                 {
+                    "force-client-integrity": False,
                     "api-header": [("Authorization", "OAuth invalid-token")],
                 },
                 {
@@ -908,7 +925,7 @@ class TestTwitchAPIAccessToken:
         ],
         indirect=True,
     )
-    def test_failed_integrity_check(self, plugin: Twitch, mock: rm.Mocker):
+    def test_integrity_check_not_forced(self, plugin: Twitch, mock: rm.Mocker):
         data = plugin._access_token(True, "channelname")
         assert data == ("sig", '{"channel":"foo"}', [])
         assert len(mock.request_history) == 2, "Always tries again on error, with integrity-token on second attempt"
@@ -922,6 +939,66 @@ class TestTwitchAPIAccessToken:
         assert headers["Authorization"] == "OAuth invalid-token"
         assert headers["Device-Id"] == "device-id"
         assert headers["Client-Integrity"] == "client-integrity-token"
+
+    @pytest.mark.usefixtures("_assert_live")
+    @pytest.mark.parametrize(
+        ("plugin", "mock"),
+        [
+            (
+                {
+                    "force-client-integrity": True,
+                    "api-header": [("Authorization", "OAuth invalid-token")],
+                },
+                {
+                    "response_list": [
+                        {
+                            "json": {"data": {"streamPlaybackAccessToken": {"value": '{"channel":"foo"}', "signature": "sig"}}},
+                        },
+                    ],
+                },
+            ),
+        ],
+        indirect=True,
+    )
+    def test_integrity_check_forced(self, plugin: Twitch, mock: rm.Mocker):
+        data = plugin._access_token(True, "channelname")
+        assert data == ("sig", '{"channel":"foo"}', [])
+        assert len(mock.request_history) == 1
+
+        headers: dict = mock.request_history[0]._request.headers
+        assert headers["Authorization"] == "OAuth invalid-token"
+        assert headers["Device-Id"] == "device-id"
+        assert headers["Client-Integrity"] == "client-integrity-token"
+
+    @pytest.mark.usefixtures("_assert_vod")
+    @pytest.mark.parametrize(
+        ("plugin", "mock"),
+        [
+            (
+                {
+                    "force-client-integrity": True,
+                    "api-header": [("Authorization", "OAuth invalid-token")],
+                },
+                {
+                    "response_list": [
+                        {
+                            "json": {"data": {"videoPlaybackAccessToken": {"value": '{"channel":"foo"}', "signature": "sig"}}},
+                        },
+                    ],
+                },
+            ),
+        ],
+        indirect=True,
+    )
+    def test_integrity_check_vod(self, plugin: Twitch, mock: rm.Mocker):
+        data = plugin._access_token(False, "vodid")
+        assert data == ("sig", '{"channel":"foo"}', [])
+        assert len(mock.request_history) == 1
+
+        headers: dict = mock.request_history[0]._request.headers
+        assert headers["Authorization"] == "OAuth invalid-token"
+        assert "Device-Id" not in headers
+        assert "Client-Integrity" not in headers
 
 
 class TestTwitchHLSMultivariantResponse:


### PR DESCRIPTION
A couple of code refactor commits.

The initial motivation for these changes was adding authentication debug log messages. But then I decided against adding this, as it's unnecessary. If the `Authorization` Twitch API HTTP header has an invalid value, acquiring an access token will fail with an error message that perfectly describes the error. No auth and valid auth data pass silently. We don't need to log this and the user's name. Doing this only bloats up the GQL access token request by also querying `VerifyEmail_CurrentUser` (the most sensible query I could find on their website) and doing additional error handling.

----

1. Refactor tests for easier test-setup of plugin options
2. Refactor logic for acquiring an access token and fix duplicate GQL requests for VOD when client-integrity token is forced
3. Refactor TwitchAPI class and fix validation schemas

I'm going to leave this open for a bit and have another look later some time, to ensure there's no mistake which I didn't spot yet...