### PR TITLE
docs: add FFmpeg to Linux AppImages

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -689,7 +689,7 @@ Linux AppImages
 
 **Contents**
 
-.. grid:: 2
+.. grid:: 3
     :padding: 0
     :class-container: grid-with-images
 
@@ -714,6 +714,17 @@ Linux AppImages
             :alt: Streamlink
 
         Streamlink |br| :sub:`and dependencies`
+
+    .. grid-item-card::
+        :padding: 3
+        :link: https://github.com/streamlink/FFmpeg-Builds
+        :link-alt: FFmpeg, required for muxing streams
+        :text-align: center
+
+        .. image:: _static/icon-ffmpeg.svg
+            :alt: FFmpeg
+
+        FFmpeg |br| :sub:`for muxing streams` |br| :sub:`(optional)`
 
 **How-To**
 


### PR DESCRIPTION
I've added secondary AppImage builds which bundle [Streamlink's FFmpeg Linux builds for both `x86_64` and `aarch64`](https://github.com/streamlink/FFmpeg-Builds):
- https://github.com/streamlink/streamlink-appimage/compare/7.1.2-1...dbfed5180690c3c0c9cd3dfc6f31285e9d0b235a
- https://github.com/streamlink/streamlink-appimage/actions/runs/12991168153

The current non-FFmpeg AppImages will be kept unless we'll see that these new ones will be preferred by users. FFmpeg is optional, and it's available on the user's distro in most cases anyway.

Apart from the file system access times, there shouldn't be an increase in loading time when using the AppImages with the bundled FFmpeg binary. The AppImage file size has grown from ~36MiB to ~83MiB (on `x86_64`).

With FFmpeg (`--ffmpeg-ffmpeg` is always set and its value relative to the AppImage dir, mounted or extracted)
```
$ ./dist/streamlink+ffmpeg-7.1.2-1-cp312-cp312-manylinux_2_28_x86_64.AppImage --no-config -l debug
[cli][debug] OS:         Linux-6.13.0-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.8
[cli][debug] OpenSSL:    OpenSSL 1.1.1k  FIPS 25 Mar 2021
[cli][debug] Streamlink: 7.1.2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.12.14
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.28.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  --no-config=True
[cli][debug]  --loglevel=debug
[cli][debug]  --ffmpeg-ffmpeg=/tmp/.mount_stream1e9duD/usr/bin/ffmpeg
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```

Without FFmpeg (no changes)
```
$ ./dist/streamlink-7.1.2-1-cp312-cp312-manylinux_2_28_x86_64.AppImage --no-config -l debug
[cli][debug] OS:         Linux-6.13.0-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.8
[cli][debug] OpenSSL:    OpenSSL 1.1.1k  FIPS 25 Mar 2021
[cli][debug] Streamlink: 7.1.2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.12.14
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.28.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  --no-config=True
[cli][debug]  --loglevel=debug
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```

----

Example with x86_64
```
$ ./streamlink+ffmpeg-7.1.2-1-cp312-cp312-manylinux_2_28_x86_64.AppImage -l debug https://steamcommunity.com/broadcast/watch/76561199757265166 best
[session][debug] Loading plugin: steam
[cli][debug] OS:         Linux-6.13.0-1-git-x86_64-with-glibc2.40
[cli][debug] Python:     3.12.8
[cli][debug] OpenSSL:    OpenSSL 1.1.1k  FIPS 25 Mar 2021
[cli][debug] Streamlink: 7.1.2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.12.14
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.28.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://steamcommunity.com/broadcast/watch/76561199757265166
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --ffmpeg-ffmpeg=/tmp/.mount_streamYIc0JD/usr/bin/ffmpeg
[cli][debug]  --webbrowser-headless=True
[plugins.steam][debug] Restored cookies: REDACTED
[cli][info] Found matching plugin steam for URL https://steamcommunity.com/broadcast/watch/76561199757265166
[plugins.steam][debug] Getting broadcast stream: sessionid=REDACTED
[utils.l10n][debug] Language code: en_US
[stream.dash][debug] Available languages for DASH audio streams: und (using: und)
[cli][info] Available streams: 360p (worst), 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (dash)
[cli][info] Starting player: /usr/bin/mpv
[stream.dash][debug] Opening DASH reader for: ('1', 'video', '1') - video/mp4
[stream.dash][debug] Opening DASH reader for: ('1', 'audio', '1') - audio/mp4
[stream.ffmpegmux][debug] ffmpeg version n7.1-153-gaeb8631048-20250121 Copyright (c) 2000-2024 the FFmpeg developers
built with gcc 14.2.0 (crosstool-NG 1.26.0.120_4d36f27)
configuration: --prefix=/ffbuild/prefix --pkg-config-flags=--static --pkg-config=pkg-config --cross-prefix=x86_64-ffbuild-linux-gnu- --arch=x86_64 --target-os=linux --enable-gpl --enable-version3 --disable-debug --enable-iconv --enable-zlib --enable-libfreetype --enable-libfribidi --enable-gmp --enable-libxml2 --enable-openssl --enable-lzma --enable-fontconfig --enable-libharfbuzz --enable-libvorbis --enable-opencl --enable-libpulse --enable-libvmaf --enable-libxcb --enable-xlib --enable-amf --enable-libaom --enable-libaribb24 --enable-avisynth --enable-chromaprint --enable-libdav1d --enable-libdavs2 --enable-libdvdread --enable-libdvdnav --disable-libfdk-aac --enable-ffnvcodec --enable-cuda-llvm --enable-frei0r --enable-libgme --enable-libkvazaar --enable-libaribcaption --enable-libass --enable-libbluray --enable-libjxl --enable-libmp3lame --enable-libopus --enable-librist --enable-libssh --enable-libtheora --enable-libvpx --enable-libwebp --enable-libzmq --enable-lv2 --enable-libvpl --enable-openal --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenh264 --enable-libopenjpeg --enable-libopenmpt --enable-librav1e --enable-librubberband --disable-schannel --enable-sdl2 --enable-libsnappy --enable-libsoxr --enable-libsrt --enable-libsvtav1 --enable-libtwolame --enable-libuavs3d --enable-libdrm --enable-vaapi --enable-libvidstab --enable-vulkan --enable-libshaderc --enable-libplacebo --disable-libvvenc --enable-libx264 --enable-libx265 --enable-libxavs2 --enable-libxvid --enable-libzimg --enable-libzvbi --extra-cflags=-DLIBTWOLAME_STATIC --extra-cxxflags= --extra-libs='-ldl -lgomp' --extra-ldflags=-pthread --extra-ldexeflags=-pie --cc=x86_64-ffbuild-linux-gnu-gcc --cxx=x86_64-ffbuild-linux-gnu-g++ --ar=x86_64-ffbuild-linux-gnu-gcc-ar --ranlib=x86_64-ffbuild-linux-gnu-gcc-ranlib --nm=x86_64-ffbuild-linux-gnu-gcc-nm --extra-version=20250121
libavutil      59. 39.100 / 59. 39.100
libavcodec     61. 19.101 / 61. 19.101
libavformat    61.  7.100 / 61.  7.100
libavdevice    61.  3.100 / 61.  3.100
libavfilter    10.  4.100 / 10.  4.100
libswscale      8.  3.100 /  8.  3.100
libswresample   5.  3.100 /  5.  3.100
libpostproc    58.  3.100 / 58.  3.100
[stream.dash][debug] video/mp4 segment initialization: downloading (2025-01-27T04:21:18.000000Z / 2025-01-27T14:38:51.572346Z)
[stream.dash.manifest][debug] Generating segment numbers for dynamic playlist: ('1', 'video', '1')
[stream.dash.manifest][debug] Stream start: 2025-01-27 04:21:18+00:00
[stream.dash.manifest][debug] Current time: 2025-01-27 14:38:51.476209+00:00
[stream.dash.manifest][debug] Availability: 2025-01-27 14:38:44+00:00
[stream.dash.manifest][debug] presentationTimeOffset: 0:00:00; suggestedPresentationDelay: 0:00:03; minBufferTime: 0:00:03
[stream.dash.manifest][debug] segmentDuration: 2.0; segmentStart: 1; segmentOffset: 18523 (37047.476209s)
[utils.named_pipe][info] Creating pipe streamlinkpipe-414292-1-484
[stream.dash][debug] audio/mp4 segment initialization: downloading (2025-01-27T04:21:18.000000Z / 2025-01-27T14:38:51.574302Z)
[stream.dash.manifest][debug] Generating segment numbers for dynamic playlist: ('1', 'audio', '1')
[stream.dash.manifest][debug] Stream start: 2025-01-27 04:21:18+00:00
[stream.dash.manifest][debug] Current time: 2025-01-27 14:38:51.476209+00:00
[stream.dash.manifest][debug] Availability: 2025-01-27 14:38:44+00:00
[stream.dash.manifest][debug] presentationTimeOffset: 0:00:00; suggestedPresentationDelay: 0:00:03; minBufferTime: 0:00:03
[stream.dash.manifest][debug] segmentDuration: 2.0; segmentStart: 1; segmentOffset: 18523 (37047.476209s)
[utils.named_pipe][info] Creating pipe streamlinkpipe-414292-2-2672
[stream.ffmpegmux][debug] ffmpeg command: /tmp/.mount_streamYIc0JD/usr/bin/ffmpeg -y -nostats -loglevel info -i /tmp/streamlinkpipe-414292-1-484 -i /tmp/streamlinkpipe-414292-2-2672 -c:v copy -c:a copy -copyts -f matroska pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-414292-1-484
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-414292-2-2672
[cli][debug] Pre-buffering 8192 bytes
[stream.dash][debug] audio/mp4 segment 18524: downloading (2025-01-27T14:38:44.000000Z / 2025-01-27T14:38:51.703078Z)
[stream.dash][debug] audio/mp4 segment initialization: completed
[stream.dash][debug] video/mp4 segment 18524: downloading (2025-01-27T14:38:44.000000Z / 2025-01-27T14:38:51.706611Z)
[stream.dash][debug] video/mp4 segment initialization: completed
[stream.dash][debug] audio/mp4 segment 18525: downloading (2025-01-27T14:38:46.000000Z / 2025-01-27T14:38:51.774471Z)
[stream.dash][debug] audio/mp4 segment 18524: completed
[stream.dash][debug] audio/mp4 segment 18526: downloading (2025-01-27T14:38:48.000000Z / 2025-01-27T14:38:51.904348Z)
[stream.dash][debug] audio/mp4 segment 18525: completed
[stream.dash][debug] audio/mp4 segment 18527: downloading (2025-01-27T14:38:50.000000Z / 2025-01-27T14:38:51.947308Z)
[stream.dash][debug] audio/mp4 segment 18526: completed
[stream.dash][debug] audio/mp4 segment 18528: waiting 0.0s (2025-01-27T14:38:52.000000Z / 2025-01-27T14:38:51.997465Z)
[stream.dash][debug] audio/mp4 segment 18527: completed
[stream.dash][debug] audio/mp4 segment 18528: downloading (2025-01-27T14:38:52.000000Z / 2025-01-27T14:38:52.000266Z)
[stream.dash][debug] video/mp4 segment 18525: downloading (2025-01-27T14:38:46.000000Z / 2025-01-27T14:38:52.021586Z)
[stream.dash][debug] video/mp4 segment 18524: completed
[stream.dash][debug] video/mp4 segment 18526: downloading (2025-01-27T14:38:48.000000Z / 2025-01-27T14:38:52.082972Z)
[stream.dash][debug] video/mp4 segment 18525: completed
[stream.dash][debug] audio/mp4 segment 18529: waiting 1.9s (2025-01-27T14:38:54.000000Z / 2025-01-27T14:38:52.102861Z)
[stream.dash][debug] audio/mp4 segment 18528: completed
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://steamcommunity.com/broadcast/watch/76561199757265166', '-']
[stream.dash][debug] video/mp4 segment 18527: downloading (2025-01-27T14:38:50.000000Z / 2025-01-27T14:38:52.174498Z)
[stream.dash][debug] video/mp4 segment 18526: completed
[stream.dash][debug] video/mp4 segment 18528: downloading (2025-01-27T14:38:52.000000Z / 2025-01-27T14:38:52.278934Z)
[stream.dash][debug] video/mp4 segment 18527: completed
[stream.dash][debug] video/mp4 segment 18529: waiting 1.6s (2025-01-27T14:38:54.000000Z / 2025-01-27T14:38:52.384751Z)
[stream.dash][debug] video/mp4 segment 18528: completed
[cli][debug] Writing stream to output
[stream.dash][debug] audio/mp4 segment 18529: downloading (2025-01-27T14:38:54.000000Z / 2025-01-27T14:38:54.000315Z)
[stream.dash][debug] video/mp4 segment 18529: downloading (2025-01-27T14:38:54.000000Z / 2025-01-27T14:38:54.001512Z)
[stream.dash][debug] audio/mp4 segment 18530: waiting 2.0s (2025-01-27T14:38:56.000000Z / 2025-01-27T14:38:54.038006Z)
[stream.dash][debug] audio/mp4 segment 18529: completed
[cli][info] Player closed
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-414292-1-484
[stream.dash][debug] audio/mp4 segment 18530: cancelled
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-414292-2-2672
[stream.dash][warning] video/mp4 segment 18529: aborted
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

Example with aarch64 on x86_64 via qemu (I don't have aarch64 libfuse, so `--appimage-extract` was run prior with zlib)
```
$ qemu-aarch64-static -L /usr/aarch64-linux-gnu ./squashfs-root/usr/bin/python -m streamlink -l debug https://steamcommunity.com/broadcast/watch/76561199757265166 best
[session][debug] Loading plugin: steam
[cli][debug] OS:         Linux-6.13.0-1-git-aarch64-with-glibc2.40
[cli][debug] Python:     3.12.8
[cli][debug] OpenSSL:    OpenSSL 1.1.1k  FIPS 25 Mar 2021
[cli][debug] Streamlink: 7.1.2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.12.14
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.28.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://steamcommunity.com/broadcast/watch/76561199757265166
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
[plugins.steam][debug] Restored cookies: REDACTED
[cli][info] Found matching plugin steam for URL https://steamcommunity.com/broadcast/watch/76561199757265166
[plugins.steam][debug] Getting broadcast stream: sessionid=REDACTED
[utils.l10n][debug] Language code: en_US
[stream.dash][debug] Available languages for DASH audio streams: und (using: und)
[cli][info] Available streams: 360p (worst), 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (dash)
[cli][info] Starting player: /usr/bin/mpv
[stream.dash][debug] Opening DASH reader for: ('1', 'video', '1') - video/mp4
[stream.dash][debug] Opening DASH reader for: ('1', 'audio', '1') - audio/mp4
[stream.ffmpegmux][debug] ffmpeg version n7.1 Copyright (c) 2000-2024 the FFmpeg developers
built with gcc 14.2.1 (GCC) 20240910
configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-frei0r --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libdvdnav --enable-libdvdread --enable-libfreetype --enable-libfribidi --enable-libglslang --enable-libgsm --enable-libharfbuzz --enable-libiec61883 --enable-libjack --enable-libjxl --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librav1e --enable-librsvg --enable-librubberband --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpl --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-vapoursynth --enable-version3 --enable-vulkan
libavutil      59. 39.100 / 59. 39.100
libavcodec     61. 19.100 / 61. 19.100
libavformat    61.  7.100 / 61.  7.100
libavdevice    61.  3.100 / 61.  3.100
libavfilter    10.  4.100 / 10.  4.100
libswscale      8.  3.100 /  8.  3.100
libswresample   5.  3.100 /  5.  3.100
libpostproc    58.  3.100 / 58.  3.100
[stream.dash][debug] video/mp4 segment initialization: downloading (2025-01-27T04:21:18.000000Z / 2025-01-27T14:36:34.077900Z)
[stream.dash.manifest][debug] Generating segment numbers for dynamic playlist: ('1', 'video', '1')
[stream.dash.manifest][debug] Stream start: 2025-01-27 04:21:18+00:00
[stream.dash.manifest][debug] Current time: 2025-01-27 14:36:34.007418+00:00
[stream.dash.manifest][debug] Availability: 2025-01-27 14:36:28+00:00
[stream.dash.manifest][debug] presentationTimeOffset: 0:00:00; suggestedPresentationDelay: 0:00:03; minBufferTime: 0:00:03
[stream.dash.manifest][debug] segmentDuration: 2.0; segmentStart: 1; segmentOffset: 18455 (36910.007418s)
[utils.named_pipe][info] Creating pipe streamlinkpipe-413891-1-8368
[stream.dash][debug] audio/mp4 segment initialization: downloading (2025-01-27T04:21:18.000000Z / 2025-01-27T14:36:34.100787Z)
[stream.dash.manifest][debug] Generating segment numbers for dynamic playlist: ('1', 'audio', '1')
[stream.dash.manifest][debug] Stream start: 2025-01-27 04:21:18+00:00
[stream.dash.manifest][debug] Current time: 2025-01-27 14:36:34.007418+00:00
[stream.dash.manifest][debug] Availability: 2025-01-27 14:36:28+00:00
[stream.dash.manifest][debug] presentationTimeOffset: 0:00:00; suggestedPresentationDelay: 0:00:03; minBufferTime: 0:00:03
[stream.dash.manifest][debug] segmentDuration: 2.0; segmentStart: 1; segmentOffset: 18455 (36910.007418s)
[utils.named_pipe][info] Creating pipe streamlinkpipe-413891-2-4321
[stream.ffmpegmux][debug] ffmpeg command: /usr/bin/ffmpeg -y -nostats -loglevel info -i /tmp/streamlinkpipe-413891-1-8368 -i /tmp/streamlinkpipe-413891-2-4321 -c:v copy -c:a copy -copyts -f matroska pipe:1
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-413891-1-8368
[stream.dash][debug] video/mp4 segment 18456: downloading (2025-01-27T14:36:28.000000Z / 2025-01-27T14:36:34.124259Z)
[stream.dash][debug] video/mp4 segment initialization: completed
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-413891-2-4321
[cli][debug] Pre-buffering 8192 bytes
[stream.dash][debug] audio/mp4 segment 18456: downloading (2025-01-27T14:36:28.000000Z / 2025-01-27T14:36:34.262766Z)
[stream.dash][debug] audio/mp4 segment initialization: completed
[stream.dash][debug] video/mp4 segment 18457: downloading (2025-01-27T14:36:30.000000Z / 2025-01-27T14:36:34.324231Z)
[stream.dash][debug] video/mp4 segment 18456: completed
[stream.dash][debug] audio/mp4 segment 18457: downloading (2025-01-27T14:36:30.000000Z / 2025-01-27T14:36:34.347105Z)
[stream.dash][debug] audio/mp4 segment 18456: completed
[stream.dash][debug] audio/mp4 segment 18458: downloading (2025-01-27T14:36:32.000000Z / 2025-01-27T14:36:34.389369Z)
[stream.dash][debug] audio/mp4 segment 18457: completed
[stream.dash][debug] video/mp4 segment 18458: downloading (2025-01-27T14:36:32.000000Z / 2025-01-27T14:36:34.419244Z)
[stream.dash][debug] video/mp4 segment 18457: completed
[stream.dash][debug] audio/mp4 segment 18459: downloading (2025-01-27T14:36:34.000000Z / 2025-01-27T14:36:34.443828Z)
[stream.dash][debug] audio/mp4 segment 18458: completed
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://steamcommunity.com/broadcast/watch/76561199757265166', '-']
[stream.dash][debug] audio/mp4 segment 18460: waiting 1.5s (2025-01-27T14:36:36.000000Z / 2025-01-27T14:36:34.493450Z)
[stream.dash][debug] audio/mp4 segment 18459: completed
[stream.dash][debug] video/mp4 segment 18459: downloading (2025-01-27T14:36:34.000000Z / 2025-01-27T14:36:34.524363Z)
[stream.dash][debug] video/mp4 segment 18458: completed
[stream.dash][debug] video/mp4 segment 18460: waiting 1.4s (2025-01-27T14:36:36.000000Z / 2025-01-27T14:36:34.622100Z)
[stream.dash][debug] video/mp4 segment 18459: completed
[cli][debug] Writing stream to output
[stream.dash][debug] audio/mp4 segment 18460: downloading (2025-01-27T14:36:36.000000Z / 2025-01-27T14:36:36.001416Z)
[stream.dash][debug] video/mp4 segment 18460: downloading (2025-01-27T14:36:36.000000Z / 2025-01-27T14:36:36.007382Z)
[stream.dash][debug] audio/mp4 segment 18461: waiting 1.9s (2025-01-27T14:36:38.000000Z / 2025-01-27T14:36:36.053742Z)
[stream.dash][debug] audio/mp4 segment 18460: completed
[stream.dash][debug] video/mp4 segment 18461: waiting 1.8s (2025-01-27T14:36:38.000000Z / 2025-01-27T14:36:36.181203Z)
[stream.dash][debug] video/mp4 segment 18460: completed
[cli][info] Player closed
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.segmented][debug] Closing worker thread
[stream.dash][debug] video/mp4 segment 18461: cancelled
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-413891-1-8368
[stream.segmented][debug] Closing writer thread
[stream.dash][debug] audio/mp4 segment 18461: cancelled
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-413891-2-4321
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```