### PR TITLE
build: add Python 3.14 to package classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Multimedia :: Sound/Audio",
   "Topic :: Multimedia :: Video",


### PR DESCRIPTION
Let's update Streamlink's package metadata now that Python 3.14 RC1 has been tagged and everything's working fine. The CI runners haven't received updated builds yet, but I've built and check everything locally, so tagging full 3.14 compatibility with the first release candidate is fine.

Once 3.14.0 final has been released, we can move the CI runners to the default test matrix.