### PR TITLE
plugins.nrk: identify as tv-player v9

### DIFF
--- a/src/streamlink/plugins/nrk.py
+++ b/src/streamlink/plugins/nrk.py
@@ -70,6 +70,7 @@ class NRK(Plugin):
     def _get_assets(self, manifest_type, program_id):
         return self.session.http.get(
             self._URL_MANIFEST.format(manifest_type=manifest_type, program_id=program_id),
+            headers={"Accept": "application/vnd.nrk.psapi+json; version=9; player=tv-player; device=player-core"},
             schema=validate.Schema(
                 validate.parse_json(),
                 {


### PR DESCRIPTION
This matches current versions of tv.nrk.no, and gives access to a wider range of formats (such as 1080p50).

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

There isn't much to say here, just a single HTTP header.