### PR TITLE
validate: check for Container in contains()

### DIFF
--- a/src/streamlink/validate/_validators.py
+++ b/src/streamlink/validate/_validators.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import operator
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Container, Mapping
 from typing import Any, Literal
 from urllib.parse import urlparse
 
@@ -141,9 +141,10 @@ def validator_endswith(string: str) -> Callable[[str], bool]:
     return ends_with
 
 
-def validator_contains(string: str) -> Callable[[str], bool]:
+def validator_contains(obj: object) -> Callable[[Container], bool]:
     """
-    Utility function for checking whether the input string contains another string.
+    Utility function for checking whether the input contains a certain element,
+    e.g. a string within a string, an object in a list, a key in a dict, etc.
 
     Example:
 
@@ -156,17 +157,26 @@ def validator_contains(string: str) -> Callable[[str], bool]:
         schema.validate("987654321")  # raises ValidationError
         schema.validate(None)  # raises ValidationError
 
-    :raise ValidationError: If input is not an instance of :class:`str`
-    :raise ValidationError: If input doesn't contain ``string``
+    .. code-block:: python
+
+        schema = validate.Schema(
+            validate.contains(456),
+        )
+        assert schema.validate([123, 456, 789]) == [123, 456, 789]
+        schema.validate([987, 654, 321])  # raises ValidationError
+        schema.validate(None)  # raises ValidationError
+
+    :raise ValidationError: If input is not an instance of :class:`collections.abc.Container`
+    :raise ValidationError: If input doesn't contain ``obj``
     """
 
     def contains_str(value):
-        validate(str, value)
-        if string not in value:
+        validate(Container, value)
+        if obj not in value:
             raise ValidationError(
-                "{value} does not contain {string}",
+                "{value} does not contain {obj}",
                 value=repr(value),
-                string=repr(string),
+                obj=repr(obj),
                 schema="contains",
             )
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1084,10 +1084,11 @@ class TestEndsWithValidator:
 
 
 class TestContainsValidator:
-    def test_success(self):
-        assert validate.validate(validate.contains("bar"), "foo bar baz")
+    def test_string_success(self):
+        obj = "foo bar baz"
+        assert validate.validate(validate.contains("bar"), obj) is obj
 
-    def test_failure(self):
+    def test_string_failure(self):
         with pytest.raises(ValidationError) as cm:
             validate.validate(validate.contains("invalid"), "foo bar baz")
         assert_validationerror(
@@ -1098,6 +1099,36 @@ class TestContainsValidator:
             """,
         )
 
+    def test_list_success(self):
+        obj = [123, 456, 789]
+        assert validate.validate(validate.contains(456), obj) is obj
+
+    def test_list_failure(self):
+        with pytest.raises(ValidationError) as cm:
+            validate.validate(validate.contains(456), [987, 654, 321])
+        assert_validationerror(
+            cm.value,
+            """
+                ValidationError(contains):
+                  [987, 654, 321] does not contain 456
+            """,
+        )
+
+    def test_dict_success(self):
+        obj = {"abc": 123, "def": 456, "ghi": 789}
+        assert validate.validate(validate.contains("def"), obj) is obj
+
+    def test_dict_failure(self):
+        with pytest.raises(ValidationError) as cm:
+            validate.validate(validate.contains("def"), {"ihg": 987, "fed": 654, "cba": 321})
+        assert_validationerror(
+            cm.value,
+            """
+                ValidationError(contains):
+                  {'ihg': 987, 'fed': 654, 'cba': 321} does not contain 'def'
+            """,
+        )
+
     def test_failure_schema(self):
         with pytest.raises(ValidationError) as cm:
             validate.validate(validate.contains("invalid"), 1)
@@ -1105,7 +1136,7 @@ class TestContainsValidator:
             cm.value,
             """
                 ValidationError(type):
-                  Type of 1 should be str, but is int
+                  Type of 1 should be Container, but is int
             """,
         )
 


### PR DESCRIPTION
Check for `collections.abc.Container` instances in `validate.contains()` rather than `str` objects, so everything that implements `__contains__` can be validated as well, like lists, dicts, etc.
