### PR TITLE
plugins.vkvideolive: add missing VOD qualities

### DIFF
--- a/src/streamlink/plugins/vkvideolive.py
+++ b/src/streamlink/plugins/vkvideolive.py
@@ -29,6 +29,8 @@ class VKvideolive(Plugin):
     API_URL = "https://api.live.vkvideo.ru/v1"
 
     _WEIGHTS = {
+        "quad_hd": 5,
+        "full_hd": 4,
         "high": 3,
         "medium": 2,
         "low": 1,
@@ -132,7 +134,7 @@ class VKvideolive(Plugin):
                     yield from HLSStream.parse_variant_playlist(self.session, streamurl).items()
         else:
             for streamtype, streamurl in streams:
-                if streamurl and streamtype in ("high", "medium", "low"):
+                if streamurl and streamtype in self._WEIGHTS:
                     yield streamtype, HTTPStream(self.session, streamurl)
 
 


### PR DESCRIPTION
See https://github.com/streamlink/streamlink/issues/6639#issuecomment-3229531225

```bash
url=https://live.vkvideo.ru/funny/record/e385402f-26d0-4331-a2bd-3dd89a97ca9a?tab=records
for quality in $(streamlink --json "$url" | jq -r '.streams | keys[]'); do
  echo $quality
  streamlink --quiet --stdout "$url" "$quality" \
    | ffprobe -v error -of json -show_streams - \
    | jq -r '.streams[] | select(.codec_type == "video") | "\(.width)x\(.height)"'
done
```
```
best
2560x1440
full_hd
1920x1080
high
1280x720
low
640x360
medium
852x480
quad_hd
2560x1440
worst
640x360
```