### PR TITLE
plugins.twitch: new access_token GQL query

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -370,7 +370,7 @@ class TwitchAPI:
     def metadata_video(self, video_id):
         query = self._gql_persisted_query(
             "VideoMetadata",
-            "cb3b1eb2f2d2b2f65b8389ba446ec521d76c3aa44f5424a1b1d235fe21eb4806",
+            "45111672eea2e507f8ba44d101a61862f9c56b11dee09a15634cb75cb9b9084d",
             channelLogin="",  # parameter can be empty
             videoID=video_id,
         )
@@ -406,14 +406,14 @@ class TwitchAPI:
         queries = [
             self._gql_persisted_query(
                 "ChannelShell",
-                "c3ea5a669ec074a58df5c11ce3c27093fa38534c94286dc14b68a25d5adcbf55",
+                "fea4573a7bf2644f5b3f2cbbdcbee0d17312e48d2e55f080589d053aad353f11",
                 login=channel,
-                lcpVideosEnabled=False,
             ),
             self._gql_persisted_query(
                 "StreamMetadata",
-                "059c4653b788f5bdb2f5a2d2a24b0ddc3831a15079001a3d927556a96fb0517f",
+                "b57f9b910f8cd1a4659d894fe7550ccc81ec9052c01e438b290fd66a040b9b93",
                 channelLogin=channel,
+                includeIsDJ=True,
             ),
         ]
 

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -1183,12 +1183,11 @@ class TestTwitchMetadata:
                 "extensions": {
                     "persistedQuery": {
                         "version": 1,
-                        "sha256Hash": "c3ea5a669ec074a58df5c11ce3c27093fa38534c94286dc14b68a25d5adcbf55",
+                        "sha256Hash": "fea4573a7bf2644f5b3f2cbbdcbee0d17312e48d2e55f080589d053aad353f11",
                     },
                 },
                 "variables": {
                     "login": "foo",
-                    "lcpVideosEnabled": False,
                 },
             },
             {
@@ -1196,11 +1195,12 @@ class TestTwitchMetadata:
                 "extensions": {
                     "persistedQuery": {
                         "version": 1,
-                        "sha256Hash": "059c4653b788f5bdb2f5a2d2a24b0ddc3831a15079001a3d927556a96fb0517f",
+                        "sha256Hash": "b57f9b910f8cd1a4659d894fe7550ccc81ec9052c01e438b290fd66a040b9b93",
                     },
                 },
                 "variables": {
                     "channelLogin": "foo",
+                    "includeIsDJ": True,
                 },
             },
         ]
@@ -1219,7 +1219,7 @@ class TestTwitchMetadata:
             "extensions": {
                 "persistedQuery": {
                     "version": 1,
-                    "sha256Hash": "cb3b1eb2f2d2b2f65b8389ba446ec521d76c3aa44f5424a1b1d235fe21eb4806",
+                    "sha256Hash": "45111672eea2e507f8ba44d101a61862f9c56b11dee09a15634cb75cb9b9084d",
                 },
             },
             "variables": {


### PR DESCRIPTION
Fixes #6719 

Twitch has changed/replaced their persisted GQL API query for getting the streaming access token. The new one also expects a new parameter, `platform`, which can be overridden via `--twitch-access-token-param`, just like the `playerType` one (e.g. "frontpage" instead of the default "embed", which sometimes prevents preroll ads).

Live, VOD and clips seem to be working:

```
$ ./script/test-plugin-urls.py twitch -m -r CHANNELNAME shroud
:: https://clips.twitch.tv/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://player.twitch.tv/?parent=twitch.tv&channel=shroud
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://player.twitch.tv/?parent=twitch.tv&video=1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://player.twitch.tv/?parent=twitch.tv&video=1963401646&t=1h23m45s
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://twitch.tv/papaplatte/clip/SmellyDeadMomBloodTrail-WWr5gMxd0pe0BAge
::  360p30, 480p30, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/clip/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/dota2ti/v/1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/dota2ti/video/1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/lirik/clip/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/shroud
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/shroud/
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/shroud/?
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/shroud?
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/videos/1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
:: https://www.twitch.tv/videos/1963401646?t=1h23m45s
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': None, 'author': None, 'category': None, 'title': None}
```

Considering the timing of this change with breaking changes already merged into master and the significance of the Twitch plugin, this probably means that the 8.0.0 release needs to be done sooner. I don't expect many users installing pre-release builds or sideloading the updated plugin. Annoying...