### PR TITLE
docs: add support for Sphinx 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,10 +122,10 @@ typing = [
 ]
 docs = [
   { include-group = "dev" },
-  "sphinx >=6.0.0,<9",
-  "furo ==2025.09.25",
-  "myst-parser >=1.0.0,<5",
-  "sphinx-design >=0.5.0,<=0.6.1",
+  "sphinx >=7.0.0,<10",
+  "furo ==2025.12.19",
+  "myst-parser >=4.0.0,<6",
+  "sphinx-design >=0.6.0,<0.8",
 ]
 build = [
   { include-group = "dev" },


### PR DESCRIPTION
- bump Sphinx to >=7.0.0,<10
- bump myst-parser to >=4.0.0,<6
- bump sphinx-design to >=0.6.0,<0.8
- bump furo docs theme to ==2025.12.19

This also bumps docutils from 0.21.x to 0.22.x

----

Resolves #6748

I couldn't find any issues with the built docs after building locally...
