### PR TITLE
plugins.twitch: switch to usher v2 endpoints

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -305,10 +305,10 @@ class UsherService:
             ).validate(extra_params)
             log.debug(f"{extra_params_debug!r}")
 
-        return self._create_url(f"/api/channel/hls/{channel.lower()}.m3u8", **extra_params)
+        return self._create_url(f"/api/v2/channel/hls/{channel.lower()}.m3u8", **extra_params)
 
     def video(self, video_id: str, **extra_params) -> str:
-        return self._create_url(f"/vod/{video_id}", **extra_params)
+        return self._create_url(f"/vod/v2/{video_id}.m3u8", **extra_params)
 
 
 class TwitchAPI:

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -617,7 +617,7 @@ class TestUsherService:
         [
             pytest.param(
                 {"service": "channel", "args": ("TWITCH",)},
-                "/api/channel/hls/twitch.m3u8",
+                "/api/v2/channel/hls/twitch.m3u8",
                 [
                     (
                         "streamlink.plugins.twitch",
@@ -629,7 +629,7 @@ class TestUsherService:
             ),
             pytest.param(
                 {"service": "video", "args": ("1234567890",)},
-                "/vod/1234567890",
+                "/vod/v2/1234567890.m3u8",
                 [],
                 id="video",
             ),


### PR DESCRIPTION
See #6838 

No functional changes. Since Twitch's website is using the v2 endpoints, Streamlink should do this as well.

```
$ ./script/test-plugin-urls.py twitch -m -r CHANNELNAME esl_dota2
:: https://clips.twitch.tv/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': '1230765715', 'author': 'LIRIK', 'category': 'Pax Dei', 'title': 'Lirik loves Pax Dei'}
:: https://player.twitch.tv/?parent=twitch.tv&channel=esl_dota2
::  160k, 160p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '316275755751', 'author': 'ESL_DOTA2', 'category': 'Dota 2', 'title': 'LIVE: Team Liquid vs. PARIVISION - DreamLeague Season 28'}
:: https://player.twitch.tv/?parent=twitch.tv&video=1963401646
::  220k, 160p, 360p, 480p, 720p_alt, 720p, 1080p, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://player.twitch.tv/?parent=twitch.tv&video=1963401646&t=1h23m45s
::  220k, 160p, 360p, 480p, 720p_alt, 720p, 1080p, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://twitch.tv/papaplatte/clip/SmellyDeadMomBloodTrail-WWr5gMxd0pe0BAge
::  360p30, 480p30, 1080p60, worst, best
::   {'id': '2105975528', 'author': 'Papaplatte', 'category': 'GeoGuessr', 'title': 'fan moment'}
:: https://www.twitch.tv/clip/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': '1230765715', 'author': 'LIRIK', 'category': 'Pax Dei', 'title': 'Lirik loves Pax Dei'}
:: https://www.twitch.tv/dota2ti/v/1963401646
::  220k, 160p, 360p, 480p, 720p_alt, 720p, 1080p, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://www.twitch.tv/dota2ti/video/1963401646
::  220k, 160p, 360p, 480p, 720p_alt, 720p, 1080p, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://www.twitch.tv/esl_dota2
::  160k, 160p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '316275755751', 'author': 'ESL_DOTA2', 'category': 'Dota 2', 'title': 'LIVE: Team Liquid vs. PARIVISION - DreamLeague Season 28'}
:: https://www.twitch.tv/esl_dota2/
::  160k, 160p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '316275755751', 'author': 'ESL_DOTA2', 'category': 'Dota 2', 'title': 'LIVE: Team Liquid vs. PARIVISION - DreamLeague Season 28'}
:: https://www.twitch.tv/esl_dota2/?
::  160k, 160p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '316275755751', 'author': 'ESL_DOTA2', 'category': 'Dota 2', 'title': 'LIVE: Team Liquid vs. PARIVISION - DreamLeague Season 28'}
:: https://www.twitch.tv/esl_dota2?
::  160k, 160p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '316275755751', 'author': 'ESL_DOTA2', 'category': 'Dota 2', 'title': 'LIVE: Team Liquid vs. PARIVISION - DreamLeague Season 28'}
:: https://www.twitch.tv/lirik/clip/GoodEndearingPassionfruitPMSTwin-QfRLYDPKlscgqt-4
::  360p30, 480p30, 720p60, 1080p60, worst, best
::   {'id': '1230765715', 'author': 'LIRIK', 'category': 'Pax Dei', 'title': 'Lirik loves Pax Dei'}
:: https://www.twitch.tv/videos/1963401646
::  220k, 160p, 360p, 480p, 720p_alt, 720p, 1080p, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
:: https://www.twitch.tv/videos/1963401646?t=1h23m45s
::  220k, 160p, 360p, 480p, 720p_alt, 720p, 1080p, worst, best
::   {'id': '1963401646', 'author': 'dota2ti', 'category': 'Dota 2', 'title': 'LGD Gaming vs Gaimin Gladiators [0-0] - TI 12 LOWER BRACKET FINAL'}
```