### PR TITLE
plugins.kick: solve JS challenge

### DIFF
--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -2,19 +2,24 @@
 $description Global live-streaming and video hosting social platform owned by Kick Streaming Pty Ltd.
 $url kick.com
 $type live, vod
+$webbrowser Required for solving a JS challenge that allows access to the Kick API
 $metadata id
 $metadata author
 $metadata category
 $metadata title
 """
 
+import logging
 import re
 from ssl import OP_NO_TICKET
 
-from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.session.http import SSLContextAdapter
 from streamlink.stream.hls import HLSStream
+
+
+log = logging.getLogger(__name__)
 
 
 class KickAdapter(SSLContextAdapter):
@@ -37,8 +42,16 @@ class KickAdapter(SSLContextAdapter):
     name="clip",
     pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/(?!video/)(?P<channel>[^/?]+)\?clip=(?P<clip>[^&]+)$"),
 )
+@pluginargument(
+    "purge-token",
+    action="store_true",
+    help="Purge stored Kick JS challenge token and acquire a new one if necessary.",
+)
 class Kick(Plugin):
-    _URL_TOKEN = "https://kick.com/"
+    _TOKEN_NAME = "XSRF-TOKEN"
+    _TOKEN_EXPIRATION = 3600 * 24 * 30
+
+    _URL_API_CHECK_TOKEN = "https://kick.com/api/v1/categories/top"
     _URL_API_LIVESTREAM = "https://kick.com/api/v2/channels/{channel}/livestream"
     _URL_API_VOD = "https://kick.com/api/v1/video/{vod}"
     _URL_API_CLIP = "https://kick.com/api/v2/clips/{clip}"
@@ -48,19 +61,73 @@ class Kick(Plugin):
         self.session.http.mount("https://kick.com/", KickAdapter())
         self.session.http.headers.update({"Sec-Fetch-User": "?1"})
 
-    def _get_token(self):
-        res = self.session.http.get(self._URL_TOKEN, raise_for_status=False)
-        return res.cookies.get("XSRF-TOKEN", "")
+        self._token = self.cache.get(self._TOKEN_NAME)
+        if self._token and self.options.get("purge-token"):
+            log.debug("Purging stored JS challenge token")
+            self._clear_token()
+            self._token = None
 
     def _get_api_headers(self):
-        token = self._get_token()
-
-        return {
+        headers = {
             "Accept": "application/json",
             "Accept-Language": "en-US",
             "Referer": self.url,
-            "Authorization": f"Bearer {token}",
         }
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+
+        return headers
+
+    def _clear_token(self):
+        self.cache.set(self._TOKEN_NAME, None, expires=0)
+
+    def _check_token(self):
+        if not self._token:
+            return False
+
+        res = self.session.http.get(
+            self._URL_API_CHECK_TOKEN,
+            headers=self._get_api_headers(),
+            raise_for_status=False,
+        )
+        if 400 <= res.status_code < 500:
+            log.error("The stored JS challenge token has expired")
+            self._clear_token()
+            return False
+
+        log.debug("Using stored JS challenge token")
+
+        return True
+
+    def _get_token(self):
+        from streamlink.compat import BaseExceptionGroup  # noqa: PLC0415
+        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession  # noqa: PLC0415
+
+        eval_timeout = self.session.get_option("webbrowser-timeout")
+
+        async def get_challenge_cookies(client: CDPClient):
+            client_session: CDPClientSession
+            async with client.session() as client_session:
+                async with client_session.navigate(self.url) as frame_id:
+                    await client_session.loaded(frame_id)
+                    return await client_session.evaluate("document.cookie", timeout=eval_timeout)
+
+        log.info("Acquiring new JS challenge token using the webbrowser API")
+
+        cookiestring = ""
+        try:
+            cookiestring = CDPClient.launch(self.session, get_challenge_cookies)
+        except BaseExceptionGroup:
+            log.exception("Failed solving JS challenge")
+        except Exception as err:
+            log.error(err)
+
+        cookies = dict(cookie.split("=", 1) for cookie in cookiestring.split("; "))
+        self._token = cookies.get(self._TOKEN_NAME)
+
+        if self._token:
+            self.cache.set(self._TOKEN_NAME, self._token, expires=self._TOKEN_EXPIRATION)
+            log.info("Successfully solved JS challenge and stored the acquired token")
 
     def _get_streams_live(self):
         self.author = self.match["channel"]
@@ -194,6 +261,9 @@ class Kick(Plugin):
         return {"clip": HLSStream(self.session, hls_url)}
 
     def _get_streams(self):
+        if not self._check_token():
+            self._get_token()
+
         if self.matches["live"]:
             return self._get_streams_live()
         if self.matches["vod"]:


### PR DESCRIPTION
Resolves #6414 
Replaces #6325

From #6325

> The plugin is currently completely broken on master, because Kick has added a JS challenge for being able to access their REST APIs. The required token was previously simply set as a cookie from an initial HTTP request+response made on their front page which we could simply read. Now, a JS challenge similar to Twitch's has to be solved, where the cookie with the token is then set via JS APIs.
>
> So in order to fix the plugin, Streamlink's webbrowser API has to be used where the JS challenge can be solved and the cookie value with the token be read. This works fine, even in headless mode.
>
> I've added token caching, because apparently it's valid for 30 days (according to the cookie expiration times)

----

This branch is basically the same as #6325 from a few months ago which I then closed because it looked like Kick was making constant changes, which made developing this unnecessarily difficult. It also turned out that they were simply checking requests for certain HTTP headers that are only set by default by modern web browsers, and not by other libs/tools like curl or python-requests, so I closed the PR in favor of #6384.

I had another look at the kick issue yesterday and today, and apparently they're whitelisting the user's IP address when making certain API requests with the token from the solved JS challenge. I could observe the same thing yesterday again. This whitelisting apparently expires after a day, so without checking their site in my web browser today (which would lead to them whitelisting me again), I could validate that this PR fixes the 403 API issues when getting the HLS playlist URL.

In addition to the old PR, this one also adds the `--kick-purge-token` plugin argument, so the stored token can be cleared. That shouldn't matter too much though, as it'll be unset and discarded anyway if the API can't be accessed with it anymore. If no token could be acquired after being denied access on their API, it will still try to get the HLS playlist URL (there's no check that prevents this), but that should be fine, as we want to know the error message in this case anyway...

Some observations:
The HLS playlist URL (including an access token) is embedded in their site when accessing a live channel, so their site itself never accesses the API endpoint for requesting the HLS playlist URL which the plugin (still) does. I had an unfinished/uncommitted stash on my old PR branch where I replaced the token acquirement and API requests with a webbrowser API call that would intercept the HLS playlist request, so the URL could be used by Streamlink's HLS implementation (simply requesting the input URL via python-requests won't work). This kind of approach however would mean that the webbrowser API would need to be used every time, which is pretty bad.

----

Pinging those users who commented in #6414 
@ffbw4hwj @kjake

**Please check this PR branch and report back** (without using custom HTTP headers/cookies)
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

I'm looking for any potential issues with this implementation when trying to watch any kind of channel.

Clips are still broken, but fixing this is not the intention of this PR. This can be done separately.

----

**master**

```
$ streamlink kick.com/admiralbulldog
[cli][info] Found matching plugin kick for URL kick.com/admiralbulldog
error: Unable to open URL: https://kick.com/api/v2/channels/admiralbulldog/livestream (403 Client Error: Forbidden for url: https://kick.com/api/v2/channels/admiralbulldog/livestream)
```

**PR**

Stored/cached token

```
$ streamlink -l debug kick.com/admiralbulldog best
[cli][debug] OS:         Linux-6.14.0-1-git-x86_64-with-glibc2.41
[cli][debug] Python:     3.13.2
[cli][debug] OpenSSL:    OpenSSL 3.4.1 11 Feb 2025
[cli][debug] Streamlink: 7.1.3+31.g073e189d
[cli][debug] Dependencies:
[cli][debug]  certifi: 2025.1.31
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.1
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.22.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.29.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=kick.com/admiralbulldog
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin kick for URL kick.com/admiralbulldog
[plugins.kick][debug] Using stored JS challenge token
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 3376; Last Sequence: 3389
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 3387; End Sequence: None
[stream.hls][debug] Adding segment 3387 to queue
[stream.hls][debug] Adding segment 3388 to queue
[stream.hls][debug] Adding segment 3389 to queue
[stream.hls][debug] Writing segment 3387 to output
[stream.hls][debug] Segment 3387 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=kick.com/admiralbulldog', '-']
[stream.hls][debug] Writing segment 3388 to output
[stream.hls][debug] Segment 3388 complete
[stream.hls][debug] Writing segment 3389 to output
[stream.hls][debug] Segment 3389 complete
[cli][debug] Writing stream to output
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

Purging stored/cached token (`--kick-purge-token`) and acquiring a new one by solving the JS challenge

```
$ streamlink -l debug --kick-purge-token kick.com/admiralbulldog best
[cli][debug] OS:         Linux-6.14.0-1-git-x86_64-with-glibc2.41
[cli][debug] Python:     3.13.2
[cli][debug] OpenSSL:    OpenSSL 3.4.1 11 Feb 2025
[cli][debug] Streamlink: 7.1.3+31.g073e189d
[cli][debug] Dependencies:
[cli][debug]  certifi: 2025.1.31
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.3.1
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.22.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.29.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  urllib3: 2.3.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  url=kick.com/admiralbulldog
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
[cli][debug]  --kick-purge-token=True
[plugins.kick][debug] Purging stored JS challenge token
[cli][info] Found matching plugin kick for URL kick.com/admiralbulldog
[plugins.kick][info] Acquiring new JS challenge token using the webbrowser API
[webbrowser.webbrowser][info] Launching web browser: /usr/bin/chromium (headless=True)
[webbrowser.webbrowser][debug] Waiting for web browser process to terminate
[plugins.kick][info] Successfully solved JS challenge and stored the acquired token
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: /usr/bin/mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 3392; Last Sequence: 3406
[stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 3404; End Sequence: None
[stream.hls][debug] Adding segment 3404 to queue
[stream.hls][debug] Adding segment 3405 to queue
[stream.hls][debug] Adding segment 3406 to queue
[stream.hls][debug] Writing segment 3404 to output
[stream.hls][debug] Segment 3404 complete
[cli.output][debug] Opening subprocess: ['/usr/bin/mpv', '--force-media-title=kick.com/admiralbulldog', '-']
[stream.hls][debug] Writing segment 3405 to output
[stream.hls][debug] Segment 3405 complete
[stream.hls][debug] Writing segment 3406 to output
[stream.hls][debug] Segment 3406 complete
[cli][debug] Writing stream to output
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```