### PR TITLE
docs: fix header icon sizes on install page

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -301,7 +301,7 @@ details.sd-dropdown .sd-summary-content {
 }
 
 .installation-grid .fab {
-  font-size: 5em;
+  font-size: clamp(1rem, 10vw, 5rem);
 }
 
 .grid-with-icons .sd-card-header .fas {


### PR DESCRIPTION
Icons can overflow if there's not enough space

master
<img width="420" height="140" alt="image" src="https://github.com/user-attachments/assets/184ee9cc-768c-42cd-a855-11dc5cf82c66" />

PR
<img width="420" height="140" alt="image" src="https://github.com/user-attachments/assets/49949aab-a382-4469-acbe-7917af97d005" />
