### PR TITLE
plugins.telefe: rewrite plugin

### DIFF
--- a/src/streamlink/plugins/telefe.py
+++ b/src/streamlink/plugins/telefe.py
@@ -7,7 +7,7 @@ $region Argentina
 """
 
 import re
-from urllib.parse import urljoin
+from urllib.parse import urlparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
@@ -18,47 +18,70 @@ from streamlink.stream.hls import HLSStream
 log = getLogger(__name__)
 
 
-@pluginmatcher(re.compile(r"https://mitelefe\.com/vivo"))
+@pluginmatcher(re.compile(r"https://mitelefe\.com/(?:telefe-en-)?vivo"))
 class Telefe(Plugin):
+    _URL_TOKENIZE = "https://mitelefe.com/vidya/tokenize"
+
     def _get_streams(self):
-        self.title, hls_url = self.session.http.get(
+        self.title, stream_url = self.session.http.get(
             self.url,
             schema=validate.Schema(
                 validate.parse_html(),
-                validate.xml_xpath_string(".//script[contains(text(), 'HLS')]/text()"),
-                validate.none_or_all(
-                    re.compile(r"=\s*(\{.+?});", re.DOTALL | re.MULTILINE),
-                    validate.none_or_all(
-                        validate.get(1),
-                        validate.parse_json(),
+                validate.union((
+                    validate.xml_xpath_string(".//meta[@property='og:title'][@content][1]/@content"),
+                    validate.all(
+                        validate.xml_xpath_string(".//*[@data-player-url][1]/@data-player-url"),
+                        validate.none_or_all(
+                            validate.url(),
+                        ),
+                    ),
+                )),
+            ),
+        )
+        if not stream_url:
+            log.error("Could not find stream URL")
+            return None
+
+        parsed = urlparse(stream_url)
+        netloc = parsed.netloc.removeprefix("www.")
+        if netloc in ("youtube.com", "youtu.be", "dailymotion.com"):
+            return self.session.streams(stream_url)
+
+        headers = {
+            "Origin": "https://mitelefe.com",
+            "Referer": self.url,
+        }
+
+        hls_url = self.session.http.post(
+            self._URL_TOKENIZE,
+            headers={
+                "Content-Type": "application/json",
+                **headers,
+            },
+            json={
+                "url": stream_url,
+            },
+            schema=validate.Schema(
+                validate.parse_json(),
+                validate.any(
+                    validate.all(
                         {
-                            str: {
-                                "children": {
-                                    "top": {
-                                        "model": {
-                                            "videos": [
-                                                {
-                                                    "title": str,
-                                                    "sources": validate.all(
-                                                        [{"url": str, "type": str}],
-                                                        validate.filter(lambda p: p["type"].lower() == "hls"),
-                                                        validate.get((0, "url")),
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    },
-                                },
-                            },
+                            "url": validate.url(path=validate.endswith(".m3u8")),
                         },
-                        validate.transform(lambda k: next(iter(k.values()))),
-                        validate.get(("children", "top", "model", "videos", 0)),
-                        validate.union_get("title", "sources"),
+                        validate.get("url"),
+                    ),
+                    validate.all(
+                        str,
+                        validate.url(path=validate.endswith(".m3u8")),
                     ),
                 ),
             ),
         )
-        return HLSStream.parse_variant_playlist(self.session, urljoin(self.url, hls_url))
+        if self.session.http.head(hls_url, raise_for_status=False).status_code >= 400:
+            log.error("Access restricted")
+            return None
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url, headers=headers)
 
 
 __plugin__ = Telefe

--- a/tests/plugins/test_telefe.py
+++ b/tests/plugins/test_telefe.py
@@ -7,7 +7,7 @@ class TestPluginCanHandleUrlTelefe(PluginCanHandleUrl):
 
     should_match = [
         "https://mitelefe.com/vivo",
-        "https://mitelefe.com/vivo/",
+        "https://mitelefe.com/telefe-en-vivo",
     ]
 
     should_not_match = [


### PR DESCRIPTION
Fixes #6879

@ItsIgnacioPortal
Please test these plugin changes and report back with a full debug log.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

I don't know if this PR's changes are working. The site is agressively blocking VPNs, and those free HTTP/SOCKS proxies from Argentina that are not offline result in the same access restriction when trying to access the HLS stream URL. I've tried this for several hours and am not willing to spend any more time on geo-restrictions like this. The plugin changes reflect what their JS code is doing, but it's also possible that I've missed some detail. Either way, I can't fix this myself without help from someone who can access the stream on their website.