### PR TITLE
cli: disable colored CLI usage text output

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -41,6 +41,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
     def __init__(self, *args, **kwargs):
         self.NESTED_ARGUMENT_GROUPS = {}
+        self.color = True  # pre 3.14 compat
         super().__init__(*args, **kwargs)
 
     # noinspection PyUnresolvedReferences,PyProtectedMember
@@ -108,6 +109,15 @@ class ArgumentParser(argparse.ArgumentParser):
 
         # return the number of arguments matched
         return len(match.group(1))
+
+    # disable color output for the "usage" text
+    def format_usage(self):
+        color = self.color
+        self.color = False
+        try:
+            return super().format_usage()
+        finally:
+            self.color = color
 
     # fix `--help` not including nested argument groups
     def format_help(self):


### PR DESCRIPTION
Python 3.14 added colored output by default for its ArgumentParser. The main intent is to color the generated --help text.

This however does also color the CLI usage text, which Streamlink outputs if no arguments (stream URL, --help, --plugins, --show-matchers or --can-handle-url{,-no-redirect}) were set by the user.

While this is probably fine in this case, it doesn't make sense coloring the text output if text was already written to the output previously, like debug log for example. So simply disable colored CLI usage output and keep it for the --help text, the main intention of this feature.

----

Going to leave this open, in case someone has an opinion on this. Otherwise, I'm going to merge this.

In case it's not clear why this is bad, here's a screenshot of the rendered text
<img width="1008" height="630" alt="image" src="https://github.com/user-attachments/assets/d777af13-137b-483c-978d-39a0ecad9fa7" />

If we want colored text output, then this should be done in a non-inconsistent way.