### PR TITLE
ci.github: add macos-latest runners

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 12
+    after_n_builds: 18
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/install-temp-dependencies.sh
+++ b/.github/workflows/install-temp-dependencies.sh
@@ -4,30 +4,42 @@ set -euxo pipefail
 PY=$(python -c 'import platform,sysconfig;v="".join(platform.python_version_tuple()[:2]);t="t" if sysconfig.get_config_var("Py_GIL_DISABLED") else "";print(f"cp{v}-cp{v}{t}")')
 [[ "${PY}" == cp314-cp314 || "${PY}" == cp314-cp314t ]] || exit 0
 
-[[ "$(uname)" == Linux ]] && PLATFORM=linux_x86_64 || PLATFORM=win_amd64
+if [[ "$(uname)" == Linux ]]; then
+    PLATFORM=linux_x86_64
+elif [[ "$(uname)" == Darwin ]]; then
+    PLATFORM=macosx_10_15_universal2
+elif [[ "$(uname)" == MINGW64_NT* ]]; then
+    PLATFORM=win_amd64
+else
+    exit 1
+fi
 
 
 BASE=https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download
 DEPS=()
 
+# individual platform dependencies
 if [[ "${PLATFORM}" == linux_x86_64 ]]; then
+    DEPS+=()
+elif [[ "${PLATFORM}" == macosx_10_15_universal2 ]]; then
     DEPS+=()
 elif [[ "${PLATFORM}" == win_amd64 ]]; then
     DEPS+=()
 fi
 
+# no-GIL / free-threaded dependencies
 if [[ "${PY}" == *t ]]; then
     DEPS+=(
-        'brotli-20251007-1/brotli-1.2.0'
-        'pycryptodome-20251017-1/pycryptodome-3.23.0'
+        'brotli-20260424-1/brotli-1.2.0'
+        'pycryptodome-20260424-1/pycryptodome-3.24.0b0'
     )
 fi
 
-deps=()
-for dep in "${DEPS[@]}"; do
-    deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
-done
+if [[ ${#DEPS[@]} != 0 ]]; then
+    deps=()
+    for dep in "${DEPS[@]}"; do
+        deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
+    done
 
-if [[ ${#deps[@]} != 0 ]]; then
     python -m pip install -U "${deps[@]}"
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         python-version:
           - "3.10"


### PR DESCRIPTION
See #6903 

No idea about the reliability of macOS runners...

`macos-latest` are the ARM64-based ones:
https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for--private-repositories

Let's see if there are any compatibility issues. Adding macOS runners also means that we now have 18 test runners, which might be a bit too much. I'll think about only adding one macOS test runner using the latest Python version, since we only need to hit certain code paths (without mocking) that are macOS-specific and not Python-version-specific on macOS.