### PR TITLE
chore: minor typing fixes

### DIFF
--- a/src/streamlink/cache.py
+++ b/src/streamlink/cache.py
@@ -88,7 +88,7 @@ class Cache:
         self._cache.clear()
 
         # noinspection PyUnresolvedReferences
-        log.trace(f"Loading cache file: {self.filename}")
+        log.trace(f"Loading cache file: {self.filename}")  # type: ignore[attr-defined]
 
         try:
             with self.filename.open("r", encoding="utf-8") as fd:
@@ -121,7 +121,7 @@ class Cache:
             return
 
         # noinspection PyUnresolvedReferences
-        log.trace(f"Scheduling write to cache file: {WRITE_DEBOUNCE_TIME:.1f}s")
+        log.trace(f"Scheduling write to cache file: {WRITE_DEBOUNCE_TIME:.1f}s")  # type: ignore[attr-defined]
         self._timer = Timer(WRITE_DEBOUNCE_TIME, self._save)
         self._timer.daemon = True
         self._timer.name = "CacheSaveThread"
@@ -135,7 +135,7 @@ class Cache:
             return
 
         # noinspection PyUnresolvedReferences
-        log.trace(f"Writing to cache file: {self.filename}")
+        log.trace(f"Writing to cache file: {self.filename}")  # type: ignore[attr-defined]
 
         fd = None
         try:

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -253,7 +253,7 @@ class FFMPEGMuxer(StreamIO):
         return self
 
     def read(self, size=-1):
-        return self.process.stdout.read(size)
+        return self.process.stdout.read(size)  # type: ignore[attr-defined]
 
     def close(self):
         if self.closed:
@@ -263,7 +263,7 @@ class FFMPEGMuxer(StreamIO):
         if self.process:
             # kill ffmpeg
             self.process.kill()
-            self.process.stdout.close()
+            self.process.stdout.close()  # type: ignore[attr-defined]
 
             executor = concurrent.futures.ThreadPoolExecutor()
 
@@ -284,7 +284,7 @@ class FFMPEGMuxer(StreamIO):
             ]  # fmt: skip
             concurrent.futures.wait(futures, return_when=concurrent.futures.ALL_COMPLETED)
 
-        if self.errorlog is not sys.stderr and self.errorlog is not subprocess.DEVNULL:
+        if self.errorlog is not sys.stderr and not isinstance(self.errorlog, int):
             with suppress(OSError):
                 self.errorlog.close()
 

--- a/src/streamlink/stream/hls/m3u8.py
+++ b/src/streamlink/stream/hls/m3u8.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING, ClassVar, Generic, TypeVar
 from urllib.parse import urljoin, urlparse
 
-from isodate import ISO8601Error, parse_datetime  # type: ignore[import]
+from isodate import ISO8601Error, parse_datetime  # type: ignore[import]  # ty:ignore[unused-ignore-comment]
 from requests import Response
 
 from streamlink.logger import ALL
@@ -146,7 +146,8 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
     _res_re = re.compile(r"(\d+)x(\d+)")
 
     def __init__(self, base_uri: str | None = None):
-        self.m3u8: TM3U8_co = self.__m3u8__(base_uri)  # type: ignore[assignment]  # PEP 696 might solve this
+        # PEP 696 might solve this
+        self.m3u8: TM3U8_co = self.__m3u8__(base_uri)  # type: ignore[assignment]  # ty:ignore[unused-ignore-comment]
 
         self._expect_playlist: bool = False
         self._streaminf: dict[str, str] | None = None
@@ -172,7 +173,7 @@ class M3U8Parser(Generic[TM3U8_co, THLSSegment_co, THLSPlaylist_co], metaclass=M
         res = streaminf.get("RESOLUTION")
         resolution = None if not res else cls.parse_resolution(res)
 
-        codecs = (streaminf.get("CODECS") or "").split(",")
+        codecs = str(streaminf.get("CODECS") or "").split(",")
 
         if streaminfoclass is IFrameStreamInfo:
             return IFrameStreamInfo(


### PR DESCRIPTION
Last set of typing fixes outside of the `streamlink.plugins` package and the vendored stuff in the `streamlink.packages` package (which I don't want to touch anyway).

Plugin-wise, #6810 already fixed 120 issues. 51 still remaining for now...
```
$ ty check --output-format concise --exclude src/streamlink/packages | tail -n1
Found 54 diagnostics
```

With this commit and ignoring the plugins:
```
$ ty check --exclude src/streamlink/packages --exclude src/streamlink/plugins
All checks passed!
$ mypy
Success: no issues found in 506 source files
```

Once all plugin issues have been fixed and `ty` will have reached at least version `0.1.0`, I'm going to add it to the typing dependency group and CI runners, in addition to `mypy`. Once `ty` has matured enough, `mypy` will be removed.

----

These changes here are mainly just error suppressions.

The one issue which is annoying is that we add `TRACE` and `ALL` log levels (with respective log level methods) to our custom `StreamlinkLogger(logging.Logger)` class that's set as the default logger via `logging.setLoggerClass()` and which is then returned by `logging.getLogger(__name__)`. Trace log messages are mostly printed by plugins, which is where most of the remaining issues are coming from. Type checkers don't know that it's a StreamlinkLogger.

There are three solutions:
- Suppress all typing errors on these logger method calls
- Use a custom `getLogger` utility function which must be imported instead
- Override the typing data of the stdlib's `logging` module