### PR TITLE
stream.hls: refactor playlist reload

### DIFF
--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -79,11 +79,10 @@ class KickHLSStreamWorker(HLSStreamWorker):
     writer: KickHLSStreamWriter
     stream: KickHLSStream
 
-    def _playlist_reload_time(self, playlist: KickM3U8):  # type: ignore[override]
-        if self.stream.low_latency and playlist.segments:
-            return playlist.segments[-1].duration
-
-        return super()._playlist_reload_time(playlist)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.stream.low_latency:
+            self.reload_time = "segment"
 
     def process_segments(self, playlist: KickM3U8):  # type: ignore[override]
         # ignore prefetch segments if not LL streaming

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -173,12 +173,8 @@ class TwitchHLSStreamWorker(HLSStreamWorker):
         self.had_content: bool = False
         self.logged_ads: deque[str] = deque(maxlen=10)
         super().__init__(reader, *args, **kwargs)
-
-    def _playlist_reload_time(self, playlist: TwitchM3U8):  # type: ignore[override]
-        if self.stream.low_latency and playlist.segments:
-            return playlist.segments[-1].duration
-
-        return super()._playlist_reload_time(playlist)
+        if self.stream.low_latency:
+            self.reload_time = "segment"
 
     def process_segments(self, playlist: TwitchM3U8):  # type: ignore[override]
         # ignore prefetch segments if not LL streaming

--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -16,7 +16,7 @@ from tests.testutils.handshake import Handshake
 TIMEOUT_AWAIT_READ = 5
 TIMEOUT_AWAIT_READ_ONCE = 5
 TIMEOUT_AWAIT_WRITE = 60  # https://github.com/streamlink/streamlink/issues/3868
-TIMEOUT_AWAIT_PLAYLIST_RELOAD = 5
+TIMEOUT_AWAIT_RELOAD = 5
 TIMEOUT_AWAIT_PLAYLIST_WAIT = 5
 TIMEOUT_AWAIT_CLOSE = 5
 
@@ -100,9 +100,9 @@ class EventedHLSStreamWorker(_HLSStreamWorker):
         self.handshake_wait = Handshake()
         self.time_wait = None
 
-    def reload_playlist(self):
+    def reload(self):
         with self.handshake_reload():
-            return super().reload_playlist()
+            return super().reload()
 
     def wait(self, time):
         self.time_wait = time
@@ -251,7 +251,7 @@ class TestMixinStreamHLS(unittest.TestCase):
         thread.join(timeout)
         assert self.thread.reader.closed, "Stream reader is closed"
 
-    def await_playlist_reload(self, timeout=TIMEOUT_AWAIT_PLAYLIST_RELOAD) -> None:
+    def await_reload(self, timeout=TIMEOUT_AWAIT_RELOAD) -> None:
         worker: EventedHLSStreamWorker = self.thread.reader.worker  # type: ignore[assignment]
         assert worker.is_alive()
         assert worker.handshake_reload.step(timeout)

--- a/tests/plugins/test_kick.py
+++ b/tests/plugins/test_kick.py
@@ -108,6 +108,7 @@ class TestKickHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert all(self.called(s) for s in segments.values() if s.num <= 7), "Ignores prefetch segments"
         assert not any(self.called(s) for s in segments.values() if s.num > 7), "Ignores prefetch segments"
         assert mock_log.info.mock_calls == []
+        assert self.thread.reader.worker._reload_time == 3.0
 
     @patch("streamlink.plugins.kick.log")
     def test_hls_low_latency_no_prefetch(self, mock_log):
@@ -138,4 +139,4 @@ class TestKickHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
         self.await_write(4)
         self.await_read(read_all=True)
-        assert self.thread.reader.worker.playlist_reload_time == pytest.approx(23 / 3)
+        assert self.thread.reader.worker._reload_time == pytest.approx(23 / 3)

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -412,6 +412,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
         assert mock_log.info.mock_calls == [
             call("Will skip ad segments"),
         ]
+        assert self.thread.reader.worker._reload_time == 3.0
 
     @patch("streamlink.plugins.twitch.log")
     def test_hls_low_latency_no_prefetch(self, mock_log):
@@ -534,7 +535,7 @@ class TestTwitchHLSStream(TestMixinStreamHLS, unittest.TestCase):
 
         self.await_write(4)
         self.await_read(read_all=True)
-        assert self.thread.reader.worker.playlist_reload_time == pytest.approx(23 / 3)
+        assert self.thread.reader.worker._reload_time == pytest.approx(23 / 3)
 
     @patch("streamlink.stream.hls.hls.log")
     def test_hls_prefetch_after_discontinuity(self, mock_log):


### PR DESCRIPTION
- Refactor `HLSStreamWorker`:
  - Rename `reload_playlist()` to `reload()`
  - Rename `_playlist_reload_time()` to `_get_reload_time()`
  - Rename `playlist_reload_last` to `_reload_last`
  - Rename `playlist_reload_time` to `_reload_time`
  - Rename `playlist_reload_time_override` to `reload_time`
  - Rename `playlist_reload_retries` to `reload_attempts`
- `TestHlsPlaylistReloadTime`:
  - Rename to `TestHlsReloadTime`
  - Remove prefixes of various test method names
- `TestMixinStreamHLS`:
  - Rename `await_playlist_reload()` to `await_reload()`
- Kick and Twitch plugins:
  - Remove `_playlist_reload_time()` override and instead set the `reload_time` attr value to `segment` in the worker's constructor override if low-latency streaming
  - Test reload time for non-low-latency streams

----

This is based on the (current) first commit of #6347. That PR also moves lots of code into an intermediate abstract base class for playlist polling. Since I'm still not sure about this (I'll also have to look at the changes in detail again as I wrote this last year), I've decided to split this into two PRs.

This PR here therefore simply renames some class attributes and methods, and it updates the Kick and Twitch plugins in regards to playlist reloading times when low-latency streaming. The intention is to clean up some "public" and "non-public" attributes, and also prepare for the code refactoring of the other PR.

Theoretically, none of the stream implementations apart from their main class constructors and documented classmethods are public interfaces, but since I don't want to potentially and unnecessarily break any (third-party) plugins, a change like this is ideal for the upcoming 8.0.0 release when we drop py39.

Plugins like Kick and Twitch for example need to override stuff for low-latency streaming, so it doesn't make sense doing this with private methods. The updated solution is much cleaner by setting `self.reload_time = "segment"` instead of overriding `_get_reload_time()` and duplicating/forcing the "segment" logic from the base class.

As said, I'll need to have another look at this and then make a decision. I don't know though when I will have the time for this because of my current health issues and the resulting appointments at the hospital in the coming days.