### PR TITLE
plugins.mediaklikk: fix player data regex

### DIFF
--- a/src/streamlink/plugins/mediaklikk.py
+++ b/src/streamlink/plugins/mediaklikk.py
@@ -2,6 +2,7 @@
 $description Live TV channels from MTVA, a Hungarian public, state-owned broadcaster.
 $url mediaklikk.hu
 $url m4sport.hu
+$url hirado.hu
 $type live
 $region Hungary
 """
@@ -20,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 @pluginmatcher(
-    re.compile(r"https?://(?:www\.)?(?:mediaklikk|m4sport|hirado|petofilive)\.hu/"),
+    re.compile(r"https?://(?:www\.)?(?:mediaklikk|m4sport|hirado)\.hu/"),
 )
 class Mediaklikk(Plugin):
     PLAYER_URL = "https://player.mediaklikk.hu/playernew/player.php"
@@ -31,10 +32,10 @@ class Mediaklikk(Plugin):
             schema=validate.Schema(
                 re.compile(
                     r"""
-                        mtva_player_manager\.player\s*\(\s*
-                            document\.getElementById\(\s*"\w+"\s*\)\s*,\s*
+                        loadPlayer\s*\(\s*
+                            (?P<q>['"]).+?(?P=q)\s*,\s*
                             (?P<json>{.*?})\s*
-                        \)\s*;
+                        \)
                     """,
                     re.VERBOSE | re.DOTALL,
                 ),
@@ -51,7 +52,7 @@ class Mediaklikk(Plugin):
             ),
         )
         if not params:
-            log.error("Could not find player manager data")
+            log.error("Could not find player data")
             return
 
         params.update({

--- a/tests/plugins/test_mediaklikk.py
+++ b/tests/plugins/test_mediaklikk.py
@@ -7,15 +7,13 @@ class TestPluginCanHandleUrlMediaklikk(PluginCanHandleUrl):
 
     should_match = [
         "https://www.mediaklikk.hu/duna-world-elo/",
-        "https://www.mediaklikk.hu/duna-world-radio-elo",
         "https://www.mediaklikk.hu/m1-elo",
         "https://www.mediaklikk.hu/m2-elo",
-        "https://mediaklikk.hu/video/hirado-2021-06-24-i-adas-6/",
         "https://m4sport.hu/elo/",
         "https://m4sport.hu/elo/?channelId=m4sport+",
         "https://m4sport.hu/elo/?showchannel=mtv4plus",
-        "https://m4sport.hu/euro2020-video/goool2-13-resz",
-        "https://hirado.hu/videok/",
-        "https://hirado.hu/videok/nemzeti-sporthirado-2021-06-24-i-adas-2/",
-        "https://petofilive.hu/video/2021/06/23/the-anahit-klip-limited-edition/",
+        "https://m4sport.hu/video/2025/08/08/fizz-liga-kolorcity-kazincbarcika-sc-dvsc-merkozes",
+        "https://hirado.hu/elo/m1",
+        "https://hirado.hu/elo/m2",
+        "https://hirado.hu/belfold/video/2025/08/09/szuletesnap-a-budapesti-allat-es-novenykertben",
     ]


### PR DESCRIPTION
Fixes #6626

The sports channels are all geo-blocked, so I don't know if they're actually working. What I'm seeing is a template stream with a geo-block message.

```
$ ./script/test-plugin-urls.py mediaklikk
:: https://hirado.hu/belfold/video/2025/08/09/szuletesnap-a-budapesti-allat-es-novenykertben
::  400k, 800k, 1200k, 1600k, 3000k, worst, best
:: https://hirado.hu/elo/m1
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://hirado.hu/elo/m2
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://m4sport.hu/elo/
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://m4sport.hu/elo/?channelId=m4sport+
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://m4sport.hu/elo/?showchannel=mtv4plus
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://m4sport.hu/video/2025/08/08/fizz-liga-kolorcity-kazincbarcika-sc-dvsc-merkozes
::  400k, 800k, 1200k, 1600k, 3000k, worst, best
:: https://www.mediaklikk.hu/duna-world-elo/
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://www.mediaklikk.hu/m1-elo
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
:: https://www.mediaklikk.hu/m2-elo
::  240p, 360p, 480p, 540p, 720p, 1080p, worst, best
```