### PR TITLE
plugins.twitch: fix clips GQL persisted query

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -551,8 +551,9 @@ class TwitchAPI:
     def clips(self, clipname):
         query = self._gql_persisted_query(
             "VideoAccessToken_Clip",
-            "36b89d2507fce29e5ca551df756d27c1cfe079e2609642b4390aa4c35796eb11",
+            "993d9a5131f15a37bd16f32342c44ed1e0b1a9b968c6afdb662d2cddd595f6c5",
             slug=clipname,
+            platform="web",
         )
 
         return self.call(


### PR DESCRIPTION
Resolves #6743 

```
$ streamlink --no-config -l trace -o /dev/null https://www.twitch.tv/plaqueboymax/clip/ZanySweetRadicchioFUNgineer-bdO4uLkV-u_G6a78 best
[22:52:27.903772][MainThread][cli][debug] OS:         Linux-6.17.10-1-git-x86_64-with-glibc2.42
[22:52:27.903952][MainThread][cli][debug] Python:     3.14.2
[22:52:27.904039][MainThread][cli][debug] OpenSSL:    OpenSSL 3.6.0 1 Oct 2025
[22:52:27.904086][MainThread][cli][debug] Streamlink: 8.0.0+19.ge81e8d44
[22:52:27.904130][MainThread][cli][debug] Dependencies:
[22:52:27.905307][MainThread][cli][debug]  certifi: 2025.11.12
[22:52:27.905961][MainThread][cli][debug]  isodate: 0.7.2
[22:52:27.906333][MainThread][cli][debug]  lxml: 6.0.2
[22:52:27.906817][MainThread][cli][debug]  pycountry: 24.6.1
[22:52:27.907142][MainThread][cli][debug]  pycryptodome: 3.23.0
[22:52:27.907546][MainThread][cli][debug]  PySocks: 1.7.1
[22:52:27.907939][MainThread][cli][debug]  requests: 2.32.5
[22:52:27.908339][MainThread][cli][debug]  trio: 0.32.0
[22:52:27.908671][MainThread][cli][debug]  trio-websocket: 0.12.2
[22:52:27.909046][MainThread][cli][debug]  urllib3: 2.6.1
[22:52:27.909465][MainThread][cli][debug]  websocket-client: 1.9.0
[22:52:27.909564][MainThread][cli][debug] Arguments:
[22:52:27.909614][MainThread][cli][debug]  url=https://www.twitch.tv/plaqueboymax/clip/ZanySweetRadicchioFUNgineer-bdO4uLkV-u_G6a78
[22:52:27.909661][MainThread][cli][debug]  stream=['best']
[22:52:27.909711][MainThread][cli][debug]  --no-config=True
[22:52:27.909757][MainThread][cli][debug]  --loglevel=trace
[22:52:27.909815][MainThread][cli][debug]  --output=/dev/null
[22:52:27.910078][MainThread][cli][info] Found matching plugin twitch for URL https://www.twitch.tv/plaqueboymax/clip/ZanySweetRadicchioFUNgineer-bdO4uLkV-u_G6a78
[22:52:27.910226][MainThread][cache][trace] Loading cache file: /home/basti/.cache/streamlink/plugin-cache.json
[22:52:28.204660][MainThread][cli][info] Available streams: 360p30 (worst), 480p30, 720p60, 1080p60 (best)
[22:52:28.204771][MainThread][cli][info] Opening stream: 1080p60 (http)
[22:52:28.204905][MainThread][cli][info] Writing output to
/dev/null
[22:52:28.204957][MainThread][cli][debug] Checking file output
[22:52:28.313268][MainThread][cli][debug] Pre-buffering 8192 bytes
[22:52:28.313435][MainThread][cli][debug] Writing stream to output
[22:52:28.503574][MainThread][cli][info] Stream ended
[22:52:28.503669][MainThread][cli][info] Closing currently open stream...
[download] Written 6.08 MiB to /dev/null (0s)
```

```
$ ./script/test-plugin-urls.py twitch -m -r CHANNELNAME lirik
:: https://clips.twitch.tv/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': '1230765715', 'author': 'LIRIK', 'category': 'Pax Dei', 'title': 'Lirik loves Pax Dei'}
:: https://player.twitch.tv/?parent=twitch.tv&channel=lirik
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '316320157920', 'author': 'LIRIK', 'category': 'Cyberpunk 2077', 'title': 'DLC slightly modded'}
:: https://player.twitch.tv/?parent=twitch.tv&video=1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://player.twitch.tv/?parent=twitch.tv&video=1963401646&t=1h23m45s
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://twitch.tv/papaplatte/clip/SmellyDeadMomBloodTrail-WWr5gMxd0pe0BAge
::  360p30, 480p30, 1080p60, worst, best
::   {'id': '2105975528', 'author': 'Papaplatte', 'category': 'GeoGuessr', 'title': 'fan moment'}
:: https://www.twitch.tv/clip/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': '1230765715', 'author': 'LIRIK', 'category': 'Pax Dei', 'title': 'Lirik loves Pax Dei'}
:: https://www.twitch.tv/dota2ti/v/1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://www.twitch.tv/dota2ti/video/1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://www.twitch.tv/lirik
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '316320157920', 'author': 'LIRIK', 'category': 'Cyberpunk 2077', 'title': 'DLC slightly modded'}
:: https://www.twitch.tv/lirik/
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '316320157920', 'author': 'LIRIK', 'category': 'Cyberpunk 2077', 'title': 'DLC slightly modded'}
:: https://www.twitch.tv/lirik/?
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '316320157920', 'author': 'LIRIK', 'category': 'Cyberpunk 2077', 'title': 'DLC slightly modded'}
:: https://www.twitch.tv/lirik/clip/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': '1230765715', 'author': 'LIRIK', 'category': 'Pax Dei', 'title': 'Lirik loves Pax Dei'}
:: https://www.twitch.tv/lirik?
::  audio_only, 160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '316320157920', 'author': 'LIRIK', 'category': 'Cyberpunk 2077', 'title': 'DLC slightly modded'}
:: https://www.twitch.tv/videos/1963401646
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://www.twitch.tv/videos/1963401646?t=1h23m45s
::  audio, 160p, 360p, 480p, 720p, 720p60, 1080p60, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
```