### PR TITLE
cli.output.http: fix typing issues

### DIFF
--- a/src/streamlink_cli/output/http.py
+++ b/src/streamlink_cli/output/http.py
@@ -31,14 +31,17 @@ class HTTPOutput(Output):
         self.conn: socket.socket | None = None
 
     @property
-    def addresses(self):
+    def addresses(self) -> list[str]:
         if self.host:
             return [self.host]
 
         addrs = {"127.0.0.1"}
         with suppress(socket.gaierror):
-            for info in socket.getaddrinfo(socket.gethostname(), self.port, socket.AF_INET):
-                addrs.add(info[4][0])
+            addrinfo = socket.getaddrinfo(socket.gethostname(), self.port, socket.AF_INET)
+            for _family, _type, _proto, _canonname, (address, *_) in addrinfo:
+                if not isinstance(address, str):
+                    continue
+                addrs.add(address)
 
         return sorted(addrs)
 


### PR DESCRIPTION
Python can apparently return an `int` for the address if it's been compiled with `--disable-ipv6`, so typeshed added this potential return value, which throws an error on the latest version of ty:
https://github.com/python/typeshed/blob/3e9ca33422712b471f885a2b7dba08c023e6998e/stdlib/socket.pyi#L1448-L1450
https://docs.python.org/3/library/socket.html#socket.getaddrinfo

They should've probably used an overload here for AF_INET values...