### PR TITLE
stream.hls: remove deprecated url_master arg+attr

### DIFF
--- a/docs/deprecations.rst
+++ b/docs/deprecations.rst
@@ -147,9 +147,11 @@ streamlink 4.2.0
 url_master in HLSStream
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-The ``url_master`` parameter and attribute of the :py:class:`HLSStream <streamlink.stream.HLSStream>`
-and :py:class:`MuxedHLSStream <streamlink.stream.MuxedHLSStream>` classes have been deprecated in favor of
-the ``multivariant`` parameter and attribute. ``multivariant`` is an :py:class:`M3U8` reference of the parsed
+:bdg-ref-danger:`Removed in 8.0.0 <migrations:HLSStream url_master argument>`
+
+The ``url_master`` parameter and attribute of the :class:`HLSStream <streamlink.stream.HLSStream>`
+and :class:`MuxedHLSStream <streamlink.stream.MuxedHLSStream>` classes have been deprecated in favor of
+the ``multivariant`` parameter and attribute. ``multivariant`` is an :class:`M3U8` reference of the parsed
 HLS multivariant playlist.
 
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -1,6 +1,26 @@
 Migrations
 ==========
 
+streamlink 8.0.0
+----------------
+
+HLSStream url_master argument
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Support for the :ref:`deprecated <deprecations:url_master in HLSStream>` ``url_master`` argument and respective class attribute
+in :class:`HLSStream <streamlink.stream.HLSStream>` and :class:`MuxedHLSStream <streamlink.stream.MuxedHLSStream>`
+has been removed.
+
+| :octicon:`git-pull-request` #6688
+
+.. admonition:: Migration
+   :class: hint
+
+   ``HLSStream`` and ``MuxedHLSStream`` objects which originate from a multivariant (master) playlist should receive a reference
+   to the ``M3U8`` instance of the parsed multivariant playlist via the ``multivariant`` argument. The ``multivariant.uri``
+   attribute is a string of the multivariant playlist address.
+
+
 streamlink 7.0.0
 ----------------
 

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -576,7 +576,6 @@ class MuxedHLSStream(MuxedStream[TMuxedHLSStream_co]):
         video: str,
         audio: str | list[str],
         hlsstream: type[TMuxedHLSStream_co] | None = None,
-        url_master: str | None = None,
         multivariant: M3U8 | None = None,
         force_restart: bool = False,
         ffmpeg_options: Mapping[str, Any] | None = None,
@@ -606,22 +605,23 @@ class MuxedHLSStream(MuxedStream[TMuxedHLSStream_co]):
         # https://github.com/python/mypy/issues/18017
         TStream: type[TMuxedHLSStream_co] = hlsstream if hlsstream is not None else HLSStream  # type: ignore[assignment]
         substreams = [
-            TStream(session, url, force_restart=force_restart, name=None if idx == 0 else "audio", **kwargs)
+            TStream(
+                session,
+                url,
+                multivariant=multivariant,
+                force_restart=force_restart,
+                name=None if idx == 0 else "audio",
+                **kwargs,
+            )
             for idx, url in enumerate(tracks)
         ]
         ffmpeg_options = ffmpeg_options or {}
 
         super().__init__(session, *substreams, format="mpegts", maps=maps, **ffmpeg_options)
-        self._url_master = url_master
         self.multivariant = multivariant if multivariant and multivariant.is_master else None
 
-    @property
-    def url_master(self):
-        """Deprecated"""
-        return self.multivariant.uri if self.multivariant and self.multivariant.uri else self._url_master
-
     def to_manifest_url(self):
-        url = self.multivariant.uri if self.multivariant and self.multivariant.uri else self.url_master
+        url = self.multivariant.uri if self.multivariant and self.multivariant.uri else None
 
         if url is None:
             return super().to_manifest_url()
@@ -642,7 +642,6 @@ class HLSStream(HTTPStream):
         self,
         session: Streamlink,
         url: str,
-        url_master: str | None = None,
         multivariant: M3U8 | None = None,
         name: str | None = None,
         force_restart: bool = False,
@@ -653,7 +652,6 @@ class HLSStream(HTTPStream):
         """
         :param session: Streamlink session instance
         :param url: The URL of the HLS playlist
-        :param url_master: The URL of the HLS playlist's multivariant playlist (deprecated)
         :param multivariant: The parsed multivariant playlist
         :param name: Optional name suffix for the stream's worker and writer threads
         :param force_restart: Start from the beginning after reaching the playlist's end
@@ -663,7 +661,6 @@ class HLSStream(HTTPStream):
         """
 
         super().__init__(session, url, **kwargs)
-        self._url_master = url_master
         self.multivariant = multivariant if multivariant and multivariant.is_master else None
         self.name = name
         self.force_restart = force_restart
@@ -683,13 +680,8 @@ class HLSStream(HTTPStream):
 
         return json
 
-    @property
-    def url_master(self):
-        """Deprecated"""
-        return self.multivariant.uri if self.multivariant and self.multivariant.uri else self._url_master
-
     def to_manifest_url(self):
-        url = self.multivariant.uri if self.multivariant and self.multivariant.uri else self.url_master
+        url = self.multivariant.uri if self.multivariant and self.multivariant.uri else None
 
         if url is None:
             return super().to_manifest_url()

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -101,7 +101,9 @@ def test_repr(session: Streamlink):
     stream = HLSStream(session, "https://foo.bar/playlist.m3u8")
     assert repr(stream) == "<HLSStream ['hls', 'https://foo.bar/playlist.m3u8']>"
 
-    stream = HLSStream(session, "https://foo.bar/playlist.m3u8", "https://foo.bar/master.m3u8")
+    multivariant: M3U8[HLSSegment, HLSPlaylist] = M3U8("https://foo.bar/master.m3u8")
+    multivariant.is_master = True
+    stream = HLSStream(session, "https://foo.bar/playlist.m3u8", multivariant=multivariant)
     assert repr(stream) == "<HLSStream ['hls', 'https://foo.bar/playlist.m3u8', 'https://foo.bar/master.m3u8']>"
 
 
@@ -129,14 +131,6 @@ class TestHLSVariantPlaylist:
 
         assert stream.multivariant is not None
         assert stream.multivariant.uri == f"{base}/master.m3u8"
-        assert stream.url_master == f"{base}/master.m3u8"
-
-    def test_url_master(self, session: Streamlink):
-        stream = HLSStream(session, "http://mocked/foo", url_master="http://mocked/master.m3u8")
-
-        assert stream.multivariant is None
-        assert stream.url == "http://mocked/foo"
-        assert stream.url_master == "http://mocked/master.m3u8"
 
 
 class EventedWorkerHLSStreamReader(HLSStreamReader):

--- a/tests/stream/test_stream_json.py
+++ b/tests/stream/test_stream_json.py
@@ -10,7 +10,7 @@ from requests.utils import DEFAULT_ACCEPT_ENCODING  # type: ignore[attr-defined]
 
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.file import FileStream
-from streamlink.stream.hls import HLSStream
+from streamlink.stream.hls import M3U8, HLSStream
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.stream import Stream
 
@@ -98,7 +98,9 @@ def test_hls_stream(session, common_args, expected_headers):
 
 
 def test_hls_stream_master(session, common_args, expected_headers):
-    stream = HLSStream(session, "http://host/stream.m3u8?foo=bar", "http://host/master.m3u8?foo=bar", **common_args)
+    multivariant = M3U8("http://host/master.m3u8?foo=bar")
+    multivariant.is_master = True
+    stream = HLSStream(session, "http://host/stream.m3u8?foo=bar", multivariant=multivariant, **common_args)
     assert stream.__json__() == {
         "type": "hls",
         "url": "http://host/stream.m3u8?foo=bar&sessionqueryparamkey=sessionqueryparamval&queryparamkey=queryparamval",

--- a/tests/stream/test_stream_to_url.py
+++ b/tests/stream/test_stream_to_url.py
@@ -4,7 +4,7 @@ import pytest
 
 from streamlink.stream.dash import DASHStream
 from streamlink.stream.file import FileStream
-from streamlink.stream.hls import HLSStream
+from streamlink.stream.hls import M3U8, HLSStream
 from streamlink.stream.http import HTTPStream
 from streamlink.stream.stream import Stream
 
@@ -62,7 +62,9 @@ def test_hls_stream(session, common_args):
 
 
 def test_hls_stream_master(session, common_args):
-    stream = HLSStream(session, "http://host/stream.m3u8?foo=bar", "http://host/master.m3u8?foo=bar", **common_args)
+    multivariant = M3U8("http://host/master.m3u8?foo=bar")
+    multivariant.is_master = True
+    stream = HLSStream(session, "http://host/stream.m3u8?foo=bar", multivariant=multivariant, **common_args)
     assert stream.to_url() == "http://host/stream.m3u8?foo=bar&queryparamkey=queryparamval"
     assert stream.to_manifest_url() == "http://host/master.m3u8?foo=bar&queryparamkey=queryparamval"
 


### PR DESCRIPTION
This is mainly just used by internal code, but since it's part of the class constructors which are public interfaces, it needed a deprecation phase.

It is very unlikely that third-party plugin implementors will ever create `HLSStream`/`MuxedHLSStream` instances with a reference to a multivariant/master playlist themselves. This is done automatically via the `HLSStream.parse_variant_playlist()` classmethod.

----

Just for additional clarification, this is not about the "multivariant" and "master" terminology. The "master" name is still part of RFC 8216, and it's also still used by the `M3U8` implementation (`is_master`). The `multivariant` argument and attribute names were added with respect of the (still-in-draft-phase) HLS revisions, where this was renamed.

The switch from a simple multivariant playlist URL reference to the `M3U8` instance was done in 7cb0ebe96f659f3eeb7b36e58eb545cd2cb9894c.