### PR TITLE
utils.args: remove unneeded comparison protocols

### DIFF
--- a/src/streamlink/utils/args.py
+++ b/src/streamlink/utils/args.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
-
-
-if TYPE_CHECKING:
-    from _typeshed import SupportsDunderGE, SupportsDunderGT, SupportsDunderLE, SupportsDunderLT
+from typing import Any, Generic, TypeVar
 
 
 _BOOLEAN_TRUE = "yes", "1", "true", "on"
@@ -78,11 +74,10 @@ class num(Generic[_TNum]):
         lt: _TNum | None = None,
     ):
         self.numtype: type[_TNum] = numtype
-        # ge/gt/le/lt use their respective reflection type, as they are the RHS argument of the comparison
-        self.ge: SupportsDunderLE[_TNum] | None = ge
-        self.gt: SupportsDunderLT[_TNum] | None = gt
-        self.le: SupportsDunderGE[_TNum] | None = le
-        self.lt: SupportsDunderGT[_TNum] | None = lt
+        self.ge: _TNum | None = ge
+        self.gt: _TNum | None = gt
+        self.le: _TNum | None = le
+        self.lt: _TNum | None = lt
         self.__name__ = numtype.__name__
 
     def __call__(self, value: Any) -> _TNum:


### PR DESCRIPTION
ty 0.0.14 required these comparison protocols, even though int and float from the used typevar should match the protocols. It's apparently fixed now in the latest ty version and causes issues if the input value also doesn't explicitly inherit from the protocols.

```
$ git checkout master && uv pip install -U ty==0.0.15 && ty check --output-format=concise --exclude src/streamlink/packages --exclude src/streamlink/plugins
Already on 'master'
Your branch is up to date with 'upstream/master'.
Using Python 3.14.2 environment at: /home/basti/venv/streamlink-314
Resolved 1 package in 102ms
Audited 1 package in 0.04ms
src/streamlink/utils/args.py:91:41: error[unsupported-operator] Operator `>=` is not supported between objects of type `_TNum@num` and `SupportsDunderLE[_TNum@num]`
src/streamlink/utils/args.py:93:41: error[unsupported-operator] Operator `>` is not supported between objects of type `_TNum@num` and `SupportsDunderLT[_TNum@num]`
src/streamlink/utils/args.py:95:41: error[unsupported-operator] Operator `<=` is not supported between objects of type `_TNum@num` and `SupportsDunderGE[_TNum@num]`
src/streamlink/utils/args.py:97:41: error[unsupported-operator] Operator `<` is not supported between objects of type `_TNum@num` and `SupportsDunderGT[_TNum@num]`
Found 4 diagnostics
```

```
$ git checkout utils/args/remove-comparison-protocols && uv pip install -U ty==0.0.15 && ty check --output-format=concise --exclude src/streamlink/packages --exclude src/streamlink/plugins
Switched to branch 'utils/args/remove-comparison-protocols'
Using Python 3.14.2 environment at: /home/basti/venv/streamlink-314
Resolved 1 package in 81ms
Audited 1 package in 0.03ms
All checks passed!
```