### PR TITLE
ci.github: bump codecov-action to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Upload coverage data
         if: github.event_name != 'schedule'
         continue-on-error: ${{ matrix.continue || false }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           name: os:${{ matrix.runs-on }} py:${{ matrix.python-version }}
         env:


### PR DESCRIPTION
This should fix the node-20 deprecation warnings