### PR TITLE
ci.github: add free-threaded test runners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 10
+    after_n_builds: 12
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.13t"
         include:
           - runs-on: ubuntu-latest
             python-version: "3.14-dev"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,8 +17,7 @@ coverage[toml]
 ruff ==0.12.1
 
 # typing
-mypy[faster-cache] ==1.16.1 ; python_version<'3.14'
-mypy ==1.16.1 ; python_version>='3.14'  # orjson (faster-cache mypy extra) currently fails building on 3.14
+mypy ==1.16.1
 typing-extensions >=4.0.0
 lxml-stubs
 trio-typing


### PR DESCRIPTION
See #6591

There could possibly be some test failures. I didn't see anything on my local system ever since lxml (built with recent Cython) added support for free-threaded mode.