### PR TITLE
plugins.pluto: use v2 streams

### DIFF
--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -182,6 +182,7 @@ class Pluto(Plugin):
                 "deviceType": "web",
                 "clientID": self._client_id,
                 "clientModelNumber": "1.0.0",
+                "serverSideAds": "false",
                 **request,
             },
             schema=validate.Schema(
@@ -260,7 +261,9 @@ class Pluto(Plugin):
 
             params = dict(parse_qsl(data["stitcherParams"]))
             params["jwt"] = data["sessionToken"]
-            url = urljoin(data["servers"]["stitcher"], path)
+            params["includeExtendedEvents"] = "true"
+            params["masterJWTPassthrough"] = "true"
+            url = urljoin(data["servers"]["stitcher"], "v2" + path)
             url = update_qsd(url, params)
 
             return PlutoHLSStream.parse_variant_playlist(self.session, url)


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

Hello, this fixes the pluto plugin #6844, I have tried live and VOD and both seem to work. Issue: https://github.com/streamlink/streamlink/issues/6844

Thank you for this project!


