### PR TITLE
tests: only load pytest_cov plugin in CI runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         run: |
           export PYTHON_GIL=$(python -c 'import sysconfig;print(1 - sysconfig.get_config_var("Py_GIL_DISABLED"))')
-          pytest --trace-config -r a --cov --cov-branch --cov-report=xml --durations 10
+          pytest --trace-config -r a -p pytest_cov --cov --cov-branch --cov-report=xml --durations 10
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ method = { module = "build_backend.onbuild", value = "onbuild" }
 minversion = "8.4.0"
 addopts = """
 --disable-plugin-autoload
--p pytest_cov
 -p trio
 -p requests_mock
 """


### PR DESCRIPTION
Remove `pytest_cov` from the explicit list of pytest plugins in the pytest config (pyproject.toml). Otherwise, locally run tests unnecessarily require `pytest_cov`. This negatively affects packagers of Streamlink, who now require pytest-cov as a make dependency.

This was an unintended side-effect of d3ea4f2d.