### PR TITLE
ci.github: add preview-build workflow

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,46 @@
+name: Preview build
+run-name: "Preview build - ${{ github.ref }}"
+
+on:
+  push:
+    branches:
+      - "master"
+    tags-ignore:
+      - "**"
+    paths:
+      - "pyproject.toml"
+      - "setup.py"
+      - "MANIFEST.in"
+      - "build_backend/**"
+      - "src/**"
+
+jobs:
+  trigger:
+    name: "Preview build - ${{ github.ref }}"
+    if: github.repository == 'streamlink/streamlink'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Windows builds
+        run: |
+          curl -sfL \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -H 'Authorization: Bearer ${{ secrets.STREAMLINKBOT_PREVIEW_BUILD }}' \
+            -d '{"ref":"master","inputs":{"ref":"${{ github.ref }}"}}' \
+            https://api.github.com/repos/streamlink/windows-builds/actions/workflows/preview-build.yml/dispatches
+
+          echo -e '## Windows builds\n\nhttps://github.com/streamlink/windows-builds/actions/workflows/preview-build.yml\n' \
+            >> "${GITHUB_STEP_SUMMARY}"
+      - name: Linux AppImage
+        run: |
+          curl -sfL \
+            -X POST \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            -H 'Authorization: Bearer ${{ secrets.STREAMLINKBOT_PREVIEW_BUILD }}' \
+            -d '{"ref":"master","inputs":{"ref":"${{ github.ref }}"}}' \
+            https://api.github.com/repos/streamlink/streamlink-appimage/actions/workflows/preview-build.yml/dispatches
+
+          echo -e '## AppImage\n\nhttps://github.com/streamlink/streamlink-appimage/actions/workflows/preview-build.yml\n' \
+            >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -304,7 +304,6 @@ table.table-custom-layout.table-custom-layout-dependencies tbody td {
 
 .grid-with-icons .sd-card-body .fas {
   padding-right: 0.1em;
-  font-size: 1.75em;
   vertical-align: middle;
 }
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -543,21 +543,21 @@ Windows binaries
 
         **Windows stable releases**
         ^^^
-        :fas:`download` GitHub releases page
+        :fas:`download;fa-2x` GitHub releases page
 
-        The most recent Streamlink release
+        :fas:`check-circle;sd-text-success fa-lg` The most recent Streamlink release
 
     .. grid-item-card::
         :padding: 3
-        :link: https://github.com/streamlink/windows-builds/actions?query=event%3Aschedule+is%3Asuccess+branch%3Amaster
-        :link-alt: Windows nightly builds
+        :link: https://github.com/streamlink/windows-builds/actions/workflows/preview-build.yml
+        :link-alt: Windows preview builds
         :text-align: center
 
-        **Windows nightly builds**
+        **Windows preview builds**
         ^^^
-        :fas:`download` GitHub actions build artifacts
+        :fas:`download;fa-2x` GitHub actions build artifacts
 
-        Built once each day at midnight UTC |br| :sub:`GitHub account required`
+        :fab:`github;fa-lg` Account required
 
 **Flavors**
 
@@ -654,21 +654,21 @@ Linux AppImages
 
         **AppImage stable releases**
         ^^^
-        :fas:`download` GitHub releases page
+        :fas:`download;fa-2x` GitHub releases page
 
-        The most recent Streamlink release
+        :fas:`check-circle;sd-text-success fa-lg` The most recent Streamlink release
 
     .. grid-item-card::
         :padding: 3
-        :link: https://github.com/streamlink/streamlink-appimage/actions?query=event%3Aschedule+is%3Asuccess+branch%3Amaster
-        :link-alt: AppImage nightly builds
+        :link: https://github.com/streamlink/streamlink-appimage/actions/workflows/preview-build.yml
+        :link-alt: AppImage preview builds
         :text-align: center
 
-        **AppImage nightly builds**
+        **AppImage preview builds**
         ^^^
-        :fas:`download` GitHub actions build artifacts
+        :fas:`download;fa-2x` GitHub actions build artifacts
 
-        Built once each day at midnight UTC |br| :sub:`GitHub account required`
+        :fab:`github;fa-lg` Account required
 
 **Architectures**
 


### PR DESCRIPTION
Closes #6424 

This new `preview-build` workflow triggers the `preview-build` workflows on the `streamlink/windows-builds` and `streamlink/streamlink-appimage` repos whenever something was pushed to `master` and either `pyproject.toml`, `setup.py`, `MANIFEST.in` or `src/**` was modified:
- https://github.com/streamlink/windows-builds/actions/workflows/preview-build.yml
- https://github.com/streamlink/streamlink-appimage/actions/workflows/preview-build.yml

These two links are added to the run's summary markdown text, so users can find the build artifacts easily when clicking the workflow here. Unfortunately, direct links in the summary can't be included, as the workflow here merely triggers the workflows on the other repos. GitHub doesn't include a workflow run ID in its API response.

The docs have also been updated accordingly. I will remove the nightly workflows from the repos after this PR here was merged. The recent runs and their build artifacts should remain for 90 days (until expiration) when deleting workflow files.

I've checked and triggered the workflows using a GH PAT, but I don't know if `secrets.GITHUB_TOKEN` with `permissions.actions=write` also has the permissions to trigger a workflow on other repos. If it doesn't, then I will have to add a PAT for the @streamlinkbot and use that instead.

Does the `on.push` config here look fine? Not 100% sure... Tags pushed should be ignored and the paths should be correct.
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token