### PR TITLE
buffers: set/clear event_free first

### DIFF
--- a/src/streamlink/buffers.py
+++ b/src/streamlink/buffers.py
@@ -85,15 +85,15 @@ class RingBuffer(Buffer):
         self.event_used = Event()
 
     def _check_events(self):
-        if self.length > 0:
-            self.event_used.set()
-        else:
-            self.event_used.clear()
-
         if self.is_full:
             self.event_free.clear()
         else:
             self.event_free.set()
+
+        if self.length > 0:
+            self.event_used.set()
+        else:
+            self.event_used.clear()
 
     def _read(self, size=-1):
         with self.buffer_lock:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -191,7 +191,7 @@ class TestThreadedRingBuffer:
                 read = buffer.read(block=True, timeout=self.TIMEOUT)
 
         read = None
-        runnerthread = Thread(target=runner)
+        runnerthread = Thread(daemon=True, target=runner)
         runnerthread.start()
 
         buffer.write(b"0123")
@@ -220,7 +220,7 @@ class TestThreadedRingBuffer:
             with handshake():
                 buffer.write(b"01234567")
 
-        runnerthread = Thread(target=runner)
+        runnerthread = Thread(daemon=True, target=runner)
         runnerthread.start()
 
         handshake.go()
@@ -245,7 +245,7 @@ class TestThreadedRingBuffer:
             with handshake():
                 buffer.write(b"01234567")
 
-        runnerthread = Thread(target=runner)
+        runnerthread = Thread(daemon=True, target=runner)
         runnerthread.start()
 
         handshake.go()


### PR DESCRIPTION
Signal other threads that the buffer is or is not free first, before signaling that the buffer is or is not used, and fix flaky buffer tests in free-threaded mode.
