### PR TITLE
session.http: fix set_interface on macOS

### DIFF
--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -38,7 +38,11 @@ if TYPE_CHECKING:
         def __call__(self, byte_str: bytes, should_rename_legacy: bool = False, **kwargs: Any) -> _DetectEncodingResult: ...
 
 
+is_linux = sys.platform == "linux"
+is_android = sys.platform == "android"
 is_darwin = sys.platform == "darwin"
+is_freebsd = sys.platform.startswith("freebsd")
+is_posix = os.name == "posix"
 is_win32 = os.name == "nt"
 
 
@@ -96,6 +100,10 @@ __all__ = [
     "ExceptionGroup",
     "deprecated",
     "detect_encoding",
+    "is_linux",
+    "is_android",
     "is_darwin",
+    "is_freebsd",
+    "is_posix",
     "is_win32",
 ]

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -26,8 +26,12 @@ from streamlink.utils.parse import parse_json, parse_xml
 
 if TYPE_CHECKING:
     import re
+    from collections.abc import Iterator
+    from typing import TypeAlias
 
     from requests import PreparedRequest
+
+    _TYPE_SOCKET_OPTION: TypeAlias = tuple[int, int, int | bytes]
 
 
 log = getLogger(__name__)
@@ -58,6 +62,31 @@ class Urllib3UtilUrlPercentReOverride:
 
 
 urllib3.util.url._PERCENT_RE = Urllib3UtilUrlPercentReOverride  # type: ignore[attr-defined, ty:unresolved-attribute]
+
+
+# Monkey-patch urllib3's set_socket_options,
+# so we can filter out certain options which are incompatible based on certain socket attributes.
+# The main intention is to filter out socket options on darwin when setting the network interface by name (see down below).
+def urllib3_set_socket_options(sock: socket.socket, options: list[_TYPE_SOCKET_OPTION] | None) -> None:
+    if not options:
+        return
+
+    for opt in _filter_socket_options(sock, options):
+        sock.setsockopt(*opt)
+
+
+def _filter_socket_options(sock: socket.socket, options: list[_TYPE_SOCKET_OPTION]) -> Iterator[_TYPE_SOCKET_OPTION]:
+    for option in options:
+        match sock.family, *option:
+            case socket.AF_INET, socket.IPPROTO_IPV6, *_:
+                pass
+            case socket.AF_INET6, socket.IPPROTO_IP, *_:
+                pass
+            case _:
+                yield option
+
+
+urllib3.util.connection._set_socket_options = urllib3_set_socket_options  # type: ignore[attr-defined, ty:unresolved-attribute]
 
 
 # requests.Request.__init__ keywords, except for "hooks"

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -17,8 +17,9 @@ from urllib3.connection import HTTPConnection
 from urllib3.util import create_urllib3_context  # type: ignore[attr-defined, ty:unresolved-import]
 
 import streamlink.session.http_useragents as useragents
-from streamlink.compat import is_win32
+from streamlink.compat import is_darwin, is_linux, is_win32
 from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
+from streamlink.logger import getLogger
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.utils.parse import parse_json, parse_xml
 
@@ -27,6 +28,9 @@ if TYPE_CHECKING:
     import re
 
     from requests import PreparedRequest
+
+
+log = getLogger(__name__)
 
 
 _original_allowed_gai_family = urllib3_util_connection.allowed_gai_family  # type: ignore[attr-defined, ty:unresolved-attribute]
@@ -133,10 +137,22 @@ class HTTPSession(Session):
                         iface = interface
 
             if iface:
-                connection_pool_kw["socket_options"] = [
-                    *HTTPConnection.default_socket_options,
-                    (socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode()),
-                ]
+                if is_linux:
+                    connection_pool_kw["socket_options"] = [
+                        *HTTPConnection.default_socket_options,
+                        (socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode()),
+                    ]
+                elif is_darwin:  # pragma: no branch
+                    try:
+                        idx = socket.if_nametoindex(iface)
+                    except OSError as err:
+                        log.error(err)
+                    else:
+                        connection_pool_kw["socket_options"] = [
+                            *HTTPConnection.default_socket_options,
+                            (socket.IPPROTO_IP, getattr(socket, "IP_BOUND_IF", 25), idx),
+                            (socket.IPPROTO_IPV6, getattr(socket, "IPV6_BOUND_IF", 125), idx),
+                        ]
             if host:
                 connection_pool_kw["source_address"] = (host, 0)
 

--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -71,6 +71,8 @@ _Exception: TypeAlias = type[Exception]
 
 # ----
 
+def urllib3_set_socket_options(sock: socket.socket, options: list[tuple[int, int, int | bytes]] | None) -> None: ...
+
 class SSLContextAdapter(HTTPAdapter):
     def get_ssl_context(self) -> ssl.SSLContext: ...
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 _TEST_CONDITION_MARKERS: Mapping[str, tuple[bool, str] | Callable[[Any], tuple[bool, str]]] = {
+    "linux_only": (sys.platform == "linux", "only applicable on Linux"),
+    "darwin_only": (sys.platform == "darwin", "only applicable on macOS"),
     "posix_only": (os.name == "posix", "only applicable on a POSIX OS"),
     "windows_only": (os.name == "nt", "only applicable on Windows"),
     "python": lambda *ver, **_: (  # pragma: no cover
@@ -41,6 +43,8 @@ _TEST_PRIORITIES = (
 
 
 def pytest_configure(config: pytest.Config):
+    config.addinivalue_line("markers", "linux_only: tests which are only applicable on Linux")
+    config.addinivalue_line("markers", "darwin_only: tests which are only applicable on macOS")
     config.addinivalue_line("markers", "posix_only: tests which are only applicable on a POSIX OS")
     config.addinivalue_line("markers", "windows_only: tests which are only applicable on Windows")
     config.addinivalue_line("markers", "python(version): tests which are only applicable on specific Python versions")

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -18,7 +18,13 @@ from urllib3.connection import HTTPConnection
 from urllib3.response import HTTPResponse
 
 from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
-from streamlink.session.http import HTTPSession, SSLContextAdapter, TLSNoDHAdapter, TLSSecLevel1Adapter
+from streamlink.session.http import (
+    HTTPSession,
+    SSLContextAdapter,
+    TLSNoDHAdapter,
+    TLSSecLevel1Adapter,
+    urllib3_set_socket_options,
+)
 from streamlink.session.http_useragents import DEFAULT
 
 
@@ -100,6 +106,45 @@ class TestUrllib3Overrides:
         req = requests.Request(method="GET", url=url)
         prep = httpsession.prepare_request(req)
         assert prep.url == expected
+
+    @pytest.mark.parametrize(
+        ("sock", "options", "expected"),
+        [
+            pytest.param(
+                {},
+                [],
+                [],
+                id="no-options",
+            ),
+            pytest.param(
+                {},
+                [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],
+                [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],
+                id="no-filters",
+            ),
+            # see set_interface() on darwin
+            pytest.param(
+                {},
+                [(socket.IPPROTO_IP, 25, 1), (socket.IPPROTO_IPV6, 125, 1)],
+                [(socket.IPPROTO_IP, 25, 1)],
+                id="inet-filter-ipproto-ipv6",
+            ),
+            # see set_interface() on darwin
+            pytest.param(
+                {"family": socket.AF_INET6},
+                [(socket.IPPROTO_IP, 25, 1), (socket.IPPROTO_IPV6, 125, 1)],
+                [(socket.IPPROTO_IPV6, 125, 1)],
+                id="inet6-filter-ipproto-ip",
+            ),
+        ],
+    )
+    def test_set_socket_options(self, sock: dict, options: list, expected: list):
+        sock.setdefault("family", socket.AF_INET)
+        sock.setdefault("type", socket.SOCK_STREAM)
+        sock.setdefault("proto", socket.IPPROTO_TCP)
+        mock_socket = Mock(**sock)
+        urllib3_set_socket_options(mock_socket, options)
+        assert mock_socket.setsockopt.call_args_list == [call(*item) for item in expected]
 
 
 class TestHTTPSession:

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -235,54 +235,98 @@ class TestHTTPSession:
         assert res.encoding == expected
         assert res.text == "Bär"
 
-    # not defined in stdlib on Windows
-    SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 0)
+    # Linux
+    SOL_SOCKET = getattr(socket, "SOL_SOCKET", 1)
+    SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 25)
+
+    # Darwin
+    IPPROTO_IP = getattr(socket, "IPPROTO_IP", 0)
+    IPPROTO_IPV6 = getattr(socket, "IPPROTO_IPV6", 41)
+    IP_BOUND_IF = getattr(socket, "IP_BOUND_IF", 25)
+    IPV6_BOUND_IF = getattr(socket, "IPV6_BOUND_IF", 125)
 
     @pytest.mark.parametrize(
-        ("interface", "source_address", "socket_options"),
+        ("interface", "source_address", "socket_options", "log"),
         [
             pytest.param(
                 None,
                 None,
                 None,
+                [],
                 id="none",
             ),
             pytest.param(
                 "",
                 None,
                 None,
+                [],
                 id="empty",
             ),
             pytest.param(
                 "0.0.0.0",
                 ("0.0.0.0", 0),
                 None,
+                [],
                 id="ipv4",
             ),
             pytest.param(
                 "::1",
                 ("::1", 0),
                 None,
+                [],
                 id="ipv6",
             ),
             pytest.param(
                 "my-interface",
                 None,
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
-                id="unix-iface",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"my-interface"),
+                ],
+                [],
+                id="linux-iface",
+                marks=pytest.mark.linux_only,
             ),
             pytest.param(
                 "if!my-interface",
                 None,
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
-                id="unix-iface-prefix",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"my-interface"),
+                ],
+                [],
+                id="linux-iface-prefix",
+                marks=pytest.mark.linux_only,
+            ),
+            pytest.param(
+                "my-interface",
+                None,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (IPPROTO_IP, IP_BOUND_IF, 1),
+                    (IPPROTO_IPV6, IPV6_BOUND_IF, 1),
+                ],
+                [],
+                id="darwin-iface",
+                marks=pytest.mark.darwin_only,
+            ),
+            pytest.param(
+                "if!my-interface",
+                None,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (IPPROTO_IP, IP_BOUND_IF, 1),
+                    (IPPROTO_IPV6, IPV6_BOUND_IF, 1),
+                ],
+                [],
+                id="darwin-iface-prefix",
+                marks=pytest.mark.darwin_only,
             ),
             pytest.param(
                 "host!0.0.0.0",
                 ("0.0.0.0", 0),
                 None,
+                [],
                 id="unix-host-prefix",
                 marks=pytest.mark.posix_only,
             ),
@@ -290,27 +334,59 @@ class TestHTTPSession:
                 "host!foo",
                 ("foo", 0),
                 None,
+                [],
                 id="unix-host-prefix-hostname",
                 marks=pytest.mark.posix_only,
             ),
             pytest.param(
                 "ifhost!my-interface!0.0.0.0",
                 ("0.0.0.0", 0),
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
-                id="unix-ifhost-prefix",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"my-interface"),
+                ],
+                [],
+                id="linux-ifhost-prefix",
+                marks=pytest.mark.linux_only,
             ),
             pytest.param(
                 "ifhost!my-interface",
                 None,
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"ifhost!my-interface")],
-                id="unix-ifhost-prefix-invalid",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"ifhost!my-interface"),
+                ],
+                [],
+                id="linux-ifhost-prefix-invalid",
+                marks=pytest.mark.linux_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface!0.0.0.0",
+                ("0.0.0.0", 0),
+                [
+                    *HTTPConnection.default_socket_options,
+                    (IPPROTO_IP, IP_BOUND_IF, 1),
+                    (IPPROTO_IPV6, IPV6_BOUND_IF, 1),
+                ],
+                [],
+                id="darwin-ifhost-prefix",
+                marks=pytest.mark.darwin_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface",
+                None,
+                None,
+                [
+                    ("streamlink.session.http", "error", "Invalid network interface name"),
+                ],
+                id="darwin-ifhost-prefix-invalid",
+                marks=pytest.mark.darwin_only,
             ),
             pytest.param(
                 "my-interface",
                 ("my-interface", 0),
                 None,
+                [],
                 id="win32-iface",
                 marks=pytest.mark.windows_only,
             ),
@@ -318,12 +394,30 @@ class TestHTTPSession:
                 "ifhost!my-interface!0.0.0.0",
                 ("ifhost!my-interface!0.0.0.0", 0),
                 None,
+                [],
                 id="win32-prefix",
                 marks=pytest.mark.windows_only,
             ),
         ],
     )
-    def test_set_interface(self, interface: str, source_address: tuple | None, socket_options: list[tuple] | None):
+    def test_set_interface(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        interface: str,
+        source_address: tuple | None,
+        socket_options: list[tuple] | None,
+        log: list,
+    ):
+        def _mock_socket_if_nametoindex(iface: str):
+            match iface:
+                case "my-interface":
+                    return 1
+                case _:
+                    raise OSError("Invalid network interface name")
+
+        monkeypatch.setattr("socket.if_nametoindex", _mock_socket_if_nametoindex)
+
         session = HTTPSession()
         session.mount("custom://", TLSNoDHAdapter())
 
@@ -341,6 +435,7 @@ class TestHTTPSession:
         for adapter in a_http, a_https, a_custom:
             assert adapter.poolmanager.connection_pool_kw.get("source_address") == source_address
             assert adapter.poolmanager.connection_pool_kw.get("socket_options") == socket_options
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == log
 
         session.set_interface(interface="")
         for adapter in a_http, a_https, a_custom:


### PR DESCRIPTION
Fixes #6903 

Opening this as a draft, since I'll have to go soon and thus can't do any further tests/checks. I also just noticed right before submitting this PR that I will also have to adjust the CLI argument's help text. I'll do this later...

As explained in https://github.com/streamlink/streamlink/issues/6903#issuecomment-4315750958, fixing #6903 also required an override of urllib3's `set_socket_options` util function, as we need to set socket options for both IPv4 and IPv6 beforehand. Without filtering, macOS would return an error because options for both address families are set. The filters I've added shouldn't cause any issues (I think).

@sandydoo If you want, you can give this PR branch a quick test. It's been working fine in my macOS 15 VM, with `--ipv4`/`--ipv6` added. Unfortunately, selecting an invalid interface name will only log an error message and continue using the default interface, otherwise an exception stack would be logged, which I don't want. On Linux, when selecting an invalid interface name, HTTP requests simply fail, which is the preferred result.