### PR TITLE
stream.file: switch to pathlib

### DIFF
--- a/src/streamlink/stream/file.py
+++ b/src/streamlink/stream/file.py
@@ -2,24 +2,40 @@
 Stream wrapper around a file
 """
 
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 from streamlink.stream.stream import Stream
+
+
+if TYPE_CHECKING:
+    from io import BytesIO
 
 
 class FileStream(Stream):
     __shortname__ = "file"
 
-    def __init__(self, session, path=None, fileobj=None):
+    path: Path | None
+    fileobj: BytesIO | None
+
+    def __init__(self, session, path: Path | str | None = None, fileobj: BytesIO | None = None):
         super().__init__(session)
-        self.path = path
-        self.fileobj = fileobj
-        if not self.path and not self.fileobj:
+        if path:
+            self.path = Path(path)
+            self.fileobj = None
+        elif fileobj:
+            self.path = None
+            self.fileobj = fileobj
+        else:
             raise ValueError("path or fileobj must be set")
 
     def __json__(self):  # noqa: PLW3201
         json = super().__json__()
 
         if self.path:
-            json["path"] = self.path
+            json["path"] = str(self.path)
 
         return json
 
@@ -27,7 +43,10 @@ class FileStream(Stream):
         if self.path is None:
             return super().to_url()
 
-        return self.path
+        return str(self.path)
 
     def open(self):
-        return self.fileobj or open(self.path, "rb")  # noqa: PTH123
+        if self.fileobj:
+            return self.fileobj
+        elif self.path:  # pragma: no branch
+            return self.path.open("rb")

--- a/tests/stream/test_file.py
+++ b/tests/stream/test_file.py
@@ -14,17 +14,21 @@ if TYPE_CHECKING:
 
 
 class TestFileStream:
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def mock_open(self, monkeypatch: pytest.MonkeyPatch) -> Mock:
         mock_open = Mock(return_value=BytesIO(b"foo"))
-        monkeypatch.setattr("builtins.open", mock_open)
+        monkeypatch.setattr("pathlib.Path.open", mock_open)
 
         return mock_open
+
+    def test_no_path_no_fileobj(self, session: Streamlink):
+        with pytest.raises(ValueError, match=r"^path or fileobj must be set$"):
+            FileStream(session)
 
     def test_open_path(self, session: Streamlink, mock_open: Mock):
         stream = FileStream(session, path="/test/path")
         streamio = stream.open()
-        assert mock_open.call_args_list == [call("/test/path", "rb")]
+        assert mock_open.call_args_list == [call("rb")]
         assert streamio.read() == b"foo"
 
         streamio.close()

--- a/tests/stream/test_stream_json.py
+++ b/tests/stream/test_stream_json.py
@@ -62,11 +62,18 @@ def test_base_stream(session):
     assert stream.json == """{"type": "stream"}"""
 
 
-def test_file_stream_path(session):
-    stream = FileStream(session, "/path/to/file")
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/path/to/file", id="POSIX", marks=pytest.mark.posix_only),
+        pytest.param("C:\\path\\to\\file", id="Windows", marks=pytest.mark.windows_only),
+    ],
+)
+def test_file_stream_path(session: Streamlink, path: str):
+    stream = FileStream(session, path)
     assert stream.__json__() == {
         "type": "file",
-        "path": "/path/to/file",
+        "path": path,
     }
 
 

--- a/tests/stream/test_stream_to_url.py
+++ b/tests/stream/test_stream_to_url.py
@@ -37,9 +37,16 @@ def test_file_stream_handle(session):
     assert str(cm.value) == "<FileStream [file]> cannot be translated to a manifest URL"
 
 
-def test_file_stream_path(session):
-    stream = FileStream(session, "/path/to/file")
-    assert stream.to_url() == "/path/to/file"
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/path/to/file", id="POSIX", marks=pytest.mark.posix_only),
+        pytest.param("C:\\path\\to\\file", id="Windows", marks=pytest.mark.windows_only),
+    ],
+)
+def test_file_stream_path(session, path):
+    stream = FileStream(session, path)
+    assert stream.to_url() == path
     with pytest.raises(TypeError) as cm:
         stream.to_manifest_url()
     assert str(cm.value) == "<FileStream [file]> cannot be translated to a manifest URL"


### PR DESCRIPTION
Fix the test errors on cp314/cp314t when using `coverage==7.11.1` by avoiding the monkeypatching of `builtins.open`.

I've tried to reproduce the error and report the issue upstream, but couldn't figure it out, so let's just fix the nonsense monkeypatching of `builtins.open` by switching to `pathlib.Path.open`.

----

`FileStream` was added in 4176c99db241ff6fa46ec9a6a0f30fda28a183be (#609), but hasn't been used by any other plugin since then. The plugin it was added for has been removed in 2018 (a6f094e5b96191e3bc959213008e4e2d1213f31d). The goal apparently was to write subtitle data to a temporary file for the `MuxedStream` and then reading from it using the same `Stream` interfaces.