### PR TITLE
docs: replace debian bookworm with trixie

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -177,10 +177,10 @@ Linux and BSD
       - .. code-block:: bash
 
             # If you don't have Debian backports already (see link below):
-            echo "deb http://deb.debian.org/debian bookworm-backports main" | sudo tee "/etc/apt/sources.list.d/streamlink.list"
+            echo "deb http://deb.debian.org/debian trixie-backports main" | sudo tee "/etc/apt/sources.list.d/streamlink.list"
 
             sudo apt update
-            sudo apt -t bookworm-backports install streamlink
+            sudo apt -t trixie-backports install streamlink
 
         `Installing Debian backported packages`_
     * - :octicon:`package-dependents` `Fedora`_
@@ -231,7 +231,7 @@ Linux and BSD
 .. _Arch Linux: https://archlinux.org/packages/extra/any/streamlink/
 .. _Arch Linux (AUR, git): https://aur.archlinux.org/packages/streamlink-git/
 .. _Debian (sid, testing): https://packages.debian.org/sid/streamlink
-.. _Debian (stable): https://packages.debian.org/bookworm-backports/streamlink
+.. _Debian (stable): https://packages.debian.org/trixie-backports/streamlink
 .. _Fedora: https://src.fedoraproject.org/rpms/python-streamlink
 .. _FreeBSD (pkg): https://ports.freebsd.org/cgi/ports.cgi?query=streamlink&stype=name
 .. _FreeBSD (ports): https://www.freshports.org/multimedia/streamlink


### PR DESCRIPTION
- https://www.debian.org/News/2025/20250809
- https://packages.debian.org/trixie-backports/streamlink