### PR TITLE
plugins.goodgame: fix plugin

### DIFF
--- a/tests/plugins/test_goodgame.py
+++ b/tests/plugins/test_goodgame.py
@@ -6,16 +6,16 @@ class TestPluginCanHandleUrlGoodGame(PluginCanHandleUrl):
     __plugin__ = GoodGame
 
     should_match_groups = [
-        (("default", "https://goodgame.ru/CHANNELNAME"), {"name": "CHANNELNAME"}),
-        (("default", "https://goodgame.ru/CHANNELNAME/"), {"name": "CHANNELNAME"}),
-        (("default", "https://goodgame.ru/CHANNELNAME?foo=bar"), {"name": "CHANNELNAME"}),
-        (("default", "https://www.goodgame.ru/CHANNELNAME"), {"name": "CHANNELNAME"}),
+        (("default", "https://goodgame.ru/USERNAME"), {"name": "USERNAME"}),
+        (("default", "https://goodgame.ru/USERNAME/"), {"name": "USERNAME"}),
+        (("default", "https://goodgame.ru/USERNAME?foo=bar"), {"name": "USERNAME"}),
+        (("default", "https://www.goodgame.ru/USERNAME"), {"name": "USERNAME"}),
         (("channel", "https://goodgame.ru/channel/CHANNELNAME"), {"channel": "CHANNELNAME"}),
         (("channel", "https://goodgame.ru/channel/CHANNELNAME/"), {"channel": "CHANNELNAME"}),
         (("channel", "https://goodgame.ru/channel/CHANNELNAME?foo=bar"), {"channel": "CHANNELNAME"}),
         (("channel", "https://www.goodgame.ru/channel/CHANNELNAME"), {"channel": "CHANNELNAME"}),
-        (("player", "https://goodgame.ru/player?1234"), {"id": "1234"}),
-        (("player", "https://www.goodgame.ru/player?1234"), {"id": "1234"}),
+        (("player", "https://goodgame.ru/player?CHANNELNAME"), {"channel": "CHANNELNAME"}),
+        (("player", "https://www.goodgame.ru/player?CHANNELNAME"), {"channel": "CHANNELNAME"}),
     ]
 
     should_not_match = [


### PR DESCRIPTION
Fixes #6584

HLS playlist URLs are now returned by the API, and they now require an access token that's already included in the query strings.

```
$ ./script/test-plugin-urls.py goodgame -r USERNAME bonivur -r CHANNELNAME boni
:: https://goodgame.ru/bonivur
::  240p, 480p, 720p, source, worst, best
:: https://goodgame.ru/bonivur/
::  240p, 480p, 720p, source, worst, best
:: https://goodgame.ru/bonivur?foo=bar
::  240p, 480p, 720p, source, worst, best
:: https://goodgame.ru/channel/boni
::  240p, 480p, 720p, source, worst, best
:: https://goodgame.ru/channel/boni/
::  240p, 480p, 720p, source, worst, best
:: https://goodgame.ru/channel/boni?foo=bar
::  240p, 480p, 720p, source, worst, best
:: https://goodgame.ru/player?boni
::  240p, 480p, 720p, source, worst, best
:: https://www.goodgame.ru/bonivur
::  240p, 480p, 720p, source, worst, best
:: https://www.goodgame.ru/channel/boni
::  240p, 480p, 720p, source, worst, best
:: https://www.goodgame.ru/player?boni
::  240p, 480p, 720p, source, worst, best
```