### PR TITLE
stream.dash: log available periods

### DIFF
--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -292,6 +292,9 @@ class DASHStream(Stream):
         video: list[Representation | None] = [None] if with_audio_only else []
         audio: list[Representation | None] = [None] if with_video_only else []
 
+        available_periods = [f"{idx}{f' (id={p.id!r})' if p.id is not None else ''}" for idx, p in enumerate(mpd.periods)]
+        log.debug(f"Available DASH periods: {', '.join(available_periods)}")
+
         try:
             if isinstance(period, int):
                 period_selection = mpd.periods[period]

--- a/tests/resources/dash/test_period_selection.mpd
+++ b/tests/resources/dash/test_period_selection.mpd
@@ -11,6 +11,18 @@
   type="dynamic"
   xsi:schemaLocation="urn:mpeg:dash:schema:mpd:2011 DASH-MPD.xsd"
 >
+  <Period start="PT12M34S">
+    <AdaptationSet id="0" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25">
+      <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="10000000">
+        <SegmentList timescale="90000" duration="900000">
+          <Initialization sourceURL="p0-init.m4s"/>
+          <SegmentURL media="p0-1.m4s"/>
+          <SegmentURL media="p0-2.m4s"/>
+          <SegmentURL media="p0-3.m4s"/>
+        </SegmentList>
+      </Representation>
+    </AdaptationSet>
+  </Period>
   <Period id="p1" start="PT12M34S">
     <AdaptationSet id="0" mimeType="video/mp4" maxWidth="1920" maxHeight="1080" par="16:9" frameRate="25">
       <Representation id="0" codecs="avc1.640028" width="1920" height="1080" sar="1:1" bandwidth="10000000">

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -334,19 +334,32 @@ class TestDASHStreamParseManifest:
         [
             pytest.param(0, does_not_raise, id="index-0"),
             pytest.param(1, does_not_raise, id="index-1"),
+            pytest.param(2, does_not_raise, id="index-2"),
             pytest.param("p1", does_not_raise, id="id-p1"),
             pytest.param("p2", does_not_raise, id="id-p2"),
-            pytest.param(2, pytest.raises(PluginError, match=r"^DASH period 2 not found\."), id="error-index"),
+            pytest.param(3, pytest.raises(PluginError, match=r"^DASH period 3 not found\."), id="error-index"),
             pytest.param("p3", pytest.raises(PluginError, match=r"^DASH period 'p3' not found\."), id="error-id"),
         ],
     )
-    def test_period_selection(self, session: Streamlink, mpd: Mock, period: int | str, raises: nullcontext):
+    def test_period_selection(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        session: Streamlink,
+        mpd: Mock,
+        period: int | str,
+        raises: nullcontext,
+    ):
+        caplog.set_level(1, "streamlink")
+
         with xml("dash/test_period_selection.mpd") as mpd_xml:
             mpd.return_value = MPD(mpd_xml, base_url="http://test/manifest.mpd", url="http://test/manifest.mpd")
 
         with raises:
             streams = DASHStream.parse_manifest(session, "http://test/manifest.mpd", period=period)
             assert streams
+
+        records = [(record.name, record.levelname, record.message) for record in caplog.records]
+        assert ("streamlink.stream.dash", "debug", "Available DASH periods: 0, 1 (id='p1'), 2 (id='p2')") in records
 
 
 class TestDASHStreamOpen:


### PR DESCRIPTION
Follow-up of #6518 

Let's log the available DASH periods, so they can easily be selected when using the DASH plugin (`dash://URL period=...`).

The log message doesn't make much sense for regular plugins returning `DASHStream`s, as the user doesn't control which period is being used. But since it's just a debug message, that should be fine...