### PR TITLE
plugins.pandalive: fix user_id, update matcher

### DIFF
--- a/src/streamlink/plugins/pandalive.py
+++ b/src/streamlink/plugins/pandalive.py
@@ -18,22 +18,45 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(
-    re.compile(r"https?://(?:www\.)?pandalive\.co\.kr/live/play/[^/]+"),
+    re.compile(r"https?://(?:\w+\.)?pandalive\.co\.kr/(?:\w+/)?play/(?P<channel>[^/#?]+)"),
 )
 class Pandalive(Plugin):
+    _URL_API_MEMBER = "https://api.pandalive.co.kr/v1/member/bj"
+
     def _get_streams(self):
-        media_code = self.session.http.get(
-            self.url,
+        result, user_id = self.session.http.post(
+            self._URL_API_MEMBER,
+            data={"userId": self.match["channel"]},
+            raise_for_status=False,
             schema=validate.Schema(
-                re.compile(r"""routePath:\s*(?P<q>["'])(\\u002F|/)live(\\u002F|/)play(\\u002F|/)(?P<id>.+?)(?P=q)"""),
-                validate.any(None, validate.get("id")),
+                validate.parse_json(),
+                validate.any(
+                    validate.all(
+                        {
+                            "result": False,
+                            "message": str,
+                        },
+                        validate.union_get("result", "message"),
+                    ),
+                    validate.all(
+                        {
+                            "bjInfo": {
+                                "idx": int,
+                            },
+                        },
+                        validate.get(("bjInfo", "idx")),
+                        validate.transform(lambda data: (True, data)),
+                    ),
+                ),
             ),
         )
-
-        if not media_code:
+        if not result:
+            log.error(user_id or "Failed to get user ID")
+            return
+        if not user_id:
             return
 
-        log.debug(f"Media code: {media_code}")
+        log.debug(f"{user_id=}")
 
         json = self.session.http.post(
             "https://api.pandalive.co.kr/v1/live/play",
@@ -42,7 +65,7 @@ class Pandalive(Plugin):
             },
             data={
                 "action": "watch",
-                "userId": media_code,
+                "userId": user_id,
             },
             acceptable_status=(200, 400),
             schema=validate.Schema(

--- a/tests/plugins/test_pandalive.py
+++ b/tests/plugins/test_pandalive.py
@@ -5,6 +5,7 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlPandalive(PluginCanHandleUrl):
     __plugin__ = Pandalive
 
-    should_match = [
-        "https://www.pandalive.co.kr/live/play/CHANNEL",
+    should_match_groups = [
+        ("https://www.pandalive.co.kr/live/play/CHANNEL", {"channel": "CHANNEL"}),
+        ("https://w2.pandalive.co.kr/en/play/CHANNEL", {"channel": "CHANNEL"}),
     ]


### PR DESCRIPTION
Fixes #6432 

@KOONWHITE @lloyd18 
Please check and see if some streams are not working correctly. My local tests appeared fine, but I only checked one stream I picked randomly while using my local German IP address.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

When requesting the input URL, their servers return an HTTP 500 status. That's also the case in your web browser, btw. Since extracting the user/channel ID from the HTML page which the previous plugin implementation did was already a bit questionable, the simple fix was to request it from their API instead.

```
$ ./script/test-plugin-urls.py pandalive -r CHANNEL flowerwar
:: https://w2.pandalive.co.kr/en/play/flowerwar
:::: Broadcast type: live
::  160p, 360p, 480p, 720p60, 1080p60, worst, best
:: https://www.pandalive.co.kr/live/play/flowerwar
:::: Broadcast type: live
::  160p, 360p, 480p, 720p60, 1080p60, worst, best
```

```
$ streamlink -l debug --hls-duration=5 -o /dev/null https://www.pandalive.co.kr/live/play/flowerwar best
[cli][debug] OS:         Linux-6.13.1-1-git-x86_64-with-glibc2.41
[cli][debug] Python:     3.13.1
[cli][debug] OpenSSL:    OpenSSL 3.4.0 22 Oct 2024
[cli][debug] Streamlink: 7.1.2+27.g03dc6a04
[cli][debug] Dependencies:
[cli][debug]  certifi: 2025.1.31
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.28.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.pandalive.co.kr/live/play/flowerwar
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --output=/dev/null
[cli][debug]  --hls-duration=5.0
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin pandalive for URL https://www.pandalive.co.kr/live/play/flowerwar
[plugins.pandalive][debug] user_id=24925015
[plugins.pandalive][info] Broadcast type: live
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Writing output to
/dev/null
[cli][debug] Checking file output
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 12063; Last Sequence: 12076
[stream.hls][debug] Start offset: 0; Duration: 5; Start Sequence: 12074; End Sequence: None
[stream.hls][debug] Adding segment 12074 to queue
[stream.hls][debug] Adding segment 12075 to queue
[stream.hls][debug] Adding segment 12076 to queue
[stream.hls][info] Stopping stream early after 5
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 12074 to output
[stream.hls][debug] Segment 12074 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Writing segment 12075 to output
[stream.hls][debug] Segment 12075 complete
[stream.hls][debug] Writing segment 12076 to output
[stream.hls][debug] Segment 12076 complete
[stream.segmented][debug] Closing writer thread
[download] Written 6.03 MiB to /dev/null (0s)                                                                                                   
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```