### PR TITLE
stream.ffmpegmux: fix logging format of cmd argv

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -219,7 +219,7 @@ class FFMPEGMuxer(StreamIO):
                 self._cmd.extend(["-metadata{0}".format(stream_id), datum])
 
         self._cmd.extend(["-f", ofmt, outpath])
-        log.debug("ffmpeg command: {0}".format(" ".join(self._cmd)))
+        log.debug(f"ffmpeg command: {self._cmd!r}")
 
         if session.options.get("ffmpeg-verbose-path"):
             self.errorlog = Path(session.options.get("ffmpeg-verbose-path")).expanduser().open("w")


### PR DESCRIPTION
Correctly log the command argument vector instead of a non-shlex concatenated command line string.

```
[stream.ffmpegmux][debug] ffmpeg command: ['/usr/bin/ffmpeg', '-y', '-nostats', '-loglevel', 'info', '-i', '/tmp/streamlinkpipe-1452919-1-6843', '-i', '/tmp/streamlinkpipe-1452919-2-7479', '-c:v', 'copy', '-c:a', 'copy', '-copyts', '-f', 'matroska', 'pipe:1']
```