### PR TITLE
docs: fix compatibility with docutils==0.22

### DIFF
--- a/docs/ext_argparse.py
+++ b/docs/ext_argparse.py
@@ -15,7 +15,7 @@ from textwrap import dedent
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst.directives import unchanged
-from docutils.statemachine import ViewList
+from docutils.statemachine import StringList
 from sphinx.errors import ExtensionError
 from sphinx.util.nodes import nested_parse_with_titles
 
@@ -175,13 +175,10 @@ class ArgparseDirective(Directive):
             # positional parameters have an empty option_strings list
             self._available_options += action.option_strings or [action.dest]
 
-        node = nodes.section()
-        node.document = self.state.document
-        result = ViewList()
-        for line in self.generate_parser_rst(parser):
-            result.append(line, "argparse")
-
+        node = nodes.Element(document=self.state.document)
+        result = StringList(list(self.generate_parser_rst(parser)), "argparse")
         nested_parse_with_titles(self.state, result, node)
+
         return node.children
 
 

--- a/docs/ext_plugins.py
+++ b/docs/ext_plugins.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from docutils import nodes
 from docutils.parsers.rst import Directive
-from docutils.statemachine import ViewList
+from docutils.statemachine import StringList
 from sphinx.errors import ExtensionError
 from sphinx.util.nodes import nested_parse_with_titles
 
@@ -257,17 +257,18 @@ class PluginFinder:
 
 
 class PluginsDirective(Directive):
-    def run(self):
+    # noinspection PyMethodMayBeStatic
+    def generate(self):
         pluginfinder = PluginFinder()
 
-        node = nodes.section()
-        node.document = self.state.document
-        result = ViewList()
         for pluginmetadata in pluginfinder.get_plugins():
-            for line in pluginmetadata.generate():
-                result.append(line, "plugins")
+            yield from pluginmetadata.generate()
 
+    def run(self):
+        node = nodes.Element(document=self.state.document)
+        result = StringList(list(self.generate()), "plugins")
         nested_parse_with_titles(self.state, result, node)
+
         return node.children
 
 


### PR DESCRIPTION
- Switch from `nodes.section` to `node.Element`
- Replace `ViewList` with `StringList` for typing reasons
- Clean up `{Argparse,Plugins}Directive.run()`:
  - Set `document` attribute directly
  - Don't repeatedly `append()` to the `StringList` object

----

Resolves #6624 
See https://github.com/streamlink/streamlink/issues/6624#issuecomment-3145870992
