### PR TITLE
build: switch to PEP 639 license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools >=65.6",
+  "setuptools >=77",
   "wheel",
   # The versioningit build-requirement gets removed from the source distribution,
   # as the version string is already built into it (see the onbuild versioningit hook):
@@ -20,14 +20,14 @@ description = """\
 Streamlink is a command-line utility that extracts streams from various services and pipes them into a video player of choice.\
 """
 readme = "README.md"
-license = { text = "Simplified BSD" }
+license = "BSD-2-Clause"
+license-files = ["LICENSE"]
 authors = [
   { name = "Streamlink" },
   { email = "streamlink@protonmail.com" }
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
-  "License :: OSI Approved :: BSD License",
   "Environment :: Console",
   "Intended Audience :: End Users/Desktop",
   "Operating System :: POSIX",
@@ -88,9 +88,6 @@ Funding = "https://streamlink.github.io/latest/support.html"
 # https://setuptools.pypa.io/en/stable/userguide/pyproject_config.html
 # https://setuptools.pypa.io/en/stable/userguide/package_discovery.html
 # https://setuptools.pypa.io/en/stable/userguide/datafiles.html
-[tool.setuptools]
-license-files = ["LICENSE"]
-
 [tool.setuptools.packages.find]
 where = ["src"]
 namespaces = false


### PR DESCRIPTION
PEP 639 support was added in setuptools 77 (2025-03-19):
- https://peps.python.org/pep-0639/#goals
- https://setuptools.pypa.io/en/latest/history.html#v77-0-0

This deprecates the `project.license` table in favor of a standardized SPDX license string, as well as the temporary setuptools-specific `tools.setuptools.license-files` table in favor of `project.license-files`.

`tools.setuptools.license-files` and `project.license-files` can't be set at the same time. ~~Considering that setuptools 77 was only released in March, we should wait a bit more before switching the metadata format, as recent enough setuptools versions might not be packaged yet on all Linux distros where we have recent Streamlink releases packaged.~~

```
$ pip install .
...

$ grep -E '^License' $VIRTUAL_ENV/lib/python3.13/site-packages/streamlink-7.2.0+13.g1cebf437.dist-info/METADATA
License-Expression: BSD-2-Clause
License-File: LICENSE

$ cat $VIRTUAL_ENV/lib/python3.13/site-packages/streamlink-7.2.0+13.g1cebf437.dist-info/licenses/LICENSE 
Copyright (c) 2011-2016, Christopher Rosell
Copyright (c) 2016-2025, Streamlink Team
All rights reserved.

Redistribution and use in source and binary forms, with or without
modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this
   list of conditions and the following disclaimer.
2. Redistributions in binary form must reproduce the above copyright notice,
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
```