### PR TITLE
build: add typing-extensions runtime dep on py310

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -434,8 +434,8 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
       - Used for loading the CA bundle extracted from the Mozilla Included CA Certificate List
     * - runtime
       - `exceptiongroup`_
-      - Only required when ``python_version<"3.11"`` |br|
-        Used for ``ExceptionGroup`` handling
+      - | Only required on ``python_version<"3.11"``
+        | Used for ``ExceptionGroup`` handling on older Python versions
     * - runtime
       - `isodate`_
       - Used for parsing ISO8601 strings
@@ -460,6 +460,10 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
     * - runtime
       - `trio-websocket`_
       - Used for WebSocket connections on top of the async trio framework
+    * - runtime
+      - `typing-extensions`_
+      - | Only required on ``python_version<"3.11"``
+        | Used for :pep:`681` on older Python versions
     * - runtime
       - `urllib3`_
       - Used internally by `requests`_, defined as direct dependency
@@ -500,6 +504,7 @@ Streamlink defines a `build system <pyproject.toml_>`__ according to `PEP-517`_ 
 .. _requests: https://requests.readthedocs.io/en/latest/
 .. _trio: https://trio.readthedocs.io/en/stable/
 .. _trio-websocket: https://trio-websocket.readthedocs.io/en/stable/
+.. _typing-extensions: https://typing-extensions.readthedocs.io/
 .. _urllib3: https://urllib3.readthedocs.io/en/stable/
 .. _websocket-client: https://pypi.org/project/websocket-client/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ dependencies = [
   "trio >=0.25.0,<1 ; python_version>='3.13'",
   "trio >=0.22.0,<1 ; python_version<'3.13'",
   "trio-websocket >=0.9.0,<1",
+  # typing-extensions >=4.6.0 is already a transitive runtime dependency of exceptiongroup >=1.3.0
+  "typing-extensions >=4.1.0 ; python_version<'3.11'",
   "urllib3 >=2.0.0,<3",
   "websocket-client >=1.2.1,<2",
 ]


### PR DESCRIPTION
Streamlink requires `exceptiongroup` as a runtime dependency on py310.
With `exceptiongroup ==1.3.0` (2025-05-10), this implicitly added `typing-extensions >=4.6.0` as a transitive runtime dependency:
agronholm/exceptiongroup@2a84dfd5599b

We accidentally relied on this implicit transitive runtime dependency on py310 when 8a0bd0767951 was merged in Streamlink 8.1.0 (2025-12-13).

To fix this implicit runtime dependency, add `typing-extensions >=4.1.0` on py310 due to lack of `typing.dataclass_transform` in the stdlib.
See PEP 681.

We could alternatively backport the `dataclass_transform` decorator and remove it again when support for py310 ends in October 2026, but since we already depend on `exceptiongroup` for backporting reasons, there is no need to, unless they declare `typing-extensions` as a non-runtime dependency in the meantime.