### PR TITLE
chore: remove error handling for typing imports

### DIFF
--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -30,15 +30,12 @@ if TYPE_CHECKING:
     from concurrent.futures import Future
     from datetime import datetime
 
+    from typing_extensions import Self
+
     from streamlink.buffers import RingBuffer
     from streamlink.session import Streamlink
     from streamlink.stream.hls.m3u8 import M3U8
     from streamlink.stream.hls.segment import ByteRange, HLSPlaylist, Key, Map, Media
-
-    try:
-        from typing import Self  # type: ignore[attr-defined]
-    except ImportError:
-        from typing_extensions import Self
 
 
 log = logging.getLogger(".".join(__name__.split(".")[:-1]))
@@ -738,8 +735,8 @@ class HLSStream(HTTPStream):
             raise OSError(f"Failed to parse playlist: {err}") from err
 
         stream_name: str | None
-        stream: HLSStream | MuxedHLSStream
-        streams: dict[str, HLSStream | MuxedHLSStream] = {}
+        stream: Self | MuxedHLSStream[Self]
+        streams: dict[str, Self | MuxedHLSStream[Self]] = {}
 
         for playlist in multivariant.playlists:
             if playlist.is_iframe:

--- a/src/streamlink/stream/hls/m3u8.py
+++ b/src/streamlink/stream/hls/m3u8.py
@@ -34,11 +34,6 @@ if TYPE_CHECKING:
 
     from streamlink.logger import StreamlinkLogger
 
-    try:
-        from typing import Self  # type: ignore[attr-defined]
-    except ImportError:
-        from typing_extensions import Self
-
 
 log: StreamlinkLogger = logging.getLogger(__name__)  # type: ignore[assignment]
 
@@ -119,7 +114,8 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
     __segment__: ClassVar[type[HLSSegment]] = HLSSegment
     __playlist__: ClassVar[type[HLSPlaylist]] = HLSPlaylist
 
-    _TAGS: ClassVar[Mapping[str, Callable[[Self, str], None]]]
+    # TODO: fix this (can't use Self in a ClassVar)
+    _TAGS: ClassVar[Mapping[str, Callable[[M3U8Parser, str], None]]]
 
     _extinf_re = re.compile(r"(?P<duration>\d+(\.\d+)?)(,(?P<title>.+))?")
     _attr_re = re.compile(

--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -17,13 +17,10 @@ from streamlink.webbrowser.chromium import ChromiumWebbrowser
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Awaitable, Callable, Coroutine, Mapping, MutableMapping
 
+    from typing_extensions import Self
+
     from streamlink.session import Streamlink
     from streamlink.webbrowser.cdp.connection import CDPSession
-
-    try:
-        from typing import Self  # type: ignore[attr-defined]
-    except ImportError:
-        from typing_extensions import Self
 
     TRequestHandlerCallable: TypeAlias = "Callable[[CDPClientSession, fetch.RequestPaused], Awaitable]"
 

--- a/src/streamlink/webbrowser/cdp/connection.py
+++ b/src/streamlink/webbrowser/cdp/connection.py
@@ -21,14 +21,10 @@ if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Generator, MutableMapping
 
     from trio_websocket import WebSocketConnection
+    from typing_extensions import Self
 
     from streamlink.webbrowser.cdp.devtools.target import TargetID
     from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT
-
-    try:
-        from typing import Self  # type: ignore[attr-defined]
-    except ImportError:
-        from typing_extensions import Self
 
 
 log = logging.getLogger(__name__)

--- a/src/streamlink/webbrowser/cdp/devtools/util.py
+++ b/src/streamlink/webbrowser/cdp/devtools/util.py
@@ -7,23 +7,21 @@
 
 from __future__ import annotations
 
+from abc import ABC, ABCMeta, abstractmethod
 from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
 
-    try:
-        from typing import Self  # type: ignore[attr-defined]
-    except ImportError:
-        from typing_extensions import Self
+    from typing_extensions import Self
 
 
 T_JSON_DICT: TypeAlias = dict[str, Any]
 _event_parsers: MutableMapping[str, type[CDPEvent]] = {}
 
 
-class _CDPEventMeta(type):
+class _CDPEventMetaBase(type):
     def __new__(
         cls,
         name,
@@ -31,7 +29,7 @@ class _CDPEventMeta(type):
         namespace,
         event: str | None = None,
         **kwargs,
-    ) -> _CDPEventMeta:
+    ) -> _CDPEventMetaBase:
         obj = super().__new__(cls, name, bases, namespace, **kwargs)
         if event is not None:
             _event_parsers[event] = cast("type[CDPEvent]", obj)
@@ -39,9 +37,15 @@ class _CDPEventMeta(type):
         return obj
 
 
-class CDPEvent(metaclass=_CDPEventMeta):
+class _CDPEventMeta(_CDPEventMetaBase, ABCMeta):
+    pass
+
+
+class CDPEvent(ABC, metaclass=_CDPEventMeta):
     @classmethod
-    def from_json(cls, json: T_JSON_DICT) -> Self: ...  # pragma: no cover
+    @abstractmethod
+    def from_json(cls, json: T_JSON_DICT) -> Self:  # pragma: no cover
+        raise NotImplementedError
 
 
 def parse_json_event(json: T_JSON_DICT) -> CDPEvent:

--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -24,14 +24,10 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
     from trio.testing import MockClock
+    from typing_extensions import Self
 
     from streamlink.webbrowser.cdp.connection import CDPEventListener
     from streamlink.webbrowser.cdp.devtools.util import T_JSON_DICT
-
-    try:
-        from typing import Self  # type: ignore[attr-defined]
-    except ImportError:
-        from typing_extensions import Self
 
 
 EPSILON = 0.1


### PR DESCRIPTION
Don't fall back to `typing_extensions` when importing from the `typing` module fails on older Python versions.

The reason for this is that the try-except blocks are actually not supported by type-checkers, leading to potential errors being suppressed or ignored.

Instead, always import from `typing_extensions`, which simply aliases everything supported by the stdlib.

Also fix issues caused by the import-fallback removal:
- Fix `Self` in `HLSStream.parse_variant_playlist()`
- Fix `Self` in `M3U8Parser._TAGS`
- Fix `Self` in `CDPEvent.from_json()` and turn it into an abstract method (fix generator script accordingly)