### PR TITLE
ci.github: remove -dev suffix from py314 runners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 12
+    after_n_builds: 14
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/install-temp-dependencies.sh
+++ b/.github/workflows/install-temp-dependencies.sh
@@ -2,31 +2,26 @@
 set -euxo pipefail
 
 PY=$(python -c 'import platform,sysconfig;v="".join(platform.python_version_tuple()[:2]);t="t" if sysconfig.get_config_var("Py_GIL_DISABLED") else "";print(f"cp{v}-cp{v}{t}")')
-[[ "${PY}" == cp313-cp313t || "${PY}" == cp314-cp314 || "${PY}" == cp314-cp314t ]] || exit 0
+[[ "${PY}" == cp314-cp314 || "${PY}" == cp314-cp314t ]] || exit 0
 
 [[ "$(uname)" == Linux ]] && PLATFORM=linux_x86_64 || PLATFORM=win_amd64
 
 
 BASE=https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download
 DEPS=(
-    'lxml-20250630-1/lxml-6.0.0'
-    'brotli-20250630-1/brotli-1.1.0'
-    'zstandard-20250630-1/zstandard-0.24.0.dev0'
+    'brotli-20251007-1/brotli-1.2.0'
+    'zstandard-20251007-1/zstandard-0.25.0'
 )
-DEPS_WINDOWS=(
-    'cffi-20250630-1/cffi-1.17.1'
-)
+
+if [[ "${PLATFORM}" == linux_x86_64 ]]; then
+    DEPS+=()
+elif [[ "${PLATFORM}" == win_amd64 ]]; then
+    DEPS+=()
+fi
 
 deps=()
-
 for dep in "${DEPS[@]}"; do
     deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
 done
-
-if [[ "${PLATFORM}" == win_amd64 ]]; then
-    for dep in "${DEPS_WINDOWS[@]}"; do
-        deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
-    done
-fi
 
 python -m pip install -U "${deps[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,14 +27,15 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-          - "3.13t"
-        include:
-          - runs-on: ubuntu-latest
-            python-version: "3.14-dev"
-            continue: true
-          - runs-on: windows-latest
-            python-version: "3.14-dev"
-            continue: true
+          - "3.14"
+          - "3.14t"
+        # include:
+        #   - runs-on: ubuntu-latest
+        #     python-version: "3.15-dev"
+        #     continue: true
+        #   - runs-on: windows-latest
+        #     python-version: "3.15-dev"
+        #     continue: true
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
- Move py314 runners to default test matrix
- Replace py313t with py314t
- Update temp dependencies script