### PR TITLE
build: add decompress extras marker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Python dependencies
         run: >
           python -m pip install -U
-          -e .
+          -e .[decompress]
           -r dev-requirements.txt
         continue-on-error: ${{ matrix.continue || false }}
       - name: Install optional Python dependencies

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -501,6 +501,14 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
 
         - DASH streams with video and audio content always have to get remuxed.
         - HLS streams optionally need to get remuxed depending on the stream selection.
+    * - optional
+      - | `brotli`_
+        | ``decompress`` extras marker
+      - Used for decompressing HTTP responses
+    * - optional
+      - | `zstandard`_
+        | ``decompress`` extras marker
+      - Used for decompressing HTTP responses
 
 .. _pyproject.toml: https://github.com/streamlink/streamlink/blob/master/pyproject.toml
 .. _PEP-517: https://peps.python.org/pep-0517/
@@ -523,6 +531,9 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
 .. _trio-websocket: https://trio-websocket.readthedocs.io/en/stable/
 .. _urllib3: https://urllib3.readthedocs.io/en/stable/
 .. _websocket-client: https://pypi.org/project/websocket-client/
+
+.. _brotli: https://pypi.org/project/Brotli/
+.. _zstandard: https://pypi.org/project/zstandard/
 
 .. _FFmpeg: https://www.ffmpeg.org/
 .. _muxing: https://en.wikipedia.org/wiki/Multiplexing#Video_processing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,13 @@ dependencies = [
   "websocket-client >=1.2.1,<2",
 ]
 
+[project.optional-dependencies]
+decompress = [
+  # don't define brotli or zstandard library versions here
+  # and instead rely on urllib3's version requirements
+  "urllib3[brotli,zstd] >=1.26.0,<3"
+]
+
 [project.urls]
 Homepage = "https://github.com/streamlink/streamlink"
 Documentation = "https://streamlink.github.io/"


### PR DESCRIPTION
Instead of defining brotli and zstandard directly, rely on urllib3's version requirements and use its brotli and zstd extras markers.

brotli or zstandard may be required by some websites which ignore the HTTP client's decompression capabilities set in the Accept-Encoding HTTP header. Both dependencies are picked up automatically if available.

----

https://github.com/urllib3/urllib3/blob/2.3.0/pyproject.toml#L41-L48