### PR TITLE
plugins.dailymotion: fix 403 HLS playlist response

### DIFF
--- a/src/streamlink/plugins/dailymotion.py
+++ b/src/streamlink/plugins/dailymotion.py
@@ -83,6 +83,11 @@ class DailyMotion(Plugin):
         self.author = media["owner"]["username"]
         self.title = media["title"]
 
+        # required for preventing 403 responses when using a French IP address
+        self.session.http.headers.update({
+            "priority": "u=1, i",
+        })
+
         for quality, streams in media["qualities"].items():
             for stream in streams:
                 if stream["type"] == "application/x-mpegURL":


### PR DESCRIPTION
Resolves #6772 

@ogmkp, @56k-modem please check and see if this PR fixes the plugin for you as well
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

```
$ streamlink -l debug -o /dev/null --stream-segmented-duration=10 --http-proxy socks5h://localhost:1920 https://www.dailymotion.com/video/x3b68jn best
[cli][debug] OS:         Linux-6.18.4-1-git-x86_64-with-glibc2.42
[cli][debug] Python:     3.14.2
[cli][debug] OpenSSL:    OpenSSL 3.6.0 1 Oct 2025
[cli][debug] Streamlink: 8.1.0+29.g3da4c8c8
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.1.4
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.0.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.5
[cli][debug]  trio: 0.32.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  urllib3: 2.6.3
[cli][debug]  websocket-client: 1.9.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.dailymotion.com/video/x3b68jn
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --output=/dev/null
[cli][debug]  --stream-segmented-duration=10.0
[cli][debug]  --http-proxy=socks5h://localhost:1920
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin dailymotion for URL https://www.dailymotion.com/video/x3b68jn
[plugins.dailymotion][debug] Found media ID: x3b68jn
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 180p (worst), 288p, 477p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Writing output to
/dev/null
[cli][debug] Checking file output
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 1768154917; Last Sequence: 1768159716
[stream.hls][debug] Start offset: 0; Duration: 10.0; Start Sequence: 1768159714; End Sequence: None
[stream.segmented][debug] Queuing HLSSegment(num=1768159714, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:00.221000Z, map=None, fileext='ts')
[stream.segmented][debug] Queuing HLSSegment(num=1768159715, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:03.221000Z, map=None, fileext='ts')
[stream.segmented][debug] Queuing HLSSegment(num=1768159716, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:06.221000Z, map=None, fileext='ts')
[stream.hls][debug] Writing segment 1768159714 to output
[stream.hls][debug] Segment 1768159714 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Writing segment 1768159715 to output
[stream.hls][debug] Segment 1768159715 complete
[stream.hls][debug] Writing segment 1768159716 to output
[stream.hls][debug] Segment 1768159716 complete
[stream.hls][debug] Reloading playlist
[stream.segmented][debug] Queuing HLSSegment(num=1768159717, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:09.221000Z, map=None, fileext='ts')
[stream.segmented][info] Stopping stream early after 10.00s
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 1768159717 to output
[stream.hls][debug] Segment 1768159717 complete
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[download] Written 11.88 MiB to /dev/null (2s @ 4.89 MiB/s)
```

```
$ streamlink -l debug -o /dev/null --stream-segmented-duration=10 --http-proxy socks5h://localhost:1920 https://www.lequipe.fr/tv/ best
[cli][debug] OS:         Linux-6.18.4-1-git-x86_64-with-glibc2.42
[cli][debug] Python:     3.14.2
[cli][debug] OpenSSL:    OpenSSL 3.6.0 1 Oct 2025
[cli][debug] Streamlink: 8.1.0+29.g3da4c8c8
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.1.4
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.0.2
[cli][debug]  pycountry: 24.6.1
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.32.5
[cli][debug]  trio: 0.32.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  urllib3: 2.6.3
[cli][debug]  websocket-client: 1.9.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.lequipe.fr/tv/
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --output=/dev/null
[cli][debug]  --stream-segmented-duration=10.0
[cli][debug]  --http-proxy=socks5h://localhost:1920
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin dailymotion for URL https://www.lequipe.fr/tv/
[plugins.dailymotion][debug] Found media ID: k5s40USR9HxnG5aCf1y
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 180p_alt (worst), 180p, 288p_alt, 288p, 477p_alt, 477p, 720p_alt, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Writing output to
/dev/null
[cli][debug] Checking file output
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 1767869824; Last Sequence: 1767874623
[stream.hls][debug] Start offset: 0; Duration: 10.0; Start Sequence: 1767874621; End Sequence: None
[stream.segmented][debug] Queuing HLSSegment(num=1767874621, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:31.785000Z, map=None, fileext='ts')
[stream.segmented][debug] Queuing HLSSegment(num=1767874622, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:34.785000Z, map=None, fileext='ts')
[stream.segmented][debug] Queuing HLSSegment(num=1767874623, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:37.785000Z, map=None, fileext='ts')
[stream.hls][debug] Writing segment 1767874621 to output
[stream.hls][debug] Segment 1767874621 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Writing segment 1767874622 to output
[stream.hls][debug] Segment 1767874622 complete
[stream.hls][debug] Writing segment 1767874623 to output
[stream.hls][debug] Segment 1767874623 complete
[stream.hls][debug] Reloading playlist
[stream.segmented][debug] Queuing HLSSegment(num=1767874624, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-01-13T11:43:40.785000Z, map=None, fileext='ts')
[stream.segmented][info] Stopping stream early after 10.00s
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 1767874624 to output
[stream.hls][debug] Segment 1767874624 complete
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[download] Written 9.00 MiB to /dev/null (2s @ 3.37 MiB/s)
```