### PR TITLE
Add permissive CORS header to http stream

### DIFF
--- a/src/streamlink_cli/output/http.py
+++ b/src/streamlink_cli/output/http.py
@@ -91,6 +91,7 @@ class HTTPOutput(Output):
             conn.send(b"HTTP/1.1 200 OK\r\n")
             conn.send(b"Server: Streamlink\r\n")
             conn.send(b"Content-Type: video/unknown\r\n")
+            conn.send(b"Access-Control-Allow-Origin: *\r\n")
             conn.send(b"\r\n")
         except OSError as err:
             raise OSError("Failed to write data to socket") from err


### PR DESCRIPTION
I am trying to build an app on top of streamlink which uses a javascript library to stream onto a webpage with some context-specific graphics and controls. Currently, it doesn't work because of CORS! This fixes that.