### PR TITLE
release: 8.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## streamlink 8.1.1 (2026-01-17)
+
+- Fixed: `--stream-segmented-queue-deadline` not being applied correctly to the Streamlink session options ([#6758](https://github.com/streamlink/streamlink/pull/6758))
+- Changed: `--hls-segment-ignore-names` to not hardcode `.ts` HLS segment file name extensions ([#6747](https://github.com/streamlink/streamlink/pull/6747))
+- Updated plugins:
+  - dailymotion: fixed 403 HLS playlist responses ([#6773](https://github.com/streamlink/streamlink/pull/6773))
+  - pluto: fixed url matchers and ad detection ([#6767](https://github.com/streamlink/streamlink/pull/6767))
+  - soop: fixed CDN mapping for `ld_cdn` based regions ([#6749](https://github.com/streamlink/streamlink/pull/6749))
+- Build: removed unneeded `wheel` dependency from `build-system.requires` and the `build` dependency group ([#6754](https://github.com/streamlink/streamlink/pull/6754))
+
+[Full changelog](https://github.com/streamlink/streamlink/compare/8.1.0...8.1.1)
+
+
 ## streamlink 8.1.0 (2025-12-14)
 
 - Deprecated: `--hls-segment-queue-threshold` in favor of `--stream-segmented-queue-deadline` ([#6734](https://github.com/streamlink/streamlink/pull/6734))


### PR DESCRIPTION
Small patch release, because it's been over a month since the last release, and some of the plugin changes shouldn't linger on the master branch for that long.

Release date is set to tomorrow, but I'm not sure about that yet because of the recent YouTube plugin issues.