### PR TITLE
cli: add thread name to trace logging format

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -357,7 +357,7 @@ def build_parser():
 
             For verbose levels (`trace` and `all`):
 
-            Default is "[{asctime}][{name}][{levelname}] {message}".
+            Default is "[{asctime}][{threadName}][{name}][{levelname}] {message}".
 
             Otherwise:
 

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -909,7 +909,7 @@ def setup_logger() -> None:
     verbose = level in (logging.getLevelName(logger.TRACE), logging.getLevelName(logger.ALL))
     if not fmt:
         if verbose:
-            fmt = "[{asctime}][{name}][{levelname}] {message}"
+            fmt = "[{asctime}][{threadName}][{name}][{levelname}] {message}"
         else:
             fmt = "[{name}][{levelname}] {message}"
     if not datefmt:

--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -408,14 +408,14 @@ class TestInfos:
         pytest.param(
             ["--loglevel", "trace"],
             TRACE,
-            "[{asctime}][{name}][{levelname}] {message}",
+            "[{asctime}][{threadName}][{name}][{levelname}] {message}",
             "%H:%M:%S.%f",
             id="loglevel=trace",
         ),
         pytest.param(
             ["--loglevel", "all"],
             ALL,
-            "[{asctime}][{name}][{levelname}] {message}",
+            "[{asctime}][{threadName}][{name}][{levelname}] {message}",
             "%H:%M:%S.%f",
             id="loglevel=all",
         ),
@@ -429,7 +429,7 @@ class TestInfos:
         pytest.param(
             ["--loglevel", "all", "--logdateformat", "%Y-%m-%dT%H:%M:%S.%f"],
             ALL,
-            "[{asctime}][{name}][{levelname}] {message}",
+            "[{asctime}][{threadName}][{name}][{levelname}] {message}",
             "%Y-%m-%dT%H:%M:%S.%f",
             id="logdateformat",
         ),


### PR DESCRIPTION
Follow-up of #6556 

```
$ streamlink -l trace
[20:43:49.001245][MainThread][cli][debug] OS:         Linux-6.14.10-1-git-x86_64-with-glibc2.41
[20:43:49.001380][MainThread][cli][debug] Python:     3.13.3
[20:43:49.001438][MainThread][cli][debug] OpenSSL:    OpenSSL 3.5.0 8 Apr 2025
[20:43:49.001482][MainThread][cli][debug] Streamlink: 7.4.0+6.g4dd62f2d
[20:43:49.001523][MainThread][cli][debug] Dependencies:
[20:43:49.002676][MainThread][cli][debug]  certifi: 2025.4.26
[20:43:49.003257][MainThread][cli][debug]  isodate: 0.7.2
[20:43:49.003561][MainThread][cli][debug]  lxml: 5.4.0
[20:43:49.003972][MainThread][cli][debug]  pycountry: 24.6.1
[20:43:49.004225][MainThread][cli][debug]  pycryptodome: 3.23.0
[20:43:49.004557][MainThread][cli][debug]  PySocks: 1.7.1
[20:43:49.004842][MainThread][cli][debug]  requests: 2.32.3
[20:43:49.005152][MainThread][cli][debug]  trio: 0.30.0
[20:43:49.005416][MainThread][cli][debug]  trio-websocket: 0.12.2
[20:43:49.005713][MainThread][cli][debug]  urllib3: 2.4.0
[20:43:49.006011][MainThread][cli][debug]  websocket-client: 1.8.0
[20:43:49.006125][MainThread][cli][debug] Arguments:
[20:43:49.006180][MainThread][cli][debug]  --loglevel=trace
[20:43:49.006234][MainThread][cli][debug]  --player=/usr/bin/mpv
[20:43:49.006303][MainThread][cli][debug]  --webbrowser-headless=True
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```

```
$ streamlink -l debug
[cli][debug] OS:         Linux-6.14.10-1-git-x86_64-with-glibc2.41
[cli][debug] Python:     3.13.3
[cli][debug] OpenSSL:    OpenSSL 3.5.0 8 Apr 2025
[cli][debug] Streamlink: 7.4.0+6.g4dd62f2d
[cli][debug] Dependencies:
[cli][debug]  certifi: 2025.4.26
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 5.4.0
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.3
[cli][debug]  trio: 0.30.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  urllib3: 2.4.0
[cli][debug]  websocket-client: 1.8.0
[cli][debug] Arguments:
[cli][debug]  --loglevel=debug
[cli][debug]  --player=/usr/bin/mpv
[cli][debug]  --webbrowser-headless=True
usage: streamlink [OPTIONS] <URL> [STREAM]

Use -h/--help to see the available options or read the manual at https://streamlink.github.io/
```