### PR TITLE
ci.github: temporarily disable py314 Linux runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,10 +27,10 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-        include:
-          - runs-on: ubuntu-latest
-            python-version: "3.14-dev"
-            continue: true
+        # include:
+        #   - runs-on: ubuntu-latest
+        #     python-version: "3.14-dev"
+        #     continue: true
         #   - runs-on: windows-latest
         #     python-version: "3.14-dev"
         #     continue: true


### PR DESCRIPTION
The `3.14.0b2` runner has stopped working two days ago:
https://github.com/streamlink/streamlink/actions/runs/15646409717/job/44084622309#step:7:1

No idea what this is about, but pytest stalls for over an hour and then the job gets cancelled. I can't reproduce this on my local machine with the same Python version. This must be something on GitHub's end with their Python builds, so let's just disable the runner for now. Our tests were passing before this issue came up.