### PR TITLE
docs: add section about AI-assisted contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,14 @@
 <!--
-Thanks for opening a pull request!
+Thank you very much for opening a pull request!
 
-Before you continue, please make sure that you have read and understood the contribution guidelines, otherwise your changes may be rejected:
-https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink
+Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.
 
-If possible, run the tests, perform code linting and build the documentation locally on your system first to avoid unnecessary build failures:
-https://streamlink.github.io/latest/developing.html#validating-changes
-
-Also don't forget to add a meaningful description of your changes, so that the reviewing process is as simple as possible for the maintainers.
-
-Thank you very much!
+Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
 -->
+
+- [ ] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
+- [ ] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)
+
+----
+
+Replace this with your detailed pull request description.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,29 @@ Adhering to the following process is the best way to get your work included in t
 under the terms of the [BSD 2-clause license][license].
 
 
+## AI-assisted contributions
+
+We value the time of our maintainers and the quality of our codebase above all else. While AI tools can assist in development, they can also result in low-effort, subpar, or broken submissions.
+
+To maintain the integrity of the project, we enforce the following rules. Failure to comply will result in your pull request being closed immediately. Repeat or extreme offenses will lead to an organization-wide ban.
+
+1. **Mandatory disclosure**
+
+    You must disclose any level of AI assistance used in your contribution (code, documentation, etc.). This includes fully AI-generated content or refactors, AI-based code completions, as well as AI-generated or translated text within the pull request description.
+
+2. **Full comprehension**
+
+    You are the owner of your submission. You must be able to explain every line of your code upon request. If a reviewer asks about a specific logic block, data structure, or the use of a particular API, "the AI suggested it" is never an acceptable answer. If you do not understand the code you are submitting, do not submit it.
+
+3. **Functionality and intent**
+
+    Unless explicitly marked as a draft, code must be fully functional and tested. We do not accept "hallucinated" or unfinished code with the expectation that maintainers will fix or complete it.
+
+    You must test your changes before submission. For example, if adding or fixing a plugin, you must include debug log output for at least one verified input URL in the PR description.
+
+    While we don't expect "perfect" code and are always happy to provide guidance or mentorship, we only do so for genuine attempts. We will not provide assistance for code that was mindlessly generated and submitted without verification.
+
+
 ## Pull request feedback
 
 Please don't hesitate to provide feedback after a pull request was submitted which will close/resolve an issue you've opened or which you've been following. Depending on the kind of issue the pull request will solve, additional feedback from users is important. This feedback can either be a comment, a simple code review, or better, a validation of all the changes by installing and running Streamlink from the pull request's branch and [providing a full debug log][debug-log].


### PR DESCRIPTION
More and more FOSS projects have been adding rules for AI-assisted contributions, because it's become a necessity. I'm therefore adding rules for this to Streamlink now, to avoid future issues with vibe-coded PRs that are a waste of time.

I don't care if anyone submits AI-assisted code or documentation, because it'll be reviewed by a human anyway before merging, but there need to be strict rules about disclosure, the quality, functionality and intent. The most important part is that the maintainer's or reviewer's time does not get wasted by vibe-coded stuff the author doesn't understand and hasn't tested/verified.

I think the rules I've come up with cover the most important parts. Having a dedicated AGENTS.md with instructions for LLMs is counter-productive IMO, because it invites these kinds of contributions, and I doubt those will be useful.