### PR TITLE
ci.github: pycryptodome wheels on cp314-cp314t

### DIFF
--- a/.github/workflows/install-temp-dependencies.sh
+++ b/.github/workflows/install-temp-dependencies.sh
@@ -19,6 +19,12 @@ elif [[ "${PLATFORM}" == win_amd64 ]]; then
     DEPS+=()
 fi
 
+if [[ "${PY}" == *t ]]; then
+    DEPS+=(
+        'pycryptodome-20251017-1/pycryptodome-3.23.0'
+    )
+fi
+
 deps=()
 for dep in "${DEPS[@]}"; do
     deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")


### PR DESCRIPTION
The latest pycryptodome release doesn't have pre-built `cp314-cp314t` wheels available, so let's add custom built ones to not unnecessarily slow down the CI test runners.
https://pypi.org/project/pycryptodome/3.23.0/#files

The previous PR took 5 minutes to build the missing wheel on Windows (in addition to 3 mins of installing 3.14t):
https://github.com/streamlink/streamlink/actions/runs/18600027152/job/53035968219?pr=6692#step:6:1