### PR TITLE
cli.console: implement status messages

### DIFF
--- a/src/streamlink_cli/console/progress.py
+++ b/src/streamlink_cli/console/progress.py
@@ -154,6 +154,7 @@ class Progress(Thread):
         interval: float = 0.25,
         history: int = 20,
         threshold: int = 2,
+        status: bool = True,
     ):
         """
         :param console: The console output
@@ -177,6 +178,7 @@ class Progress(Thread):
         self.started: float = 0.0
         self.overall: int = 0
         self.written: int = 0
+        self.status: bool = status
 
     def close(self):
         self._wait.set()
@@ -220,4 +222,7 @@ class Progress(Thread):
             )
 
             status = formatter.format(formats, params)
-            self.console.msg_status(status)
+            if self.status:
+                self.console.msg_status(status)
+            else:
+                self.console.msg(status)

--- a/src/streamlink_cli/console/progress.py
+++ b/src/streamlink_cli/console/progress.py
@@ -8,8 +8,9 @@ from pathlib import PurePath
 from string import Formatter as StringFormatter
 from threading import Event, RLock, Thread
 from time import time
-from typing import TYPE_CHECKING, TextIO
+from typing import TYPE_CHECKING
 
+from streamlink_cli.console.console import ConsoleOutput
 from streamlink_cli.console.terminal import cut_text, term_width, text_width
 
 
@@ -148,15 +149,14 @@ class ProgressFormatter:
 class Progress(Thread):
     def __init__(
         self,
-        stream: TextIO,
+        console: ConsoleOutput,
         path: PurePath,
         interval: float = 0.25,
         history: int = 20,
         threshold: int = 2,
     ):
         """
-        :param stream: The output stream
-        :param path: The path that's being written
+        :param console: The console output
         :param interval: Time in seconds between updates
         :param history: Number of seconds of how long download speed history is kept
         :param threshold: Number of seconds until download speed is shown
@@ -168,7 +168,7 @@ class Progress(Thread):
 
         self.formatter = ProgressFormatter()
 
-        self.stream: TextIO = stream
+        self.console: ConsoleOutput = console
         self.path: PurePath = path
         self.interval: float = interval
         self.history: deque[tuple[float, int]] = deque(maxlen=int(history / interval))
@@ -194,7 +194,6 @@ class Progress(Thread):
                 self.update()
         finally:
             self.update()
-            self.print_end()
 
     def update(self):
         with self._lock:
@@ -221,16 +220,4 @@ class Progress(Thread):
             )
 
             status = formatter.format(formats, params)
-
-            self.print_inplace(status)
-
-    def print_inplace(self, msg: str):
-        """Clears the previous line and prints a new one."""
-        spacing = term_width() - text_width(msg)
-
-        self.stream.write(f"\r{msg}{' ' * max(0, spacing)}")
-        self.stream.flush()
-
-    def print_end(self):
-        self.stream.write("\n")
-        self.stream.flush()
+            self.console.msg_status(status)

--- a/src/streamlink_cli/console/stream.py
+++ b/src/streamlink_cli/console/stream.py
@@ -1,5 +1,143 @@
+from __future__ import annotations
+
+import os
+from io import TextIOWrapper
+from threading import RLock
+from typing import Iterable, Iterator
+
 from streamlink_cli.console.stream_wrapper import StreamWrapper
 
 
-class ConsoleOutputStream(StreamWrapper):
+class ConsoleStatusMessage(str):
     pass
+
+
+class ConsoleOutputStream(StreamWrapper):
+    def __new__(cls, stream: TextIOWrapper) -> ConsoleOutputStream:
+        if stream.isatty():
+            if os.environ.get("TERM", "").lower() not in ("dumb", "unknown"):
+                return super().__new__(ConsoleOutputStreamANSI)
+
+        return super().__new__(cls)
+
+    def __init__(self, stream: TextIOWrapper):
+        super().__init__(stream)
+        self._lock = RLock()
+        self._line_buffer: list[str] = []
+
+    @classmethod
+    def supports_status_messages(cls):
+        return False
+
+    def _get_lines(self, msg: str) -> Iterator[str]:
+        while msg:
+            line, nl, msg = msg.partition("\n")
+            if nl:
+                yield f"{''.join(self._line_buffer)}{line}{nl}"
+                self._line_buffer.clear()
+            else:
+                self._line_buffer.append(line)
+
+    def close(self):
+        with self._lock:
+            if not self.closed:
+                self.flush()
+
+            return self._stream.close()
+
+    def flush(self):
+        with self._lock:
+            if self._stream.closed:
+                raise ValueError("I/O operation on closed file.")
+
+            if rest := "".join(self._line_buffer):
+                self._line_buffer.clear()
+                self._stream.write(rest)
+            self._stream.flush()
+
+    def write(self, s: str) -> int:
+        written = 0
+
+        with self._lock:
+            if self._stream.closed:
+                raise ValueError("I/O operation on closed file.")
+
+            if type(s) is not ConsoleStatusMessage:
+                if lines := "".join(self._get_lines(s)):
+                    written = self._stream.write(lines)
+
+        return written
+
+    def writelines(self, lines: Iterable[str], /) -> None:  # type: ignore[override]
+        with self._lock:
+            if self._stream.closed:
+                raise ValueError("I/O operation on closed file.")
+
+            self.write("".join(lines))
+
+
+class _ConsoleOutputStreamWithStatusMessages(ConsoleOutputStream):
+    def __init__(self, stream: TextIOWrapper):
+        super().__init__(stream)
+        self._last_status: str = ""
+
+    @classmethod
+    def supports_status_messages(cls):
+        return True
+
+    def clear_line(self, s: str) -> str:  # pragma: no cover
+        return s
+
+    def close(self):
+        with self._lock:
+            if not self.closed:
+                if self._line_buffer:
+                    if self._last_status:
+                        s = self.clear_line(f"{''.join(self._line_buffer)}\n{self._last_status}\n")
+                    else:
+                        s = f"{''.join(self._line_buffer)}\n"
+                else:
+                    if self._last_status:
+                        s = "\n"
+                    else:
+                        s = ""
+                self._line_buffer.clear()
+                self._last_status = ""
+                if s:
+                    self._stream.write(s)
+                    self._stream.flush()
+
+            return self._stream.close()
+
+    def write(self, s: str) -> int:
+        written = 0
+
+        with self._lock:
+            if self._stream.closed:
+                raise ValueError("I/O operation on closed file.")
+
+            if type(s) is ConsoleStatusMessage:
+                s = s.strip("\r\n")
+                if self._last_status:
+                    self._last_status = s
+                    s = self.clear_line(s)
+                else:
+                    self._last_status = s
+                written = self._stream.write(s)
+                self._stream.flush()
+
+            elif lines := "".join(self._get_lines(s)):
+                if self._last_status:
+                    s = self.clear_line(f"{lines}{self._last_status}")
+                else:
+                    s = lines
+                written = self._stream.write(s)
+
+        return written
+
+
+class ConsoleOutputStreamANSI(_ConsoleOutputStreamWithStatusMessages):
+    _CR_CLREOL = "\r\x1b[K"
+
+    def clear_line(self, s: str) -> str:
+        return f"{self._CR_CLREOL}{s}"

--- a/src/streamlink_cli/console/windows.py
+++ b/src/streamlink_cli/console/windows.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from ctypes import CDLL, POINTER, Structure, byref
+from ctypes.wintypes import (
+    BOOL,
+    DWORD,
+    HANDLE,
+    SHORT,
+    SMALL_RECT,
+    WCHAR,
+    WORD,
+)
+from io import TextIOWrapper
+from typing import Callable, ClassVar
+
+
+# https://learn.microsoft.com/en-us/windows/console/coord-str
+class COORD(Structure):
+    _fields_: ClassVar = [
+        ("X", SHORT),
+        ("Y", SHORT),
+    ]
+
+
+# https://learn.microsoft.com/en-us/windows/console/console-screen-buffer-info-str
+# noinspection PyPep8Naming
+class CONSOLE_SCREEN_BUFFER_INFO(Structure):
+    _fields_: ClassVar = [
+        ("dwSize", COORD),
+        ("dwCursorPosition", COORD),
+        ("wAttributes", WORD),
+        ("srWindow", SMALL_RECT),
+        ("dwMaximumWindowSize", COORD),
+    ]
+
+
+class _WinApiCall:
+    argtypes: ClassVar[Sequence]
+    restype: ClassVar
+    method: Callable
+
+    def __init__(self, dll: CDLL):
+        self._dll = dll
+        method = getattr(dll, self.__class__.__name__)
+        method.argtypes = self.argtypes
+        method.restype = self.restype
+        self.method = method
+
+    def __call__(self, *args):  # pragma: no cover
+        return self.method(*args)
+
+    def _call_success(self, *args):
+        if not self.method(*args):
+            # https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror
+            # https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes#system-error-codes
+            last_error = self._dll.GetLastError()
+
+            raise OSError(f"Error while calling kernel32.{self.__class__.__name__} ({last_error=:#x})")
+
+
+class GetStdHandle(_WinApiCall):
+    """
+    https://learn.microsoft.com/en-us/windows/console/getstdhandle
+    """
+
+    STD_OUTPUT_HANDLE = -11
+    STD_ERROR_HANDLE = -12
+
+    argtypes: ClassVar = [DWORD]
+    restype: ClassVar = HANDLE
+
+    def __call__(self, handle: TextIOWrapper | None) -> HANDLE:
+        if handle is sys.stderr:
+            std_handle = self.STD_ERROR_HANDLE
+        else:
+            std_handle = self.STD_OUTPUT_HANDLE
+
+        return self.method(std_handle)
+
+
+class GetConsoleMode(_WinApiCall):
+    """
+    https://learn.microsoft.com/en-us/windows/console/getconsolemode
+    """
+
+    ENABLE_VIRTUAL_TERMINAL_PROCESSING = 4
+
+    argtypes: ClassVar = [HANDLE, POINTER(DWORD)]
+    restype: ClassVar = BOOL
+
+    def __call__(self, console_output: HANDLE) -> int:
+        mode = DWORD()
+        self._call_success(console_output, mode)
+
+        return mode.value
+
+    def supports_virtual_terminal_processing(self, console_output: HANDLE) -> bool:
+        try:
+            console_mode = self(console_output)
+        except OSError:
+            return False
+
+        return console_mode & self.ENABLE_VIRTUAL_TERMINAL_PROCESSING > 0
+
+
+class GetConsoleScreenBufferInfo(_WinApiCall):
+    """
+    https://learn.microsoft.com/en-us/windows/console/getconsolescreenbufferinfo
+    """
+
+    argtypes: ClassVar = [HANDLE, POINTER(CONSOLE_SCREEN_BUFFER_INFO)]
+    restype: ClassVar = BOOL
+
+    def __call__(self, console_output: HANDLE) -> CONSOLE_SCREEN_BUFFER_INFO:
+        console_screen_buffer_info = CONSOLE_SCREEN_BUFFER_INFO()
+        self._call_success(console_output, byref(console_screen_buffer_info))
+
+        return console_screen_buffer_info
+
+
+class SetConsoleCursorPosition(_WinApiCall):
+    """
+    https://learn.microsoft.com/en-us/windows/console/setconsolecursorposition
+    """
+
+    argtypes: ClassVar = [HANDLE, COORD]
+    restype: ClassVar = BOOL
+
+    def __call__(self, console_output: HANDLE, cursor_position: COORD) -> None:
+        self._call_success(console_output, cursor_position)
+
+
+class FillConsoleOutputAttribute(_WinApiCall):
+    """
+    https://learn.microsoft.com/en-us/windows/console/fillconsoleoutputattribute
+    """
+
+    argtypes: ClassVar = [HANDLE, WORD, DWORD, COORD, POINTER(DWORD)]
+    restype: ClassVar = BOOL
+
+    def __call__(self, console_output: HANDLE, attribute: int, length: int, write_coord: COORD) -> int:
+        attrs = WORD(attribute)
+        size = DWORD(length)
+        number_of_attrs_written = DWORD()
+        self._call_success(console_output, attrs, size, write_coord, byref(number_of_attrs_written))
+
+        return number_of_attrs_written.value
+
+
+class FillConsoleOutputCharacterW(_WinApiCall):
+    """
+    https://learn.microsoft.com/en-us/windows/console/fillconsoleoutputcharacter
+    """
+
+    argtypes: ClassVar = [HANDLE, WCHAR, DWORD, COORD, POINTER(DWORD)]
+    restype: ClassVar = BOOL
+
+    def __call__(self, console_output: HANDLE, character: str, length: int, write_coord: COORD) -> int:
+        char = WCHAR(character)
+        size = DWORD(length)
+        number_of_chars_written = DWORD()
+        self._call_success(console_output, char, size, write_coord, byref(number_of_chars_written))
+
+        return number_of_chars_written.value
+
+
+class WindowsConsole:
+    def __new__(cls, *args, **kwargs):
+        try:
+            from ctypes import windll  # noqa: PLC0415
+        except ImportError:  # pragma: no cover
+            return None
+
+        kernel32 = windll.kernel32
+        cls.get_std_handle = GetStdHandle(kernel32)
+        cls.get_console_mode = GetConsoleMode(kernel32)
+        cls.get_console_screen_buffer_info = GetConsoleScreenBufferInfo(kernel32)
+        cls.set_console_cursor_position = SetConsoleCursorPosition(kernel32)
+        cls.fill_console_output_attribute = FillConsoleOutputAttribute(kernel32)
+        cls.fill_console_output_character_w = FillConsoleOutputCharacterW(kernel32)
+
+        return super().__new__(cls)
+
+    def __init__(self, handle: TextIOWrapper | None = None):
+        self.handle = self.get_std_handle(handle)
+
+    def supports_virtual_terminal_processing(self):
+        return self.get_console_mode.supports_virtual_terminal_processing(self.handle)
+
+    def clear_line(self):
+        info = self.get_console_screen_buffer_info(self.handle)
+
+        def_attrs = info.wAttributes
+        length = info.dwSize.X
+        cursor_position = COORD(X=0, Y=info.dwCursorPosition.Y)
+        self.fill_console_output_character_w(self.handle, " ", length, cursor_position)
+        self.fill_console_output_attribute(self.handle, def_attrs, length, cursor_position)
+        self.set_console_cursor_position(self.handle, cursor_position)

--- a/src/streamlink_cli/constants.py
+++ b/src/streamlink_cli/constants.py
@@ -15,6 +15,8 @@ DEFAULT_STREAM_METADATA = {
     "game": "No Game/Category",
 }
 
+PROGRESS_INTERVAL_NO_STATUS = 2
+
 CONFIG_FILES: list[Path]
 PLUGIN_DIRS: list[Path]
 LOG_DIR: Path
@@ -58,6 +60,7 @@ __all__ = [
     "DEFAULT_STREAM_METADATA",
     "LOG_DIR",
     "PLUGIN_DIRS",
+    "PROGRESS_INTERVAL_NO_STATUS",
     "STREAM_PASSTHROUGH",
     "STREAM_SYNONYMS",
 ]

--- a/tests/cli/console/test_stream.py
+++ b/tests/cli/console/test_stream.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+from io import BytesIO, TextIOWrapper
+from os import linesep
+from typing import TYPE_CHECKING
+
+import pytest
+
+from streamlink_cli.console.stream import (
+    ConsoleOutputStream,
+    ConsoleOutputStreamANSI,
+    ConsoleStatusMessage,
+)
+
+
+if TYPE_CHECKING:
+    from typing_extensions import Buffer
+
+
+nl = linesep.encode("ascii")
+
+
+@pytest.fixture()
+def buffer():
+    return BytesIO()
+
+
+@pytest.fixture()
+def stream(buffer: BytesIO):
+    # stdout/stderr is line buffered, which implies flushes when writing \n or \r
+    return TextIOWrapper(buffer, encoding="utf-8", line_buffering=True)
+
+
+@pytest.fixture()
+def console_output_stream(stream: TextIOWrapper):
+    return ConsoleOutputStream(stream)
+
+
+class TestConsoleOutputStreamFeatureDetection:
+    @pytest.fixture()
+    def stream(self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, stream: TextIOWrapper):
+        isatty = getattr(request, "param", True)
+        setattr(stream, "isatty", lambda: isatty)  # noqa: B010
+
+        return stream
+
+    # noinspection PyTestParametrized
+    @pytest.mark.parametrize(
+        ("stream", "os_environ", "expected"),
+        [
+            pytest.param(False, {}, ConsoleOutputStream, id="posix-notatty"),
+            pytest.param(True, {}, ConsoleOutputStreamANSI, id="posix-isatty"),
+            pytest.param(True, {"TERM": "dumb"}, ConsoleOutputStream, id="posix-TERM=dumb"),
+            pytest.param(True, {"TERM": "unknown"}, ConsoleOutputStream, id="posix-TERM=unknown"),
+        ],
+        indirect=["os_environ", "stream"],
+    )
+    def test_class_type(self, os_environ: dict, console_output_stream: ConsoleOutputStream, expected: ConsoleOutputStream):
+        assert type(console_output_stream) is expected
+
+
+class TestConsoleOutputStream:
+    @pytest.fixture(autouse=True)
+    def _mock_new(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(ConsoleOutputStream, "__new__", lambda *_, **__: object.__new__(ConsoleOutputStream))
+
+    def test_supports_status_messages(self, console_output_stream: ConsoleOutputStream):
+        assert not console_output_stream.supports_status_messages()
+
+    def test_write(self, buffer: BytesIO, console_output_stream: ConsoleOutputStream):
+        assert buffer.getvalue() == b""
+
+        assert console_output_stream.write("foo") == 0
+        assert buffer.getvalue() == b""
+        assert console_output_stream._line_buffer == ["foo"]
+
+        assert console_output_stream.write("bar") == 0
+        assert buffer.getvalue() == b""
+        assert console_output_stream._line_buffer == ["foo", "bar"]
+
+        assert console_output_stream.write("baz\n123\n456\n") == (6 + 4) + 4 + 4
+        assert buffer.getvalue() == b"foobarbaz" + nl + b"123" + nl + b"456" + nl
+        assert console_output_stream._line_buffer == []
+
+        assert console_output_stream.write("abc") == 0
+        console_output_stream.flush()
+        assert buffer.getvalue() == b"foobarbaz" + nl + b"123" + nl + b"456" + nl + b"abc"
+        assert console_output_stream._line_buffer == []
+
+        console_output_stream.writelines(["QWERTY\n", "ASDF"])
+        assert buffer.getvalue() == b"foobarbaz" + nl + b"123" + nl + b"456" + nl + b"abcQWERTY" + nl
+        assert console_output_stream._line_buffer == ["ASDF"]
+        console_output_stream.flush()
+        assert buffer.getvalue() == b"foobarbaz" + nl + b"123" + nl + b"456" + nl + b"abcQWERTY" + nl + b"ASDF"
+
+    def test_write_status_message(self, buffer: BytesIO, console_output_stream: ConsoleOutputStream):
+        assert console_output_stream.write(ConsoleStatusMessage("foo")) == 0
+        assert console_output_stream._line_buffer == []
+        console_output_stream.flush()
+        assert buffer.getvalue() == b""
+
+    def test_close(self, buffer: BytesIO, console_output_stream: ConsoleOutputStream):
+        def fakewrite(s: Buffer) -> int:
+            msg = bytes(s)
+            fakebuffer.append(msg)
+
+            return len(msg)
+
+        fakebuffer: list[Buffer] = []
+        buffer.write = fakewrite  # type: ignore[method-assign]
+
+        assert console_output_stream.write("foo") == 0
+        assert fakebuffer == []
+        assert console_output_stream._line_buffer == ["foo"]
+        assert not console_output_stream.closed
+
+        console_output_stream.close()
+        assert fakebuffer == [b"foo"]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream.closed
+
+        console_output_stream.close()  # noop - does not raise
+
+        with pytest.raises(ValueError, match=r"^I/O operation on closed file\.$"):
+            console_output_stream.write("foo")
+
+        with pytest.raises(ValueError, match=r"^I/O operation on closed file\.$"):
+            console_output_stream.writelines(["foo", "bar"])
+
+        with pytest.raises(ValueError, match=r"^I/O operation on closed file\.$"):
+            console_output_stream.flush()
+
+
+class TestConsoleOutputStreamANSI:
+    @pytest.fixture(autouse=True)
+    def _mock_new(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(ConsoleOutputStream, "__new__", lambda *_, **__: object.__new__(ConsoleOutputStreamANSI))
+
+    @pytest.fixture()
+    def fakebuffer(self, buffer: BytesIO):
+        def fakewrite(s: Buffer) -> int:
+            msg = bytes(s)
+            fakebuffer.append(msg)
+
+            return len(msg)
+
+        fakebuffer: list[Buffer] = []
+        buffer.write = fakewrite  # type: ignore[method-assign]
+
+        return fakebuffer
+
+    def test_supports_status_messages(self, console_output_stream: ConsoleOutputStreamANSI):
+        assert console_output_stream.supports_status_messages()
+
+    def test_write(self, buffer: BytesIO, console_output_stream: ConsoleOutputStreamANSI):
+        clr_eol = console_output_stream._CR_CLREOL.encode("ascii")
+        len_clr_eol = len(clr_eol)
+        assert len_clr_eol == 4
+
+        assert console_output_stream.write("foo") == 0
+        assert buffer.getvalue() == b""
+        assert console_output_stream._line_buffer == ["foo"]
+        assert console_output_stream._last_status == ""
+
+        assert console_output_stream.write("bar\n") == 3 + 4
+        assert buffer.getvalue() == b"foobar" + nl
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+
+        assert console_output_stream.write(ConsoleStatusMessage("123\n")) == 3
+        assert buffer.getvalue() == b"foobar" + nl + b"123"
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == "123"
+
+        assert console_output_stream.write(ConsoleStatusMessage("456\n")) == len_clr_eol + 3
+        assert buffer.getvalue() == b"foobar" + nl + b"123" + clr_eol + b"456"
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == "456"
+
+        assert console_output_stream.write("abc") == 0
+        assert buffer.getvalue() == b"foobar" + nl + b"123" + clr_eol + b"456"
+        assert console_output_stream._line_buffer == ["abc"]
+        assert console_output_stream._last_status == "456"
+
+        assert console_output_stream.write(ConsoleStatusMessage("789\n")) == len_clr_eol + 3
+        assert buffer.getvalue() == b"foobar" + nl + b"123" + clr_eol + b"456" + clr_eol + b"789"
+        assert console_output_stream._line_buffer == ["abc"]
+        assert console_output_stream._last_status == "789"
+
+        assert console_output_stream.write("def\n") == 3 + 4 + len_clr_eol + len(console_output_stream._last_status)
+        assert buffer.getvalue() == (
+            b"foobar" + nl + b"123" + clr_eol + b"456" + clr_eol + b"789" + clr_eol + b"abcdef" + nl + b"789"
+        )
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == "789"
+
+    def test_close(self, console_output_stream: ConsoleOutputStreamANSI):
+        console_output_stream.close()
+
+        with pytest.raises(ValueError, match=r"^I/O operation on closed file\.$"):
+            console_output_stream.write("foo")
+
+        with pytest.raises(ValueError, match=r"^I/O operation on closed file\.$"):
+            console_output_stream.writelines(["foo", "bar"])
+
+        with pytest.raises(ValueError, match=r"^I/O operation on closed file\.$"):
+            console_output_stream.flush()
+
+    def test_close_without_line_buffer_without_status(
+        self,
+        fakebuffer: list[bytes],
+        console_output_stream: ConsoleOutputStreamANSI,
+    ):
+        assert console_output_stream.write("foo\n") == 4
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert not console_output_stream.closed
+
+        console_output_stream.close()
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert console_output_stream.closed
+
+        console_output_stream.close()  # noop - does not raise
+
+    def test_close_with_line_buffer_without_status(
+        self,
+        fakebuffer: list[bytes],
+        console_output_stream: ConsoleOutputStreamANSI,
+    ):
+        assert console_output_stream.write("foo\n") == 4
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert not console_output_stream.closed
+
+        assert console_output_stream.write("bar") == 0
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == ["bar"]
+        assert console_output_stream._last_status == ""
+        assert not console_output_stream.closed
+
+        console_output_stream.close()
+        assert fakebuffer == [b"foo" + nl, b"bar" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert console_output_stream.closed
+
+        console_output_stream.close()  # noop - does not raise
+
+    def test_close_without_line_buffer_with_status(
+        self,
+        fakebuffer: list[bytes],
+        console_output_stream: ConsoleOutputStreamANSI,
+    ):
+        assert console_output_stream.write("foo\n") == 4
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert not console_output_stream.closed
+
+        assert console_output_stream.write(ConsoleStatusMessage("123\n")) == 3
+        assert fakebuffer == [b"foo" + nl, b"123"]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == "123"
+        assert not console_output_stream.closed
+
+        console_output_stream.close()
+        assert fakebuffer == [b"foo" + nl, b"123", nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert console_output_stream.closed
+
+        console_output_stream.close()  # noop - does not raise
+
+    def test_close_with_line_buffer_with_status(
+        self,
+        fakebuffer: list[bytes],
+        console_output_stream: ConsoleOutputStreamANSI,
+    ):
+        clr_eol = console_output_stream._CR_CLREOL.encode("ascii")
+
+        assert console_output_stream.write("foo\n") == 4
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert not console_output_stream.closed
+
+        assert console_output_stream.write("bar") == 0
+        assert fakebuffer == [b"foo" + nl]
+        assert console_output_stream._line_buffer == ["bar"]
+        assert console_output_stream._last_status == ""
+        assert not console_output_stream.closed
+
+        assert console_output_stream.write(ConsoleStatusMessage("123\n")) == 3
+        assert fakebuffer == [b"foo" + nl, b"123"]
+        assert console_output_stream._line_buffer == ["bar"]
+        assert console_output_stream._last_status == "123"
+        assert not console_output_stream.closed
+
+        console_output_stream.close()
+        assert fakebuffer == [b"foo" + nl, b"123", clr_eol + b"bar" + nl + b"123" + nl]
+        assert console_output_stream._line_buffer == []
+        assert console_output_stream._last_status == ""
+        assert console_output_stream.closed
+
+        console_output_stream.close()  # noop - does not raise

--- a/tests/cli/console/test_stream_wrapper.py
+++ b/tests/cli/console/test_stream_wrapper.py
@@ -6,6 +6,11 @@ import pytest
 from streamlink_cli.console.stream import ConsoleOutputStream
 
 
+@pytest.fixture(autouse=True)
+def _console_output_stream(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(ConsoleOutputStream, "__new__", lambda *_, **__: object.__new__(ConsoleOutputStream))
+
+
 def test_wrap_error():
     with pytest.raises(AttributeError):
         ConsoleOutputStream.wrap(sys, "version")

--- a/tests/cli/console/test_windows.py
+++ b/tests/cli/console/test_windows.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import sys
+
+# noinspection PyProtectedMember
+from ctypes import Structure, _SimpleCData  # noqa: PLC2701
+from ctypes.wintypes import DWORD, WCHAR, WORD
+from io import TextIOWrapper
+from types import ModuleType
+from typing import ClassVar, Generic, TypeVar
+from unittest.mock import ANY, Mock, call
+
+import pytest
+
+from streamlink_cli.console.windows import COORD, WindowsConsole
+
+
+_TCTypesType = TypeVar("_TCTypesType")
+
+
+class _CTypesComparable(Generic[_TCTypesType]):
+    """Allow comparing ctypes data types with built-in types for equality"""
+
+    _type: ClassVar[type]
+
+    def __init__(self, data: _TCTypesType):
+        self.data: tuple = self._get_data(data)
+
+    def _get_data(self, data: _TCTypesType) -> tuple:  # pragma: no cover
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        if isinstance(other, self._type):
+            return self.__eq__(type(self)(other))
+        if not isinstance(other, type(self)):  # pragma: no cover
+            return False
+
+        return self.data == other.data
+
+    def __hash__(self):  # pragma: no cover
+        return super().__hash__()
+
+
+class EqSimpleCData(_CTypesComparable[_SimpleCData]):
+    _type: ClassVar = _SimpleCData
+
+    def _get_data(self, data: _SimpleCData) -> tuple:
+        # noinspection PyProtectedMember
+        return data._type_, data.value  # type: ignore[attr-defined]
+
+
+class EqStructure(_CTypesComparable[Structure]):
+    _type: ClassVar = Structure
+
+    def _get_data(self, data: Structure) -> tuple:
+        # noinspection PyProtectedMember
+        return tuple(getattr(data, item) for (item, *_) in data._fields_)
+
+
+@pytest.fixture(autouse=True)
+def _mock_byref(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("streamlink_cli.console.windows.byref", Mock(side_effect=lambda obj, *_, **__: obj))
+
+
+@pytest.fixture(autouse=True)
+def mock_windll(monkeypatch: pytest.MonkeyPatch):
+    mock_windll = Mock()
+    monkeypatch.setattr("ctypes.windll", mock_windll, raising=False)
+
+    return mock_windll
+
+
+def test_no_windll(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setitem(sys.modules, "ctypes", ModuleType("ctypes"))
+    assert WindowsConsole() is None
+
+
+@pytest.mark.parametrize(
+    ("method", "function"),
+    [
+        ("get_std_handle", "GetStdHandle"),
+        ("get_console_mode", "GetConsoleMode"),
+        ("get_console_screen_buffer_info", "GetConsoleScreenBufferInfo"),
+        ("set_console_cursor_position", "SetConsoleCursorPosition"),
+        ("fill_console_output_attribute", "FillConsoleOutputAttribute"),
+        ("fill_console_output_character_w", "FillConsoleOutputCharacterW"),
+    ],
+)
+def test_functions(mock_windll: Mock, method: str, function: str):
+    windows_console = WindowsConsole()
+    assert isinstance(windows_console, WindowsConsole)
+    assert getattr(windows_console, method).method is getattr(mock_windll.kernel32, function)
+
+
+def test_call_success_error(monkeypatch: pytest.MonkeyPatch, mock_windll: Mock):
+    windows_console = WindowsConsole()
+    monkeypatch.setattr(windows_console.set_console_cursor_position, "method", Mock(return_value=False))
+    mock_windll.kernel32.GetLastError.return_value = 87
+
+    with pytest.raises(OSError) as exc_info:  # noqa: PT011
+        windows_console.set_console_cursor_position(123, 456)
+    assert str(exc_info.value) == "Error while calling kernel32.SetConsoleCursorPosition (last_error=0x57)"
+
+
+@pytest.mark.parametrize(
+    ("stream", "expected"),
+    [
+        pytest.param(None, -11, id="None"),
+        pytest.param(sys.stdout, -11, id="stdout"),
+        pytest.param(sys.stderr, -12, id="stderr"),
+    ],
+)
+def test_std_handle(mock_windll: Mock, stream: TextIOWrapper | None, expected: int):
+    windows_console = WindowsConsole(stream)
+    assert mock_windll.kernel32.GetStdHandle.call_args_list == [call(expected)]
+    assert windows_console.handle is mock_windll.kernel32.GetStdHandle.return_value
+
+
+@pytest.mark.parametrize(
+    ("value", "success", "expected"),
+    [
+        pytest.param(0, False, False, id="error"),
+        pytest.param(3, True, False, id="no-virtual-terminal-processing"),
+        pytest.param(7, True, True, id="virtual-terminal-processing"),
+    ],
+)
+def test_supports_virtual_terminal_processing(mock_windll: Mock, value: int, success: bool, expected: bool):
+    def fake_get_console_mode(_handle, mode):
+        mode.value = value
+
+        return success
+
+    mock_windll.kernel32.GetConsoleMode.side_effect = fake_get_console_mode
+    mock_windll.kernel32.GetLastError.return_value = 87
+
+    windows_console = WindowsConsole()
+    assert windows_console.supports_virtual_terminal_processing() == expected
+    assert mock_windll.kernel32.GetConsoleMode.call_args_list == [call(mock_windll.kernel32.GetStdHandle.return_value, ANY)]
+
+
+def test_clear_line(mock_windll: Mock):
+    def fake_get_console_screen_buffer_info(_handle, console_screen_buffer_info):
+        console_screen_buffer_info.dwSize.X = 144
+        console_screen_buffer_info.dwSize.Y = 42
+        console_screen_buffer_info.dwCursorPosition.X = 20
+        console_screen_buffer_info.dwCursorPosition.Y = 15
+        console_screen_buffer_info.wAttributes = 0
+
+        return True
+
+    mock_windll.kernel32.GetConsoleScreenBufferInfo.side_effect = fake_get_console_screen_buffer_info
+
+    windows_console = WindowsConsole()
+    windows_console.clear_line()
+    assert mock_windll.kernel32.GetConsoleScreenBufferInfo.call_args_list == [
+        call(mock_windll.kernel32.GetStdHandle.return_value, ANY),
+    ]
+    assert mock_windll.kernel32.FillConsoleOutputCharacterW.call_args_list == [
+        call(
+            mock_windll.kernel32.GetStdHandle.return_value,
+            EqSimpleCData(WCHAR(" ")),
+            EqSimpleCData(DWORD(144)),
+            EqStructure(COORD(0, 15)),
+            EqSimpleCData(DWORD(0)),
+        ),
+    ]
+    assert mock_windll.kernel32.FillConsoleOutputAttribute.call_args_list == [
+        call(
+            mock_windll.kernel32.GetStdHandle.return_value,
+            EqSimpleCData(WORD(0)),
+            EqSimpleCData(DWORD(144)),
+            EqStructure(COORD(0, 15)),
+            EqSimpleCData(DWORD(0)),
+        ),
+    ]
+    assert mock_windll.kernel32.SetConsoleCursorPosition.call_args_list == [
+        call(
+            mock_windll.kernel32.GetStdHandle.return_value,
+            EqStructure(COORD(0, 15)),
+        ),
+    ]

--- a/tests/cli/main/conftest.py
+++ b/tests/cli/main/conftest.py
@@ -19,6 +19,8 @@ def argv(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
 def _console_output_stream(monkeypatch: pytest.MonkeyPatch):
     # don't wrap stdout/stderr in CLI integration tests, as we're capturing the output
     monkeypatch.setattr("streamlink_cli.console.stream_wrapper.StreamWrapper._wrap", Mock())
+    # don't do any feature checks
+    monkeypatch.setattr("streamlink_cli.console.stream.ConsoleOutputStream.__new__", lambda cls, *_, **__: object.__new__(cls))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/cli/main/test_output_stream.py
+++ b/tests/cli/main/test_output_stream.py
@@ -9,6 +9,7 @@ import pytest
 import streamlink_cli.main
 from streamlink.exceptions import StreamError
 from streamlink.stream.stream import Stream
+from streamlink_cli.constants import PROGRESS_INTERVAL_NO_STATUS
 from streamlink_cli.exceptions import StreamlinkCLIError
 from streamlink_cli.main import build_parser, setup_args
 from streamlink_cli.output import FileOutput, PlayerOutput
@@ -169,7 +170,7 @@ player_recording = PlayerOutput(Path("player"), record=file_output)
             ["--progress=force"],
             False,
             file_output,
-            {"path": filename},
+            {"path": filename, "interval": PROGRESS_INTERVAL_NO_STATUS, "status": False},
             id="force-progress-no-status-messages",
         ),
     ],

--- a/tests/cli/test_streamrunner.py
+++ b/tests/cli/test_streamrunner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import errno
-import sys
 from collections import deque
 from collections.abc import Callable
 from pathlib import Path
@@ -155,27 +154,28 @@ class TestPlayerOutput:
         return player_process
 
     @pytest.fixture()
-    def output(self, player_process: Mock):
-        with (
-            patch("subprocess.Popen") as mock_popen,
-            patch("streamlink_cli.output.player.sleep"),
-        ):
-            mock_popen.return_value = player_process
-            output = FakePlayerOutput(Path("mocked"))
-            output.open()
+    def output(self, monkeypatch: pytest.MonkeyPatch, player_process: Mock):
+        mock_popen = Mock(return_value=player_process)
+        monkeypatch.setattr("subprocess.Popen", mock_popen)
+        monkeypatch.setattr("streamlink_cli.output.player.sleep", Mock())
+
+        output = FakePlayerOutput(Path("mocked"))
+        output.open()
+        try:
             yield output
+        finally:
             output.close()
 
     @pytest.fixture()
-    def stream_runner(self, stream: FakeStream, output: FakePlayerOutput):
-        with patch("streamlink_cli.streamrunner.PlayerPollThread", EventedPlayerPollThread):
-            stream_runner = StreamRunner(stream, output)
-            assert isinstance(stream_runner.playerpoller, EventedPlayerPollThread)
-            assert not stream_runner.playerpoller.is_alive()
-            assert not stream_runner.is_http
-            assert not stream_runner.progress
-            yield stream_runner
-            assert not stream_runner.playerpoller.is_alive()
+    def stream_runner(self, monkeypatch: pytest.MonkeyPatch, stream: FakeStream, output: FakePlayerOutput):
+        monkeypatch.setattr("streamlink_cli.streamrunner.PlayerPollThread", EventedPlayerPollThread)
+        stream_runner = StreamRunner(stream, output)
+        assert isinstance(stream_runner.playerpoller, EventedPlayerPollThread)
+        assert not stream_runner.playerpoller.is_alive()
+        assert not isinstance(stream_runner.output, HTTPOutput)
+        assert not stream_runner.progress
+        yield stream_runner
+        assert not stream_runner.playerpoller.is_alive()
 
     @pytest.mark.trio()
     async def test_read_write(
@@ -456,7 +456,7 @@ class TestHTTPServer:
         stream_runner = StreamRunner(stream, output)
         assert not stream_runner.playerpoller
         assert not stream_runner.progress
-        assert stream_runner.is_http
+        assert isinstance(stream_runner.output, HTTPOutput)
         return stream_runner
 
     @pytest.mark.trio()
@@ -552,96 +552,23 @@ class TestHTTPServer:
         assert [(record.module, record.levelname, record.message) for record in caplog.records] == expectedlogs
 
 
-class TestHasProgress:
-    @pytest.mark.parametrize(
-        ("output", "stderr"),
-        [
-            pytest.param(
-                FakePlayerOutput(Path("mocked")),
-                True,
-                id="Player output without record",
-            ),
-            pytest.param(
-                FakeFileOutput(fd=Mock()),
-                True,
-                id="FileOutput with file descriptor",
-            ),
-            pytest.param(
-                FakeHTTPOutput(),
-                True,
-                id="HTTPServer",
-            ),
-            pytest.param(
-                FakeFileOutput(filename=Path("mocked")),
-                False,
-                id="no-stderr",
-            ),
-        ],
-    )
-    def test_no_progress(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-        output: FakePlayerOutput | FakeFileOutput | FakeHTTPOutput,
-        stderr: bool,
-    ):
-        if not stderr:
-            monkeypatch.setattr("sys.stderr", None)
-        stream_runner = FakeStreamRunner(StreamIO(), output, show_progress=True)
-        assert not stream_runner.progress
-
-    @pytest.mark.parametrize(
-        ("output", "expected"),
-        [
-            pytest.param(
-                FakePlayerOutput(Path("mocked"), record=FakeFileOutput(Path("record"))),
-                Path("record"),
-                id="PlayerOutput with record",
-            ),
-            pytest.param(
-                FakeFileOutput(filename=Path("filename")),
-                Path("filename"),
-                id="FileOutput with file name",
-            ),
-            pytest.param(
-                FakeFileOutput(record=FakeFileOutput(filename=Path("record"))),
-                Path("record"),
-                id="FileOutput with record",
-            ),
-            pytest.param(
-                FakeFileOutput(filename=Path("filename"), record=FakeFileOutput(filename=Path("record"))),
-                Path("filename"),
-                id="FileOutput with file name and record",
-            ),
-        ],
-    )
-    def test_has_progress(
-        self,
-        output: FakePlayerOutput | FakeFileOutput,
-        expected: Path,
-    ):
-        stream_runner = FakeStreamRunner(StreamIO(), output, show_progress=True)
-        assert stream_runner.progress
-        assert not stream_runner.progress.is_alive()
-        assert stream_runner.progress.stream is sys.stderr
-        assert stream_runner.progress.path == expected
-
-
 class TestProgress:
     @pytest.fixture()
     def output(self):
         return FakeFileOutput(Path("filename"))
 
     @pytest.fixture()
-    def stream_runner(self, stream: FakeStream, output: FakeFileOutput):
-        with patch("streamlink_cli.streamrunner.Progress", FakeProgress):
-            stream_runner = FakeStreamRunner(stream, output, show_progress=True)
-            assert not stream_runner.playerpoller
-            assert not stream_runner.is_http
-            assert isinstance(stream_runner.progress, FakeProgress)
-            assert stream_runner.progress.path == Path("filename")
-            assert not stream_runner.progress.is_alive()
-            yield stream_runner
-            assert not stream_runner.progress.is_alive()
+    def progress(self):
+        return FakeProgress(console=Mock(), path=Path("filename"))
+
+    @pytest.fixture()
+    def stream_runner(self, stream: FakeStream, output: FakeFileOutput, progress: FakeProgress):
+        stream_runner = FakeStreamRunner(stream, output, progress=progress)
+        assert not stream_runner.playerpoller
+        assert stream_runner.progress is progress
+        assert not stream_runner.progress.is_alive()
+        yield stream_runner
+        assert not stream_runner.progress.is_alive()
 
     @pytest.mark.trio()
     async def test_read_write(


### PR DESCRIPTION
Resolves #6449

~~These are unfinished changes... The implementation works and should mostly be fine, apart from stuff that may come up while finishing and cleaning this up. Most tests however still need to be done (the CI status checks will therefore currently fail, tests and typing stuff). I still decided to open this PR, because this helps me finding potential issues.~~

~~The PR branch is currently based on #6496, because this branch hasn't been merged yet. Once merged, I'm going to rebase here.~~

----

1. Implement status messages on the console output via `ConsoleOutput.msg_status()`
    - Add base line-buffered `ConsoleOutputStream(StreamWrapper)` without status message support
    - Add `ConsoleOutputStreamANSI` with status message support via ANSI control sequences
    - Check for available support and choose the right class automatically when initializing
2. Implement `WindowsConsole` and `ConsoleOutputStreamWindows`
    - Check whether "virtual terminal processing" is supported (ANSI control sequences), which is the case since newer versions of PowerShell and the Windows Terminal
    - If it's not supported, then use the classic Windows Console APIs (deprecated, but supported indefinitely)
3. Refactor `Process` and `StreamRunner`
    - Make `Progress` call the newly added `ConsoleOutput.msg_status()` instead of writing to `stderr` and adding whitespace padding to each message
    - Initialize the `Progress` instance outside of `StreamRunner`
4. Make `--progress=force` write regular console output messages in a slower interval when not a TTY. This restores and improves the old behavior.

----

This assumes that ANSI control sequence processing is supported by each terminal application on non-Windows unless the env vars `TERM=dumb` or `TERM=unknown` are set. That feature assumption should be fine though.

The docs of the Windows Console API calls are all linked in the implementation.

One issue I noticed while testing this in my Windows 10 VM was while using the mintty terminal from git-for-windows (MinGW / MSYS2). Apparently, `isatty()` calls always return false because the stdio streams are wrapped. This means that status messages won't work here. The workaround for that is wrapping the command in `winpty` (`winpty streamlink ...`). This is a known issue in this env and git even implements its own workarounds in its code, according to my research. This isn't feasible for Streamlink though and should be done by CPython anyway, so I don't care.

As commented in the last commit, `--progress=force` now doesn't make any sense anymore, as the support for status messages needs to be checked at runtime and can't be forced. Previously we simply wrote status messages to `stderr` and added whitespace padding, so forcing status messages on non-interactive stdio streams made sense. `--progress=force` now could be changed so that it'll make `Progress` write non-status-messages to the non-interactive console output, but in a slower interval, so that it doesn't spam that many messages.