### PR TITLE
ci.github: also test build/docs on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,6 @@ jobs:
 
   test_build:
     name: Test build
-    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -114,7 +113,6 @@ jobs:
 
   documentation:
     name: Test docs
-    if: github.event_name != 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
I think these `if: github.event_name != 'push'` constraints were added because of the `schedule` event, which was supposed to find issues with non-pinpointed dependencies. Streamlink and its docs should however also be built on push to master (when merging a PR), as there could always be issues if the PR branch was older than the current master HEAD, leading to build failures.