### PR TITLE
plugins.soop: add support for play.sooplive.com URL

### DIFF
--- a/src/streamlink/plugins/soop.py
+++ b/src/streamlink/plugins/soop.py
@@ -1,5 +1,6 @@
 """
 $description TV and live video game broadcasts, artist performances and personal daily-life video blogs & shows.
+$url play.sooplive.com
 $url play.sooplive.co.kr
 $url play.afreecatv.com
 $type live
@@ -37,20 +38,20 @@ class SoopHLSStream(HLSStream):
 
 
 @pluginmatcher(
-    re.compile(r"https?://play\.(sooplive\.co\.kr|afreecatv\.com)/(?P<channel>\w+)(?:/(?P<bno>\d+))?"),
+    re.compile(r"https?://play\.(sooplive\.com|sooplive\.co\.kr|afreecatv\.com)/(?P<channel>\w+)(?:/(?P<bno>\d+))?"),
 )
 @pluginargument(
     "username",
     sensitive=True,
     requires=["password"],
     metavar="USERNAME",
-    help="The username used to register with sooplive.co.kr.",
+    help="The username used to register with sooplive.com.",
 )
 @pluginargument(
     "password",
     sensitive=True,
     metavar="PASSWORD",
-    help="A sooplive.co.kr account password to use with --soop-username.",
+    help="A sooplive.com account password to use with --soop-username.",
 )
 @pluginargument(
     "purge-credentials",

--- a/tests/plugins/test_soop.py
+++ b/tests/plugins/test_soop.py
@@ -17,6 +17,8 @@ class TestPluginCanHandleUrlSoop(PluginCanHandleUrl):
     __plugin__ = Soop
 
     should_match_groups = [
+        ("https://play.sooplive.com/CHANNEL", {"channel": "CHANNEL"}),
+        ("https://play.sooplive.com/CHANNEL/0123456789", {"channel": "CHANNEL", "bno": "0123456789"}),
         ("https://play.sooplive.co.kr/CHANNEL", {"channel": "CHANNEL"}),
         ("https://play.sooplive.co.kr/CHANNEL/0123456789", {"channel": "CHANNEL", "bno": "0123456789"}),
         ("https://play.afreecatv.com/CHANNEL", {"channel": "CHANNEL"}),
@@ -24,6 +26,8 @@ class TestPluginCanHandleUrlSoop(PluginCanHandleUrl):
     ]
 
     should_not_match = [
+        "https://sooplive.com/CHANNEL",
+        "https://sooplive.com/CHANNEL/0123456789",
         "https://sooplive.co.kr/CHANNEL",
         "https://sooplive.co.kr/CHANNEL/0123456789",
         "https://afreecatv.com/CHANNEL",


### PR DESCRIPTION
## Summary

SOOP (formerly AfreecaTV) is migrating from `sooplive.co.kr` to `sooplive.com`. As of recently, https://www.sooplive.co.kr/ redirects to https://www.sooplive.com/, and `play.sooplive.co.kr` redirects to `play-origin.sooplive.com` in the browser.

This change proactively adds `play.sooplive.com` as a supported URL so the plugin is ready for potential `.co.kr` deprecation in the future, and for users who are already using the new `sooplive.com` URLs. The `.co.kr` domain is kept for backwards compatibility in case the migration is rolled back. The legacy `play.afreecatv.com` URL also remains supported and functional.

## Changes

- Added `sooplive.com` to the `@pluginmatcher` URL regex
- Added `$url play.sooplive.com` to plugin metadata
- Updated help text to reference `sooplive.com`
- Added corresponding test cases for URL matching and non-matching

## Test plan

Tested live recording with all three supported domains — login, stream discovery, and HLS recording all work correctly:

- [x] `https://play.sooplive.com/channel/` — new `.com` URL works
- [x] `https://play.sooplive.co.kr/channel/` — existing `.co.kr` URL still works
- [x] `https://play.afreecatv.com/channel/` — legacy afreecatv URL still works
- [x] `https://sooplive.com/channel/` (without `play.`) — correctly rejected
- [x] Unit tests pass (`tests/plugins/test_soop.py` — 27/27 passed)