### PR TITLE
cli.console: refactor and split into two streams

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -412,9 +412,7 @@ def build_parser():
         "--quiet",
         action="store_true",
         help="""
-            Hide all log output.
-
-            Alias for --loglevel=none.
+            Suppress all console and log output, and also disable user prompts.
         """,
     )
     logging.add_argument(

--- a/src/streamlink_cli/console.py
+++ b/src/streamlink_cli/console.py
@@ -25,7 +25,7 @@ class ConsoleUserInputRequester(UserInputRequester):
     def ask_password(self, prompt: str) -> str:
         if not sys.stdin or not sys.stdin.isatty():
             raise OSError("no TTY available")
-        return self.console.askpass(f"{prompt.strip()}: ")
+        return self.console.ask_password(f"{prompt.strip()}: ")
 
 
 class ConsoleOutput:
@@ -45,7 +45,7 @@ class ConsoleOutput:
         except Exception:
             return None
 
-    def askpass(self, prompt: str) -> str | None:
+    def ask_password(self, prompt: str) -> str | None:
         if not sys.stdin or not sys.stdin.isatty():
             return None
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -86,12 +86,12 @@ def check_file_output(path: Path, force: bool) -> Path:
     log.debug("Checking file output")
 
     if realpath.is_file() and not force:
-        if sys.stdin and sys.stdin.isatty():
+        try:
             answer = console.ask(f"File {path} already exists! Overwrite it? [y/N] ")
-            if not answer or answer.lower() != "y":
-                raise StreamlinkCLIError()
-        else:
+        except OSError:
             log.error(f"File {path} already exists, use --force to overwrite it.")
+            raise StreamlinkCLIError() from None
+        if not answer or answer.lower() != "y":
             raise StreamlinkCLIError()
 
     return realpath

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -852,7 +852,9 @@ def setup_console() -> None:
     global console
 
     console_output: TextIO | None
-    if args.stdout or args.output == "-" or args.record == "-" or args.record_and_pipe:
+    if args.quiet:
+        console_output = None
+    elif args.stdout or args.output == "-" or args.record == "-" or args.record_and_pipe:
         # Console output should be on stderr if we are outputting a stream to stdout
         console_output = sys.stderr
     else:

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -856,7 +856,7 @@ def setup_console() -> None:
         # Console output should be on stderr if we are outputting a stream to stdout
         console_output = sys.stderr
     else:
-        console_output = sys.stdout
+        console_output = sys.stdout or sys.stderr
 
     console = ConsoleOutput(console_output=console_output, json=args.json)
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -891,7 +891,7 @@ def setup_logger_and_console(
     except Exception as err:
         raise StreamlinkCLIError(f"Logging setup error: {err}") from err
 
-    console = ConsoleOutput(streamhandler.stream, json)
+    console = ConsoleOutput(console_output=streamhandler.stream, json=json)
 
 
 def setup(parser: ArgumentParser) -> None:

--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -60,7 +60,7 @@ class TestStdoutStderr:
         assert clilogger.parent is rootlogger
         assert isinstance(rootlogger.handlers[0], logging.StreamHandler)
         assert rootlogger.handlers[0].stream is streamobj
-        assert streamlink_cli.main.console.output is streamobj
+        assert streamlink_cli.main.console.console_output is streamobj
 
     @pytest.mark.parametrize(
         ("argv", "stdout", "stderr"),
@@ -462,7 +462,7 @@ class TestLogfile:
         rootlogger = logging.getLogger("streamlink")
         assert isinstance(rootlogger.handlers[0], logging.StreamHandler)
         assert rootlogger.handlers[0].stream is sys.stdout
-        assert streamlink_cli.main.console.output is sys.stdout
+        assert streamlink_cli.main.console.console_output is sys.stdout
 
         streamlink_cli.main.log.info("a")
         streamlink_cli.main.console.msg("b")
@@ -519,7 +519,7 @@ class TestLogfile:
         assert isinstance(rootlogger.handlers[0], logging.FileHandler)
         assert rootlogger.handlers[0].baseFilename == str(abspath)
         assert rootlogger.handlers[0].stream is streamobj
-        assert streamlink_cli.main.console.output is streamobj
+        assert streamlink_cli.main.console.console_output is streamobj
 
         streamlink_cli.main.log.info("a")
         streamlink_cli.main.console.msg("b")

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -296,13 +296,6 @@ def test_cli_main_setup_session_options(monkeypatch: pytest.MonkeyPatch, parser:
 
 
 class TestSetupPluginArgsAndOptions:
-    @pytest.fixture(autouse=True)
-    def stdin(self, monkeypatch: pytest.MonkeyPatch):
-        mock_stdin = Mock(isatty=Mock(return_value=True))
-        monkeypatch.setattr("sys.stdin", mock_stdin)
-
-        return mock_stdin
-
     @pytest.fixture()
     def console(self):
         return Mock(
@@ -487,24 +480,14 @@ class TestSetupPluginArgsAndOptions:
             "four-b": "default",
         }
 
-    def test_setup_options_no_tty(
+    def test_setup_options_user_input_oserror(
         self,
         session: Streamlink,
         plugin: type[Plugin],
-        stdin: Mock,
+        console: Mock,
     ):
-        stdin.isatty.return_value = False
+        console.ask.side_effect = OSError("No input TTY available")
+        console.ask_password.side_effect = OSError("No input TTY available")
         with pytest.raises(StreamlinkCLIError) as exc_info:
             setup_plugin_options(session, Mock(mock_user="username", mock_pass=None, mock_qux=None), "mock", plugin)
-        assert str(exc_info.value) == "no TTY available"
-
-    def test_setup_options_no_stdin(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        session: Streamlink,
-        plugin: type[Plugin],
-    ):
-        monkeypatch.setattr("sys.stdin", None)
-        with pytest.raises(StreamlinkCLIError) as exc_info:
-            setup_plugin_options(session, Mock(mock_user="username", mock_pass=None, mock_qux=None), "mock", plugin)
-        assert str(exc_info.value) == "no TTY available"
+        assert str(exc_info.value) == "No input TTY available"

--- a/tests/cli/test_argparser.py
+++ b/tests/cli/test_argparser.py
@@ -307,7 +307,7 @@ class TestSetupPluginArgsAndOptions:
     def console(self):
         return Mock(
             ask=Mock(return_value="answer"),
-            askpass=Mock(return_value="password"),
+            ask_password=Mock(return_value="password"),
         )
 
     @pytest.fixture()
@@ -324,7 +324,7 @@ class TestSetupPluginArgsAndOptions:
         @pluginargument("qux", help=SUPPRESS)
         # required argument with dependencies
         @pluginargument("user", required=True, requires=["pass", "captcha"])
-        # sensitive argument (using console.askpass if unset)
+        # sensitive argument (using console.ask_password if unset)
         @pluginargument("pass", sensitive=True)
         # argument with custom prompt (using console.ask if unset)
         @pluginargument("captcha", prompt="CAPTCHA code")
@@ -371,7 +371,7 @@ class TestSetupPluginArgsAndOptions:
         assert options.defaults == {}
 
         assert not console.ask.called
-        assert not console.askpass.called
+        assert not console.ask_password.called
 
     def test_setup_options_no_user_input_requester(self, session: Streamlink, plugin: type[Plugin]):
         session.set_option("user-input-requester", None)
@@ -391,7 +391,7 @@ class TestSetupPluginArgsAndOptions:
         options = setup_plugin_options(session, args, "mock", plugin)
 
         assert console.ask.call_args_list == [call("CAPTCHA code: ")]
-        assert console.askpass.call_args_list == [call("Enter mock pass: ")]
+        assert console.ask_password.call_args_list == [call("Enter mock pass: ")]
 
         assert plugin.arguments
         arg_foo = plugin.arguments.get("foo-bar")

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -9,7 +9,10 @@ import pytest
 from streamlink_cli.console import ConsoleOutput, ConsoleUserInputRequester
 
 
-def getvalue(output: TextIOWrapper, size: int = -1):
+def getvalue(output: TextIOWrapper | None, size: int = -1):
+    if output is None:
+        return None
+
     output.seek(0)
 
     return output.read(size)
@@ -38,76 +41,173 @@ def stdin(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture()
-def output(request: pytest.FixtureRequest):
-    params = getattr(request, "param", {})
-    output = build_textiowrapper(params)
+def console_output(request: pytest.FixtureRequest):
+    return build_textiowrapper(getattr(request, "param", {}))
 
-    return output
+
+@pytest.fixture()
+def file_output(request: pytest.FixtureRequest):
+    return build_textiowrapper(getattr(request, "param", {}))
+
+
+@pytest.mark.parametrize(
+    ("console_output", "file_output", "has_file_output", "expected_console_output", "expected_file_output"),
+    [
+        pytest.param(
+            {"exists": False},
+            {"exists": False},
+            False,
+            None,
+            None,
+            id="no-output-streams",
+        ),
+        pytest.param(
+            {"isatty": True},
+            {"exists": False},
+            False,
+            'foo\n{\n  "foo": "bar"\n}\n',
+            None,
+            id="console-output-is-a-tty",
+        ),
+        pytest.param(
+            {"isatty": False},
+            {"exists": False},
+            False,
+            'foo\n{\n  "foo": "bar"\n}\n',
+            None,
+            id="console-output-is-not-a-tty",
+        ),
+        pytest.param(
+            {},
+            {"isatty": True},
+            False,
+            'foo\n{\n  "foo": "bar"\n}\n',
+            "",
+            id="file-output-is-a-tty",
+        ),
+        pytest.param(
+            {},
+            {"isatty": False},
+            True,
+            'foo\n{\n  "foo": "bar"\n}\n',
+            'foo\n{\n  "foo": "bar"\n}\n',
+            id="file-output-is-not-a-tty",
+        ),
+    ],
+    indirect=["console_output", "file_output"],
+)
+def test_streams(
+    console_output: TextIOWrapper | None,
+    file_output: TextIOWrapper | None,
+    has_file_output: bool,
+    expected_console_output: str,
+    expected_file_output: str,
+):
+    console = ConsoleOutput()
+    assert console.console_output is None
+    assert console.file_output is None
+
+    console.console_output = console_output
+    console.file_output = file_output
+    assert console.console_output is console_output
+    assert console.file_output is (file_output if has_file_output else None)
+
+    console.msg("foo")
+    console.json = True
+    console.msg_json(foo="bar")
+    assert getvalue(console_output) == expected_console_output
+    assert getvalue(file_output) == expected_file_output
+
+
+@pytest.mark.parametrize("method_raises", ["write", "flush"])
+def test_broken_stream(monkeypatch: pytest.MonkeyPatch, console_output: TextIOWrapper, method_raises: str):
+    monkeypatch.setattr(console_output, method_raises, Mock(side_effect=BrokenPipeError))
+    console = ConsoleOutput(console_output=console_output)
+    console.msg("foo")
+    console.msg("bar")
 
 
 class TestMessages:
     @pytest.mark.parametrize(
-        ("output", "expected"),
+        ("console_output", "expected_console_output", "expected_file_output"),
         [
             pytest.param(
                 {"encoding": "utf-8"},
-                "Bär: 🐻",
+                "Bär: 🐻\n",
+                "Bär: 🐻\n",
                 id="utf-8 encoding",
             ),
             pytest.param(
                 {"encoding": "ascii"},
-                "B\\xe4r: \\U0001f43b",  # Unicode character: "Bear Face" (U+1F43B)
+                "B\\xe4r: \\U0001f43b\n",  # Unicode character: "Bear Face" (U+1F43B)
+                "Bär: 🐻\n",
                 id="ascii encoding",
             ),
         ],
-        indirect=["output"],
+        indirect=["console_output"],
     )
-    def test_msg(self, output: TextIOWrapper, expected: str):
-        console = ConsoleOutput(output)
+    def test_no_json(
+        self,
+        console_output: TextIOWrapper,
+        file_output: TextIOWrapper,
+        expected_console_output: str,
+        expected_file_output: str,
+    ):
+        console = ConsoleOutput(console_output=console_output, file_output=file_output)
         console.msg("Bär: 🐻")
         console.msg_json({"test": 1})
-        assert getvalue(output) == f"{expected}\n"
+        assert getvalue(console_output) == expected_console_output
+        assert getvalue(file_output) == expected_file_output
 
     @pytest.mark.parametrize(
-        ("output", "expected"),
+        ("console_output", "expected_console_output", "expected_file_output"),
         [
             pytest.param(
                 {"encoding": "utf-8"},
-                "Bär: 🐻",
+                '{\n  "test": "Bär: 🐻"\n}\n',
+                '{\n  "test": "Bär: 🐻"\n}\n',
                 id="utf-8 encoding",
             ),
             pytest.param(
                 {"encoding": "ascii"},
-                "B\\u00e4r: \\ud83d\\udc3b",  # Unicode character: "Bear Face" (U+1F43B) - UTF-16: 0xD83D 0xDC3B
+                '{\n  "test": "B\\u00e4r: \\ud83d\\udc3b"\n}\n',  # Unicode character: "Bear Face" (U+1F43B)
+                '{\n  "test": "Bär: 🐻"\n}\n',
                 id="ascii encoding",
             ),
         ],
-        indirect=["output"],
+        indirect=["console_output"],
     )
-    def test_msg_json(self, output: TextIOWrapper, expected: str):
-        console = ConsoleOutput(output, json=True)
+    def test_json(
+        self,
+        console_output: TextIOWrapper,
+        file_output: TextIOWrapper,
+        expected_console_output: str,
+        expected_file_output: str,
+    ):
+        console = ConsoleOutput(console_output=console_output, file_output=file_output, json=True)
         console.msg("foo")
         console.msg_json({"test": "Bär: 🐻"})
-        assert getvalue(output) == f'{{\n  "test": "{expected}"\n}}\n'
+        assert getvalue(console_output) == expected_console_output
+        assert getvalue(file_output) == expected_file_output
 
-    def test_msg_json_object(self, output: TextIOWrapper):
-        console = ConsoleOutput(output, json=True)
+    def test_msg_json_object(self, console_output: TextIOWrapper):
+        console = ConsoleOutput(console_output=console_output, json=True)
         console.msg_json(Mock(__json__=lambda: {"test": "Hello world, Γειά σου Κόσμε, こんにちは世界"}))  # noqa: RUF001
-        assert getvalue(output) == '{\n  "test": "Hello world, Γειά σου Κόσμε, こんにちは世界"\n}\n'  # noqa: RUF001
+        assert getvalue(console_output) == '{\n  "test": "Hello world, Γειά σου Κόσμε, こんにちは世界"\n}\n'  # noqa: RUF001
 
-    def test_msg_json_list(self, output: TextIOWrapper):
-        console = ConsoleOutput(output, json=True)
+    def test_msg_json_list(self, console_output: TextIOWrapper):
+        console = ConsoleOutput(console_output=console_output, json=True)
         test_list = ["Hello world, Γειά σου Κόσμε, こんにちは世界", '"🐻"']  # noqa: RUF001
         console.msg_json(test_list)
-        assert getvalue(output) == '[\n  "Hello world, Γειά σου Κόσμε, こんにちは世界",\n  "\\"🐻\\""\n]\n'  # noqa: RUF001
+        assert getvalue(console_output) == '[\n  "Hello world, Γειά σου Κόσμε, こんにちは世界",\n  "\\"🐻\\""\n]\n'  # noqa: RUF001
 
-    def test_msg_json_merge_object(self, output: TextIOWrapper):
-        console = ConsoleOutput(output, json=True)
+    def test_msg_json_merge_object(self, console_output: TextIOWrapper):
+        console = ConsoleOutput(console_output=console_output, json=True)
         test_obj1 = {"test": 1, "foo": "foo"}
         test_obj2 = Mock(__json__=Mock(return_value={"test": 2}))
         console.msg_json(test_obj1, test_obj2, ["qux"], foo="bar", baz="qux")
         assert (
-            getvalue(output)
+            getvalue(console_output)
             == dedent("""
                 {
                   "test": 2,
@@ -118,13 +218,13 @@ class TestMessages:
         )
         assert list(test_obj1.items()) == [("test", 1), ("foo", "foo")]
 
-    def test_msg_json_merge_list(self, output: TextIOWrapper):
-        console = ConsoleOutput(output, json=True)
+    def test_msg_json_merge_list(self, console_output: TextIOWrapper):
+        console = ConsoleOutput(console_output=console_output, json=True)
         test_list1 = ["foo", "bar"]
         test_list2 = Mock(__json__=Mock(return_value={"foo": "bar"}))
         console.msg_json(test_list1, ["baz"], test_list2, {"foo": "bar"}, foo="bar", baz="qux")
         assert (
-            getvalue(output)
+            getvalue(console_output)
             == dedent("""
                 [
                   "foo",
@@ -147,8 +247,8 @@ class TestMessages:
 
 
 class TestPrompts:
-    def test_prompt_exception(self, output: TextIOWrapper):
-        console = ConsoleOutput(output)
+    def test_prompt_exception(self, console_output: TextIOWrapper):
+        console = ConsoleOutput(console_output=console_output)
         with pytest.raises(BaseException) as exc_info:  # noqa: PT011
             with console._prompt():
                 raise EOFError
@@ -156,74 +256,81 @@ class TestPrompts:
         assert isinstance(exc_info.value.__cause__, EOFError)
 
     @pytest.mark.parametrize("exception", [OSError, KeyboardInterrupt])
-    def test_prompt_exception_passthrough(self, output: TextIOWrapper, exception: type[Exception]):
-        console = ConsoleOutput(output)
+    def test_prompt_exception_passthrough(self, console_output: TextIOWrapper, exception: type[Exception]):
+        console = ConsoleOutput(console_output=console_output)
         with pytest.raises(BaseException) as exc_info:  # noqa: PT011
             with console._prompt():
                 raise exception
         assert isinstance(exc_info.value, exception)
 
-    def test_ask(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
+    def test_ask(self, monkeypatch: pytest.MonkeyPatch, console_output: TextIOWrapper, file_output: TextIOWrapper):
         monkeypatch.setattr("builtins.input", Mock(return_value="hello"))
 
-        console = ConsoleOutput(output)
+        console = ConsoleOutput(console_output=console_output, file_output=file_output)
         user_input = ConsoleUserInputRequester(console)
         assert user_input.ask("test") == "hello"
-        assert getvalue(output) == "test: "
+        assert getvalue(console_output) == "test: "
+        assert getvalue(file_output) == ""
 
     @pytest.mark.parametrize(
-        ("stdin", "output", "expected"),
+        ("stdin", "console_output", "expected"),
         [
             pytest.param({"exists": False}, {}, "^No input TTY available$", id="no-stdin"),
             pytest.param({"isatty": False}, {}, "^No input TTY available$", id="stdin-no-tty"),
             pytest.param({}, {"exists": False}, "^No output TTY available$", id="no-output"),
             pytest.param({}, {"isatty": False}, "^No output TTY available$", id="output-no-tty"),
         ],
-        indirect=["stdin", "output"],
+        indirect=["stdin", "console_output"],
     )
-    def test_ask_failure(self, monkeypatch: pytest.MonkeyPatch, stdin: TextIOWrapper, output: TextIOWrapper, expected: str):
+    def test_ask_failure(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        stdin: TextIOWrapper,
+        console_output: TextIOWrapper,
+        expected: str,
+    ):
         mock_input = Mock()
         monkeypatch.setattr("builtins.input", mock_input)
 
-        console = ConsoleOutput(output)
+        console = ConsoleOutput(console_output=console_output)
         user_input = ConsoleUserInputRequester(console)
         with pytest.raises(OSError, match=expected):
             user_input.ask("test")
         assert mock_input.call_args_list == []
 
-    def test_ask_password(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
+    def test_ask_password(self, monkeypatch: pytest.MonkeyPatch, console_output: TextIOWrapper):
         def getpass(prompt, stream):
             stream.write(prompt)
             return "hello"
 
         monkeypatch.setattr("streamlink_cli.console.getpass", getpass)
 
-        console = ConsoleOutput(output)
+        console = ConsoleOutput(console_output=console_output)
         user_input = ConsoleUserInputRequester(console)
         assert user_input.ask_password("test") == "hello"
-        assert getvalue(output) == "test: "
+        assert getvalue(console_output) == "test: "
 
     @pytest.mark.parametrize(
-        ("stdin", "output", "expected"),
+        ("stdin", "console_output", "expected"),
         [
             pytest.param({"exists": False}, {}, "^No input TTY available$", id="no-stdin"),
             pytest.param({"isatty": False}, {}, "^No input TTY available$", id="stdin-no-tty"),
             pytest.param({}, {"exists": False}, "^No output TTY available$", id="no-output"),
             pytest.param({}, {"isatty": False}, "^No output TTY available$", id="output-no-tty"),
         ],
-        indirect=["stdin", "output"],
+        indirect=["stdin", "console_output"],
     )
     def test_ask_password_failure(
         self,
         monkeypatch: pytest.MonkeyPatch,
         stdin: TextIOWrapper,
-        output: TextIOWrapper,
+        console_output: TextIOWrapper,
         expected: str,
     ):
         mock_getpass = Mock()
         monkeypatch.setattr("streamlink_cli.console.getpass", mock_getpass)
 
-        console = ConsoleOutput(output)
+        console = ConsoleOutput(console_output=console_output)
         user_input = ConsoleUserInputRequester(console)
         with pytest.raises(OSError, match=expected):
             user_input.ask_password("test")

--- a/tests/cli/test_console.py
+++ b/tests/cli/test_console.py
@@ -157,7 +157,7 @@ class TestConsoleOutput:
         assert console.ask("test: ") is None
         assert getvalue(output) == "test: "
 
-    def test_askpass(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
+    def test_ask_password(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
         def getpass(prompt, stream):
             stream.write(prompt)
             return "hello"
@@ -165,17 +165,17 @@ class TestConsoleOutput:
         monkeypatch.setattr("streamlink_cli.console.getpass", getpass)
 
         console = ConsoleOutput(output)
-        assert console.askpass("test: ") == "hello"
+        assert console.ask_password("test: ") == "hello"
         assert getvalue(output) == "test: "
 
-    def test_askpass_no_tty(self, output: TextIOWrapper):
+    def test_ask_password_no_tty(self, output: TextIOWrapper):
         console = ConsoleOutput(output)
-        assert console.askpass("test: ") is None
+        assert console.ask_password("test: ") is None
         assert getvalue(output) == ""
 
-    def test_askpass_no_stdin(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
+    def test_ask_password_no_stdin(self, monkeypatch: pytest.MonkeyPatch, output: TextIOWrapper):
         monkeypatch.setattr("sys.stdin", None)
 
         console = ConsoleOutput(output)
-        assert console.askpass("test: ") is None
+        assert console.ask_password("test: ") is None
         assert getvalue(output) == ""

--- a/tests/test_plugin_userinput.py
+++ b/tests/test_plugin_userinput.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, call, patch
+from unittest.mock import Mock, call
 
 import pytest
 
@@ -8,51 +8,67 @@ from streamlink_cli.console import ConsoleUserInputRequester
 from tests.plugin.testplugin import TestPlugin as _TestPlugin
 
 
-def test_session():
-    console_input = ConsoleUserInputRequester(Mock())
-    session = Streamlink({"user-input-requester": console_input}, plugins_builtin=False)
-    assert session.get_option("user-input-requester") is console_input
+@pytest.fixture()
+def console(request: pytest.FixtureRequest):
+    param = getattr(request, "param", {})
+
+    console = Mock()
+    if not param.get("failure", False):
+        console.ask.return_value = "username"
+        console.ask_password.return_value = "password"
+    else:
+        console.ask.side_effect = OSError("No input TTY available")
+        console.ask_password.side_effect = OSError("No input TTY available")
+
+    return console
 
 
-class TestPluginUserInput:
-    @pytest.fixture()
-    def testplugin(self, session: Streamlink):
-        return _TestPlugin(session, "http://test.se/")
+@pytest.fixture()
+def session(session: Streamlink, console: Mock):
+    user_input = ConsoleUserInputRequester(console)
+    session.set_option("user-input-requester", user_input)
 
-    @pytest.fixture()
-    def console_input(self, request, session: Streamlink):
-        isatty: bool = request.param
-        with patch("streamlink_cli.console.sys.stdin.isatty", return_value=isatty):
-            mock_console = Mock()
-            mock_console.ask.return_value = "username"
-            mock_console.ask_password.return_value = "password"
-            console_input = ConsoleUserInputRequester(mock_console)
-            session.set_option("user-input-requester", console_input)
-            yield console_input
+    return session
 
-    def test_user_input_not_implemented(self, testplugin: _TestPlugin):
-        with pytest.raises(FatalPluginError) as cm:
-            testplugin.input_ask("test")
-        assert str(cm.value) == "This plugin requires user input, however it is not supported on this platform"
 
-        with pytest.raises(FatalPluginError) as cm:
-            testplugin.input_ask_password("test")
-        assert str(cm.value) == "This plugin requires user input, however it is not supported on this platform"
+@pytest.fixture()
+def testplugin(session: Streamlink):
+    return _TestPlugin(session, "http://test.se/")
 
-    @pytest.mark.parametrize("console_input", [True], indirect=True)
-    def test_user_input_console(self, testplugin: _TestPlugin, console_input: ConsoleUserInputRequester):
-        assert testplugin.input_ask("username") == "username"
-        assert console_input.console.ask.call_args_list == [call("username: ")]
 
-        assert testplugin.input_ask_password("password") == "password"
-        assert console_input.console.ask_password.call_args_list == [call("password: ")]
+def test_session(session: Streamlink, console: Mock):
+    user_input = session.get_option("user-input-requester")
+    assert user_input
+    assert user_input.console is console
 
-    @pytest.mark.parametrize("console_input", [False], indirect=True)
-    def test_user_input_console_no_tty(self, testplugin: _TestPlugin, console_input: ConsoleUserInputRequester):
-        with pytest.raises(FatalPluginError) as cm:
-            testplugin.input_ask("username")
-        assert str(cm.value) == "User input error: no TTY available"
 
-        with pytest.raises(FatalPluginError) as cm:
-            testplugin.input_ask_password("username")
-        assert str(cm.value) == "User input error: no TTY available"
+def test_user_input_not_implemented(session: Streamlink, testplugin: _TestPlugin):
+    session.set_option("user-input-requester", None)
+
+    with pytest.raises(FatalPluginError) as cm:
+        testplugin.input_ask("test")
+    assert str(cm.value) == "This plugin requires user input, however it is not supported on this platform"
+
+    with pytest.raises(FatalPluginError) as cm:
+        testplugin.input_ask_password("test")
+    assert str(cm.value) == "This plugin requires user input, however it is not supported on this platform"
+
+
+@pytest.mark.parametrize("console", [{"failure": False}], indirect=True)
+def test_user_input_console(console: Mock, testplugin: _TestPlugin):
+    assert testplugin.input_ask("username") == "username"
+    assert console.ask.call_args_list == [call("username: ")]
+
+    assert testplugin.input_ask_password("password") == "password"
+    assert console.ask_password.call_args_list == [call("password: ")]
+
+
+@pytest.mark.parametrize("console", [{"failure": True}], indirect=True)
+def test_user_input_console_no_tty(console: Mock, testplugin: _TestPlugin):
+    with pytest.raises(FatalPluginError) as cm:
+        testplugin.input_ask("username")
+    assert str(cm.value) == "User input error: No input TTY available"
+
+    with pytest.raises(FatalPluginError) as cm:
+        testplugin.input_ask_password("username")
+    assert str(cm.value) == "User input error: No input TTY available"

--- a/tests/test_plugin_userinput.py
+++ b/tests/test_plugin_userinput.py
@@ -25,7 +25,7 @@ class TestPluginUserInput:
         with patch("streamlink_cli.console.sys.stdin.isatty", return_value=isatty):
             mock_console = Mock()
             mock_console.ask.return_value = "username"
-            mock_console.askpass.return_value = "password"
+            mock_console.ask_password.return_value = "password"
             console_input = ConsoleUserInputRequester(mock_console)
             session.set_option("user-input-requester", console_input)
             yield console_input
@@ -45,7 +45,7 @@ class TestPluginUserInput:
         assert console_input.console.ask.call_args_list == [call("username: ")]
 
         assert testplugin.input_ask_password("password") == "password"
-        assert console_input.console.askpass.call_args_list == [call("password: ")]
+        assert console_input.console.ask_password.call_args_list == [call("password: ")]
 
     @pytest.mark.parametrize("console_input", [False], indirect=True)
     def test_user_input_console_no_tty(self, testplugin: _TestPlugin, console_input: ConsoleUserInputRequester):


### PR DESCRIPTION
Replaces #6457
In preparation for #6449

This PR fixes a couple of console output issues and logger setup issues, and also splits the console output into two streams. The separation of console output streams is necessary in order for the download progress to be fixed later on. Progress output should never be written to a file, but since we want some console output to be written to log files as well, especially error messages, we need to use two streams.

Currently on master, the `ConsoleOutput` always inherits the stream of Streamlink's root logger. This is problematic because `--logfile=...` sets the logger stream to a file, which means all `ConsoleOutput` including user prompts are written to the log file instead of being written to a TTY where the user has to write their input.

Also, `--quiet` currently does only affect the log level, as it's treated as an alias of `--loglevel=none`, which means the inherited output stream is still `stdout`, so all console messages and error messages are printed regardless. `--quiet` should mean no output at all.

Another problem is that if there's no TTY output for user prompts, those prompts currently don't fail. If the user doesn't have a chance to know what's prompted, then the prompt must fail. And failure is currently also not handled correctly and `None` is returned instead, which is wrong.

----

I've decided to use one single PR branch for these changes, because they are all a bit intertwined. Splitting this up would make this unnecessarily complicated for me.

----

So, a quick overview of the individual commits:

1. Fix the method name of the `ConsoleOutput` password prompt according to Streamlink's public interface of the `UserInputRequester`
2. Fix the prompts, raise `OSError` on failure, and most importantly, check for valid input and output TTY streams (must exist and must not be file streams).
3. Update the error handling of the one function in Streamlink's CLI that doesn't use the `Streamlink` session's `UserInputRequester` and that instead calls the `ask()` method of the `ConsoleOutput` directly.
4. Refactor `ConsoleOutput` and use two separate streams, one for console output and one for file output. Both are optional, as `stdout`/`stderr` can be missing, or there's no log file stream. Also ensure that the file output is not a TTY, so that `--logfile=/dev/tty` doesn't duplicate console messages (as `msg()` and `msg_json()` write to both streams).
5. Refactor the setup of `ConsoleOutput` and Streamlink's root logger and actually use two separate streams. Make the root logger inherit the primary stream of the `ConsoleOutput` (not the other way around). If there's a log file, attach the file stream to the `ConsoleOutput` instance.
6. Add lazily opened file descriptors for `devnull` to the CLI's `compat` module and rename existing attributes accordingly. Changes are required for the next commit.
7. Check if the output stream for Streamlink's root logger actually exists. Previously, the `logging` module of Python's stdlib switched to `stderr` if the passed stream was `None`, and we also had to check if `stderr` existed and use an additional fallback to devnull as a `FileHandler` in that case. Simply don't attach any log handlers to the root logger if there's the passed stream is `None`.
8. Make `ConsoleOutput` fall back from `stdout` to `stderr` if `stdout` doesn't exist, to align with the previous fallback mechanic of the root logger that was removed in the previous commit. Since the primary `ConsoleOutput` stream is inherited by the logger now, the old behavior is restored. But now, both console and log output have a fallback.

----

Considering that there are a lot of changes, this needs a bit of additional testing before I'm going to merge this. As always, I've added tests with full coverage for the changed code parts, but this doesn't cover all potential combinations of CLI arguments and environments.