### PR TITLE
ci.github: fix mypy docs step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,4 +67,4 @@ jobs:
       - name: mypy docs
         if: always()
         run: >
-          python -m mypy --no-incremental docs
+          python -m mypy --python-version=3.12 --no-incremental docs


### PR DESCRIPTION
Python 3.12 is required for Sphinx 9.

The following doesn't work, as mypy doesn't allow setting `python_version` for specific module paths.

```
[[tool.mypy.overrides]]
module = "docs"
python_version = "3.12"
```

https://mypy.readthedocs.io/en/stable/config_file.html#using-a-pyproject-toml-file