### PR TITLE
build: remove wheel from build-system.requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,6 @@ build = [
   { include-group = "dev" },
   "shtab",
   "build",
-  "wheel",
 ]
 script = [
   "inflection",

--- a/script/build-and-sign.sh
+++ b/script/build-and-sign.sh
@@ -36,7 +36,7 @@ pushd "${ROOT}"
 
 check_deps() {
     local dep
-    for dep in build wheel versioningit; do
+    for dep in build versioningit; do
         if ! python -m pip -q show "${dep}"; then
             err "Missing python package: ${dep}"
         fi


### PR DESCRIPTION
Setuptools vendors `wheel` logic:
https://setuptools.pypa.io/en/latest/history.html#v70-1-0

`wheel` doesn't belong into the `build-system.requires` list, and also not into `dependency-groups.build`.

This should've been removed ages ago...