### PR TITLE
cli: push console.close() to the atexit stack

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -10,6 +10,7 @@ import signal
 import ssl
 import sys
 import warnings
+from atexit import register as _atexit_register
 from collections.abc import Mapping
 from contextlib import closing, suppress
 from gettext import gettext
@@ -899,6 +900,9 @@ def setup_console() -> None:
 
     console = ConsoleOutput(console_output=console_output, json=args.json)
 
+    # flush+close console and file streams on exit, and remove stream wrapper
+    _atexit_register(console.close)
+
 
 def setup_logger() -> None:
     level: str = args.loglevel if not args.silent_log else logging.getLevelName(logger.NONE)
@@ -1016,9 +1020,6 @@ def main():
                 console.msg_json({"error": msg})
             else:
                 console.msg(f"error: {msg}")
-
-    # flush+close console and file streams, and remove stream wrapper
-    console.close()
 
     # https://docs.python.org/3/library/signal.html#note-on-sigpipe
     # Prevent BrokenPipeError: unset sys.stdout, so Python doesn't attempt a flush() on exit


### PR DESCRIPTION
Push `console.close()` to the atexit callback stack instead of calling it at the end of the `streamlink_cli.main.main()` function, so console and log messages can still be written in custom functions pushed to the atexit stack.

----

This is required for an upcoming change in the `streamlink.cache` module, which refactors, simplifies and improves cache file IO, where it also logs something in an `atexit` callback. This is currently not possible without these changes here.