### PR TITLE
plugins.youtube: bump API clientVersion

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -342,7 +342,7 @@ class YouTube(Plugin):
                 "context": {
                     "client": {
                         "clientName": "ANDROID",
-                        "clientVersion": "19.45.36",
+                        "clientVersion": "21.08.266",
                         "platform": "DESKTOP",
                         "clientScreen": "EMBED",
                         "clientFormFactor": "UNKNOWN_FORM_FACTOR",


### PR DESCRIPTION
Fixes #6852 

This bumps the clientVersion of the Android YouTube app which we're using to a newer one. The API endpoint is still working correctly.

```
$ ./script/test-plugin-urls.py youtube -m -r CHANNELNAME hospitalrecords -r CHANNELID UCw49uOTAJjGUdoAeUcp7tOg
:: https://www.youtube.com/@hospitalrecords
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/@hospitalrecords/live
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/c/hospitalrecords
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/c/hospitalrecords/live
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/channel/UCw49uOTAJjGUdoAeUcp7tOg
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/channel/UCw49uOTAJjGUdoAeUcp7tOg/live
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/embed/aqz-KE-bpKQ
::  360p, worst, best
::   {'id': 'aqz-KE-bpKQ', 'author': 'Blender', 'category': 'Film & Animation', 'title': 'Big Buck Bunny 60fps 4K - Official Blender Foundation Short Film'}
:: https://www.youtube.com/embed/live_stream?channel=hospitalrecords
!! Error while fetching streams
:: https://www.youtube.com/hospitalrecords
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/hospitalrecords/live
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/live/aqz-KE-bpKQ
!! Error while fetching streams
:: https://www.youtube.com/user/hospitalrecords
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/user/hospitalrecords/live
::  144p, 240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': 'Cwq3AFyV044', 'author': 'Hospital Records', 'category': 'Music', 'title': 'Drum & Bass 24/7 Radio 🔴 Live | Non-Stop DNB'}
:: https://www.youtube.com/v/aqz-KE-bpKQ
::  360p, worst, best
::   {'id': 'aqz-KE-bpKQ', 'author': 'Blender', 'category': 'Film & Animation', 'title': 'Big Buck Bunny 60fps 4K - Official Blender Foundation Short Film'}
:: https://www.youtube.com/watch?foo=bar&baz=qux&v=aqz-KE-bpKQ&asdf=1234
::  360p, worst, best
::   {'id': 'aqz-KE-bpKQ', 'author': 'Blender', 'category': 'Film & Animation', 'title': 'Big Buck Bunny 60fps 4K - Official Blender Foundation Short Film'}
:: https://youtu.be/aqz-KE-bpKQ
::  360p, worst, best
::   {'id': 'aqz-KE-bpKQ', 'author': 'Blender', 'category': 'Film & Animation', 'title': 'Big Buck Bunny 60fps 4K - Official Blender Foundation Short Film'}
```