### PR TITLE
stream: set specific names for each thread

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -236,7 +236,7 @@ class TwitchHLSStreamReader(HLSStreamReader):
     writer: TwitchHLSStreamWriter
     stream: TwitchHLSStream
 
-    def __init__(self, stream: TwitchHLSStream):
+    def __init__(self, stream: TwitchHLSStream, **kwargs):
         if stream.disable_ads:
             log.info("Will skip ad segments")
         if stream.low_latency:
@@ -244,7 +244,8 @@ class TwitchHLSStreamReader(HLSStreamReader):
             stream.session.options.set("hls-live-edge", live_edge)
             stream.session.options.set("hls-segment-stream-data", True)
             log.info(f"Low latency streaming (HLS live edge: {live_edge})")
-        super().__init__(stream)
+
+        super().__init__(stream, **kwargs)
 
 
 class TwitchHLSStream(HLSStream):

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -183,8 +183,9 @@ class DASHStreamReader(SegmentedStreamReader[DASHSegment, Response]):
         stream: DASHStream,
         representation: Representation,
         timestamp: datetime,
+        name: str | None = None,
     ):
-        super().__init__(stream)
+        super().__init__(stream, name=name)
         self.ident = representation.ident
         self.mime_type = representation.mimeType
         self.timestamp = timestamp
@@ -397,11 +398,11 @@ class DASHStream(Stream):
         timestamp = now()
 
         if rep_video:
-            video = DASHStreamReader(self, rep_video, timestamp)
+            video = DASHStreamReader(self, rep_video, timestamp, name="video")
             log.debug(f"Opening DASH reader for: {rep_video.ident!r} - {rep_video.mimeType}")
 
         if rep_audio:
-            audio = DASHStreamReader(self, rep_audio, timestamp)
+            audio = DASHStreamReader(self, rep_audio, timestamp, name="audio")
             log.debug(f"Opening DASH reader for: {rep_audio.ident!r} - {rep_audio.mimeType}")
 
         if video and audio and FFMPEGMuxer.is_usable(self.session):

--- a/src/streamlink/utils/thread.py
+++ b/src/streamlink/utils/thread.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from itertools import count
+from threading import RLock, Thread
+from typing import Iterator
+
+
+_threadname_lock = RLock()
+_threadname_counters: defaultdict[str, Iterator[int]] = defaultdict(count)
+
+
+class NamedThread(Thread):
+    def __init__(self, *args, name: str | None = None, **kwargs):
+        with _threadname_lock:
+            newname = self.__class__.__name__
+            if name:
+                newname += f"-{name}"
+
+            # noinspection PyUnresolvedReferences
+            kwargs["name"] = f"{newname}-{next(_threadname_counters[newname])}"
+
+        super().__init__(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,9 @@ import requests_mock as rm
 
 from streamlink.session import Streamlink
 
+# noinspection PyProtectedMember
+from streamlink.utils.thread import _threadname_counters  # noqa: PLC2701
+
 
 _TEST_CONDITION_MARKERS: Mapping[str, tuple[bool, str] | Callable[[Any], tuple[bool, str]]] = {
     "posix_only": (os.name == "posix", "only applicable on a POSIX OS"),
@@ -133,3 +136,9 @@ def _patch_trio_run():
     trio.run = partial(trio.run, strict_exception_groups=True)
     yield
     trio.run = trio_run
+
+
+@pytest.fixture(autouse=True)
+def _clear_threadname_counters():
+    yield
+    _threadname_counters.clear()

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -381,7 +381,7 @@ class TestDASHStreamOpen:
         stream = DASHStream(session, Mock(), rep_video)
         stream.open()
 
-        assert reader.call_args_list == [call(stream, rep_video, timestamp)]
+        assert reader.call_args_list == [call(stream, rep_video, timestamp, name="video")]
         assert reader().open.call_count == 1
         assert muxer.call_args_list == []
 
@@ -392,12 +392,15 @@ class TestDASHStreamOpen:
         mock_reader_video = Mock()
         mock_reader_audio = Mock()
         readers = {rep_video: mock_reader_video, rep_audio: mock_reader_audio}
-        reader.side_effect = lambda _stream, _representation, _timestamp: readers[_representation]
+        reader.side_effect = lambda _stream, _representation, _timestamp, *_, **__: readers[_representation]
 
         stream = DASHStream(session, Mock(), rep_video, rep_audio)
         stream.open()
 
-        assert reader.call_args_list == [call(stream, rep_video, timestamp), call(stream, rep_audio, timestamp)]
+        assert reader.call_args_list == [
+            call(stream, rep_video, timestamp, name="video"),
+            call(stream, rep_audio, timestamp, name="audio"),
+        ]
         assert mock_reader_video.open.call_count == 1
         assert mock_reader_audio.open.call_count == 1
         assert muxer.call_args_list == [call(session, mock_reader_video, mock_reader_audio, copyts=True)]

--- a/tests/utils/test_thread.py
+++ b/tests/utils/test_thread.py
@@ -1,0 +1,20 @@
+from streamlink.utils.thread import NamedThread
+
+
+def test_named_thread():
+    class One(NamedThread):
+        pass
+
+    class Two(NamedThread):
+        pass
+
+    assert One().name == "One-0"
+    assert One().name == "One-1"
+    assert Two().name == "Two-0"
+    assert Two().name == "Two-1"
+
+    assert One(name="foo").name == "One-foo-0"
+    assert One(name="foo").name == "One-foo-1"
+    assert One(name="bar").name == "One-bar-0"
+    assert One(name="bar").name == "One-bar-1"
+    assert One().name == "One-2"


### PR DESCRIPTION
- Add `NamedThread` class that automatically sets its name from its class name, with an optional suffix, and with a unique counter
- Make `SegmentedStreamWriter` and `SegmentedStreamWorker` subclass from `NamedThread` and pass through the optional `name` suffix
- Make `SegmentedStreamReader` and its subclasses (HLS and DASH) set the optional name suffix for its writer and worker threads, and fix signature of the Twitch plugin's subclass
- Add `name` argument to `HLSStream`, so it can be passed to its reader
- Make `MuxedHLSStream` set the "audio" suffix for all audio substreams
- Add and update existing tests accordingly

----

https://github.com/streamlink/streamlink/issues/6550#issuecomment-2957280081

After this has been merged, I will add the thread name to the default logformat for the trace log level.

The `FFMPEGMuxer` class has not been touched. The `copy_to_pipe` threads already have a unique name, and the thread pool that's used for concurrently closing the substreams is not important. The whole class needs to be rewritten anyway, so there's no reason to modify it now.

The only plugin that needed an update was Twitch, because the constructor of the `HLSStreamReader` subclass was modified, and the signatures didn't match anymore. Other plugins that subclass the HLS reader were fine. Since this is not a public interface, I don't care about 3rd party plugins.

----

**Unmuxed HLS**
Worker and writer+children are now properly named

```
$ streamlink -l trace --logformat '[{asctime}][{threadName}][{name}][{levelname}] {message}' twitch.tv/gorgc best -o /dev/null
...
[19:13:17.129366][MainThread][cli][info] Available streams: audio_only, 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[19:13:17.129468][MainThread][cli][info] Opening stream: 1080p60 (hls)
[19:13:17.129584][MainThread][cli][info] Writing output to
/dev/null
[19:13:17.129632][MainThread][cli][debug] Checking file output
[19:13:17.129689][MainThread][plugins.twitch][info] Will skip ad segments
[19:13:17.129739][MainThread][plugins.twitch][info] Low latency streaming (HLS live edge: 2)
[19:13:17.130143][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:17.130236][MainThread][cli][debug] Pre-buffering 8192 bytes
[19:13:17.177571][TwitchHLSStreamWorker-0][plugins.twitch][info] Waiting for pre-roll ads to finish, be patient
[19:13:17.177641][TwitchHLSStreamWorker-0][plugins.twitch][info] Detected advertisement break of 15 seconds
[19:13:17.177706][TwitchHLSStreamWorker-0][stream.hls][debug] First Sequence: 0; Last Sequence: 2
[19:13:17.177748][TwitchHLSStreamWorker-0][stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 1; End Sequence: None
[19:13:17.177787][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 1 to queue
[19:13:17.179144][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 2 to queue
[19:13:17.313426][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 1
[19:13:17.452467][TwitchHLSStreamWriter-0][stream.hls][info] Filtering out segments and pausing stream output
[19:13:17.452609][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 2
[19:13:19.130230][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:19.172007][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 3 to queue
[19:13:19.199792][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 3
[19:13:21.130230][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:21.180675][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 4 to queue
[19:13:21.209430][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 4
[19:13:23.130228][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:23.168254][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 5 to queue
[19:13:23.197849][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 5
[19:13:25.130227][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:25.170412][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 6 to queue
[19:13:25.200579][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 6
[19:13:27.130241][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:27.171132][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 7 to queue
[19:13:27.200844][TwitchHLSStreamWriter-0][stream.hls][debug] Discarding segment 7
[19:13:28.365241][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:29.365237][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:29.407373][TwitchHLSStreamWorker-0][plugins.twitch][info] This is not a low latency stream
[19:13:29.407467][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 8 to queue
[19:13:29.435554][TwitchHLSStreamWriter-0][stream.hls][debug] Writing segment 8 to output
[19:13:29.435908][MainThread][cli][debug] Writing stream to output
[19:13:29.461404][TwitchHLSStreamWriter-0][stream.hls][debug] Segment 8 complete
[19:13:29.461505][TwitchHLSStreamWriter-0][stream.hls][warning] Encountered a stream discontinuity. This is unsupported and will result in incoherent output data.
[19:13:29.461598][TwitchHLSStreamWriter-0][stream.hls][info] Resuming stream output
[19:13:31.350241][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:31.392735][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 9 to queue
[19:13:31.419997][TwitchHLSStreamWriter-0][stream.hls][debug] Writing segment 9 to output
[19:13:31.439483][TwitchHLSStreamWriter-0][stream.hls][debug] Segment 9 complete
[19:13:33.336243][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:33.378669][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 10 to queue
[19:13:33.402670][TwitchHLSStreamWriter-0][stream.hls][debug] Writing segment 10 to output
[19:13:33.420519][TwitchHLSStreamWriter-0][stream.hls][debug] Segment 10 complete
[19:13:35.321239][TwitchHLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:13:35.361958][TwitchHLSStreamWorker-0][stream.hls][debug] Adding segment 11 to queue
[19:13:35.389469][TwitchHLSStreamWriter-0][stream.hls][debug] Writing segment 11 to output
[19:13:35.406669][TwitchHLSStreamWriter-0][stream.hls][debug] Segment 11 complete
[19:13:37.247249][MainThread][stream.segmented][debug] Closing worker thread
[19:13:37.247359][MainThread][stream.segmented][debug] Closing writer thread
[19:13:37.407311][MainThread][cli][info] Stream ended
Interrupted! Exiting...
[19:13:37.407426][MainThread][cli][info] Closing currently open stream...
...
```

**Muxed HLS**
Threads of the audio substreams have the "audio" name suffix

```
$ streamlink -l trace --logformat '[{asctime}][{threadName}][{name}][{levelname}] {message}' https://www.france.tv/france-2/direct.html best -o /dev/null --http-proxy socks5h://localhost:1920
...
[19:17:08.185977][MainThread][cli][info] Available streams: 144p (worst), 216p, 360p, 540p, 720p, 1080p (best)
[19:17:08.186044][MainThread][cli][info] Opening stream: 1080p (hls-multi)
[19:17:08.186149][MainThread][cli][info] Writing output to
/dev/null
[19:17:08.186192][MainThread][cli][debug] Checking file output
[19:17:08.186240][MainThread][stream.ffmpegmux][debug] Opening hls substream
[19:17:08.186605][HLSStreamWorker-0][stream.hls][debug] Reloading playlist
[19:17:08.186684][MainThread][stream.ffmpegmux][debug] Opening hls substream
[19:17:08.187822][HLSStreamWorker-audio-0][stream.hls][debug] Reloading playlist
[19:17:08.188586][MainThread][utils.named_pipe][info] Creating pipe streamlinkpipe-1188679-1-433
[19:17:08.188807][MainThread][utils.named_pipe][info] Creating pipe streamlinkpipe-1188679-2-6407
[19:17:08.188942][MainThread][stream.ffmpegmux][debug] ffmpeg command: ['/usr/bin/ffmpeg', '-y', '-nostats', '-loglevel', 'info', '-i', '/tmp/streamlinkpipe-1188679-1-433', '-i', '/tmp/streamlinkpipe-1188679-2-6407', '-c:v', 'copy', '-c:a', 'copy', '-map', '0:v?', '-map', '0:a?', '-map', '1:a', '-f', 'mpegts', 'pipe:1']
[19:17:08.189071][Thread-1 (copy_to_pipe)][stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-1188679-1-433
[19:17:08.189216][Thread-2 (copy_to_pipe)][stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-1188679-2-6407
[19:17:08.189486][MainThread][cli][debug] Pre-buffering 8192 bytes
[19:17:08.584320][HLSStreamWorker-0][stream.hls][debug] Segments in this playlist are encrypted
[19:17:08.584456][HLSStreamWorker-0][stream.hls][debug] First Sequence: 5170715; Last Sequence: 5172863
[19:17:08.584502][HLSStreamWorker-0][stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 5172861; End Sequence: None
[19:17:08.584658][HLSStreamWorker-0][stream.hls][debug] Adding segment 5172861 to queue
[19:17:08.584894][HLSStreamWorker-0][stream.hls][debug] Adding segment 5172862 to queue
[19:17:08.584963][HLSStreamWorker-0][stream.hls][debug] Adding segment 5172863 to queue
[19:17:09.162894][HLSStreamWorker-audio-0][stream.hls][debug] Segments in this playlist are encrypted
[19:17:09.163058][HLSStreamWorker-audio-0][stream.hls][debug] First Sequence: 5170715; Last Sequence: 5172863
[19:17:09.163105][HLSStreamWorker-audio-0][stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 5172861; End Sequence: None
[19:17:09.163260][HLSStreamWorker-audio-0][stream.hls][debug] Adding segment 5172861 to queue
[19:17:09.164071][HLSStreamWorker-audio-0][stream.hls][debug] Adding segment 5172862 to queue
[19:17:09.164147][HLSStreamWorker-audio-0][stream.hls][debug] Adding segment 5172863 to queue
[19:17:09.451862][HLSStreamWriter-audio-0][stream.hls][debug] Writing segment 5172861 to output
[19:17:09.845592][HLSStreamWriter-audio-0][stream.hls][debug] Segment 5172861 complete
[19:17:09.845723][HLSStreamWriter-audio-0][stream.hls][debug] Writing segment 5172862 to output
[19:17:09.846060][HLSStreamWriter-audio-0][stream.hls][debug] Segment 5172862 complete
[19:17:09.846141][HLSStreamWriter-audio-0][stream.hls][debug] Writing segment 5172863 to output
[19:17:09.846416][HLSStreamWriter-audio-0][stream.hls][debug] Segment 5172863 complete
[19:17:10.274407][HLSStreamWriter-0][stream.hls][debug] Writing segment 5172861 to output
[19:17:10.326776][HLSStreamWriter-0][stream.hls][debug] Segment 5172861 complete
[19:17:10.350007][MainThread][cli][debug] Writing stream to output
[19:17:11.029498][HLSStreamWriter-0][stream.hls][debug] Writing segment 5172862 to output
[19:17:11.037794][HLSStreamWriter-0][stream.hls][debug] Segment 5172862 complete
[19:17:11.743268][HLSStreamWriter-0][stream.hls][debug] Writing segment 5172863 to output
[19:17:11.751280][HLSStreamWriter-0][stream.hls][debug] Segment 5172863 complete
[19:17:13.216786][MainThread][stream.ffmpegmux][debug] Closing ffmpeg thread
[19:17:13.217060][ThreadPoolExecutor-0_0][stream.segmented][debug] Closing worker thread
[19:17:13.217238][ThreadPoolExecutor-0_0][stream.segmented][debug] Closing writer thread
[19:17:13.217327][Thread-1 (copy_to_pipe)][stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-1188679-1-433
[19:17:13.217506][ThreadPoolExecutor-0_1][stream.segmented][debug] Closing worker thread
[19:17:13.217624][ThreadPoolExecutor-0_1][stream.segmented][debug] Closing writer thread
[19:17:13.217798][Thread-2 (copy_to_pipe)][stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-1188679-2-6407
[19:17:13.347165][MainThread][stream.ffmpegmux][debug] Closed all the substreams
[19:17:13.347382][MainThread][cli][info] Stream ended
Interrupted! Exiting...
[19:17:13.347574][MainThread][cli][info] Closing currently open stream...
...
```

**DASH**
Worker and writer+children have unique names, including "video"/"audio" name suffixes.

```
$ streamlink -l trace --logformat '[{asctime}][{threadName}][{name}][{levelname}] {message}' https://steamcommunity.com/broadcast/watch/76561199864520445 best -o /dev/null
...
[19:15:21.933444][MainThread][cli][info] Available streams: 1080p (worst, best)
[19:15:21.933511][MainThread][cli][info] Opening stream: 1080p (dash)
[19:15:21.933630][MainThread][cli][info] Writing output to
/dev/null
[19:15:21.933677][MainThread][cli][debug] Checking file output
[19:15:21.933814][MainThread][stream.dash][debug] Opening DASH reader for: ('1', 'video', '1') - video/mp4
[19:15:21.933907][MainThread][stream.dash][debug] Opening DASH reader for: ('1', 'audio', '1') - audio/mp4
[19:15:21.934004][MainThread][stream.ffmpegmux][trace] Querying FFmpeg version: ['/usr/bin/ffmpeg', '-version']
[19:15:21.981503][MainThread][stream.ffmpegmux][debug] ffmpeg version n7.1.1 Copyright (c) 2000-2025 the FFmpeg developers
built with gcc 15.1.1 (GCC) 20250425
configuration: --prefix=/usr --disable-debug --disable-static --disable-stripping --enable-amf --enable-avisynth --enable-cuda-llvm --enable-lto --enable-fontconfig --enable-frei0r --enable-gmp --enable-gnutls --enable-gpl --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libdav1d --enable-libdrm --enable-libdvdnav --enable-libdvdread --enable-libfreetype --enable-libfribidi --enable-libglslang --enable-libgsm --enable-libharfbuzz --enable-libiec61883 --enable-libjack --enable-libjxl --enable-libmodplug --enable-libmp3lame --enable-libopencore_amrnb --enable-libopencore_amrwb --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libplacebo --enable-libpulse --enable-librav1e --enable-librsvg --enable-librubberband --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libtheora --enable-libv4l2 --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpl --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxcb --enable-libxml2 --enable-libxvid --enable-libzimg --enable-libzmq --enable-nvdec --enable-nvenc --enable-opencl --enable-opengl --enable-shared --enable-vapoursynth --enable-version3 --enable-vulkan
libavutil      59. 39.100 / 59. 39.100
libavcodec     61. 19.101 / 61. 19.101
libavformat    61.  7.100 / 61.  7.100
libavdevice    61.  3.100 / 61.  3.100
libavfilter    10.  4.100 / 10.  4.100
libswscale      8.  3.100 /  8.  3.100
libswresample   5.  3.100 /  5.  3.100
libpostproc    58.  3.100 / 58.  3.100
[19:15:21.982089][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment initialization: downloading (2025-06-10T08:46:10.000000Z / 2025-06-11T17:15:21.982076Z)
[19:15:21.982782][DASHStreamWorker-video-0][stream.dash.manifest][debug] Generating segment numbers for dynamic playlist: ('1', 'video', '1')
[19:15:21.982898][DASHStreamWorker-video-0][stream.dash.manifest][debug] Stream start: 2025-06-10 08:46:10+00:00
[19:15:21.982944][DASHStreamWorker-video-0][stream.dash.manifest][debug] Current time: 2025-06-11 17:15:21.933725+00:00
[19:15:21.982984][DASHStreamWorker-video-0][stream.dash.manifest][debug] Availability: 2025-06-11 17:15:14+00:00
[19:15:21.983022][DASHStreamWorker-video-0][stream.dash.manifest][debug] presentationTimeOffset: 0:00:00; suggestedPresentationDelay: 0:00:03; minBufferTime: 0:00:03
[19:15:21.983063][DASHStreamWorker-video-0][stream.dash.manifest][debug] segmentDuration: 2.0; segmentStart: 1; segmentOffset: 58472 (116945.933725s)
[19:15:21.984007][MainThread][utils.named_pipe][info] Creating pipe streamlinkpipe-1188223-1-547
[19:15:21.984157][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment initialization: downloading (2025-06-10T08:46:10.000000Z / 2025-06-11T17:15:21.984140Z)
[19:15:21.984799][DASHStreamWorker-audio-0][stream.dash.manifest][debug] Generating segment numbers for dynamic playlist: ('1', 'audio', '1')
[19:15:21.984919][DASHStreamWorker-audio-0][stream.dash.manifest][debug] Stream start: 2025-06-10 08:46:10+00:00
[19:15:21.984965][DASHStreamWorker-audio-0][stream.dash.manifest][debug] Current time: 2025-06-11 17:15:21.933725+00:00
[19:15:21.985005][DASHStreamWorker-audio-0][stream.dash.manifest][debug] Availability: 2025-06-11 17:15:14+00:00
[19:15:21.985045][DASHStreamWorker-audio-0][stream.dash.manifest][debug] presentationTimeOffset: 0:00:00; suggestedPresentationDelay: 0:00:03; minBufferTime: 0:00:03
[19:15:21.985086][DASHStreamWorker-audio-0][stream.dash.manifest][debug] segmentDuration: 2.0; segmentStart: 1; segmentOffset: 58472 (116945.933725s)
[19:15:21.985640][MainThread][utils.named_pipe][info] Creating pipe streamlinkpipe-1188223-2-9553
[19:15:21.985765][MainThread][stream.ffmpegmux][debug] ffmpeg command: ['/usr/bin/ffmpeg', '-y', '-nostats', '-loglevel', 'info', '-i', '/tmp/streamlinkpipe-1188223-1-547', '-i', '/tmp/streamlinkpipe-1188223-2-9553', '-c:v', 'copy', '-c:a', 'copy', '-copyts', '-f', 'matroska', 'pipe:1']
[19:15:21.985888][Thread-1 (copy_to_pipe)][stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-1188223-1-547
[19:15:21.986055][Thread-2 (copy_to_pipe)][stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-1188223-2-9553
[19:15:21.986328][MainThread][cli][debug] Pre-buffering 8192 bytes
[19:15:22.007505][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58473: downloading (2025-06-11T17:15:14.000000Z / 2025-06-11T17:15:22.007488Z)
[19:15:22.007630][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment initialization: completed
[19:15:22.097152][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58473: downloading (2025-06-11T17:15:14.000000Z / 2025-06-11T17:15:22.097137Z)
[19:15:22.097260][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment initialization: completed
[19:15:22.128685][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58474: downloading (2025-06-11T17:15:16.000000Z / 2025-06-11T17:15:22.128666Z)
[19:15:22.129442][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment 58473: completed
[19:15:22.155208][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58475: downloading (2025-06-11T17:15:18.000000Z / 2025-06-11T17:15:22.155195Z)
[19:15:22.155815][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment 58474: completed
[19:15:22.180615][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58476: downloading (2025-06-11T17:15:20.000000Z / 2025-06-11T17:15:22.180600Z)
[19:15:22.181248][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment 58475: completed
[19:15:22.185017][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58474: downloading (2025-06-11T17:15:16.000000Z / 2025-06-11T17:15:22.185003Z)
[19:15:22.186373][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment 58473: completed
[19:15:22.208843][MainThread][cli][debug] Writing stream to output
[19:15:22.223501][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58477: downloading (2025-06-11T17:15:22.000000Z / 2025-06-11T17:15:22.223488Z)
[19:15:22.224174][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment 58476: completed
[19:15:22.238878][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58475: downloading (2025-06-11T17:15:18.000000Z / 2025-06-11T17:15:22.238865Z)
[19:15:22.239688][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment 58474: completed
[19:15:22.278155][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58478: waiting 1.7s (2025-06-11T17:15:24.000000Z / 2025-06-11T17:15:22.278139Z)
[19:15:22.278300][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment 58477: completed
[19:15:22.320342][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58476: downloading (2025-06-11T17:15:20.000000Z / 2025-06-11T17:15:22.320326Z)
[19:15:22.321962][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment 58475: completed
[19:15:22.367315][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58477: downloading (2025-06-11T17:15:22.000000Z / 2025-06-11T17:15:22.367299Z)
[19:15:22.367994][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment 58476: completed
[19:15:22.429760][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58478: waiting 1.6s (2025-06-11T17:15:24.000000Z / 2025-06-11T17:15:22.429746Z)
[19:15:22.430443][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment 58477: completed
[19:15:24.000345][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58478: downloading (2025-06-11T17:15:24.000000Z / 2025-06-11T17:15:24.000320Z)
[19:15:24.001171][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58478: downloading (2025-06-11T17:15:24.000000Z / 2025-06-11T17:15:24.001155Z)
[19:15:24.033695][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58479: waiting 2.0s (2025-06-11T17:15:26.000000Z / 2025-06-11T17:15:24.033680Z)
[19:15:24.033860][DASHStreamWriter-audio-0][stream.dash][debug] audio/mp4 segment 58478: completed
[19:15:24.135598][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58479: waiting 1.9s (2025-06-11T17:15:26.000000Z / 2025-06-11T17:15:24.135558Z)
[19:15:24.136398][DASHStreamWriter-video-0][stream.dash][debug] video/mp4 segment 58478: completed
[19:15:25.392924][MainThread][stream.ffmpegmux][debug] Closing ffmpeg thread
[19:15:25.393194][ThreadPoolExecutor-0_0][stream.segmented][debug] Closing worker thread
[19:15:25.393322][ThreadPoolExecutor-0_0][stream.segmented][debug] Closing writer thread
[19:15:25.393466][DASHStreamWriter-video-0-executor_0][stream.dash][debug] video/mp4 segment 58479: cancelled
[19:15:25.393696][ThreadPoolExecutor-0_1][stream.segmented][debug] Closing worker thread
[19:15:25.394107][ThreadPoolExecutor-0_1][stream.segmented][debug] Closing writer thread
[19:15:25.394218][DASHStreamWriter-audio-0-executor_0][stream.dash][debug] audio/mp4 segment 58479: cancelled
[19:15:25.394407][Thread-2 (copy_to_pipe)][stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-1188223-2-9553
[19:15:25.394836][Thread-1 (copy_to_pipe)][stream.ffmpegmux][error] Error while writing to pipe /tmp/streamlinkpipe-1188223-1-547: [Errno 32] Broken pipe
[19:15:26.137036][MainThread][stream.ffmpegmux][debug] Closed all the substreams
[19:15:26.137255][MainThread][cli][info] Stream ended
Interrupted! Exiting...
[19:15:26.137358][MainThread][cli][info] Closing currently open stream...
...
```