### PR TITLE
ci.github: get run-urls of preview-builds

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -18,29 +18,33 @@ jobs:
   trigger:
     name: "Preview build - ${{ github.sha }}"
     if: github.repository == 'streamlink/streamlink'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Windows builds
         run: |
-          curl -sfL \
+          workflow=streamlink/windows-builds/actions/workflows/preview-build.yml
+          run_url=$(curl -sfL \
             -X POST \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             -H 'Authorization: Bearer ${{ secrets.STREAMLINKBOT_PREVIEW_BUILD }}' \
-            -d '{"ref":"master","inputs":{"ref":"${{ github.sha }}"}}' \
-            https://api.github.com/repos/streamlink/windows-builds/actions/workflows/preview-build.yml/dispatches
-
-          echo -e '## Windows builds\n\nhttps://github.com/streamlink/windows-builds/actions/workflows/preview-build.yml\n' \
+            -d '{"return_run_details":true,"ref":"master","inputs":{"ref":"${{ github.sha }}"}}' \
+            "https://api.github.com/repos/${workflow}/dispatches" \
+            | jq -r '.run_url' \
+          )
+          echo -e "## Windows builds\n\n- ${run_url}\n- https://github.com/${workflow}\n" \
             >> "${GITHUB_STEP_SUMMARY}"
       - name: Linux AppImage
         run: |
-          curl -sfL \
+          workflow=streamlink/streamlink-appimage/actions/workflows/preview-build.yml
+          run_url=$(curl -sfL \
             -X POST \
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             -H 'Authorization: Bearer ${{ secrets.STREAMLINKBOT_PREVIEW_BUILD }}' \
-            -d '{"ref":"master","inputs":{"ref":"${{ github.sha }}"}}' \
-            https://api.github.com/repos/streamlink/streamlink-appimage/actions/workflows/preview-build.yml/dispatches
-
-          echo -e '## AppImage\n\nhttps://github.com/streamlink/streamlink-appimage/actions/workflows/preview-build.yml\n' \
+            -d '{"return_run_details":true,"ref":"master","inputs":{"ref":"${{ github.sha }}"}}' \
+            "https://api.github.com/repos/${workflow}/dispatches" \
+            | jq -r '.run_url' \
+          )
+          echo -e "## AppImage\n\n- ${run_url}\n- https://github.com/${workflow}\n" \
             >> "${GITHUB_STEP_SUMMARY}"


### PR DESCRIPTION
GitHub now supports getting the run-url of dispatched workflows from their API, so let's update the preview-build workflow and include the URLs of the specific runs that include the preview-build artifacts, instead of just listing all runs.

----

- https://github.blog/changelog/2026-02-19-workflow-dispatch-api-now-returns-run-ids/
- https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event