### PR TITLE
Session Option: 'stream-passthrough-encrypted'

### DIFF
--- a/src/streamlink/session/options.py
+++ b/src/streamlink/session/options.py
@@ -157,6 +157,10 @@ class StreamlinkOptions(Options):
           - ``float``
           - ``60.0``
           - Timeout for reading data from stream
+        * - stream-passthrough-encrypted
+          - ``bool``
+          - ``False``
+          - Pass through encrypted stream segments without attempting decryption
         * - hls-live-edge
           - ``int``
           - ``3``
@@ -304,6 +308,7 @@ class StreamlinkOptions(Options):
             "stream-segmented-duration": 0.0,
             "stream-segmented-queue-deadline": 3,
             "stream-timeout": 60.0,
+            "stream-passthrough-encrypted": False,
             "hls-live-edge": 3,
             "hls-live-restart": False,
             "hls-start-offset": 0.0,

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -308,6 +308,7 @@ class DASHStream(Stream):
         """
 
         manifest, mpd_params = cls.fetch_manifest(session, url_or_manifest, **kwargs)
+        passthrough_encrypted = session.options.get("stream-passthrough-encrypted")
 
         try:
             mpd = cls.parse_mpd(manifest, mpd_params)
@@ -333,15 +334,23 @@ class DASHStream(Stream):
 
         # Search for suitable video and audio representations
         for aset in period_selection.adaptationSets:
-            if aset.contentProtections:
+            if aset.contentProtections and not passthrough_encrypted:
                 raise PluginError(f"{source} is protected by DRM")
             for rep in aset.representations:
-                if rep.contentProtections:
+                if rep.contentProtections and not passthrough_encrypted:
                     raise PluginError(f"{source} is protected by DRM")
                 if rep.mimeType.startswith("video"):
                     video.append(rep)
                 elif rep.mimeType.startswith("audio"):  # pragma: no branch
                     audio.append(rep)
+
+        if passthrough_encrypted:
+            is_encrypted = any(
+                aset.contentProtections or any(rep.contentProtections for rep in aset.representations)
+                for aset in period_selection.adaptationSets
+            )
+            if is_encrypted:
+                log.warning(f"{source} is protected by DRM and won't be decrypted.")
 
         if not video:
             video.append(None)

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -349,8 +349,8 @@ class DASHStream(Stream):
                 aset.contentProtections or any(rep.contentProtections for rep in aset.representations)
                 for aset in period_selection.adaptationSets
             )
-            if is_encrypted:
-                log.warning(f"{source} is protected by DRM and won't be decrypted.")
+            if is_encrypted:  # pragma: no branch
+                log.warning(f"{source} is protected by DRM and won't be decrypted")
 
         if not video:
             video.append(None)

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -410,7 +410,7 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         if self.sequence < 0 and first_segment.key and first_segment.key.method != "NONE":
             log.debug("Segments in this playlist are encrypted")
             if self.passthrough_encrypted:
-                log.warning(f"The stream content is encrypted with '{first_segment.key.method}' and won't be decrypted.")
+                log.warning("The stream content is encrypted with '%s' and won't be decrypted", first_segment.key.method)
 
         self.playlist_changed = [s.num for s in self.playlist_segments] != [s.num for s in segments]
         self.playlist_segments = segments

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -95,6 +95,7 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
         if ignore_names:
             segments = "|".join(map(re.escape, ignore_names))
             self.ignore_names = re.compile(segments, re.IGNORECASE)
+        self.passthrough_encrypted = options.get("stream-passthrough-encrypted")
 
     @staticmethod
     def num_to_iv(n: int) -> bytes:
@@ -260,7 +261,8 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
         # TODO: Rewrite HLSSegment, HLSStreamWriter and HLSStreamWorker based on independent initialization section segments,
         #       similar to the DASH implementation
         key = segment.map.key if is_map and segment.map else segment.key
-        if key and key.method != "NONE":
+
+        if key and key.method != "NONE" and not self.passthrough_encrypted:
             try:
                 decryptor = self.create_decryptor(key, segment.num)
             except (StreamError, ValueError) as err:
@@ -331,6 +333,7 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             self.reload_time = 0.0
         self._reload_time: float = self._RELOAD_TIME_DEFAULT
         self._reload_last: datetime = now()
+        self.passthrough_encrypted = self.session.options.get("stream-passthrough-encrypted")
 
     def _warn_playlist_sequence(self):
         warnings.warn(
@@ -404,8 +407,10 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         segments = playlist.segments
         first_segment, last_segment = segments[0], segments[-1]
 
-        if first_segment.key and first_segment.key.method != "NONE":
+        if self.sequence < 0 and first_segment.key and first_segment.key.method != "NONE":
             log.debug("Segments in this playlist are encrypted")
+            if self.passthrough_encrypted:
+                log.warning(f"The stream content is encrypted with '{first_segment.key.method}' and won't be decrypted.")
 
         self.playlist_changed = [s.num for s in self.playlist_segments] != [s.num for s in segments]
         self.playlist_segments = segments

--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1060,6 +1060,16 @@ def build_parser():
         """,
     )
     transport.add_argument(
+        "--stream-passthrough-encrypted",
+        action="store_true",
+        default=None,
+        help="""
+            Pass through data from encrypted streams without decryption or encryption checks.
+
+            This applies to DASH and HLS streams, and will likely result in garbage output.
+        """,
+    )
+    transport.add_argument(
         "--mux-subtitles",
         action="store_true",
         default=None,
@@ -1568,6 +1578,7 @@ _ARGUMENT_TO_SESSIONOPTION: list[tuple[str, str, Callable[[Any], Any] | None]] =
     ("stream_segmented_duration", "stream-segmented-duration", None),
     ("stream_segmented_queue_deadline", "stream-segmented-queue-deadline", None),
     ("stream_timeout", "stream-timeout", None),
+    ("stream_passthrough_encrypted", "stream-passthrough-encrypted", None),
     ("hls_live_edge", "hls-live-edge", None),
     ("hls_live_restart", "hls-live-restart", None),
     ("hls_start_offset", "hls-start-offset", None),

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -302,19 +302,53 @@ class TestDASHStreamParseManifest:
         [
             pytest.param(
                 Mock(contentProtections="DRM", representations=[]),
-                id="ContentProtection on AdaptationSet",
+                id="adaptationset",
             ),
             pytest.param(
-                Mock(contentProtections=None, representations=[Mock(id="1", contentProtections="DRM")]),
-                id="ContentProtection on Representation",
+                Mock(contentProtections=None, representations=[Mock(id="1", contentProtections="DRM", height=1080)]),
+                id="representation",
             ),
         ],
     )
-    def test_contentprotection(self, session: Streamlink, mpd: Mock, adaptationset: Mock):
+    @pytest.mark.parametrize(
+        ("session", "raises", "logrecords"),
+        [
+            pytest.param(
+                {},
+                pytest.raises(PluginError, match=r" is protected by DRM$"),
+                [],
+                id="no-passthrough-encrypted",
+            ),
+            pytest.param(
+                {"stream-passthrough-encrypted": True},
+                does_not_raise,
+                [
+                    (
+                        "streamlink.stream.dash",
+                        "warning",
+                        "http://test/manifest.mpd is protected by DRM and won't be decrypted",
+                    ),
+                ],
+                id="passthrough-encrypted",
+            ),
+        ],
+        indirect=["session"],
+    )
+    def test_contentprotection(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        session: Streamlink,
+        raises: nullcontext,
+        adaptationset: Mock,
+        mpd: Mock,
+        logrecords: list,
+    ):
         mpd.return_value = Mock(periods=[Mock(adaptationSets=[adaptationset])])
 
-        with pytest.raises(PluginError):
+        with raises:
             DASHStream.parse_manifest(session, "http://test/manifest.mpd")
+
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == logrecords
 
     @pytest.mark.nomockedhttprequest()
     def test_string(self, session: Streamlink, mpd: Mock, parse_xml: Mock):

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -943,9 +943,10 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
     __stream__ = EventedWriterHLSStream
 
     def get_session(self, options=None, *args, **kwargs):
+        options = options or {}
+        options.setdefault("hls-live-edge", 3)
+        options.setdefault("http-headers", {"X-FOO": "BAR"})
         session = super().get_session(options)
-        session.set_option("hls-live-edge", 3)
-        session.set_option("http-headers", {"X-FOO": "BAR"})
 
         return session
 
@@ -1256,6 +1257,45 @@ class TestHLSStreamEncrypted(TestMixinStreamHLS, unittest.TestCase):
         expected += self.content(segments, cond=lambda s: 2 <= s.num <= 3)
         expected += self.content(segments, prop="content_plain", cond=lambda s: 4 <= s.num <= 5)
         assert data == expected, "Switches between encryption key methods"
+
+    @patch("streamlink.stream.hls.hls.log")
+    def test_hls_passthrough_encrypted(self, mock_log: Mock):
+        aes_key, aes_iv, key = self.gen_key()
+        segments = self.subject(
+            options={
+                "hls-live-edge": 4,
+                "stream-passthrough-encrypted": True,
+            },
+            playlists=[
+                Playlist(0, [key] + [SegmentEnc(num, aes_key, aes_iv) for num in range(4)]),
+                Playlist(4, [key] + [SegmentEnc(num, aes_key, aes_iv) for num in range(4, 8)], end=True),
+            ],
+        )
+
+        self.await_write(8)
+        data = self.await_read(read_all=True)
+        self.await_close()
+
+        expected = self.content(segments)
+        encrypted = self.content(segments, prop="content_plain")
+        assert data == expected, "Does not decrypt the stream data"
+        assert data != encrypted, "Does not decrypt the stream data"
+        assert (
+            len([
+                call_arg
+                for call_arg in mock_log.debug.call_args_list
+                if call_arg.args == ("Segments in this playlist are encrypted",)
+            ])
+            == 1
+        )
+        assert (
+            len([
+                call_arg
+                for call_arg in mock_log.warning.call_args_list
+                if call_arg.args == ("The stream content is encrypted with '%s' and won't be decrypted", "AES-128")
+            ])
+            == 1
+        )
 
 
 @patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))


### PR DESCRIPTION
- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

Introduces two new session options, `hls-no-check-formats` and `dash-no-check-formats`, which mirror the behavior of yt-dlp’s --no-check-formats flag. These options allow users to bypass standard stream validation and content-protection checks to output raw data segments.

While standard users typically benefit from format validation, these options are critical for:

- Plugin Development: Building utilities that require access to unvalidated stream data.
- Research & Debugging: Investigating raw stream chunks and manifest structures without interference from the internal processing engine.
- Edge-case Handling: Accessing data in streams where standard detection might otherwise fail or block the pipeline.

No AI was used for this commit.