### PR TITLE
plugins.tf1: fix help text of --tf1-password

### DIFF
--- a/src/streamlink/plugins/tf1.py
+++ b/src/streamlink/plugins/tf1.py
@@ -41,7 +41,7 @@ log = logging.getLogger(__name__)
     "password",
     sensitive=True,
     metavar="PASSWORD",
-    help="A tf1.fr account password to use with --tf1-username.",
+    help="A tf1.fr account password to use with --tf1-email.",
 )
 @pluginargument(
     "purge-credentials",


### PR DESCRIPTION
Noticed during #6428 