### PR TITLE
plugins.blasttv: new plugin

### DIFF
--- a/src/streamlink/plugins/blasttv.py
+++ b/src/streamlink/plugins/blasttv.py
@@ -1,0 +1,114 @@
+"""
+$description Esports tournaments run by BlastTV, based in Denmark.
+$url blast.tv
+$type live, vod
+$metadata id
+$metadata title
+"""
+
+import re
+
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.hls import HLSStream
+
+
+@pluginmatcher(
+    name="live",
+    pattern=re.compile(r"^https?://(?:www\.)?blast\.tv(?:/?$|/live(?:/(?P<channel>[a-z0-9_-]+))?)"),
+)
+@pluginmatcher(
+    name="vod",
+    pattern=re.compile(r"^https?://(?:www\.)?blast\.tv/(?P<game>[^/]+)/tournaments/[^/]+/match/(?P<shortid>\w+)/"),
+)
+class BlastTv(Plugin):
+    _URL_API_LIVE = "https://api.blast.tv/v1/broadcasts/live"
+    _URL_API_MATCHES = "https://api.blast.tv/v2/games/{game}/matches/{shortid}"
+    _URL_API_REWATCH = "https://api.blast.tv/v1/videos/rewatch/{id}"
+
+    def _get_live(self):
+        channel = self.match["channel"]
+
+        live_channels = self.session.http.get(
+            self._URL_API_LIVE,
+            schema=validate.Schema(
+                validate.parse_json(),
+                [
+                    {
+                        "id": str,
+                        "slug": str,
+                        "priority": int,
+                        "title": str,
+                        "videoSrc": validate.any("", validate.url(path=validate.endswith(".m3u8"))),
+                        "videoAlternativeSrc": validate.any("", validate.url(scheme="http")),
+                    },
+                ],
+            ),
+        )
+
+        for live_channel in sorted(live_channels, key=lambda x: x["priority"]):
+            if channel and channel != live_channel["slug"]:
+                continue
+
+            if live_channel["videoSrc"]:
+                self.id = live_channel["id"]
+                self.title = live_channel["title"]
+                return HLSStream.parse_variant_playlist(self.session, live_channel["videoSrc"])
+
+            if live_channel["videoAlternativeSrc"]:
+                return self.session.streams(live_channel["videoAlternativeSrc"])
+
+    def _get_vod(self):
+        self.id, external_stream_url = self.session.http.get(
+            self._URL_API_MATCHES.format(
+                game=self.match["game"],
+                shortid=self.match["shortid"],
+            ),
+            acceptable_status=(200, 404),
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    validate.optional("id"): str,
+                    validate.optional("metadata"): validate.all(
+                        {
+                            validate.optional("externalStreamUrl"): validate.any("", validate.url(scheme="http")),
+                        },
+                        validate.get("externalStreamUrl"),
+                    ),
+                },
+                validate.union_get(
+                    "id",
+                    "metadata",
+                ),
+            ),
+        )
+        if not self.id:
+            return
+
+        if external_stream_url:
+            return self.session.streams(external_stream_url)
+
+        hls_url = self.session.http.get(
+            self._URL_API_REWATCH.format(id=self.id),
+            acceptable_status=(200, 404),
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    validate.optional("src"): validate.url(path=validate.endswith(".m3u8")),
+                },
+                validate.get("src"),
+            ),
+        )
+        if not hls_url:
+            return
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url)
+
+    def _get_streams(self):
+        if self.matches["live"]:
+            return self._get_live()
+        if self.matches["vod"]:
+            return self._get_vod()
+
+
+__plugin__ = BlastTv

--- a/tests/plugins/test_blasttv.py
+++ b/tests/plugins/test_blasttv.py
@@ -1,0 +1,37 @@
+from streamlink.plugins.blasttv import BlastTv
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlBlastTv(PluginCanHandleUrl):
+    __plugin__ = BlastTv
+
+    should_match_groups = [
+        # live
+        (("live", "https://blast.tv"), {}),
+        (("live", "https://blast.tv/"), {}),
+        (("live", "https://blast.tv/live"), {}),
+        (("live", "https://blast.tv/live/"), {}),
+        (("live", "https://blast.tv/live/a"), {"channel": "a"}),
+        (("live", "https://blast.tv/live/co-stream"), {"channel": "co-stream"}),
+        (("live", "https://blast.tv/live/americas1"), {"channel": "americas1"}),
+        # external streams (at the time of testing)
+        (("live", "https://blast.tv/live/f"), {"channel": "f"}),
+        # VODs
+        (
+            ("vod", "https://blast.tv/cs/tournaments/rivals-2025-season-1/match/bfaaa42e/falcons-vitality"),
+            {"game": "cs", "shortid": "bfaaa42e"},
+        ),
+        (
+            ("vod", "https://blast.tv/cs/tournaments/open-2025-season-1/match/24ff9d6c/vitality-mouz"),
+            {"game": "cs", "shortid": "24ff9d6c"},
+        ),
+        # external VODs
+        (
+            ("vod", "https://blast.tv/dota/tournaments/blast-slam-iii/match/acabb915/falcons-tundra"),
+            {"game": "dota", "shortid": "acabb915"},
+        ),
+    ]
+
+    should_not_match = [
+        "https://blast.tv/a",
+    ]


### PR DESCRIPTION
Blast is a video game (mainly Counter-Strike) tournament organizer who streams their matches on their website alongside the usual Twitch and YouTube. The streams on blast.tv are usually in 4K as opposed to 1080p on other platforms.

I've been using this plugin locally for a couple years. Over time, I've  recorded different API (`https://api.blast.tv/v1/broadcasts/live`) responses in comments in the plugin code to make development and testing easier, but I'm happy to move those to a more appropriate place.

There are some caveats:
- Streams don't run 24/7--they'll only run, idk, 8-12 hours a day, 10 weeks a year, which I imagine would be annoying for reviewers. I'm creating the PR now because there should be regular daytime CST streams from now through June 22.
- The stream used to occasionally (once every hour or so, but with high variance) exit early when `streamlink` was run with default options. Adding `--hls-segment-queue-threshold 8` completely eliminated the issues. My understanding is that plugins can't do anything about this.