### PR TITLE
cli: fix ZeroDivisionError in Progress.update()

### DIFF
--- a/src/streamlink_cli/utils/progress.py
+++ b/src/streamlink_cli/utils/progress.py
@@ -280,7 +280,7 @@ class Progress(Thread):
             self.written = 0
 
             has_history = len(history) >= self.threshold
-            if not has_history:
+            if not has_history or now == history[0][0]:
                 formats = formatter.FORMATS_NOSPEED
                 speed = ""
             else:

--- a/tests/cli/utils/test_progress.py
+++ b/tests/cli/utils/test_progress.py
@@ -304,6 +304,9 @@ class TestProgress:
         progress.update()
         assert stream.getvalue().split("\r")[-1] == "[download] Written 0 bytes to ../../the/path/where/we/write/to (0s)   "
 
+        progress.update()
+        assert stream.getvalue().split("\r")[-1] == "[download] Written 0 bytes to ../../the/path/where/we/write/to (0s)   "
+
         frozen_time.tick()
         progress.write(kib * 1)
         progress.update()


### PR DESCRIPTION
Found this while adding the (currently missing) `--progress=force` changes to #6497. This is an independent bug and therefore doesn't belong into #6497.