### PR TITLE
stream.hls: reset key state on discontinuity

### DIFF
--- a/src/streamlink/stream/hls/m3u8.py
+++ b/src/streamlink/stream/hls/m3u8.py
@@ -324,6 +324,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
         """
         self._discontinuity = True
         self._map = None
+        self._key = None
 
     @parse_tag("EXT-X-KEY")
     def parse_tag_ext_x_key(self, value: str) -> None:


### PR DESCRIPTION
Don't try to decrypt segments when a discontinuity occurs after a sequence of encrypted segments

----

See https://github.com/streamlink/streamlink/pull/6441#issuecomment-2672176738

The added test fails without the fix.