### PR TITLE
plugins.cdnbg: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/cdnbg.py
+++ b/src/streamlink/plugins/cdnbg.py
@@ -4,7 +4,6 @@ $url armymedia.bg
 $url bgonair.bg
 $url bloombergtv.bg
 $url bnt.bg
-$url live.bstv.bg
 $url i.cdn.bg
 $url nova.bg
 $url mu-vi.tv
@@ -42,10 +41,6 @@ log = getLogger(__name__)
     pattern=re.compile(r"https?://(?:www\.)?(?:tv\.)?bnt\.bg/\w+(?:/\w+)?/?"),
 )
 @pluginmatcher(
-    name="bstv",
-    pattern=re.compile(r"https?://(?:www\.)?live\.bstv\.bg/?"),
-)
-@pluginmatcher(
     name="nova",
     pattern=re.compile(r"https?://(?:www\.)?nova\.bg/live/?"),
 )
@@ -59,15 +54,22 @@ log = getLogger(__name__)
 )
 class CDNBG(Plugin):
     @staticmethod
-    def _find_url(regex: re.Pattern) -> validate.all:
+    def _find_url_regex(regex: re.Pattern) -> validate.all:
         return validate.all(
             validate.regex(regex),
             validate.get("url"),
         )
 
+    @staticmethod
+    def _find_url_xpath(xpath: str) -> validate.all:
+        return validate.all(
+            validate.xml_xpath_string(xpath),
+            str,
+        )
+
     def _get_streams(self):
         if "cdn.bg" in urlparse(self.url).netloc:
-            iframe_url = self.url
+            player_url = self.url
             h = self.session.get_option("http-headers")
             if not h or not h.get("Referer"):
                 log.error('Missing Referer for iframe URL, use --http-header "Referer=URL" ')
@@ -75,46 +77,60 @@ class CDNBG(Plugin):
             referer = h.get("Referer")
         else:
             referer = self.url
-            iframe_url = self.session.http.get(
+            player_url = self.session.http.get(
                 self.url,
                 schema=validate.Schema(
                     validate.any(
-                        self._find_url(
+                        self._find_url_regex(
                             re.compile(r"'src',\s*'(?P<url>https?://i\.cdn\.bg/live/\w+)'\);"),
                         ),
                         validate.all(
                             validate.parse_html(),
-                            validate.xml_xpath_string(".//iframe[contains(@src,'cdn.bg')][1]/@src"),
+                            validate.any(
+                                self._find_url_xpath(".//iframe[contains(@src,'//i.cdn.bg/')][1]/@src"),
+                                self._find_url_xpath(".//iframe[contains(@nitro-lazy-src,'//i.cdn.bg/')][1]/@nitro-lazy-src"),
+                                self._find_url_xpath(".//source[contains(@src,'//i.cdn.bg/')][1]/@src"),
+                                self._find_url_xpath(".//a[contains(@href,'//i.cdn.bg/')][1]/@href"),
+                            ),
                         ),
+                        # silently fail
+                        validate.transform(lambda *_: None),
                     ),
                 ),
             )
 
-        if not iframe_url:
+        if not player_url:
+            log.error("Could not find player URL")
             return
 
-        iframe_url = update_scheme("https://", iframe_url, force=False)
-        log.debug(f"Found iframe: {iframe_url}")
+        player_url = update_scheme("https://", player_url, force=False)
+        log.debug(f"Found player URL: {player_url}")
 
         stream_url = self.session.http.get(
-            iframe_url,
+            player_url,
             headers={"Referer": referer},
             schema=validate.Schema(
                 validate.any(
-                    self._find_url(
+                    self._find_url_regex(
                         re.compile(r"sdata\.src.*?=.*?(?P<q>[\"'])(?P<url>.*?)(?P=q)"),
                     ),
-                    self._find_url(
-                        re.compile(r"(src|file): (?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)"),
+                    self._find_url_regex(
+                        re.compile(r"(src|file)\s*:\s*(?P<q>[\"'])(?P<url>(https?:)?//.+?m3u8.*?)(?P=q)"),
                     ),
-                    self._find_url(
-                        re.compile(r"video src=(?P<url>http[^ ]+m3u8[^ ]*)"),
+                    validate.all(
+                        validate.regex(re.compile(r"""window\.APP_CONFIG\.stream\s*=\s*(?P<url>".+?");""")),
+                        validate.get("url"),
+                        validate.parse_json(),
                     ),
-                    self._find_url(
-                        re.compile(r"source src=\"(?P<url>[^\"]+m3u8[^\"]*)\""),
+                    validate.all(
+                        validate.parse_html(),
+                        validate.any(
+                            self._find_url_xpath(".//video[contains(@src,'m3u8')][1]/@src"),
+                            self._find_url_xpath(".//source[contains(@src,'m3u8')][1]/@src"),
+                        ),
                     ),
                     # GEOBLOCKED
-                    self._find_url(
+                    self._find_url_regex(
                         re.compile(r"(?P<url>[^\"]+geoblock[^\"]+)"),
                     ),
                 ),
@@ -124,11 +140,12 @@ class CDNBG(Plugin):
             log.error("Geo-restricted content")
             return
 
-        return HLSStream.parse_variant_playlist(
-            self.session,
-            update_scheme(iframe_url, stream_url),
-            headers={"Referer": "https://i.cdn.bg/"},
-        )
+        stream_url = update_scheme(player_url, stream_url)
+
+        return (
+            HLSStream.parse_variant_playlist(self.session, stream_url, headers={"Referer": "https://i.cdn.bg/"})
+            or {"live": HLSStream(self.session, stream_url, headers={"Referer": "https://i.cdn.bg/"})}
+        )  # fmt: skip
 
 
 __plugin__ = CDNBG

--- a/tests/plugins/test_cdnbg.py
+++ b/tests/plugins/test_cdnbg.py
@@ -20,7 +20,6 @@ class TestPluginCanHandleUrlCDNBG(PluginCanHandleUrl):
         (("bnt", "http://tv.bnt.bg/bnt3"), {}),
         (("bnt", "http://tv.bnt.bg/bnt4"), {}),
         (("mu-vi", "http://mu-vi.tv/LiveStreams/pages/Live.aspx"), {}),
-        (("bstv", "http://live.bstv.bg/"), {}),
         (("bloombergtv", "https://www.bloombergtv.bg/video"), {}),
         (("cdnbg", "https://i.cdn.bg/live/xfr3453g0d"), {}),
         (("armymedia", "https://armymedia.bg/%d0%bd%d0%b0-%d0%b6%d0%b8%d0%b2%d0%be/"), {}),


### PR DESCRIPTION
- Remove dead matchers
- Fix player URL detection
- Fix HLS playlist URL detection
- Add support for direct HLS media playlists

---

Fixes #6888 

```
$ ./script/test-plugin-urls.py --interface=tun0 cdnbg
:: http://bgonair.bg/tvonline
::  576p, worst, best
:: http://bgonair.bg/tvonline/
::  576p, worst, best
:: http://bnt.bg/live
::  360p, 576p, 720p, worst, best
:: http://bnt.bg/live/bnt1
::  360p, 576p, 720p, worst, best
:: http://bnt.bg/live/bnt2
::  480p, worst, best
:: http://bnt.bg/live/bnt3
::  360p, 576p, 720p, worst, best
:: http://bnt.bg/live/bnt4
::  480p, worst, best
:: http://mu-vi.tv/LiveStreams/pages/Live.aspx
::  live, worst, best
:: http://nova.bg/live
::  720p, worst, best
:: http://tv.bnt.bg/bnt1
::  360p, 576p, 720p, worst, best
:: http://tv.bnt.bg/bnt2
::  480p, worst, best
:: http://tv.bnt.bg/bnt3
::  360p, 576p, 720p, worst, best
:: http://tv.bnt.bg/bnt4
::  480p, worst, best
:: http://www.nova.bg/live
::  720p, worst, best
:: https://armymedia.bg/%d0%bd%d0%b0-%d0%b6%d0%b8%d0%b2%d0%be/
::  576p, worst, best
:: https://i.cdn.bg/live/xfr3453g0d
:::: Missing Referer for iframe URL, use --http-header "Referer=URL"
!! No streams found
:: https://www.bloombergtv.bg/video
::  576p, worst, best
```