### PR TITLE
plugins.soop: fix return_type for lg_cdn

### DIFF
--- a/src/streamlink/plugins/soop.py
+++ b/src/streamlink/plugins/soop.py
@@ -95,6 +95,7 @@ class Soop(Plugin):
 
     CDN_TYPE_MAPPING = {
         "gs_cdn": "gs_cdn_pc_web",
+        "lg_cdn": "lg_cdn_pc_web",
     }
 
     CHANNEL_RESULT_OK = 1


### PR DESCRIPTION
### Summary
Soop has started returning `lg_cdn` as the CDN identifier (previously `gs_cdn`).
The plugin maps CDN identifiers to `*_pc_web` for the `return_type` parameter, so `lg_cdn` needs to be converted to `lg_cdn_pc_web` as well.

### Changes
- Map `lg_cdn` -> `lg_cdn_pc_web` in `Soop.CDN_TYPE_MAPPING`

### Reproduction
```bash
streamlink https://play.sooplive.co.kr/sirianrain/290044878
```

### Debug log (before)
```text
error: Unable to open URL: https://livestream-manager.sooplive.co.kr/broad_stream_assign.html (400 Client Error: Bad Request for url: https://livestream-manager.sooplive.co.kr/broad_stream_assign.html?return_type=lg_cdn&broad_key=290044878-common-sd-hls)
```

### Debug log (after)
```text
Available streams: 360p (worst), 540p, 720p, 1080p (best)
```