### PR TITLE
session.http: support SO_BINDTODEVICE on *nix

### DIFF
--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -5,6 +5,7 @@ import ssl
 import time
 import warnings
 from http.cookiejar import MozillaCookieJar
+from ipaddress import ip_address
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -12,9 +13,11 @@ import urllib3
 import urllib3.util.connection as urllib3_util_connection
 from requests import Request, Session
 from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection
 from urllib3.util import create_urllib3_context  # type: ignore[attr-defined]
 
 import streamlink.session.http_useragents as useragents
+from streamlink.compat import is_win32
 from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.utils.parse import parse_json, parse_xml
@@ -110,14 +113,39 @@ class HTTPSession(Session):
         return parse_xml(res.text, *args, **kwargs)
 
     def set_interface(self, interface: str | None) -> None:
+        connection_pool_kw: dict[str, Any] = {}
+        if interface:
+            iface: str | None = None
+            host: str | None = None
+            if is_win32:
+                host = interface
+            else:
+                if interface.startswith("if!"):
+                    iface = interface[3:]
+                elif interface.startswith("host!"):
+                    host = interface[5:]
+                elif interface.startswith("ifhost!") and "!" in interface[7:]:
+                    iface, host = interface[7:].split("!", 1)
+                else:
+                    try:
+                        host = str(ip_address(interface))
+                    except ValueError:
+                        iface = interface
+
+            if iface:
+                connection_pool_kw["socket_options"] = [
+                    *HTTPConnection.default_socket_options,
+                    (socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode()),
+                ]
+            if host:
+                connection_pool_kw["source_address"] = (host, 0)
+
         for adapter in self.adapters.values():
             if not isinstance(adapter, HTTPAdapter):
                 continue
-            if not interface:
-                adapter.poolmanager.connection_pool_kw.pop("source_address", None)
-            else:
-                # https://docs.python.org/3/library/socket.html#socket.create_connection
-                adapter.poolmanager.connection_pool_kw.update(source_address=(interface, 0))
+            adapter.poolmanager.connection_pool_kw.pop("source_address", None)
+            adapter.poolmanager.connection_pool_kw.pop("socket_options", None)
+            adapter.poolmanager.connection_pool_kw.update(connection_pool_kw)
 
     # noinspection PyMethodMayBeStatic
     def set_address_family(self, family: socket.AddressFamily | None = None) -> None:

--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -68,7 +68,7 @@ class StreamlinkOptions(Options):
         * - interface
           - ``str | None``
           - ``None``
-          - Network interface address
+          - Network interface name or address.
         * - ipv4
           - ``bool``
           - ``False``

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -468,7 +468,15 @@ def build_parser():
         type=str,
         metavar="INTERFACE",
         help="""
-            Set the network interface.
+            Select the network interface, either by IP address or by interface name.
+
+            The following optional prefixes are supported:
+
+            - `if!<name>` interface name
+            - `host!<name>` IP address or hostname
+            - `ifhost!<interface>!<host>` interface name and IP address or hostname
+
+            Note: On Windows, only IP addresses are supported and prefixes are ignored.
         """,
     )
     network.add_argument(

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import socket
 import ssl
 from operator import itemgetter
 from socket import AF_INET, AF_INET6
@@ -13,6 +14,7 @@ import requests
 import requests_mock as rm
 import urllib3
 from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection
 from urllib3.response import HTTPResponse
 
 from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
@@ -233,7 +235,95 @@ class TestHTTPSession:
         assert res.encoding == expected
         assert res.text == "Bär"
 
-    def test_set_interface(self):
+    # not defined in stdlib on Windows
+    SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 0)
+
+    @pytest.mark.parametrize(
+        ("interface", "source_address", "socket_options"),
+        [
+            pytest.param(
+                None,
+                None,
+                None,
+                id="none",
+            ),
+            pytest.param(
+                "",
+                None,
+                None,
+                id="empty",
+            ),
+            pytest.param(
+                "0.0.0.0",
+                ("0.0.0.0", 0),
+                None,
+                id="ipv4",
+            ),
+            pytest.param(
+                "::1",
+                ("::1", 0),
+                None,
+                id="ipv6",
+            ),
+            pytest.param(
+                "my-interface",
+                None,
+                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
+                id="unix-iface",
+                marks=pytest.mark.posix_only,
+            ),
+            pytest.param(
+                "if!my-interface",
+                None,
+                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
+                id="unix-iface-prefix",
+                marks=pytest.mark.posix_only,
+            ),
+            pytest.param(
+                "host!0.0.0.0",
+                ("0.0.0.0", 0),
+                None,
+                id="unix-host-prefix",
+                marks=pytest.mark.posix_only,
+            ),
+            pytest.param(
+                "host!foo",
+                ("foo", 0),
+                None,
+                id="unix-host-prefix-hostname",
+                marks=pytest.mark.posix_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface!0.0.0.0",
+                ("0.0.0.0", 0),
+                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
+                id="unix-ifhost-prefix",
+                marks=pytest.mark.posix_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface",
+                None,
+                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"ifhost!my-interface")],
+                id="unix-ifhost-prefix-invalid",
+                marks=pytest.mark.posix_only,
+            ),
+            pytest.param(
+                "my-interface",
+                ("my-interface", 0),
+                None,
+                id="win32-iface",
+                marks=pytest.mark.windows_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface!0.0.0.0",
+                ("ifhost!my-interface!0.0.0.0", 0),
+                None,
+                id="win32-prefix",
+                marks=pytest.mark.windows_only,
+            ),
+        ],
+    )
+    def test_set_interface(self, interface: str, source_address: tuple | None, socket_options: list[tuple] | None):
         session = HTTPSession()
         session.mount("custom://", TLSNoDHAdapter())
 
@@ -243,24 +333,24 @@ class TestHTTPSession:
         assert isinstance(a_custom, HTTPAdapter)
         assert not isinstance(a_file, HTTPAdapter)
 
-        assert a_http.poolmanager.connection_pool_kw.get("source_address") is None
-        assert a_https.poolmanager.connection_pool_kw.get("source_address") is None
-        assert a_custom.poolmanager.connection_pool_kw.get("source_address") is None
+        for adapter in a_http, a_https, a_custom:
+            assert adapter.poolmanager.connection_pool_kw.get("source_address") is None
+            assert adapter.poolmanager.connection_pool_kw.get("socket_options") is None
 
-        session.set_interface(interface="my-interface")
-        assert a_http.poolmanager.connection_pool_kw.get("source_address") == ("my-interface", 0)
-        assert a_https.poolmanager.connection_pool_kw.get("source_address") == ("my-interface", 0)
-        assert a_custom.poolmanager.connection_pool_kw.get("source_address") == ("my-interface", 0)
+        session.set_interface(interface=interface)
+        for adapter in a_http, a_https, a_custom:
+            assert adapter.poolmanager.connection_pool_kw.get("source_address") == source_address
+            assert adapter.poolmanager.connection_pool_kw.get("socket_options") == socket_options
 
         session.set_interface(interface="")
-        assert a_http.poolmanager.connection_pool_kw.get("source_address") is None
-        assert a_https.poolmanager.connection_pool_kw.get("source_address") is None
-        assert a_custom.poolmanager.connection_pool_kw.get("source_address") is None
+        for adapter in a_http, a_https, a_custom:
+            assert adapter.poolmanager.connection_pool_kw.get("source_address") is None
+            assert adapter.poolmanager.connection_pool_kw.get("socket_options") is None
 
         session.set_interface(interface=None)
-        assert a_http.poolmanager.connection_pool_kw.get("source_address") is None
-        assert a_https.poolmanager.connection_pool_kw.get("source_address") is None
-        assert a_custom.poolmanager.connection_pool_kw.get("source_address") is None
+        for adapter in a_http, a_https, a_custom:
+            assert adapter.poolmanager.connection_pool_kw.get("source_address") is None
+            assert adapter.poolmanager.connection_pool_kw.get("socket_options") is None
 
         # doesn't raise
         session.set_interface(interface=None)


### PR DESCRIPTION
In addition to binding to IP addresses, allow non-Windows systems to select the network interface by name. Also add support for prefixes, similar to curl's --interface syntax.

----

Resolves #6861 

@Nogesma please check and see if this successfully resolves your issue.