### PR TITLE
docs: fix sidebar-brand anchor color

### DIFF
--- a/docs/_static/styles/custom.css
+++ b/docs/_static/styles/custom.css
@@ -120,6 +120,10 @@ a[href^="https://"]:not(.no-external-link-icon):not(.muted-link):not(.sd-badge):
   background-color: transparent !important;
 }
 
+a.sidebar-brand:visited {
+  color: unset;
+}
+
 .sidebar-brand,
 .sidebar-versions,
 .sidebar-search,


### PR DESCRIPTION
We don't want the regular `a:visited` color on the sidebar-brand text.