### PR TITLE
webbrowser.cdp.client: mutable response_headers

### DIFF
--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -15,7 +15,7 @@ from streamlink.webbrowser.chromium import ChromiumWebbrowser
 
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Mapping
+    from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Mapping, MutableMapping
 
     from streamlink.session import Streamlink
     from streamlink.webbrowser.cdp.connection import CDPSession
@@ -71,7 +71,7 @@ class RequestPausedHandler:
 class CMRequestProxy:
     body: str
     response_code: int
-    response_headers: Mapping[str, str] | None
+    response_headers: MutableMapping[str, str] | None
 
 
 class CDPClient:
@@ -401,7 +401,7 @@ class CDPClientSession:
         self,
         request: fetch.RequestPaused,
         response_code: int = 200,
-        response_headers: Mapping[str, str] | None = None,
+        response_headers: MutableMapping[str, str] | None = None,
     ) -> AsyncGenerator[CMRequestProxy, None]:
         """
         Async context manager wrapper around :meth:`fulfill_request()` which retrieves the response body,

--- a/tests/webbrowser/cdp/test_client.py
+++ b/tests/webbrowser/cdp/test_client.py
@@ -807,6 +807,7 @@ class TestRequestMethods:
             async with cdp_client_session.alter_request(req_paused, 404, {"a": "b", "c": "d"}) as cmproxy:
                 assert cmproxy.body == "foo"
                 assert cmproxy.response_code == 404
+                assert cmproxy.response_headers is not None
                 assert cmproxy.response_headers == {"a": "b", "c": "d"}
                 cmproxy.body = cmproxy.body.upper()
                 cmproxy.response_code -= 3


### PR DESCRIPTION
`CDPClientSession.alter_request()`'s `response_headers` argument should be a `MutableMapping` rather than just a `Mapping`, as headers are meant to be modified in the corresponding `CMRequestProxy` object.

This broke type-checking in this test, which mypy didn't catch, but ty did:
- https://github.com/streamlink/streamlink/blob/8.1.2/tests/webbrowser/cdp/test_client.py#L795-L838