### PR TITLE
docs: add MSYS2 to packages list

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -73,6 +73,13 @@ Windows
             choco install streamlink
 
         `Installing Chocolatey packages`_
+    * - :octicon:`package` `MSYS2`_
+      - .. code-block:: bat
+
+            pacman -Ss streamlink
+            pacman -S mingw-w64-x86_64-streamlink
+
+        `Installing MSYS2 packages`_
     * - :octicon:`package-dependents` `Scoop`_
       - .. code-block::
 
@@ -88,9 +95,11 @@ Windows
         `Installing Winget packages`_
 
 .. _Chocolatey: https://chocolatey.org/packages/streamlink
+.. _MSYS2: https://packages.msys2.org/base/mingw-w64-streamlink
 .. _Scoop: https://scoop.sh/#/apps?q=streamlink&s=0&d=1&o=true
 .. _Windows Package Manager: https://github.com/microsoft/winget-pkgs/tree/master/manifests/s/Streamlink/Streamlink
 .. _Installing Chocolatey packages: https://chocolatey.org
+.. _Installing MSYS2 packages: https://www.msys2.org
 .. _Installing Scoop packages: https://scoop.sh
 .. _Installing Winget packages: https://docs.microsoft.com/en-us/windows/package-manager/
 


### PR DESCRIPTION
- https://packages.msys2.org/base/mingw-w64-streamlink
- https://www.msys2.org/
- https://www.msys2.org/docs/package-management/
- https://www.msys2.org/docs/environments/

```
$ pacman -Syu
...

$ pacman -S mingw-w64-x86_64-streamlink
...

$ /mingw64/bin/streamlink -l debug
[cli][debug] OS:         Windows 10
[cli][debug] Python:     3.12.10
[cli][debug] OpenSSL:    OpenSSL 3.5.0 8 Apr 2025
[cli][debug] Streamlink: 7.3.0
[cli][debug] Dependencies:
[cli][debug]  certifi: 2025.4.26
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.4.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.22.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.30.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  urllib3: 2.4.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  --loglevel=debug
[cli][debug]  --ffmpeg-ffmpeg=C:\Program Files\Streamlink\ffmpeg\ffmpeg.exe
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```