### PR TITLE
stream.hls: refactor wait_and_reload()

### DIFF
--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -1294,8 +1294,8 @@ class TestHlsPlaylistParseErrors(TestMixinStreamHLS, unittest.TestCase):
         self.close()
         self.await_close()
         assert mock_log.warning.mock_calls == [
-            call("Failed to reload playlist: Missing #EXTM3U header"),
-            call("Failed to reload playlist: Missing #EXTM3U header"),
+            call("Reloading failed: Missing #EXTM3U header"),
+            call("Reloading failed: Missing #EXTM3U header"),
         ]
 
     @patch("streamlink.stream.hls.hls.parse_m3u8", Mock(return_value=FakePlaylist(is_master=True)))


### PR DESCRIPTION
Tiny code refactor in preparation for future changes which aren't ready yet. This merely moves code and changes an error message when reloading the HLS playlist failed.

Once the other changes are ready - not sure when - this `wait_and_reload()` code will be moved to the base class (in a more abstract way), so it can be shared with the DASH implementation. Hence the error message change now.

edit:
To quicky explain what these other changes are (while the CI tests are running), I'm talking about a rewrite of the M3U8 parser and how HLSSegments are queued up. This will also finally change how init segments (segment maps) work in the HLS implementation. The goal is to bring HLS and DASH a little bit closer together.