### PR TITLE
session: fix HTTPSession typing

### DIFF
--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -60,7 +60,7 @@ _Params: TypeAlias = (
 )
 _TextMapping: TypeAlias = MutableMapping[str, str]
 _HeadersUpdateMapping: TypeAlias = Mapping[str, str | bytes | None]
-_Timeout: TypeAlias = float | tuple[float, float] | tuple[float, None]
+_Timeout: TypeAlias = float | tuple[float | None, float | None]
 _Verify: TypeAlias = bool | str
 
 # END: borrowed from typeshed / types-requests


### PR DESCRIPTION
Caused by `types-requests==2.32.4.20250913` (via typeshed):  
https://github.com/python/typeshed/commit/59c36c8