### PR TITLE
stream.segmented: fix typing of writer queue

### DIFF
--- a/src/streamlink/stream/segmented/segmented.py
+++ b/src/streamlink/stream/segmented/segmented.py
@@ -78,7 +78,7 @@ class SegmentedStreamWriter(AwaitableMixin, NamedThread, Generic[TSegment, TResu
         self.timeout = timeout or self.session.options.get("stream-segment-timeout")
 
         self.executor = ThreadPoolExecutor(max_workers=self.threads, thread_name_prefix=f"{self.name}-executor")
-        self._queue: queue.Queue[TQueueItem] = queue.Queue(size)
+        self._queue: queue.Queue[TQueueItem | None] = queue.Queue(size)
 
     def close(self) -> None:
         """
@@ -125,10 +125,10 @@ class SegmentedStreamWriter(AwaitableMixin, NamedThread, Generic[TSegment, TResu
             except queue.Full:  # pragma: no cover
                 continue
 
-    def _queue_put(self, item: TQueueItem) -> None:
+    def _queue_put(self, item: TQueueItem | None) -> None:
         self._queue.put(item, block=True, timeout=1)
 
-    def _queue_get(self) -> TQueueItem:
+    def _queue_get(self) -> TQueueItem | None:
         return self._queue.get(block=True, timeout=0.5)
 
     @staticmethod


### PR DESCRIPTION
`None` is put into the queue to signal the end of the stream. The typing info of queue items currently doesn't allow `None`, so fix that.