### PR TITLE
plugins.nos: update matcher, fix validation schema

### DIFF
--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(
-    re.compile(r"https?://(?:\w+\.)?nos\.nl/(?:live|video|collectie)"),
+    re.compile(r"https?://(?:\w+\.)?nos\.nl/(?:live$|livestream/|l/|video/|collectie/)"),
 )
 class NOS(Plugin):
     def _get_streams(self):
@@ -31,7 +31,13 @@ class NOS(Plugin):
                 validate.none_or_all(
                     validate.parse_json(),
                     {
-                        "@type": "VideoObject",
+                        "@type": validate.any(
+                            "VideoObject",
+                            validate.all(
+                                list,
+                                validate.contains("VideoObject"),
+                            ),
+                        ),
                         "encodingFormat": "application/vnd.apple.mpegurl",
                         "contentUrl": validate.url(),
                         "identifier": validate.any(int, str),

--- a/tests/plugins/test_nos.py
+++ b/tests/plugins/test_nos.py
@@ -7,12 +7,17 @@ class TestPluginCanHandleUrlNOS(PluginCanHandleUrl):
 
     should_match = [
         "https://nos.nl/live",
-        "https://nos.nl/collectie/13781/livestream/2385081-ek-voetbal-engeland-schotland",
+        "https://nos.nl/livestream/2539164-schaatsen-wb-milwaukee-straks-de-massastart-m",
         "https://nos.nl/collectie/13951/video/2491092-dit-was-prinsjesdag",
+        "https://nos.nl/l/2490788",
         "https://nos.nl/video/2490788-meteoor-gespot-boven-noord-nederland",
     ]
 
     should_not_match = [
+        "https://nos.nl/livestream",
+        "https://nos.nl/l",
+        "https://nos.nl/video",
+        "https://nos.nl/collectie",
         "https://nos.nl/artikel/2385784-explosieve-situatie-leidde-tot-verwoeste-huizen-en-omgewaaide-bomen-leersum",
         "https://nos.nl/sport",
         "https://nos.nl/sport/videos",


### PR DESCRIPTION
Fixes #6419 

@ltguillaume please check and see if any content on the site is still not working correctly with these plugin fixes. The live streams are geo-blocked for me, and the main live stream apparently is currently offline. That shouldn't be a problem though, considering that the plugin only required simple validation schema changes, and no other stream-related changes.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

```
$ ./script/test-plugin-urls.py nos -m
:: https://nos.nl/collectie/13951/video/2491092-dit-was-prinsjesdag
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2491092', 'author': None, 'category': None, 'title': 'Dit was Prinsjesdag'}
:: https://nos.nl/l/2490788
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2490788', 'author': None, 'category': None, 'title': 'Meteoor gespot boven noord Nederland'}
:: https://nos.nl/live
!! No streams found
:: https://nos.nl/livestream/2539164-schaatsen-wb-milwaukee-straks-de-massastart-m
:::: Content is inaccessible or may have expired
!! No streams found
:: https://nos.nl/video/2490788-meteoor-gespot-boven-noord-nederland
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2490788', 'author': None, 'category': None, 'title': 'Meteoor gespot boven noord Nederland'}
```