### PR TITLE
cli: allow --retry-streams to be set to 0

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -816,13 +816,16 @@ def build_parser():
     stream.add_argument(
         "--retry-streams",
         metavar="DELAY",
-        type=num(float, gt=0),
+        type=num(float, ge=0),
         help="""
             Retry fetching the list of available streams until streams are found
-            while waiting `DELAY` second(s) between each attempt. If unset, only one
-            attempt will be made to fetch the list of streams available.
+            while waiting `DELAY` second(s) between each attempt.
 
-            The number of fetch retry attempts can be capped with --retry-max.
+            The number of retry attempts can be capped with --retry-max.
+            A default value of ``1`` is implied for non-zero values of --retry-max.
+
+            If both --retry-streams and --retry-max are set to `0`, then only one attempt will be made
+            to fetch the list of available streams. This is the default behavior.
         """,
     )
     stream.add_argument(
@@ -830,10 +833,10 @@ def build_parser():
         metavar="COUNT",
         type=num(int, ge=0),
         help="""
-            When using --retry-streams, stop retrying the fetch after `COUNT` retry
-            attempt(s). Fetch will retry infinitely if `COUNT` is zero or unset.
+            Stop fetching the list of available streams after `COUNT` retry attempt(s).
 
-            If --retry-max is set without setting --retry-streams, the delay between retries will default to 1 second.
+            A value of `0` makes Streamlink fetch streams indefinitely if --retry-streams is set to a non-zero value.
+            If --retry-streams is unset, then the default delay between fetching available streams is 1 second.
         """,
     )
     stream.add_argument(

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -480,6 +480,8 @@ def fetch_streams_with_retry(plugin: Plugin, interval: float, count: int) -> Map
 
     try:
         streams = fetch_streams(plugin)
+    except FatalPluginError:
+        raise
     except PluginError as err:
         log.error(err)
         streams = None

--- a/tests/cli/main/test_handle_url.py
+++ b/tests/cli/main/test_handle_url.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import re
+from typing import Iterator
 from unittest.mock import Mock
 
 import pytest
 
 import streamlink_cli.main
-from streamlink.exceptions import PluginError
+from streamlink.exceptions import FatalPluginError, PluginError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.session import Streamlink
 from streamlink.stream.stream import Stream
@@ -57,27 +58,33 @@ def _stream_output(monkeypatch: pytest.MonkeyPatch):
 
 @pytest.fixture(autouse=True)
 def streams(request: pytest.FixtureRequest, session: Streamlink):
-    param = getattr(request, "param", {})
+    params = getattr(request, "param", [{}])
+    params = params if isinstance(params, list) else [params]
 
-    if exc := param.get("exc"):
-        return exc
+    def streams_generator():
+        for param in params:
+            if exc := param.get("exc"):
+                yield exc
+                continue
 
-    streams = param.get("streams", False)
-    to_url = param.get("to_url", True)
-    to_manifest_url = param.get("to_manifest_url", True)
+            streams = param.get("streams", {})
+            to_url = param.get("to_url", True)
+            to_manifest_url = param.get("to_manifest_url", True)
 
-    return {
-        name: FakeStream(
-            session,
-            url=url if to_url else None,
-            manifest_url=STREAMS_MULTIVARIANT if to_manifest_url else None,
-        )
-        for name, url in (STREAMS if streams else {}).items()
-    }
+            yield {
+                name: FakeStream(
+                    session,
+                    url=url if to_url else None,
+                    manifest_url=STREAMS_MULTIVARIANT if to_manifest_url else None,
+                )
+                for name, url in (STREAMS if streams is True else streams).items()
+            }
+
+    return streams_generator()
 
 
 @pytest.fixture(autouse=True)
-def plugin(session: Streamlink, streams: BaseException | dict[str, FakeStream]):
+def plugin(session: Streamlink, streams: Iterator[dict[str, FakeStream]]):
     @pluginmatcher(re.compile(r"https?://plugin"))
     class FakePlugin(Plugin):
         __module__ = "plugin"
@@ -88,9 +95,11 @@ def plugin(session: Streamlink, streams: BaseException | dict[str, FakeStream]):
         title = "TITLE"
 
         def _get_streams(self):
-            if isinstance(streams, BaseException):
-                raise streams
-            return streams
+            item = next(streams, None)
+            if isinstance(item, BaseException):
+                raise item
+
+            return item
 
     session.plugins.update({"plugin": FakePlugin})
 
@@ -305,11 +314,169 @@ def plugin(session: Streamlink, streams: BaseException | dict[str, FakeStream]):
     ],
     indirect=["argv", "streams"],
 )
-def test_handle_url(capsys: pytest.CaptureFixture[str], argv: list, streams: dict, exit_code: int, stdout: str):
+def test_handle_url_text_output(
+    capsys: pytest.CaptureFixture[str],
+    argv: list,
+    streams: Iterator[dict[str, FakeStream]],
+    exit_code: int,
+    stdout: str,
+):
     with pytest.raises(SystemExit) as exc_info:
         streamlink_cli.main.main()
 
     assert exc_info.value.code == exit_code
+    out, err = capsys.readouterr()
+    assert out == stdout
+    assert err == ""
+
+
+@pytest.mark.parametrize(
+    ("argv", "streams", "exit_code", "retries", "stdout"),
+    [
+        pytest.param(
+            ["plugin", "best"],
+            [],
+            1,
+            0,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "error: No playable streams found on this URL: plugin\n"
+            ),
+            id="no-retries-implicit",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-streams=0", "--retry-max=0"],
+            [],
+            1,
+            0,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "error: No playable streams found on this URL: plugin\n"
+            ),
+            id="no-retries-explicit",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-max=5"],
+            [],
+            1,
+            5,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][info] Waiting for streams, retrying every 1 second(s)\n"
+                + "error: No playable streams found on this URL: plugin\n"
+            ),
+            id="no-streams",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-max=5"],
+            [{"streams": True}],
+            0,
+            0,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][info] Available streams: audio, 720p (worst), 1080p (best)\n"
+                + "[cli][info] Opening stream: 1080p (fake)\n"
+            ),
+            id="success-on-first-attempt",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-streams=3", "--retry-max=5"],
+            [{}, {}, {"streams": True}],
+            0,
+            2,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][info] Waiting for streams, retrying every 3.0 second(s)\n"
+                + "[cli][info] Available streams: audio, 720p (worst), 1080p (best)\n"
+                + "[cli][info] Opening stream: 1080p (fake)\n"
+            ),
+            id="success-on-third-attempt",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-streams=3", "--retry-max=5"],
+            [{"exc": PluginError("failure")}, {"streams": True}],
+            0,
+            1,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][error] failure\n"
+                + "[cli][info] Waiting for streams, retrying every 3.0 second(s)\n"
+                + "[cli][info] Available streams: audio, 720p (worst), 1080p (best)\n"
+                + "[cli][info] Opening stream: 1080p (fake)\n"
+            ),
+            id="success-with-plugin-error-on-first-attempt",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-streams=3", "--retry-max=5"],
+            [{}, {"exc": PluginError("failure")}, {"streams": True}],
+            0,
+            2,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][info] Waiting for streams, retrying every 3.0 second(s)\n"
+                + "[cli][error] failure\n"
+                + "[cli][info] Available streams: audio, 720p (worst), 1080p (best)\n"
+                + "[cli][info] Opening stream: 1080p (fake)\n"
+            ),
+            id="success-with-plugin-error-on-second-attempt",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-streams=3"],
+            [{} for _ in range(20)] + [{"streams": True}],
+            0,
+            20,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][info] Waiting for streams, retrying every 3.0 second(s)\n"
+                + "[cli][info] Available streams: audio, 720p (worst), 1080p (best)\n"
+                + "[cli][info] Opening stream: 1080p (fake)\n"
+            ),
+            id="success-no-max-attempts",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-max=5"],
+            [{"exc": FatalPluginError("fatal")}, {"streams": True}],
+            1,
+            0,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "error: fatal\n"
+            ),
+            id="fatal-plugin-error-on-first-attempt",
+        ),
+        pytest.param(
+            ["plugin", "best", "--retry-max=5"],
+            [{}, {"exc": FatalPluginError("fatal")}, {"streams": True}],
+            1,
+            1,
+            (
+                "[cli][info] Found matching plugin plugin for URL plugin\n"
+                + "[cli][info] Waiting for streams, retrying every 1 second(s)\n"
+                + "error: fatal\n"
+            ),
+            id="fatal-plugin-error-on-second-attempt",
+        ),
+    ],
+    indirect=["argv", "streams"],
+)  # fmt: skip
+def test_handle_url_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv: list,
+    streams: Iterator[dict[str, FakeStream]],
+    exit_code: int,
+    retries: int,
+    stdout: list[str],
+):
+    mock_sleep = Mock()
+    monkeypatch.setattr("streamlink_cli.main.sleep", mock_sleep)
+
+    with pytest.raises(SystemExit) as exc_info:
+        streamlink_cli.main.main()
+
+    assert exc_info.value.code == exit_code
+    assert mock_sleep.call_count == retries
+
     out, err = capsys.readouterr()
     assert out == stdout
     assert err == ""


### PR DESCRIPTION
- Don't retry fetching streams if `--retry-streams` and `--retry-max` are both set to zero. This was previously only possible if both were unset.
- Update CLI argument help texts accordingly
- Fix `FatalPluginError` not being handled properly on first try
- Add tests for `fetch_streams_with_retry()`

----

Resolves #6454 

Any comprehension issues with the updated help texts? They should be fine now IMO.
https://streamlink--6455.org.readthedocs.build/cli.html#cmdoption-retry-streams