### PR TITLE
plugins.aloula: add aloula.sba.sa to URL matcher

### DIFF
--- a/src/streamlink/plugins/aloula.py
+++ b/src/streamlink/plugins/aloula.py
@@ -1,5 +1,6 @@
 """
 $description Live TV channels and video on-demand service from the SBA, a Saudi, state-owned broadcaster.
+$url aloula.sba.sa
 $url aloula.sa
 $type live, vod
 $metadata id
@@ -21,11 +22,11 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(
     name="live",
-    pattern=re.compile(r"https?://(?:www\.)?aloula\.sa/(?:\w{2}/)?live/(?P<live_slug>[^/?&]+)"),
+    pattern=re.compile(r"https?://(?:aloula\.sba\.sa|(?:www\.)?aloula\.sa)/(?:\w{2}/)?live/(?P<live_slug>[^/?&]+)"),
 )
 @pluginmatcher(
     name="vod",
-    pattern=re.compile(r"https?://(?:www\.)?aloula\.sa/(?:\w{2}/)?episode/(?P<vod_id>\d+)"),
+    pattern=re.compile(r"https?://(?:aloula\.sba\.sa|(?:www\.)?aloula\.sa)/(?:\w{2}/)?episode/(?P<vod_id>\d+)"),
 )
 class Aloula(Plugin):
     def get_live(self, live_slug):

--- a/tests/plugins/test_aloula.py
+++ b/tests/plugins/test_aloula.py
@@ -6,9 +6,13 @@ class TestPluginCanHandleUrlAloula(PluginCanHandleUrl):
     __plugin__ = Aloula
 
     should_match_groups = [
+        (("live", "https://aloula.sba.sa/live/saudiatv"), {"live_slug": "saudiatv"}),
         (("live", "https://www.aloula.sa/live/saudiatv"), {"live_slug": "saudiatv"}),
+        (("live", "https://aloula.sba.sa/en/live/saudiatv"), {"live_slug": "saudiatv"}),
         (("live", "https://www.aloula.sa/en/live/saudiatv"), {"live_slug": "saudiatv"}),
+        (("vod", "https://aloula.sba.sa/episode/6676"), {"vod_id": "6676"}),
         (("vod", "https://www.aloula.sa/episode/6676"), {"vod_id": "6676"}),
+        (("vod", "https://aloula.sba.sa/en/episode/6676"), {"vod_id": "6676"}),
         (("vod", "https://www.aloula.sa/en/episode/6676"), {"vod_id": "6676"}),
     ]
 


### PR DESCRIPTION
Fixes #6571 

```
$ ./script/test-plugin-urls.py aloula
:: https://aloula.sba.sa/en/episode/6676
::  240p, 360p, 480p, 720p, 1080p, worst, best
:: https://aloula.sba.sa/en/live/saudiatv
::  360p, 480p, 1080p, worst, best
:: https://aloula.sba.sa/episode/6676
::  240p, 360p, 480p, 720p, 1080p, worst, best
:: https://aloula.sba.sa/live/saudiatv
::  360p, 480p, 1080p, worst, best
:: https://www.aloula.sa/en/episode/6676
::  240p, 360p, 480p, 720p, 1080p, worst, best
:: https://www.aloula.sa/en/live/saudiatv
::  360p, 480p, 1080p, worst, best
:: https://www.aloula.sa/episode/6676
::  240p, 360p, 480p, 720p, 1080p, worst, best
:: https://www.aloula.sa/live/saudiatv
::  360p, 480p, 1080p, worst, best
```