### PR TITLE
cli: add --skip

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -786,6 +786,15 @@ def build_parser():
         """,
     )
     output.add_argument(
+        "--skip",
+        action="store_true",
+        help="""
+            When using --output or --record, never write to file if it already exists (don't prompt).
+
+            Takes precedence over --force.
+        """,
+    )
+    output.add_argument(
         "--progress",
         metavar="{yes,force,no}",
         choices=("yes", "force", "no"),

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -82,26 +82,31 @@ def get_formatter(plugin: Plugin):
     )
 
 
-def check_file_output(path: Path, force: bool) -> Path:
+def check_file_output(path: Path, skip: bool, force: bool) -> Path:
     """
-    Checks if path already exists and asks the user if it should be overwritten if it does.
+    Checks if `path` already exists and asks the user if it should be overwritten if it does.
     """
 
-    # rewrap path and resolve using `os.path.realpath` instead of `path.resolve()`
+    # rewrap `path` and resolve using `os.path.realpath` instead of `path.resolve()`
     # to avoid a pathlib issues on py39 and below
     realpath = Path(os.path.realpath(path))
 
     log.info(f"Writing output to\n{realpath}")
     log.debug("Checking file output")
 
-    if realpath.is_file() and not force:
-        try:
-            answer = console.ask(f"File {path} already exists! Overwrite it? [y/N] ")
-        except OSError:
-            log.error(f"File {path} already exists, use --force to overwrite it.")
-            raise StreamlinkCLIError() from None
-        if not answer or answer.lower() != "y":
+    if realpath.is_file():
+        if skip:
+            log.error(f"File {path} already exists")
             raise StreamlinkCLIError()
+
+        if not force:
+            try:
+                answer = console.ask(f"File {path} already exists! Overwrite it? [y/N] ")
+            except OSError:
+                log.error(f"File {path} already exists, use --force to overwrite it or --skip this prompt")
+                raise StreamlinkCLIError() from None
+            if not answer or answer.lower() != "y":
+                raise StreamlinkCLIError()
 
     return realpath
 
@@ -126,7 +131,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
         if args.output == "-":
             return FileOutput(fd=stdout)
         else:
-            filename = check_file_output(formatter.path(args.output, args.fs_safe_rules), args.force)
+            filename = check_file_output(formatter.path(args.output, args.fs_safe_rules), args.skip, args.force)
             return FileOutput(filename=filename)
 
     elif args.stdout:
@@ -136,7 +141,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
         if not args.record or args.record == "-":
             return FileOutput(fd=stdout)
         else:
-            filename = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
+            filename = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.skip, args.force)
             return FileOutput(fd=stdout, record=FileOutput(filename=filename))
 
     elif args.record_and_pipe:
@@ -145,7 +150,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
             StreamlinkDeprecationWarning,
             stacklevel=1,
         )
-        filename = check_file_output(formatter.path(args.record_and_pipe, args.fs_safe_rules), args.force)
+        filename = check_file_output(formatter.path(args.record_and_pipe, args.fs_safe_rules), args.skip, args.force)
         return FileOutput(fd=stdout, record=FileOutput(filename=filename))
 
     elif args.player:
@@ -163,7 +168,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
             if args.record == "-":
                 record = FileOutput(fd=stdout)
             else:
-                filename = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.force)
+                filename = check_file_output(formatter.path(args.record, args.fs_safe_rules), args.skip, args.force)
                 record = FileOutput(filename=filename)
 
         log.info(f"Starting player: {args.player}")


### PR DESCRIPTION
Resolves #6632 

This adds `--skip` in addition to the already existing `--force` CLI argument. 

With `--skip` set, no prompt will be made for overwriting the output file if it already exists, and Streamlink will immediately exit. `--skip` takes precedence over `--force`, if set.

```
$ echo 123 > /tmp/foo
$ touch /tmp/bar
```

```
$ streamlink httpstream://file:///tmp/foo best -o /tmp/bar
[cli][info] Found matching plugin http for URL httpstream://file:///tmp/foo
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/bar
File /tmp/bar already exists! Overwrite it? [y/N]
```

```
$ streamlink httpstream://file:///tmp/foo best -o /tmp/bar --skip
[cli][info] Found matching plugin http for URL httpstream://file:///tmp/foo
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/bar
[cli][error] File /tmp/bar already exists
```

```
$ streamlink httpstream://file:///tmp/foo best -o /tmp/bar --force --skip
[cli][info] Found matching plugin http for URL httpstream://file:///tmp/foo
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/bar
[cli][error] File /tmp/bar already exists
```

```
$ streamlink httpstream://file:///tmp/foo best -o /tmp/bar --force
[cli][info] Found matching plugin http for URL httpstream://file:///tmp/foo
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/tmp/bar
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[download] Written 4 bytes to /tmp/bar (0s)
```