### PR TITLE
tools: add back faster-cache mypy extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ lint = [
 typing = [
   { include-group = "test" },
   { include-group = "docs" },
-  "mypy ==1.16.1",
+  "mypy[faster-cache] ==1.16.1",
   "typing-extensions >=4.0.0",
   "lxml-stubs",
   "trio-typing",


### PR DESCRIPTION
The recent issues with `orjson` have been fixed. It should now be working on 3.14, 3.14t and 3.13t, so let's add it back to the `typing` dependency group via mypy's `faster-cache` extra.
https://github.com/ijl/orjson/releases/tag/3.11.0

Removed in #6592 (from dev-requirements.txt)