### PR TITLE
plugins.nicolive: set stream cookies from WS data

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -112,7 +112,8 @@ class NicoLiveHLSStream(HLSStream):
     __reader__ = NicoLiveHLSStreamReader
     wsclient: NicoLiveWsClient
 
-    def set_wsclient(self, wsclient: NicoLiveWsClient):
+    def __init__(self, *args, wsclient: NicoLiveWsClient, **kwargs):
+        super().__init__(*args, **kwargs)
         self.wsclient = wsclient
 
 
@@ -204,9 +205,7 @@ class NicoLive(Plugin):
         if offset and "timeshift" in wss_api_url:
             hls_stream_url = update_qsd(hls_stream_url, {"start": offset})
 
-        for quality, stream in NicoLiveHLSStream.parse_variant_playlist(self.session, hls_stream_url).items():
-            stream.set_wsclient(self.wsclient)
-            yield quality, stream
+        return NicoLiveHLSStream.parse_variant_playlist(self.session, hls_stream_url, wsclient=self.wsclient)
 
     def _get_hls_stream_url(self):
         log.debug(f"Waiting for permit (for at most {self.STREAM_READY_TIMEOUT} seconds)...")


### PR DESCRIPTION
Fixes #6440 

@cykac04 please have a look at this PR...
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

After browsing lots of streams, I was finally able to find one live stream where cookies were required. The one you posted was offline unfortunately.

HLS streams where cookies are required all appear to be multivariant streams with an external audio stream, so muxing via FFmpeg is required. I'm not sure, but I think there's an issue with the audio stream synchronization. That is unrelated to the plugin however, as it has nothing to do with the HLS protocol or the stream data. It may be an issue with the stream itself, because audio synchronization depends on the individual bitstreams and their presentation timestamps, not on the HLS metadata (this is not a packed audio stream where this would be the case). It might be necessary to set `--ffmpeg-copyts` in order to fix audio sync issues, which could also be forced by the plugin code.

Audio sync issues can happen occasionally - they don't have to appear all the time, depending on the initial sub-stream access timing. **So I'd like to ask you to check and see if there are audio sync issues on the streams you're trying to watch without the `--ffmpeg-copyts` parameter being set and whether setting the `--ffmpeg-copyts` parameter fixes them reliably 100% of the time.**

Btw, the fact that they're using a newer version of the HLS protocol (despite not annotating it correctly) which is still not yet released/finalized is irrelevant, even if Streamlink doesn't support it yet, as everything's backwards compatible.

```
$ streamlink -l debug https://live.nicovideo.jp/watch/lv347077742 best
[cli][debug] OS:         Linux-6.13.3-1-git-x86_64-with-glibc2.41
[cli][debug] Python:     3.13.2
[cli][debug] OpenSSL:    OpenSSL 3.4.1 11 Feb 2025
[cli][debug] Streamlink: 7.1.3+3.g50de81b0
[cli][debug] Dependencies:
[cli][debug]  certifi: 2024.12.14
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.21.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.27.0
[cli][debug]  trio-websocket: 0.11.1
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=https://live.nicovideo.jp/watch/lv347077742
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin nicolive for URL https://live.nicovideo.jp/watch/lv347077742
[plugin.api.websocket][debug] Connecting to: wss://a.live2.nicovideo.jp/unama/wsapi/v2/watch/66383504212555?audience_token=66383504212555_anonymous-user-30f6c6aa-599c-4d8c-ac5f-c4a25a14748c_1740064245_768ce9edb0c8c703ceab0f7af034cb2fcd9896e0&frontend_id=9
[plugins.nicolive][debug] Waiting for permit (for at most 6 seconds)...
[plugin.api.websocket][debug] Connected: wss://a.live2.nicovideo.jp/unama/wsapi/v2/watch/66383504212555?audience_token=66383504212555_anonymous-user-30f6c6aa-599c-4d8c-ac5f-c4a25a14748c_1740064245_768ce9edb0c8c703ceab0f7af034cb2fcd9896e0&frontend_id=9
[plugins.nicolive][debug] Received: {"type":"serverTime","data":{"currentMs":"2025-02-20T00:10:46.790+09:00"}}
[plugins.nicolive][debug] Received: {"type":"seat","data":{"keepIntervalSec":30}}
[plugins.nicolive][debug] Received: {"type":"stream","data":{"uri":"https://livedelivery.dlive.nicovideo.jp/hls/playlists/67b5dd2f7423e7204cf95984/8b7437f7e4354f60/multivariant/variant.m3u8","syncUri":"https://livedelivery.dlive.nicovideo.jp/hls/playlists/67b5dd2f7423e7204cf95984/8b7437f7e4354f60/multivariant/stream_sync.json","quality":"abr","availableQualities":["abr","normal","low","super_low","audio_high","audio_only"],"protocol":"hls","cookies":[{"name":"session","value":"ef819325210ade262a060cc58f5417368b7437f7e4354f600000000067b745f62da01911d336e4b4","expires":"Thu, 20 Feb 2025 15:10:46 GMT","domain":"nicovideo.jp","path":"/hls/keys/67b5dd2f7423e7204cf95984","secure":true},{"name":"CloudFront-Policy","value":"eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9saXZlZGVsaXZlcnkuZGxpdmUubmljb3ZpZGVvLmpwL2hscy9wbGF5bGlzdHMvNjdiNWRkMmY3NDIzZTcyMDRjZjk1OTg0LzhiNzQzN2Y3ZTQzNTRmNjAvKiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc0MDA2NDI0Nn19fV19","domain":"nicovideo.jp","path":"/hls/playlists/67b5dd2f7423e7204cf95984/8b7437f7e4354f60","secure":true},{"name":"CloudFront-Signature","value":"TJuZ1GBRPVjeK4GWV7a0gdSe3fbr0rIJfznu4tAn9W902YHgjwWz8atziSQvALM1R~bQdmKa0devRDJvFYo835msjduXL9rVyZ6ZjJJZBfgDT6Yck7gOkqOXgrfFYFNMRj5CnNPTnNclsHeISfnZ7puMXmRh68xSyPW9ptTd-nFXfPQhAunw51j~qJh2yU5wlpY7jDqcybqUTm97YWU-TnwvcS4DLvbajGbRDXxP7t-ei6Hc4GGLu6JNKz3ypzJt5CeoRRwYZluUE5UayKxXfWOOlVSHZ4FpnBxMAdH3t6D-Au8XX8QWcLE~-1ODBn5xvU0df9viVaIrQouVU5HUMQ__","domain":"nicovideo.jp","path":"/hls/playlists/67b5dd2f7423e7204cf95984/8b7437f7e4354f60","secure":true},{"name":"CloudFront-Key-Pair-Id","value":"K2R26IUCM0JJBQ","domain":"nicovideo.jp","path":"/hls/playlists/67b5dd2f7423e7204cf95984/8b7437f7e4354f60","secure":true},{"name":"CloudFront-Policy","value":"eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9saXZlZGVsaXZlcnkuZGxpdmUubmljb3ZpZGVvLmpwL2hscy9zZWdtZW50cy82N2I1ZGQyZjc0MjNlNzIwNGNmOTU5ODQvdmlkZW8vMTIzKiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTc0MDA2NDI0Nn19fV19","domain":"nicovideo.jp","path":"/hls/segments/67b5dd2f7423e7204cf95984/video","secure":true},{"name":"CloudFront-Signature","value":"3gsdo0KmHm66jIs7yfgkKSpNks~oWVKfoUVW3oF0k3eaD5RDOMHJRStqVWkEWvAETARCvSjFt7nNNkH-AltwF~1n5hz852Uv2oINeANp6w4ItjIJvFVyV0hqGmMxCRQqpa~WR6a9pvPPHYGIZZJD7PxSIFS2~GZJBVEvBhNPfSOoooJp~YZi0RGcFfpyJqX-WNg5ThdOE99rY4UJHDORTcEW-5fCwCPc2mM--Y5T6XfggzjtsDoCjsJsdvMEp7t1-Y1nJqHGYoqJE7WPfC7vAZqKKObyUO0tJ~zVk8HUmkYZJZwgquZ34e6LAXFLe~Z8fyURkhGJPLqZABwW1T6wxg__","domain":"nicovideo.jp","path":"/hls/segments/67b5dd2f7423e7204cf95984/video","secure":true},{"name":"CloudFront-Key-Pair-Id","value":"K2R26IUCM0JJBQ","domain":"nicovideo.jp","path":"/hls/segments/67b5dd2f7423e7204cf95984/video","secure":true},{"name":"CloudFront-Policy","value":"eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9saXZlZGVsaXZlcnkuZGxpdmUubmljb3ZpZGVvLmpwL2hscy9zZWdtZW50cy82N2I1ZGQyZjc0MjNlNzIwNGNmOTU5ODQvYXVkaW8vMSoiLCJDb25kaXRpb24iOnsiRGF0ZUxlc3NUaGFuIjp7IkFXUzpFcG9jaFRpbWUiOjE3NDAwNjQyNDZ9fX1dfQ__","domain":"nicovideo.jp","path":"/hls/segments/67b5dd2f7423e7204cf95984/audio","secure":true},{"name":"CloudFront-Signature","value":"1NQUkN2yGpHnvKUeFKRJulOoShvIDPpIlr-8QE4z6LNRX4E0lk05YRhl3pXOSzwxrfBXkqrpU3V~dGzO1n4~oJDR1Hr8mNdx9QoSa0WhHkvsKDxj~SwQP9D27qpQRlkcRENroJ91vkcVgjBHAxTbTXPLo2q5PwAmXfHx0C4bWImPmu90gA2HFvg9b-d6vA9HNETmVCopkq0OQx92JFhB-mwoUoTp2X3zhFF83GR36NKkWI5UGnpMaY5iBNRqvlpmalWTKAFXGFz0xi83G0-Gx7POPr3~dVL-H4amZPuItnst0l4gT~80kuvnAE4MvnmBr6PouJc9EIujLgI4TcLNuw__","domain":"nicovideo.jp","path":"/hls/segments/67b5dd2f7423e7204cf95984/audio","secure":true},{"name":"CloudFront-Key-Pair-Id","value":"K2R26IUCM0JJBQ","domain":"nicovideo.jp","path":"/hls/segments/67b5dd2f7423e7204cf95984/audio","secure":true},{"name":"CloudFront-Policy","value":"eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9saXZlZGVsaXZlcnkuZGxpdmUubmljb3ZpZGVvLmpwL2hscy9rZXlzLzY3YjVkZDJmNzQyM2U3MjA0Y2Y5NTk4NC8qIiwiQ29uZGl0aW9uIjp7IkRhdGVMZXNzVGhhbiI6eyJBV1M6RXBvY2hUaW1lIjoxNzQwMDY0MjQ2fX19XX0_","domain":"nicovideo.jp","path":"/hls/keys/67b5dd2f7423e7204cf95984","secure":true},{"name":"CloudFront-Signature","value":"RKWmmztV0MDtGD3mGozcaHgwwXGVeBNSk3Lw-2tTgHsI4Qv-zFhzpwfpwe5329gKkB-dwC8~MjuyvpECWFG502xQi~qH33P9Qx2hv9NxwAAxsJ~7Xp90ISJYdNQv-QS0lRfCciHHialE0xSDNGVj3DvVSAgB0Y3K2RdASxVw5bICZ38n7KWeGQFI0DgKBMBqlNhwEgxnduFdFiuhUNS2m-c47y5Zz-mlrC8ydMs7PrtW2F1qE8nCfJiUKY-dfJUlN0vys3hCirHIj5CrVJZEh~J66fMfy7OIrNkPOn1mj9UALLVx6VrgnNAp4s5eXdPs~z6u6RSC5ANA7xg7hbmyvA__","domain":"nicovideo.jp","path":"/hls/keys/67b5dd2f7423e7204cf95984","secure":true},{"name":"CloudFront-Key-Pair-Id","value":"K2R26IUCM0JJBQ","domain":"nicovideo.jp","path":"/hls/keys/67b5dd2f7423e7204cf95984","secure":true}]}}
[utils.l10n][debug] Language code: en_US
[stream.ffmpegmux][debug] ffmpeg version n7.1 Copyright (c) 2000-2024 the FFmpeg developers
built with gcc 14.2.1 (GCC) 20240910
configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-frei0r --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libdvdnav --enable-libdvdread --enable-libfreetype --enable-libfribidi --enable-libglslang --enable-libgsm --enable-libharfbuzz --enable-libiec61883 --enable-libjack --enable-libjxl --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librav1e --enable-librsvg --enable-librubberband --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpl --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-vapoursynth --enable-version3 --enable-vulkan
libavutil      59. 39.100 / 59. 39.100
libavcodec     61. 19.100 / 61. 19.100
libavformat    61.  7.100 / 61.  7.100
libavdevice    61.  3.100 / 61.  3.100
libavfilter    10.  4.100 / 10.  4.100
libswscale      8.  3.100 /  8.  3.100
libswresample   5.  3.100 /  5.  3.100
libpostproc    58.  3.100 / 58.  3.100
[stream.hls][debug] Using external audio tracks for stream 450p (language=None, name=Main Audio)
[stream.hls][debug] Using external audio tracks for stream 288p (language=None, name=Main Audio)
[stream.hls][debug] Using external audio tracks for stream 288p_alt (language=None, name=Main Audio)
[cli][info] Available streams: 288p_alt (worst), 288p, 450p (best)
[cli][info] Opening stream: 450p (hls-multi)
[cli][info] Starting player: /usr/bin/mpv
[stream.ffmpegmux][debug] Opening hls substream
[plugins.nicolive][debug] Stream opened, keeping websocket connection alive
[plugins.nicolive][debug] Received: {"type":"schedule","data":{"begin":"2025-02-19T22:31:34+09:00","end":"2025-02-20T00:31:34+09:00"}}
[plugins.nicolive][debug] Received: {"type":"messageServer","data":{"viewUri":"https://mpn.live.nicovideo.jp/api/view/v4/BBzenxaUOOiK48Oe5pPOoeerzgIBIEJZIzgSfqulHD6qZQHv7_QZfCNS56AR-QsM_aeh5qkFetHx08k","vposBaseTime":"2025-02-19T22:31:25+09:00"}}
[plugins.nicolive][debug] Received: {"type":"akashic","data":{"playId":"100768694","contentUrl":"https://resource.akashic.coe.nicovideo.jp/coe/contents/nicocas/4.2.2.6/content.json","logServerUrl":"wss://msg06.akashic.coe.nicovideo.jp/4010/","status":"ready","token":"b3782159381c43001d951bb626a70842ab4dc4b3ffb91daee43b0bdae930b3e0","playerId":"anonymous-user-30f6c6aa-599c-4d8c-ac5f-c4a25a14748c"}}
[plugins.nicolive][debug] Received: {"type":"statistics","data":{"viewers":29,"comments":83,"adPoints":0,"giftPoints":0}}
[stream.hls][debug] Reloading playlist
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[utils.named_pipe][info] Creating pipe streamlinkpipe-283573-1-176
[utils.named_pipe][info] Creating pipe streamlinkpipe-283573-2-5328
[stream.ffmpegmux][debug] ffmpeg command: ['/usr/bin/ffmpeg', '-y', '-nostats', '-loglevel', 'info', '-i', '/tmp/streamlinkpipe-283573-1-176', '-i', '/tmp/streamlinkpipe-283573-2-5328', '-c:v', 'copy', '-c:a', 'copy', '-map', '0:v?', '-map', '0:a?', '-map', '1:a', '-f', 'mpegts', 'pipe:1']
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-283573-1-176
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-283573-2-5328
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] First Sequence: 1983; Last Sequence: 1987
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 1985; End Sequence: None
[stream.hls][debug] Adding segment 1985 to queue
[stream.hls][debug] Adding segment 1986 to queue
[stream.hls][debug] Adding segment 1987 to queue
[stream.hls][debug] Writing segment 1985 to output
[stream.hls][debug] Segment initialization 1985 complete
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] First Sequence: 1983; Last Sequence: 1987
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 1985; End Sequence: None
[stream.hls][debug] Adding segment 1985 to queue
[stream.hls][debug] Adding segment 1986 to queue
[stream.hls][debug] Adding segment 1987 to queue
[stream.hls][debug] Writing segment 1985 to output
[stream.hls][debug] Segment initialization 1985 complete
[stream.hls][debug] Writing segment 1985 to output
[stream.hls][debug] Writing segment 1985 to output
[stream.hls][debug] Segment 1985 complete
[stream.hls][debug] Writing segment 1986 to output
[stream.hls][debug] Segment 1986 complete
[stream.hls][debug] Writing segment 1987 to output
[stream.hls][debug] Segment 1987 complete
[stream.hls][debug] Segment 1985 complete
[stream.hls][debug] Writing segment 1986 to output
[stream.hls][debug] Segment 1986 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=https://live.nicovideo.jp/watch/lv347077742', '-']
[cli][debug] Writing stream to output
[stream.hls][debug] Writing segment 1987 to output
[stream.hls][debug] Segment 1987 complete
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Reloading playlist
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] Adding segment 1988 to queue
[stream.hls][debug] Segments in this playlist are encrypted
[stream.hls][debug] Adding segment 1988 to queue
[stream.hls][debug] Writing segment 1988 to output
[stream.hls][debug] Segment 1988 complete
[stream.hls][debug] Writing segment 1988 to output
[stream.hls][debug] Segment 1988 complete
[cli][info] Player closed
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-283573-2-5328
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-283573-1-176
[plugin.api.websocket][debug] Closed: wss://a.live2.nicovideo.jp/unama/wsapi/v2/watch/66383504212555?audience_token=66383504212555_anonymous-user-30f6c6aa-599c-4d8c-ac5f-c4a25a14748c_1740064245_768ce9edb0c8c703ceab0f7af034cb2fcd9896e0&frontend_id=9
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```