### PR TITLE
utils: deprecate package exports

### DIFF
--- a/src/streamlink/utils/__init__.py
+++ b/src/streamlink/utils/__init__.py
@@ -1,24 +1,24 @@
-from streamlink.utils.cache import LRUCache
-from streamlink.utils.data import search_dict
-from streamlink.utils.module import load_module
-from streamlink.utils.named_pipe import NamedPipe
-from streamlink.utils.parse import parse_html, parse_json, parse_qsd, parse_xml
-from streamlink.utils.url import absolute_url, prepend_www, update_qsd, update_scheme, url_concat, url_equal
+# ruff: noqa: RUF067
+from streamlink.compat import deprecated
 
 
-__all__ = [
-    "LRUCache",
-    "search_dict",
-    "load_module",
-    "NamedPipe",
-    "parse_html",
-    "parse_json",
-    "parse_qsd",
-    "parse_xml",
-    "absolute_url",
-    "prepend_www",
-    "update_qsd",
-    "update_scheme",
-    "url_concat",
-    "url_equal",
-]
+_msg = "Importing from the 'streamlink.utils' package has been deprecated. Import from its submodules instead."
+
+deprecated({
+    "LRUCache": ("streamlink.utils.cache.LRUCache", None, _msg),
+    "search_dict": ("streamlink.utils.data.search_dict", None, _msg),
+    "load_module": ("streamlink.utils.module.load_module", None, _msg),
+    "NamedPipe": ("streamlink.utils.named_pipe.NamedPipe", None, _msg),
+    "parse_html": ("streamlink.utils.parse.parse_html", None, _msg),
+    "parse_json": ("streamlink.utils.parse.parse_json", None, _msg),
+    "parse_qsd": ("streamlink.utils.parse.parse_qsd", None, _msg),
+    "parse_xml": ("streamlink.utils.parse.parse_xml", None, _msg),
+    "absolute_url": ("streamlink.utils.url.absolute_url", None, _msg),
+    "prepend_www": ("streamlink.utils.url.prepend_www", None, _msg),
+    "update_qsd": ("streamlink.utils.url.update_qsd", None, _msg),
+    "update_scheme": ("streamlink.utils.url.update_scheme", None, _msg),
+    "url_concat": ("streamlink.utils.url.url_concat", None, _msg),
+    "url_equal": ("streamlink.utils.url.url_equal", None, _msg),
+})
+
+del _msg

--- a/tests/utils/test_init.py
+++ b/tests/utils/test_init.py
@@ -1,0 +1,37 @@
+import importlib.util
+
+import pytest
+
+from streamlink.exceptions import StreamlinkDeprecationWarning
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "LRUCache",
+        "search_dict",
+        "load_module",
+        "NamedPipe",
+        "parse_html",
+        "parse_json",
+        "parse_qsd",
+        "parse_xml",
+        "absolute_url",
+        "prepend_www",
+        "update_qsd",
+        "update_scheme",
+        "url_concat",
+        "url_equal",
+    ],
+)
+def test_deprecated(attr: str):
+    spec = importlib.util.find_spec("streamlink.utils", "streamlink")
+    assert spec
+    assert spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with pytest.warns(StreamlinkDeprecationWarning):
+        item = getattr(module, attr)
+
+    assert item


### PR DESCRIPTION
This deprecates all (re-)exports in the `streamlink.utils` package, for multiple reasons:

1. only a subset of stuff from the submodules is exported, which is inconsistent and nonsensical
2. this can lead to cyclic imports, as importing `streamlink.utils.A` for example can automatically import `streamlink.utils.B` if `B` was imported and re-exported in `streamlink.utils`. So if one of the submodules imports a module up the stack while it is being executed by the importlib, for example `streamlink.logger`, then we have a cyclic import. I've just run into this while refactoring the logger module.
3. re-exporting means that unused stuff will always be loaded, which is unnecessary. All modules in the entire `streamlink` and `streamlink_cli` packages already import from the full specs, as it should be. I'm deprecating this instead of removing it, in case this breaks third-party plugins. No docs for this deprecation, as it's something internal.