### PR TITLE
docs(validate): avoid shadowing built-in list references in autodoc

### DIFF
--- a/docs/api/validate.rst
+++ b/docs/api/validate.rst
@@ -246,8 +246,14 @@ for an introduction to this API and a list of examples.
 
 .. automodule:: streamlink.plugin.api.validate
     :imported-members:
-    :exclude-members: Schema, SchemaContainer, validate
+    :exclude-members: Schema, SchemaContainer, validate, list
     :member-order: bysource
+
+.. py:class:: list(*schemas)
+    :module: streamlink.plugin.api.validate
+    :no-index:
+
+    Alias of :class:`ListSchema <_schemas.ListSchema>`.
 
 .. automodule:: streamlink.validate._schemas
     :exclude-members: SchemaContainer


### PR DESCRIPTION
- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

## Summary
- exclude the `list` alias from the `streamlink.plugin.api.validate` automodule index so Sphinx doesn't resolve unrelated `list[...]` annotations to `streamlink.validate.list`
- keep the alias documented via a manual `py:class` entry marked `:no-index:` so API readers still see it without poisoning global cross-reference resolution

## Validation
- `uv run --group docs sphinx-build -b html docs docs/_build/html`
- verified generated API pages no longer contain links to `streamlink.validate.list` for unrelated `list[...]` annotations (`api/session.html`, `api/plugin.html`, `api/options.html`)
- verified `docs/_build/html/api/stream.html` now contains documented `HTTPStream` / `HLSStream` anchors again

## Related
Fixes #6837

## AI disclosure
- AI assistance was used for drafting and iterating this patch; I reviewed and validated all changes locally.