### PR TITLE
session.http: turn valid req args into a hashmap

### DIFF
--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -86,7 +86,7 @@ urllib3.util.url._PERCENT_RE = urllib3.util.url.PERCENT_RE = Urllib3UtilUrlPerce
 
 
 # requests.Request.__init__ keywords, except for "hooks"
-_VALID_REQUEST_ARGS = "method", "url", "headers", "files", "data", "params", "auth", "cookies", "json"
+_VALID_REQUEST_ARGS = {"method", "url", "headers", "files", "data", "params", "auth", "cookies", "json"}
 
 
 class HTTPSession(Session):


### PR DESCRIPTION
Valid HTTP request args are checked lots of times during runtime, so this should be a set/hashmap instead of a tuple/sequence