### PR TITLE
tests: bump freezegun requirement to >=1.5.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ versioningit >=2.0.0,<4  # required for being able to run editable installs
 pytest >=8.0.0
 pytest-trio
 requests-mock
-freezegun >=1.0.0
+freezegun >=1.5.0
 
 # code-coverage
 pytest-cov


### PR DESCRIPTION
freezegun==1.5.0 fixes incompatibility issues with Python >=3.13, so make that the min required version

----

https://github.com/spulec/freezegun/commit/d75458f3f691d0c2c35559872716d0ebab738817

1.5.0 has been released almost a year ago on 2024-04-23, so bumping this test requirement shouldn't cause any issues for packagers