### PR TITLE
stream.hls: warn on playlist_sequence access

### DIFF
--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import re
 import struct
+import warnings
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 from urllib.parse import urlparse
@@ -10,7 +11,7 @@ from urllib.parse import urlparse
 from requests import Response
 from requests.exceptions import ChunkedEncodingError, ConnectionError, ContentDecodingError, InvalidSchema  # noqa: A004
 
-from streamlink.exceptions import StreamError
+from streamlink.exceptions import StreamError, StreamlinkDeprecationWarning
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, MuxedStream
 from streamlink.stream.filtered import FilteredStream
 from streamlink.stream.hls.m3u8 import M3U8Parser, parse_m3u8
@@ -337,6 +338,23 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             self.reload_time = 0.0
         self._reload_time: float = self._RELOAD_TIME_DEFAULT
         self._reload_last: datetime = now()
+
+    def _warn_playlist_sequence(self):
+        warnings.warn(
+            f"{self.__class__.__name__}.playlist_sequence has been moved to SegmentedStreamWorker.sequence",
+            StreamlinkDeprecationWarning,
+            stacklevel=3,
+        )
+
+    @property
+    def playlist_sequence(self):
+        self._warn_playlist_sequence()
+        return self.sequence
+
+    @playlist_sequence.setter
+    def playlist_sequence(self, value):
+        self._warn_playlist_sequence()
+        self.sequence = value
 
     def _fetch_playlist(self) -> Response:
         res = self.session.http.get(

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -642,6 +642,44 @@ class TestHLSStreamWorkerOptions:
         assert [(record.category, str(record.message)) for record in recwarn.list] == warning
 
 
+class TestHLSStreamWorkerPlaylistSequenceWarning:
+    warns = pytest.mark.parametrize(
+        "_assert_warning",
+        [
+            pytest.param([
+                (
+                    StreamlinkDeprecationWarning,
+                    "HLSStreamWorker.playlist_sequence has been moved to SegmentedStreamWorker.sequence",
+                    __file__,
+                ),
+            ]),
+        ],
+        indirect=["_assert_warning"],
+    )
+
+    @pytest.fixture()
+    def reader(self, session: Streamlink):
+        stream = HLSStream(session, "")
+        return HLSStreamReader(stream)
+
+    @pytest.fixture(autouse=True)
+    def _assert_warning(self, request: pytest.FixtureRequest, recwarn: pytest.WarningsRecorder):
+        warnings = getattr(request, "param", [])
+        yield
+        assert [(record.category, str(record.message), record.filename) for record in recwarn.list] == warnings
+
+    def test_getter(self, reader: HLSStreamReader):
+        assert reader.worker.sequence == -1
+
+    @warns
+    def test_warns_getter(self, reader: HLSStreamReader):
+        assert reader.worker.playlist_sequence == -1
+
+    @warns
+    def test_warns_setter(self, reader: HLSStreamReader):
+        reader.worker.playlist_sequence = 0
+
+
 @patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))
 class TestHLSStreamByterange(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = EventedWriterHLSStream


### PR DESCRIPTION
`HLSStreamWorker.playlist_sequence` was moved to `SegmentedStreamWorker.sequence` in 46565ca3.

Add backwards compatibility with warning messages, in case third-party plugins override *private* HLSStream interfaces like the worker.
