### PR TITLE
cli: make --quiet also suppress ConsoleOutput

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -412,7 +412,7 @@ def build_parser():
         "--quiet",
         action="store_true",
         help="""
-            Suppress console and log output.
+            Suppress console and log output, and disable user input prompts.
         """,
     )
     logging.add_argument(

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -412,9 +412,7 @@ def build_parser():
         "--quiet",
         action="store_true",
         help="""
-            Hide all log output.
-
-            Alias for --loglevel=none.
+            Suppress console and log output.
         """,
     )
     logging.add_argument(

--- a/src/streamlink_cli/compat.py
+++ b/src/streamlink_cli/compat.py
@@ -1,18 +1,24 @@
 import sys
-from os import devnull
+from atexit import register as _atexit_register
+from os import devnull as _devnull
 from typing import BinaryIO
 
 
-try:
-    stdout: BinaryIO = sys.stdout.buffer
-except AttributeError:  # pragma: no cover
-    from atexit import register as _atexit_register
+devnull_bin = open(_devnull, "wb")
+_atexit_register(devnull_bin.close)
+devnull_txt = open(_devnull, "w", encoding=None)
+_atexit_register(devnull_txt.close)
 
-    stdout = open(devnull, "wb")
-    _atexit_register(stdout.close)
-    del _atexit_register
+try:
+    stdout_or_devnull_bin: BinaryIO = sys.stdout.buffer
+except AttributeError:  # pragma: no cover
+    stdout_or_devnull_bin = devnull_bin
+
+del _atexit_register, _devnull
 
 
 __all__ = [
-    "stdout",
+    "devnull_bin",
+    "devnull_txt",
+    "stdout_or_devnull_bin",
 ]

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -18,13 +18,9 @@ class ConsoleUserInputRequester(UserInputRequester):
         self.console = console
 
     def ask(self, prompt: str) -> str:
-        if not sys.stdin or not sys.stdin.isatty():
-            raise OSError("no TTY available")
         return self.console.ask(f"{prompt.strip()}: ")
 
     def ask_password(self, prompt: str) -> str:
-        if not sys.stdin or not sys.stdin.isatty():
-            raise OSError("no TTY available")
         return self.console.askpass(f"{prompt.strip()}: ")
 
 
@@ -33,10 +29,14 @@ class ConsoleOutput:
         self.json = json
         self.output = output
 
-    def ask(self, prompt: str) -> str | None:
+    def _check_streams(self):
         if not sys.stdin or not sys.stdin.isatty():
-            return None
+            raise OSError("No input TTY available")
+        if not self.output or not self.output.isatty():
+            raise OSError("No output TTY available")
 
+    def ask(self, prompt: str) -> str | None:
+        self._check_streams()
         self.output.write(prompt)
 
         # noinspection PyBroadException
@@ -46,8 +46,7 @@ class ConsoleOutput:
             return None
 
     def askpass(self, prompt: str) -> str | None:
-        if not sys.stdin or not sys.stdin.isatty():
-            return None
+        self._check_streams()
 
         return getpass(prompt, self.output)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -86,12 +86,12 @@ def check_file_output(path: Path, force: bool) -> Path:
     log.debug("Checking file output")
 
     if realpath.is_file() and not force:
-        if sys.stdin and sys.stdin.isatty():
+        try:
             answer = console.ask(f"File {path} already exists! Overwrite it? [y/N] ")
-            if not answer or answer.lower() != "y":
-                raise StreamlinkCLIError()
-        else:
+        except OSError:
             log.error(f"File {path} already exists, use --force to overwrite it.")
+            raise StreamlinkCLIError() from None
+        if not answer or answer.lower() != "y":
             raise StreamlinkCLIError()
 
     return realpath

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -15,7 +15,7 @@ from contextlib import closing, suppress
 from gettext import gettext
 from pathlib import Path
 from time import sleep
-from typing import Any
+from typing import Any, TextIO
 
 import streamlink.logger as logger
 from streamlink import NoPluginError, PluginError, StreamError, Streamlink, __version__ as streamlink_version
@@ -31,7 +31,7 @@ from streamlink_cli.argparser import (
     setup_plugin_options,
     setup_session_options,
 )
-from streamlink_cli.compat import stdout_or_devnull_bin
+from streamlink_cli.compat import devnull_txt, stdout_or_devnull_bin
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.exceptions import StreamlinkCLIError
@@ -899,9 +899,11 @@ def setup(parser: ArgumentParser) -> None:
     # call argument set up as early as possible to load args from config files
     setup_config_args(parser, ignore_unknown=True)
 
-    # Console output should be on stderr if we are outputting
-    # a stream to stdout.
-    if args.stdout or args.output == "-" or args.record == "-" or args.record_and_pipe:
+    # Console output should be on stderr if we are outputting a stream to stdout
+    console_out: TextIO
+    if args.quiet:
+        console_out = devnull_txt
+    elif args.stdout or args.output == "-" or args.record == "-" or args.record_and_pipe:
         console_out = sys.stderr
     else:
         console_out = sys.stdout

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -31,7 +31,7 @@ from streamlink_cli.argparser import (
     setup_plugin_options,
     setup_session_options,
 )
-from streamlink_cli.compat import stdout
+from streamlink_cli.compat import stdout_or_devnull_bin
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 from streamlink_cli.constants import CONFIG_FILES, DEFAULT_STREAM_METADATA, LOG_DIR, PLUGIN_DIRS, STREAM_SYNONYMS
 from streamlink_cli.exceptions import StreamlinkCLIError
@@ -115,7 +115,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
             raise StreamlinkCLIError("The -o/--output argument is incompatible with -r/--record and -R/--record-and-pipe")
 
         if args.output == "-":
-            return FileOutput(fd=stdout)
+            return FileOutput(fd=stdout_or_devnull_bin)
         else:
             filename = check_file_output(formatter.path(args.output, args.fs_safe_rules), args.force)
             return FileOutput(filename=filename)
@@ -125,10 +125,10 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
             raise StreamlinkCLIError("The -O/--stdout argument is incompatible with -R/--record-and-pipe")
 
         if not args.record or args.record == "-":
-            return FileOutput(fd=stdout)
+            return FileOutput(fd=stdout_or_devnull_bin)
         else:
             filename = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
-            return FileOutput(fd=stdout, record=FileOutput(filename=filename))
+            return FileOutput(fd=stdout_or_devnull_bin, record=FileOutput(filename=filename))
 
     elif args.record_and_pipe:
         warnings.warn(
@@ -137,7 +137,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
             stacklevel=1,
         )
         filename = check_file_output(formatter.path(args.record_and_pipe, args.fs_safe_rules), args.force)
-        return FileOutput(fd=stdout, record=FileOutput(filename=filename))
+        return FileOutput(fd=stdout_or_devnull_bin, record=FileOutput(filename=filename))
 
     elif args.player:
         http = namedpipe = record = None
@@ -152,7 +152,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
 
         if args.record:
             if args.record == "-":
-                record = FileOutput(fd=stdout)
+                record = FileOutput(fd=stdout_or_devnull_bin)
             else:
                 filename = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
                 record = FileOutput(filename=filename)

--- a/src/streamlink_cli/output/file.py
+++ b/src/streamlink_cli/output/file.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import BinaryIO
 
 from streamlink.compat import is_win32
-from streamlink_cli.compat import stdout
+from streamlink_cli.compat import stdout_or_devnull_bin
 from streamlink_cli.output.abc import Output
 
 
@@ -37,7 +37,7 @@ class FileOutput(Output):
             msvcrt.setmode(self.fd.fileno(), O_BINARY)
 
     def _close(self):
-        if self.fd is not stdout:
+        if self.fd is not stdout_or_devnull_bin:
             self.fd.close()
         if self.record:
             self.record.close()

--- a/tests/cli/main/test_check_file_output.py
+++ b/tests/cli/main/test_check_file_output.py
@@ -46,14 +46,9 @@ def path(monkeypatch: pytest.MonkeyPatch, request: pytest.FixtureRequest):
 @pytest.fixture()
 def prompt(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
     param = getattr(request, "param", {})
-    isatty = param.get("isatty", True)
     ask = param.get("ask", "y")
 
-    prompt = Mock(return_value=ask)
-    if param.get("no-stdin", False):
-        monkeypatch.setattr("sys.stdin", None)
-    else:
-        monkeypatch.setattr("sys.stdin.isatty", Mock(return_value=isatty))
+    prompt = Mock(side_effect=ask) if isinstance(ask, Exception) else Mock(return_value=ask)
     monkeypatch.setattr("streamlink_cli.main.console", Mock(ask=prompt))
 
     return prompt
@@ -84,30 +79,6 @@ def prompt(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
             ],
             id="exists-force",
         ),
-        pytest.param(
-            {"exists": True},
-            False,
-            {"isatty": False},
-            pytest.raises(StreamlinkCLIError),
-            [
-                ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
-                ("streamlink.cli", "debug", "Checking file output"),
-                ("streamlink.cli", "error", "File file already exists, use --force to overwrite it."),
-            ],
-            id="exists-no-tty",
-        ),
-        pytest.param(
-            {"exists": True},
-            False,
-            {"no-stdin": True},
-            pytest.raises(StreamlinkCLIError),
-            [
-                ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
-                ("streamlink.cli", "debug", "Checking file output"),
-                ("streamlink.cli", "error", "File file already exists, use --force to overwrite it."),
-            ],
-            id="exists-no-stdin",
-        ),
     ],
     indirect=["path", "prompt"],
 )
@@ -130,22 +101,44 @@ def test_exists(
 
 @pytest.mark.parametrize("path", [pytest.param({"exists": True}, id="")], indirect=True)
 @pytest.mark.parametrize(
-    ("prompt", "exits"),
+    ("prompt", "exits", "log"),
     [
         pytest.param(
             {"ask": "y"},
             nullcontext(),
+            [
+                ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
+                ("streamlink.cli", "debug", "Checking file output"),
+            ],
             id="yes",
         ),
         pytest.param(
             {"ask": "n"},
             pytest.raises(StreamlinkCLIError),
+            [
+                ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
+                ("streamlink.cli", "debug", "Checking file output"),
+            ],
             id="no",
         ),
         pytest.param(
             {"ask": None},
             pytest.raises(StreamlinkCLIError),
-            id="error",
+            [
+                ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
+                ("streamlink.cli", "debug", "Checking file output"),
+            ],
+            id="none",
+        ),
+        pytest.param(
+            {"ask": OSError()},
+            pytest.raises(StreamlinkCLIError),
+            [
+                ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
+                ("streamlink.cli", "debug", "Checking file output"),
+                ("streamlink.cli", "error", "File file already exists, use --force to overwrite it."),
+            ],
+            id="oserror",
         ),
     ],
     indirect=["prompt"],
@@ -155,14 +148,12 @@ def test_prompt(
     path: Path,
     prompt: Mock,
     exits: nullcontext,
+    log: list,
 ):
     with exits:
         output = check_file_output(path, False)
         assert isinstance(output, _FakePath)
         assert output == PurePosixPath("/path/to/file")
 
-    assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
-        ("streamlink.cli", "info", "Writing output to\n/path/to/file"),
-        ("streamlink.cli", "debug", "Checking file output"),
-    ]
+    assert [(record.name, record.levelname, record.message) for record in caplog.records] == log
     assert prompt.call_args_list == [call("File file already exists! Overwrite it? [y/N] ")]

--- a/tests/cli/main/test_create_output.py
+++ b/tests/cli/main/test_create_output.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from streamlink.exceptions import StreamlinkDeprecationWarning
-from streamlink_cli.compat import stdout
+from streamlink_cli.compat import stdout_or_devnull_bin
 from streamlink_cli.exceptions import StreamlinkCLIError
 from streamlink_cli.main import (
     Formatter,
@@ -123,7 +123,7 @@ def test_player_record_stdout(formatter: Formatter, argv: list):
     assert output.env == {"VAR1": "abc", "VAR2": "def"}
     assert type(output.record) is FileOutput
     assert output.record.filename is None
-    assert output.record.fd is stdout
+    assert output.record.fd is stdout_or_devnull_bin
     assert output.record.record is None
 
 
@@ -157,7 +157,7 @@ def test_stdout(formatter: Formatter, argv: list):
     output = create_output(formatter)
     assert isinstance(output, FileOutput)
     assert output.filename is None
-    assert output.fd is stdout
+    assert output.fd is stdout_or_devnull_bin
     assert output.record is None
 
 
@@ -203,7 +203,7 @@ def test_stdout_record(
     assert check_file_output.call_args_list == [call(Path("foo"), force)]
     assert isinstance(output, FileOutput)
     assert output.filename is None
-    assert output.fd is stdout
+    assert output.fd is stdout_or_devnull_bin
     assert isinstance(output.record, FileOutput)
     assert output.record.filename == Path("foo")
     assert output.record.fd is None

--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -13,6 +13,7 @@ import tests
 from streamlink.logger import ALL, TRACE, StringFormatter
 from streamlink.session import Streamlink
 from streamlink_cli.argparser import ArgumentParser
+from streamlink_cli.compat import devnull_txt
 from streamlink_cli.exceptions import StreamlinkCLIError
 from streamlink_cli.main import build_parser
 
@@ -41,6 +42,7 @@ class TestStdoutStderr:
         ("argv", "stream"),
         [
             pytest.param([], "stdout", id="default"),
+            pytest.param(["--quiet"], "devnull", id="--quiet"),
             pytest.param(["--stdout"], "stderr", id="--stdout"),
             pytest.param(["--output=file"], "stdout", id="--output=file"),
             pytest.param(["--output=-"], "stderr", id="--output=-"),
@@ -55,7 +57,11 @@ class TestStdoutStderr:
 
         rootlogger = logging.getLogger("streamlink")
         clilogger = streamlink_cli.main.log
-        streamobj = getattr(sys, stream)
+        streamobj = {
+            "stdout": sys.stdout,
+            "stderr": sys.stderr,
+            "devnull": devnull_txt,
+        }.get(stream)
 
         assert clilogger.parent is rootlogger
         assert isinstance(rootlogger.handlers[0], logging.StreamHandler)

--- a/tests/cli/output/test_file.py
+++ b/tests/cli/output/test_file.py
@@ -29,7 +29,7 @@ def fd(tmp_path: Path):
 def fake_stdout(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
     # can't use in-memory io.BytesIO, since fd.fileno() is called on Windows
     with _create_fd(tmp_path, "stdout") as fd:
-        monkeypatch.setattr("streamlink_cli.output.file.stdout", fd)
+        monkeypatch.setattr("streamlink_cli.output.file.stdout_or_devnull_bin", fd)
         yield fd
 
 

--- a/tests/cli/test_compat.py
+++ b/tests/cli/test_compat.py
@@ -1,6 +1,8 @@
 import importlib.util
-from io import BufferedWriter
+from contextlib import suppress
+from io import BufferedWriter, TextIOWrapper
 from os import devnull
+from types import ModuleType
 from unittest.mock import Mock, call
 
 import pytest
@@ -8,12 +10,21 @@ import pytest
 import streamlink_cli.compat
 
 
-def test_no_stdout(monkeypatch: pytest.MonkeyPatch):
+@pytest.fixture()
+def _no_sys_stdout(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("sys.stdout", None)
 
+
+@pytest.fixture()
+def mock_atexit_register(monkeypatch: pytest.MonkeyPatch):
     mock_atexit_register = Mock()
     monkeypatch.setattr("atexit.register", mock_atexit_register)
 
+    return mock_atexit_register
+
+
+@pytest.fixture()
+def module(monkeypatch: pytest.MonkeyPatch, mock_atexit_register: Mock):
     spec = importlib.util.find_spec("streamlink_cli.compat")
     assert spec
     assert spec.loader
@@ -22,9 +33,33 @@ def test_no_stdout(monkeypatch: pytest.MonkeyPatch):
     assert module is not streamlink_cli.compat
 
     spec.loader.exec_module(module)
-    assert module.sys.stdout is None
-    assert isinstance(module.stdout, BufferedWriter)
-    assert module.stdout.name == devnull
 
-    assert mock_atexit_register.call_args_list == [call(module.stdout.close)]
-    module.stdout.close()  # close manually, since we've mocked the atexit.register() call
+    try:
+        yield module
+    finally:
+        # close manually, since we've mocked the atexit.register() call
+        with suppress(Exception):
+            module.devnull_bin.close()
+        with suppress(Exception):
+            module.devnull_txt.close()
+
+
+def test_devnull(mock_atexit_register: Mock, module: ModuleType):
+    assert hasattr(module, "devnull_bin")
+    assert hasattr(module, "devnull_txt")
+    assert isinstance(module.devnull_bin, BufferedWriter)
+    assert isinstance(module.devnull_txt, TextIOWrapper)
+    assert module.devnull_bin.name == devnull
+    assert module.devnull_txt.name == devnull
+
+    assert mock_atexit_register.call_args_list == [
+        call(module.devnull_bin.close),
+        call(module.devnull_txt.close),
+    ]
+
+
+@pytest.mark.usefixtures("_no_sys_stdout")
+def test_stdout_is_devnull(module: ModuleType):
+    assert hasattr(module, "stdout_or_devnull_bin")
+    assert isinstance(module.stdout_or_devnull_bin, BufferedWriter)
+    assert module.stdout_or_devnull_bin.name == devnull


### PR DESCRIPTION
#6449 can't be resolved without prior changes to the setup of Streamlink's text output streams. This is the first step of the required setup changes.

----

This PR fixes the behavior of `--quiet`. Previously, it was treated as a simple alias of `--loglevel=none`. This however meant that the `ConsoleOutput` still remained on `stdout` (or `stderr` if `--stdout` is set), so non-log messages (especially most error messages) were still written to the output. A `--quiet` CLI argument should suppress all kinds of text output though, because that's what it implies, no text output at all.

The whole text stream setup is unfortunately a bit messy. Not only do we have two separate ways of writing text to the output, namely `logging.StreamHandler` and `ConsoleOutput`, where `ConsoleOutput` always inherits the output stream of the root logger (which also seems wrong), but `--logfile` and also potentially missing `stdout`/`stderr` file descriptors can affect the chosen output stream.

Another thing that was previously not handled correctly were user input prompts when the text output was a file stream, when setting the `--logfile` CLI argument for example, as `ConsoleOutput` does always inherit the logger's stream, or when the text output was unavailable (no file descriptors). This is now fixed and works correctly when `--quiet` is set, as it now writes to devnull.

----

Before this can be merged, I will have to check a couple of things first, because it's possible that I've broken something with these changes.

```
$ touch /tmp/foo

# Default log output and console output, with prompt
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/foo
File /tmp/foo already exists! Overwrite it? [y/N]

# Without log output, but with console output and prompt
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo --loglevel=none
File /tmp/foo already exists! Overwrite it? [y/N]

# --logfile sets stream of log output and console output, prompt not possible, immediate exit
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo --logfile=/dev/null
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo --logfile=/tmp/bar

# Weird special case, because isatty()==True on /dev/stdout. Broken... Needs further fixes...
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo --logfile=/dev/stdout
[cli][info] Found matching plugin http for URL httpstream://file:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/foo

File /tmp/foo already exists! Overwrite it? [y/N]

# missing stdout, prompt not possible, immediate exit
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo 1&>-

# no idea why missing stderr behaves the same, will have to check this again
$ streamlink httpstream://file:///dev/zero best -o /tmp/foo 2&>-
```

The `--logfile` CLI arg affecting the `ConsoleOutput` stream can be changed later. It's unrelated to this PR.