### PR TITLE
plugin: ensure URL matches

### DIFF
--- a/src/streamlink/plugin/plugin.py
+++ b/src/streamlink/plugin/plugin.py
@@ -315,6 +315,8 @@ class Plugin(metaclass=PluginMeta):
         self.session: Streamlink = session
         self.matches = Matches()
         self.url: str = url
+        if self.matchers and not self.match:
+            raise PluginError("The input URL did not match any of this plugin's matchers")
 
         self.load_cookies()
 

--- a/tests/plugins/test_soop.py
+++ b/tests/plugins/test_soop.py
@@ -79,5 +79,5 @@ class TestPluginCanHandleUrlSoop(PluginCanHandleUrl):
 def test_options(session: Streamlink, plugin_options: dict, expected: dict):
     options = Options()
     options.update(plugin_options)
-    plugin = Soop(session, "https://play.soop.co.kr/CHANNEL/0123456789", options)
+    plugin = Soop(session, "https://play.sooplive.co.kr/CHANNEL/0123456789", options)
     assert dict(plugin.options.items()) == expected

--- a/tests/plugins/test_vinhlongtv.py
+++ b/tests/plugins/test_vinhlongtv.py
@@ -20,7 +20,7 @@ class TestPluginCanHandleUrlVinhLongTV(PluginCanHandleUrl):
 @freeze_time("2022-09-25T00:04:45Z")
 def test_headers():
     # noinspection PyUnresolvedReferences
-    assert VinhLongTV(Mock(), "")._get_headers() == {
+    assert VinhLongTV(Mock(), "https://www.thvli.vn/live/thvl1-hd")._get_headers() == {
         "X-SFD-Date": "20220925000445",
         "X-SFD-Key": "3507c190ae8befda3bfa8e2c00af3c7a",
     }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,6 +20,7 @@ from streamlink.plugin import (
     Plugin,
     PluginArgument,
     PluginArguments,
+    PluginError,
     pluginargument,
     pluginmatcher,
 )
@@ -178,6 +179,18 @@ class TestPluginMatcher:
             @pluginmatcher(name="foo", pattern=re.compile(r"foo"))
             class PluginTwo(PluginOne):
                 pass
+
+    def test_matchers_not_matching(self):
+        @pluginmatcher(re.compile(r"http://foo"))
+        class MyPlugin(FakePlugin):
+            pass
+
+        with pytest.raises(PluginError, match=r"^The input URL did not match any of this plugin's matchers$"):
+            MyPlugin(Mock(), "http://bar")
+
+    def test_no_matchers_not_matching(self):
+        plugin = FakePlugin(Mock(), "")
+        assert plugin.match is None
 
     def test_url_setter(self):
         @pluginmatcher(re.compile(r"http://(foo)"))

--- a/tests/test_plugin_userinput.py
+++ b/tests/test_plugin_userinput.py
@@ -17,7 +17,7 @@ def test_session():
 class TestPluginUserInput:
     @pytest.fixture()
     def testplugin(self, session: Streamlink):
-        return _TestPlugin(session, "http://example.com/stream")
+        return _TestPlugin(session, "http://test.se/")
 
     @pytest.fixture()
     def console_input(self, request, session: Streamlink):


### PR DESCRIPTION
Yesterday I extended the API quickstart guide and mentioned importing plugins directly (#6464). This requires that the input URL must match. There's no check for this though, which means that if the plugin was not imported by the session's URL resolver, arbitrary URLs could be set on the plugin's constructor. For example, if a plugin relies on certain non-optional regex capture groups of a particular matcher, or if multiple matchers are checked and there's an else-block for a check of the first matcher, then the plugin could break, because there's no guarantee that a valid URL was passed.

So let's check for at least one match if matchers are defined. If no matchers are defined, then ignore this.