### PR TITLE
plugins.lrt: rewrite and fix stream URL schema

### DIFF
--- a/src/streamlink/plugins/lrt.py
+++ b/src/streamlink/plugins/lrt.py
@@ -2,9 +2,12 @@
 $description Live TV channels from LRT, a Lithuanian public, state-owned broadcaster.
 $url lrt.lt
 $type live
+$metadata id
+$metadata title
 """
 
 import re
+from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
@@ -16,18 +19,46 @@ from streamlink.stream.hls import HLSStream
 )
 class LRT(Plugin):
     def _get_streams(self):
-        token_url = self.session.http.get(
+        path = urlparse(self.url).path
+        channels = self.session.http.get(
             self.url,
             schema=validate.Schema(
-                re.compile(r"""var\s+tokenURL\s*=\s*(?P<q>["'])(?P<url>https://\S+)(?P=q)"""),
-                validate.none_or_all(validate.get("url")),
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[contains(text(),'/get_live_url.php?channel=')][1]/text()"),
+                re.compile(r"""\s*self\.__next_f\.push\(\[\d+,\s*(?P<payload>"\d+:\[.+")]\)"""),
+                validate.none_or_all(
+                    validate.get("payload"),
+                    validate.parse_json(),
+                    str,
+                    validate.transform(lambda data: data.split(":", maxsplit=1)[-1]),
+                    validate.parse_json(),
+                    list,
+                    validate.get(3),
+                    {
+                        "channels": [
+                            {
+                                "href": str,
+                                "channel": str,
+                                "title": str,
+                                "stream_url": validate.url(path=validate.endswith("/get_live_url.php")),
+                            },
+                        ],
+                    },
+                    validate.get("channels"),
+                ),
             ),
         )
-        if not token_url:
+        for channel in channels:
+            if channel["href"] == path:
+                break
+        else:
             return
 
+        self.id = channel["channel"]
+        self.title = channel["title"]
+
         hls_url = self.session.http.get(
-            token_url,
+            channel["stream_url"],
             schema=validate.Schema(
                 validate.parse_json(),
                 {


### PR DESCRIPTION
Resolves #6606 

Stream URLs + metadata are now embedded as DOM rehydration data. The follow-up API request is still the same.

```
$ ./script/test-plugin-urls.py -m lrt
:: https://www.lrt.lt/mediateka/tiesiogiai/lrt-klasika
::  540p, 720p, 1080p, worst, best
::   {'id': 'Klasika', 'author': None, 'category': None, 'title': 'Radijo teatras'}
:: https://www.lrt.lt/mediateka/tiesiogiai/lrt-lituanica
::  540p, 720p, 1080p, worst, best
::   {'id': 'WORLD', 'author': None, 'category': None, 'title': 'Savaitė su „Dviračio žiniomis“'}
:: https://www.lrt.lt/mediateka/tiesiogiai/lrt-opus
::  540p, 720p, 1080p, worst, best
::   {'id': 'Opus', 'author': None, 'category': None, 'title': 'Vakarų musonas'}
:: https://www.lrt.lt/mediateka/tiesiogiai/lrt-plius
::  540p, 720p, 1080p, worst, best
::   {'id': 'LTV2', 'author': None, 'category': None, 'title': 'Lietuvos futbolo A lyga'}
:: https://www.lrt.lt/mediateka/tiesiogiai/lrt-radijas
::  540p, 720p, 1080p, worst, best
::   {'id': 'LR', 'author': None, 'category': None, 'title': 'Genijaus kailyje. Ved. Livija Gradauskienė'}
:: https://www.lrt.lt/mediateka/tiesiogiai/lrt-televizija
::  540p, 720p, 1080p, worst, best
::   {'id': 'LTV1', 'author': None, 'category': None, 'title': 'Savaitė su „Dviračio žiniomis“'}
```