### PR TITLE
ci.github: always run all lint steps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,12 +11,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: File permissions
+        if: always()
         run: "! grep -Ev '^644' <(git ls-files src/ tests/ | xargs stat '--format=%a %n')"
       - name: File encodings
+        if: always()
         run: "! grep -E -e 'UTF-[^8]' -e 'UTF-[^ ]+ \\(with BOM\\)' <(git ls-files src/ tests/ | xargs stat '--format=%a %n')"
       - name: Line terminators
+        if: always()
         run: "! grep 'with CRLF line terminators' <(git ls-files | file -nNf-)"
       - name: No unicode bidirectional control characters
+        if: always()
         run: "! git grep -EIn $'[\\u2066\\u2067\\u2068\\u2069\\u202A\\u202B\\u202C\\u202D\\u202E]'"
 
   style:
@@ -34,9 +38,11 @@ jobs:
           -e .
           --group lint
       - name: ruff check
+        if: always()
         run: >
           python -m ruff check .
       - name: ruff format
+        if: always()
         run: >
           python -m ruff format --diff .
 
@@ -55,6 +61,10 @@ jobs:
           -e .
           --group typing
       - name: mypy
-        run: |
+        if: always()
+        run: >
           python -m mypy --no-incremental
-          python -m mypy --no-incremental docs
+      - name: mypy docs
+        if: always()
+        run: >
+          python -m mypy --no-incremental


### PR DESCRIPTION
Consecutive steps should always run, even if the previous one on a CI job failed.