### PR TITLE
tests: req pytest>=8.4.0, load plugins explicitly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           export PYTHON_GIL=$(python -c 'import sysconfig;print(1 - sysconfig.get_config_var("Py_GIL_DISABLED"))')
-          pytest -r a --cov --cov-branch --cov-report=xml --durations 10
+          pytest --trace-config -r a --cov --cov-branch --cov-report=xml --durations 10
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,14 @@ dev = [
 ]
 test = [
   { include-group = "dev" },
-  "pytest >=8.0.0",
-  "pytest-trio",
-  "freezegun >=1.5.0",
-  "requests-mock",
-  "coverage[toml]",
+  # pytest and plugins
+  "pytest >=8.4.0",
   "pytest-cov",
+  "pytest-trio",
+  "requests-mock",
+  # other
+  "coverage[toml]",
+  "freezegun >=1.5.0",
 ]
 lint = [
   "ruff ==0.12.3",
@@ -189,6 +191,13 @@ method = { module = "build_backend.onbuild", value = "onbuild" }
 # https://docs.pytest.org/en/latest/reference/customize.html#configuration
 # https://docs.pytest.org/en/latest/reference/reference.html#ini-options-ref
 [tool.pytest.ini_options]
+minversion = "8.4.0"
+addopts = """
+--disable-plugin-autoload
+-p pytest_cov
+-p trio
+-p requests_mock
+"""
 testpaths = [
   "build_backend",
   "tests",


### PR DESCRIPTION
Add the `--disable-plugin-autoload` pytest option (pytest >=8.4.0) and explicitly load pytest plugins which are required by Streamlink's test suite.

By default, pytest plugins are discovered automatically by checking all installed Python distributions in the current Python environment, which may lead to unwanted pytest plugins being loaded and executed.

----

Random pytest plugins shouldn't be loaded when running the test suite.

1. Some Streamlink packagers have set incorrect test dependencies in their packages (we've removed pytest-asyncio in the past), resulting in those plugins being loaded automatically.
2. Streamlink could be installed in an env that's not clean and where lots of other pytest plugins are installed. For example, I've been casually working on the transition from requests+urllib3 to httpx, and this causes plugins of both to be loaded by default.

Before merging, I'll need to have a look at which pytest versions are packaged in the main Linux distros where Streamlink is packaged. Pytest 8.4.0 is fairly recent, so this might be a problem. I'll do this later...