### PR TITLE
cli.argparser: fix type of session-option mapping

### DIFF
--- a/src/streamlink_cli/argparser.py
+++ b/src/streamlink_cli/argparser.py
@@ -1546,7 +1546,7 @@ def build_parser():
 
 # The order of arguments determines if options get overridden by `Streamlink.set_option()`
 # NOTE: arguments with `action=store_{true,false}` must set `default=None`
-_ARGUMENT_TO_SESSIONOPTION: list[tuple[str, str, Callable[[Any], Any] | None]] = [
+_ARGUMENT_TO_SESSIONOPTION: list[tuple[str, str, Callable[[Any], Any] | type | None]] = [
     # generic arguments
     ("no_plugin_cache", "no-plugin-cache", None),
     ("locale", "locale", None),


### PR DESCRIPTION
Current state on master causes a warning in pycharm's internal type checker, but works fine with mypy and ty...