### PR TITLE
plugin: move match check to url setter, fix typing

### DIFF
--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -243,7 +243,8 @@ class TestPluginMatcher:
         assert plugin.match is not None
         assert plugin.match.group(1) == "baz"
 
-        plugin.url = "http://qux"
+        with pytest.raises(PluginError, match=r"^The input URL did not match any of this plugin's matchers$"):
+            plugin.url = "http://qux"
         assert plugin.url == "http://qux"
         assert [m is not None for m in plugin.matches] == [False, False, False]
         assert plugin.matcher is None
@@ -277,7 +278,8 @@ class TestPluginMatcher:
         assert plugin.matches["foo"] is None
         assert plugin.matches["bar"] is not None
 
-        plugin.url = "http://baz"
+        with pytest.raises(PluginError, match=r"^The input URL did not match any of this plugin's matchers$"):
+            plugin.url = "http://baz"
         assert plugin.matches["foo"] is None
         assert plugin.matches["bar"] is None
 


### PR DESCRIPTION
Raise `PluginError` when the `url` attr is set and it doesn't match any of the plugin's matchers, not just once upon class initialization.

Remove `None` type from `Plugin.matcher` and `Plugin.match`: Since the input URL must always match, it is pointless to annotate these attributes as potentially being `None`. This causes lots of headaches in plugin implementations because it requires type-narrowing. Initialize them with `None`, so plugin tests without matchers don't have to call `hasattr()`.

----

This fixes 120 typing errors in Streamlink's plugins, which are not checked by mypy by default, as this requires typing annotations (unless a custom config is set). ty checks this by default because of its Unknown type.