### PR TITLE
stream.dash: fix LookupError on period selection

### DIFF
--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -365,6 +365,7 @@ class MPD(MPDNode):
 
         self.baseURLs = self.children(BaseURL)
         self.periods = self.children(Period, minimum=1)
+        self.periods_map = {period.id: period for period in self.periods if period.id is not None}
         self.programInformation = self.children(ProgramInformation)
 
     def get_representation(self, ident: TTimelineIdent) -> Representation | None:

--- a/tests/resources/dash/test_period_selection.mpd
+++ b/tests/resources/dash/test_period_selection.mpd
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<MPD
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="urn:mpeg:dash:schema:mpd:2011"
+  availabilityStartTime="1970-01-01T00:00:00Z"
+  minBufferTime="PT2S"
+  minimumUpdatePeriod="PT0S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011,http://dashif.org/guidelines/dash-if-simple"
+  publishTime="2000-01-01T00:00:00Z"
+  timeShiftBufferDepth="PT5M"
+  type="dynamic"
+  xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
+>
+  <Period id="p1" start="PT12M34S">
+    <AdaptationSet id="0" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25">
+      <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="10000000">
+        <SegmentList timescale="90000" duration="900000">
+          <Initialization sourceURL="p1-init.m4s"/>
+          <SegmentURL media="p1-1.m4s"/>
+          <SegmentURL media="p1-2.m4s"/>
+          <SegmentURL media="p1-3.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+  <Period id="p2" start="PT12M34S">
+    <AdaptationSet id="0" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25">
+      <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="10000000">
+        <SegmentList timescale="90000" duration="900000">
+          <Initialization sourceURL="p2-init.m4s"/>
+          <SegmentURL media="p2-1.m4s"/>
+          <SegmentURL media="p2-2.m4s"/>
+          <SegmentURL media="p2-3.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>


### PR DESCRIPTION
Ref https://github.com/streamlink/streamlink/issues/5058#issuecomment-2843678464

A `LookupError` should not be raised when selecting a specific DASH period. Instead, raise a `PluginError` with a better error message.

This PR also adds support for selecting DASH periods by their `id` attribute, which is an optional value. This requires quotation when using the DASH plugin (`streamlink 'dash://URL period="ID"'`), as it's parsing Python literals, and IDs are string values. Probably not ideal that Streamlink doesn't log what's available, but that's not the goal of this PR.

Example on a random DASH stream from steamcommunity.com:

IndexError/LookupError (master):
```
$ streamlink 'dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period=123' best
[cli][info] Found matching plugin dash for URL dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period=123
Traceback (most recent call last):
  File "/home/basti/venv/streamlink-313/bin/streamlink", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 1011, in main
    exit_code = run(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 994, in run
    exit_code = handle_url_wrapper()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 582, in handle_url_wrapper
    handle_url()
    ~~~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 630, in handle_url
    streams = fetch_streams(plugin)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 500, in fetch_streams
    return plugin.streams(
           ~~~~~~~~~~~~~~^
        stream_types=args.stream_types,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        sorting_excludes=args.stream_sorting_excludes,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/basti/repos/streamlink/src/streamlink/plugin/plugin.py", line 401, in streams
    ostreams = self._get_streams()
  File "/home/basti/repos/streamlink/src/streamlink/plugins/dash.py", line 43, in _get_streams
    return DASHStream.parse_manifest(self.session, url, **params)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/dash/dash.py", line 296, in parse_manifest
    for aset in mpd.periods[period].adaptationSets:
                ~~~~~~~~~~~^^^^^^^^
IndexError: list index out of range
```

IndexError/LookupError (PR):
```
$ streamlink 'dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period=does-not-exist' best
[cli][info] Found matching plugin dash for URL dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period=does-not-exist
error: DASH period 123 not found. Select a valid period by index or by id attribute value.
```

by index and `id` attr:
```
$ streamlink 'dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period=0'
[cli][info] Found matching plugin dash for URL dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period=0
Available streams: 1080p (worst, best)

$ streamlink 'dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period="1"'
[cli][info] Found matching plugin dash for URL dash://https://cache11-ams1.steamcontent.com/broadcast/76561198074710428/5461257622813668676/manifest/0/cache11-ams1.steamcontent.com/?broadcast_origin=ext2-fra1.steamserver.net period="1"
Available streams: 1080p (worst, best)
```