### PR TITLE
build: bump lxml to >=4.6.4,<7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "certifi",
   "exceptiongroup ; python_version<'3.11'",
   "isodate",
-  "lxml >=4.6.4,<6",
+  "lxml >=4.6.4,<7",
   "pycountry",
   "pycryptodome >=3.4.3,<4",
   "PySocks >=1.5.6,!=1.5.7",


### PR DESCRIPTION
https://github.com/lxml/lxml/blob/lxml-6.0.0/CHANGES.txt

Failing tests with lxml6 were already fixed in #6537 (as part of streamlink 7.4.0)

lxml 6.0.0 hasn't been published on PyPI yet, but building locally and running tests works fine...