### PR TITLE
tests: fix py314 issues

### DIFF
--- a/tests/resources/__init__.py
+++ b/tests/resources/__init__.py
@@ -1,4 +1,3 @@
-import codecs
 import os.path
 from contextlib import contextmanager
 from io import BytesIO
@@ -28,11 +27,11 @@ def _parse_xml(data, strip_ns=False):
 
 @contextmanager
 def text(path, encoding="utf8"):
-    with codecs.open(os.path.join(__here__, path), "r", encoding=encoding) as resource_fh:
+    with open(os.path.join(__here__, path), "r", encoding=encoding) as resource_fh:
         yield resource_fh
 
 
 @contextmanager
 def xml(path, encoding="utf8"):
-    with codecs.open(os.path.join(__here__, path), "r", encoding=encoding) as resource_fh:
+    with open(os.path.join(__here__, path), "r", encoding=encoding) as resource_fh:
         yield _parse_xml(resource_fh.read(), strip_ns=True)

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,4 +1,4 @@
-import importlib.abc
+import importlib.machinery
 import importlib.util
 from contextlib import nullcontext
 from textwrap import dedent
@@ -10,16 +10,16 @@ from streamlink.exceptions import StreamlinkDeprecationWarning
 
 
 class TestDeprecated:
-    class _Loader(importlib.abc.SourceLoader):
+    class _Loader(importlib.machinery.SourceFileLoader):
         def __init__(self, filename: str, content: str):
-            super().__init__()
+            super().__init__(filename, "/")
             self._filename = filename
             self._content = content
 
-        def get_filename(self, fullname):
+        def get_filename(self, *_, **__):
             return self._filename
 
-        def get_data(self, path):
+        def get_data(self, *_, **__):
             return self._content
 
     @pytest.fixture()


### PR DESCRIPTION
Python 3.14 beta 1 has been released two days ago. This fixes the failing tests due to some newly added deprecation warnings.

Runners can't be added yet despite GH having added py314 to their runners, because we'll need to build missing wheels for some dependencies first, which are currently missing. This is unrelated to this PR.