### PR TITLE
Add Deno JavaScript runtime execution utility

### DIFF
--- a/src/streamlink/utils/deno.py
+++ b/src/streamlink/utils/deno.py
@@ -1,0 +1,68 @@
+import logging
+import os
+import shlex
+import subprocess
+
+from streamlink.utils.path import resolve_executable
+
+
+log = logging.getLogger(__name__)
+
+
+class Deno:
+    def __init__(self, params: dict | None = None):
+        self._DEFAULT_PARAMS = {
+            "--ext": "js",
+            "--no-code-cache": True,
+            "--no-prompt": True,
+            "--no-remote": True,
+            "--no-lock": True,
+            "--node-modules-dir": "none",
+            "--no-config": True,
+            "--no-npm": True,
+            "--cached-only": True,
+        }
+
+        self._exec_path = resolve_executable("deno")
+        if not self._exec_path:
+            raise FileNotFoundError("Deno not found. Please install Deno from the official website")
+        self._params = {**self._DEFAULT_PARAMS, **(params or {})}
+
+    def _build_cmd(self) -> list[str]:
+        cmd = [str(self._exec_path), "run"]
+        for flag, value in self._params.items():
+            if value is True:
+                cmd.append(str(flag))
+            elif value is not False and value is not None:
+                cmd.append(f"{flag}={value}")
+        cmd.append("-")
+        return cmd
+
+    def execute(self, stdin) -> str:
+        cmd = self._build_cmd()
+        log.debug("Executing Deno: %s", shlex.join(cmd))
+
+        proc = subprocess.Popen(
+            cmd,
+            text=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ.copy(),
+            encoding="utf-8",
+        )
+        try:
+            stdout, stderr = proc.communicate(stdin)
+        except BaseException:
+            proc.kill()
+            proc.wait(timeout=0)
+            raise
+
+        if proc.returncode or stderr:
+            msg = f"Deno process failed (returncode: {proc.returncode})"
+            if stderr:
+                msg = f"{msg}: {stderr.strip()}"
+            raise Exception(msg)
+
+        log.debug("Deno process completed successfully")
+        return stdout

--- a/src/streamlink/utils/deno.py
+++ b/src/streamlink/utils/deno.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import ClassVar
+
+from streamlink.logger import getLogger
+from streamlink.utils.path import resolve_executable
+from streamlink.utils.processoutput import ProcessOutput
+
+
+log = getLogger(__name__)
+
+
+class DenoProcessor(ProcessOutput):
+    """
+    Utility class for finding and launching Deno on the user's system and processing JavaScript via stdin/stdout.
+    """
+
+    # https://docs.deno.com/runtime/reference/cli/run/#usage
+    _RUN_FLAGS: ClassVar[frozenset[str]] = frozenset([
+        "--ext=js",
+        "--no-code-cache",
+        "--no-prompt",
+        "--no-remote",
+        "--no-lock",
+        "--node-modules-dir=none",
+        "--no-config",
+        "--no-npm",
+    ])
+
+    def __init__(
+        self,
+        executable_path: str | None = None,
+        **kwargs,
+    ) -> None:
+        if (exec_path := self.resolve_path(executable_path)) is None:
+            raise FileNotFoundError("Deno not found. Please install the Deno JavaScript runtime on your system.")
+
+        kwargs.pop("stdin", None)
+        super().__init__([exec_path, "run", *self._RUN_FLAGS, "-"], **kwargs)
+        self._output_lines: list[str] = []
+
+    # noinspection PyMethodOverriding
+    async def arun(self, stdin: bytes) -> bool:  # type: ignore[override, ty:invalid-method-override]
+        log.trace("Running Deno with a stdin payload of %d bytes: %r", len(stdin), self.command)
+        return await super().arun(stdin=stdin)
+
+    @property
+    def output(self) -> str:
+        return "\n".join(self._output_lines)
+
+    def onstdout(self, idx: int, line: str) -> bool | None:
+        self._output_lines.append(line)
+
+    def onstderr(self, idx: int, line: str) -> bool | None:
+        raise RuntimeError(f"Deno error: {line}")
+
+    @staticmethod
+    @lru_cache
+    def resolve_path(executable_path: str | None = None) -> str | None:
+        if not executable_path:
+            exec_path = resolve_executable(names=["deno"])
+        else:
+            exec_path = executable_path
+
+        if not exec_path:
+            return None
+
+        return str(exec_path)

--- a/tests/utils/test_deno.py
+++ b/tests/utils/test_deno.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from streamlink.utils.deno import DenoProcessor
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolve_path_cache():
+    yield
+    DenoProcessor.resolve_path.cache_clear()
+
+
+@pytest.fixture()
+def fake_exe(tmp_path):
+    exe = tmp_path / "deno.exe"
+    exe.write_bytes(b"")
+    return exe
+
+
+class TestResolvePath:
+    @pytest.fixture()
+    def mock_resolve_executable(self, monkeypatch: pytest.MonkeyPatch, fake_exe: Path):
+        mock_resolve_executable = Mock(return_value=fake_exe)
+        monkeypatch.setattr("streamlink.utils.deno.resolve_executable", mock_resolve_executable)
+        yield mock_resolve_executable
+        assert mock_resolve_executable.call_count == 1
+
+    def test_explicit_path(self, fake_exe: Path):
+        assert DenoProcessor.resolve_path(str(fake_exe)) == str(fake_exe)
+
+    def test_not_found(self, mock_resolve_executable: Mock):
+        mock_resolve_executable.return_value = None
+        with pytest.raises(FileNotFoundError):
+            DenoProcessor()
+        with pytest.raises(FileNotFoundError):
+            DenoProcessor()
+
+    def test_auto_resolve(self, mock_resolve_executable: Mock, fake_exe: Path):
+        assert DenoProcessor.resolve_path() == str(fake_exe)
+        assert DenoProcessor.resolve_path() == str(fake_exe)
+
+
+class TestProcessOutputIntegration:
+    @pytest.fixture(autouse=True)
+    def _resolve(self, monkeypatch: pytest.MonkeyPatch, fake_exe: Path):
+        monkeypatch.setattr("streamlink.utils.deno.DenoProcessor.resolve_path", Mock(return_value=str(fake_exe)))
+
+    def test_process_args(self, fake_exe: Path):
+        proc = DenoProcessor(stdin="console.log('🐻');")
+        assert proc.command == [str(fake_exe), "run", *DenoProcessor._RUN_FLAGS, "-"]
+        assert proc.stdin == b""
+
+    @pytest.mark.trio()
+    async def test_log_command(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, fake_exe: Path):
+        monkeypatch.setattr("streamlink.utils.deno.ProcessOutput.arun", AsyncMock(return_value=True))
+        caplog.set_level(1, "streamlink")
+        proc = DenoProcessor()
+        assert await proc.arun(stdin=b"foo")
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.utils.deno",
+                "trace",
+                f"Running Deno with a stdin payload of 3 bytes: {[str(fake_exe), 'run', *DenoProcessor._RUN_FLAGS, '-']!r}",
+            ),
+        ]
+
+    def test_output_collected(self):
+        proc = DenoProcessor()
+        proc.onstdout(0, "Hello")
+        proc.onstdout(0, "World!")
+        assert proc.output == "Hello\nWorld!"
+
+    def test_onstderr_raises(self):
+        proc = DenoProcessor()
+        with pytest.raises(RuntimeError, match="Deno error: some error"):
+            proc.onstderr(0, "some error")


### PR DESCRIPTION
Introduce a Deno wrapper class for executing JavaScript via the Deno runtime as a subprocess. Supports configurable CLI flags with secure defaults (no remote, no npm, no config, cached-only) and pipes stdin to the process, returning stdout or raising on failure.

<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

