### PR TITLE
cli: replace sys.exit() and parser.error() calls

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -736,8 +736,11 @@ def setup_args(
 
     args, unknown = parser.parse_known_args(configs + arglist)
     if unknown and not ignore_unknown:
-        msg = gettext("unrecognized arguments: %s")
-        parser.error(msg % " ".join(unknown))
+        # output the same text as parser.error(), but raise a StreamlinkCLIError
+        usage = parser.format_usage()
+        msg = gettext("unrecognized arguments: %s") % " ".join(unknown)
+        error = f"{parser.prog}: error: {msg}"
+        raise StreamlinkCLIError(f"{usage}{error}", code=2)
 
     # Force lowercase to allow case-insensitive lookup
     if args.stream:
@@ -1010,7 +1013,7 @@ def main():
         setup(parser)
     except StreamlinkCLIError as err:
         sys.stderr.write(f"{err}\n")
-        raise SystemExit(1) from None
+        raise SystemExit(err.code) from None
 
     try:
         exit_code = run(parser)

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1010,7 +1010,7 @@ def main():
         setup(parser)
     except StreamlinkCLIError as err:
         sys.stderr.write(f"{err}\n")
-        sys.exit(1)
+        raise SystemExit(1) from None
 
     try:
         exit_code = run(parser)
@@ -1026,4 +1026,4 @@ def main():
     # Prevent BrokenPipeError: unset sys.stdout, so Python doesn't attempt a flush() on exit
     del sys.stdout
 
-    sys.exit(exit_code)
+    raise SystemExit(exit_code)

--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -223,6 +223,36 @@ class TestStdoutStderr:
         assert err == msg
 
 
+class TestSetupArgs:
+    @pytest.mark.parametrize(
+        ("argv", "msg"),
+        [
+            pytest.param(
+                ["--doesnotexist=foo", "--doesalsonotexist=bar", "--player=player"],
+                "\n".join([
+                    "usage: streamlink [OPTIONS] <URL> [STREAM]",
+                    "streamlink: error: unrecognized arguments: --doesnotexist=foo --doesalsonotexist=bar",
+                    "",
+                ]),
+                id="does-not-exist",
+            ),
+        ],
+        indirect=["argv"],
+    )
+    def test_unknown(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], argv: list, msg: str):
+        mock_run = Mock()
+        monkeypatch.setattr("streamlink_cli.main.run", mock_run)
+
+        with pytest.raises(SystemExit) as excinfo:
+            streamlink_cli.main.main()
+        assert excinfo.value.code == 2
+        assert not mock_run.called
+
+        out, err = capsys.readouterr()
+        assert out == ""
+        assert err == msg
+
+
 class TestInfos:
     # noinspection PyTestParametrized
     @pytest.mark.posix_only()


### PR DESCRIPTION
Let's not call `sys.exit()` or `parser.error()`, and instead raise an exception for better static code analysis.