### PR TITLE
Added DRM Support!

### DIFF
--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -200,6 +200,21 @@ class StreamlinkOptions(Options):
           - ``[]``
           - Select a specific audio source or sources when multiple audio sources are available,
             by language code or name, or ``"*"`` (asterisk)
+        * - decryption_key
+          - ``str``
+          - ``None``
+          - Use a CENC decryption key to decrypt media streams received by FFmpeg from DASH streaming.
+          If only one key is provided, it will be used for both video and audio tracks.
+          Use a hexadecimal string as the key.
+          Example: ``-decryption_key "<hex key>"``
+
+        * - decryption_key_2
+          - ``str``
+          - ``None``
+          - An optional second CENC decryption key to be used specifically for the second media track
+          (typically audio) during DASH streaming playback via FFmpeg.
+          Example: ``-decryption_key_2 "<hex key>"``
+
         * - dash-manifest-reload-attempts
           - ``int``
           - ``3``
@@ -300,6 +315,8 @@ class StreamlinkOptions(Options):
             "hls-segment-ignore-names": [],
             "hls-segment-key-uri": None,
             "hls-audio-select": [],
+            "decryption_key" : None,
+            "decryption_key_2": None,
             "dash-manifest-reload-attempts": 3,
             "ffmpeg-ffmpeg": None,
             "ffmpeg-no-validation": False,

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -309,10 +309,10 @@ class DASHStream(Stream):
         # Search for suitable video and audio representations
         for aset in period_selection.adaptationSets:
             if aset.contentProtections:
-                raise PluginError(f"{source} is protected by DRM")
+                log.debug(f"{source} is protected by DRM")
             for rep in aset.representations:
                 if rep.contentProtections:
-                    raise PluginError(f"{source} is protected by DRM")
+                    log.debug(f"{source} is protected by DRM")
                 if rep.mimeType.startswith("video"):
                     video.append(rep)
                 elif rep.mimeType.startswith("audio"):  # pragma: no branch

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1169,6 +1169,29 @@ def build_parser():
     )
 
     transport_ffmpeg.add_argument(
+        "-decryption_key",
+        metavar="FILENAME",
+        help="""
+        Use a CENC decryption key to decrypt the media that ffmpeg receives as
+        an input from the DASH streaming that you play with streamlink.
+        If only one decryption key is provided, it will be used for both video and audio.
+        If --decryption_key_2 is also provided, it will be used for the first track.
+        Example: -decryption_key "<hex key>"
+        """
+    )
+
+    transport_ffmpeg.add_argument(
+        "-decryption_key_2",
+        metavar="FILENAME",
+        help="""
+        Use a CENC decryption key to decrypt the media that ffmpeg receives as
+        an input from the DASH streaming that you play with streamlink.
+        This key will be used for the second track only.
+        Example: -decryption_key_2 "<hex key>"
+        """
+    )
+
+    transport_ffmpeg.add_argument(
         "--ffmpeg-ffmpeg",
         metavar="FILENAME",
         help="""
@@ -1492,6 +1515,8 @@ _ARGUMENT_TO_SESSIONOPTION: list[tuple[str, str, Callable[[Any], Any] | None]] =
     ("hls_segment_ignore_names", "hls-segment-ignore-names", None),
     ("hls_segment_key_uri", "hls-segment-key-uri", None),
     ("hls_audio_select", "hls-audio-select", None),
+    ("decryption_key", "decryption_key", None),
+    ("decryption_key_2", "decryption_key_2", None),
     ("dash_manifest_reload_attempts", "dash-manifest-reload-attempts", None),
     ("ffmpeg_ffmpeg", "ffmpeg-ffmpeg", None),
     ("ffmpeg_no_validation", "ffmpeg-no-validation", None),


### PR DESCRIPTION
This pull request introduces two new arguments to enable encrypted DASH media stream decryption using Common Encryption (CENC) keys via FFmpeg:

* `-decryption_key`:
  Accepts a hexadecimal string representing a CENC decryption key to decrypt media received from DASH streaming.
  If only one key is provided, it will be applied to both video and audio tracks.
  Example usage:

  ```bash
  -decryption_key "0123456789abcdef0123456789abcdef"
  ```

* `-decryption_key_2`:
  Optional second CENC decryption key, intended for the secondary media track (typically audio).
  This allows different decryption keys to be used for video and audio tracks when needed.
  Example usage:

  ```bash
  -decryption_key_2 "fedcba9876543210fedcba9876543210"
  ```

These additions enhance the flexibility of handling encrypted DASH streams and make FFmpeg integration with DRM-enabled media workflows easier.

#### Motivation

Some DASH streams encrypt video and audio tracks using different CENC keys. Previously, there was no option to specify a separate key for audio. This update resolves that limitation and allows full decryption support for both tracks.

#### Notes

* Both keys must be valid 128-bit hexadecimal strings.
* These arguments will be ignored if the stream is not encrypted or if no keys are provided.

