### PR TITLE
docs: fix streamlink.stream API docs

### DIFF
--- a/docs/api/stream.rst
+++ b/docs/api/stream.rst
@@ -1,18 +1,16 @@
 Stream
 ------
 
-.. module:: streamlink.stream
-
 All streams inherit from the :class:`Stream` base class.
 
-.. autoclass:: Stream
+.. autoclass:: streamlink.stream.stream.Stream
 
-.. autoclass:: MuxedStream
+.. autoclass:: streamlink.stream.ffmpegmux.MuxedStream
 
-.. autoclass:: HTTPStream
+.. autoclass:: streamlink.stream.http.HTTPStream
 
-.. autoclass:: HLSStream
+.. autoclass:: streamlink.stream.hls.HLSStream
 
-.. autoclass:: MuxedHLSStream
+.. autoclass:: streamlink.stream.hls.MuxedHLSStream
 
-.. autoclass:: DASHStream
+.. autoclass:: streamlink.stream.dash.DASHStream


### PR DESCRIPTION
See #6837 
Caused by #6821

The other issue caused by autodocs needs to be fixed separately. I still haven't found a solution yet after fighting with the autodocs config for a bit. This might require an override of the autodocs lookup logic and suppressing `streamlink.validate` for all builtins with the same name. Annoying.