### PR TITLE
ci.github: add py314 Linux runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,6 @@ jobs:
           -e .[decompress]
           -r dev-requirements.txt
         continue-on-error: ${{ matrix.continue || false }}
-      - name: Install optional Python dependencies
-        run: >
-          python -m pip install -U
-          brotli
       - name: Test
         continue-on-error: ${{ matrix.continue || false }}
         run: pytest -r a --cov --cov-branch --cov-report=xml --durations 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-        # include:
-        #   - runs-on: ubuntu-latest
-        #     python-version: "3.14-dev"
-        #     continue: true
+        include:
+          - runs-on: ubuntu-latest
+            python-version: "3.14-dev"
+            continue: true
         #   - runs-on: windows-latest
         #     python-version: "3.14-dev"
         #     continue: true
@@ -52,6 +52,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install temp dependency wheels
+        shell: bash
+        run: |
+          if [[ "$(uname)" == Linux && "$(python -V)" =~ 3.14. ]]; then
+            python -m pip install -U \
+              https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download/lxml-20250509-1/lxml-5.4.0-cp314-cp314-linux_x86_64.whl \
+              https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download/brotli-20250509-1/brotli-1.1.0-cp314-cp314-linux_x86_64.whl \
+              https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download/zstandard-20250509-1/zstandard-0.23.0-cp314-cp314-linux_x86_64.whl
+          fi
       - name: Install Python dependencies
         run: >
           python -m pip install -U

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,7 +17,8 @@ coverage[toml]
 ruff ==0.11.8
 
 # typing
-mypy[faster-cache] ==1.15.0
+mypy[faster-cache] ==1.15.0 ; python_version<'3.14'
+mypy ==1.15.0 ; python_version>='3.14'  # orjson (faster-cache mypy extra) currently fails building on 3.14
 typing-extensions >=4.0.0
 lxml-stubs
 trio-typing


### PR DESCRIPTION
This currently installs custom-built wheels from our `temp-dependency-builds-DO-NOT-USE` repo, so they don't have to be built on each test run here, wasting time. Those deps are `lxml`, `brotli` and `zstandard`. The other binary deps should all have matching wheels.

Streamlink's dev-requirements adds the `faster-cache` marker for `mypy`, which tries to install `orjson`. This build currently fails, hence why the marker has been temporarily disabled, not just for the CI runner.

On Windows, there were lots of build issues with pretty much everything, on top of the setup of the Python 3.14-dev build taking one and a half minute, which is quite ridiculous. So only the Linux test runner for now.