### PR TITLE
tests: await HLS thread termination in more tests

### DIFF
--- a/tests/mixins/stream_hls.py
+++ b/tests/mixins/stream_hls.py
@@ -318,5 +318,5 @@ class TestMixinStreamHLS(unittest.TestCase):
         thread.handshake.go()
 
         # terminate threads explicitly, just in case
-        thread.reader.writer.close()
+        thread.writer_close()  # see writer.close() override in HLSStreamReadThread
         thread.reader.worker.close()

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -485,8 +485,8 @@ class TestHLSStreamWorker(TestMixinStreamHLS, unittest.TestCase):
             #   which is why the test's reader thread keeps running until the test teardown,
             #   but this somehow breaks the assertion down below, so close everything manually...
             #   These tests will have to be rewritten eventually in pytest-style, without having to mock log calls.
-            self.thread.close()
-            self.thread.join(1)
+            self.close()
+            self.await_close()
 
             assert mock_log.warning.call_args_list == [call("No new segments for more than 5.00s. Stopping...")]
 
@@ -1214,8 +1214,9 @@ class TestHlsReloadTime(TestMixinStreamHLS, unittest.TestCase):
             if not get_reload_time_called.wait(timeout=5):  # pragma: no cover
                 raise RuntimeError("Missing _get_reload_time() call")
 
-            # wait for the worker thread to terminate, so that deterministic assertions can be done about the reload time
-            self.thread.reader.worker.join()
+            # close threads first, so that deterministic assertions can be done about the reload time
+            self.close()
+            self.await_close()
 
             return self.thread.reader.worker._reload_time
 


### PR DESCRIPTION
See #6863 

No idea if this fixes the flaky tests. Another attempt was already made in #6806 two months ago.

The main issue with these HLS integration tests stems from the fact that the writer-thread's run() logic is polling-based, where it needs to poll the segment queue and segment future results, which is bad. An event/signal-based system would be much better...
https://github.com/streamlink/streamlink/blob/7e3af83035c68f2f7e184d72d111d4008d535d5c/src/streamlink/stream/segmented/segmented.py#L150-L175