### PR TITLE
session.http: fix set_interface on macOS

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 12
+    after_n_builds: 18
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/install-temp-dependencies.sh
+++ b/.github/workflows/install-temp-dependencies.sh
@@ -4,30 +4,42 @@ set -euxo pipefail
 PY=$(python -c 'import platform,sysconfig;v="".join(platform.python_version_tuple()[:2]);t="t" if sysconfig.get_config_var("Py_GIL_DISABLED") else "";print(f"cp{v}-cp{v}{t}")')
 [[ "${PY}" == cp314-cp314 || "${PY}" == cp314-cp314t ]] || exit 0
 
-[[ "$(uname)" == Linux ]] && PLATFORM=linux_x86_64 || PLATFORM=win_amd64
+if [[ "$(uname)" == Linux ]]; then
+    PLATFORM=linux_x86_64
+elif [[ "$(uname)" == Darwin ]]; then
+    PLATFORM=macosx_10_15_universal2
+elif [[ "$(uname)" == MINGW64_NT* ]]; then
+    PLATFORM=win_amd64
+else
+    exit 1
+fi
 
 
 BASE=https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download
 DEPS=()
 
+# individual platform dependencies
 if [[ "${PLATFORM}" == linux_x86_64 ]]; then
+    DEPS+=()
+elif [[ "${PLATFORM}" == macosx_10_15_universal2 ]]; then
     DEPS+=()
 elif [[ "${PLATFORM}" == win_amd64 ]]; then
     DEPS+=()
 fi
 
+# no-GIL / free-threaded dependencies
 if [[ "${PY}" == *t ]]; then
     DEPS+=(
-        'brotli-20251007-1/brotli-1.2.0'
-        'pycryptodome-20251017-1/pycryptodome-3.23.0'
+        'brotli-20260424-1/brotli-1.2.0'
+        'pycryptodome-20260424-1/pycryptodome-3.24.0b0'
     )
 fi
 
-deps=()
-for dep in "${DEPS[@]}"; do
-    deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
-done
+if [[ ${#DEPS[@]} != 0 ]]; then
+    deps=()
+    for dep in "${DEPS[@]}"; do
+        deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
+    done
 
-if [[ ${#deps[@]} != 0 ]]; then
     python -m pip install -U "${deps[@]}"
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         runs-on:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         python-version:
           - "3.10"

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -38,7 +38,11 @@ if TYPE_CHECKING:
         def __call__(self, byte_str: bytes, should_rename_legacy: bool = False, **kwargs: Any) -> _DetectEncodingResult: ...
 
 
+is_linux = sys.platform == "linux"
+is_android = sys.platform == "android"
 is_darwin = sys.platform == "darwin"
+is_freebsd = sys.platform.startswith("freebsd")
+is_posix = os.name == "posix"
 is_win32 = os.name == "nt"
 
 
@@ -96,6 +100,10 @@ __all__ = [
     "ExceptionGroup",
     "deprecated",
     "detect_encoding",
+    "is_linux",
+    "is_android",
     "is_darwin",
+    "is_freebsd",
+    "is_posix",
     "is_win32",
 ]

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -26,8 +26,12 @@ from streamlink.utils.parse import parse_json, parse_xml
 
 if TYPE_CHECKING:
     import re
+    from collections.abc import Iterator
+    from typing import TypeAlias
 
     from requests import PreparedRequest
+
+    _TYPE_SOCKET_OPTION: TypeAlias = tuple[int, int, int | bytes]
 
 
 log = getLogger(__name__)
@@ -58,6 +62,31 @@ class Urllib3UtilUrlPercentReOverride:
 
 
 urllib3.util.url._PERCENT_RE = Urllib3UtilUrlPercentReOverride  # type: ignore[attr-defined, ty:unresolved-attribute]
+
+
+# Monkey-patch urllib3's set_socket_options,
+# so we can filter out certain options which are incompatible based on certain socket attributes.
+# The main intention is to filter out socket options on darwin when setting the network interface by name (see down below).
+def urllib3_set_socket_options(sock: socket.socket, options: list[_TYPE_SOCKET_OPTION] | None) -> None:
+    if not options:
+        return
+
+    for opt in _filter_socket_options(sock, options):
+        sock.setsockopt(*opt)
+
+
+def _filter_socket_options(sock: socket.socket, options: list[_TYPE_SOCKET_OPTION]) -> Iterator[_TYPE_SOCKET_OPTION]:
+    for option in options:
+        match sock.family, *option:
+            case socket.AF_INET, socket.IPPROTO_IPV6, *_:
+                pass
+            case socket.AF_INET6, socket.IPPROTO_IP, *_:
+                pass
+            case _:
+                yield option
+
+
+urllib3.util.connection._set_socket_options = urllib3_set_socket_options  # type: ignore[attr-defined, ty:unresolved-attribute]
 
 
 # requests.Request.__init__ keywords, except for "hooks"

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -17,8 +17,9 @@ from urllib3.connection import HTTPConnection
 from urllib3.util import create_urllib3_context  # type: ignore[attr-defined, ty:unresolved-import]
 
 import streamlink.session.http_useragents as useragents
-from streamlink.compat import is_win32
+from streamlink.compat import is_darwin, is_linux, is_win32
 from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
+from streamlink.logger import getLogger
 from streamlink.packages.requests_file import FileAdapter
 from streamlink.utils.parse import parse_json, parse_xml
 
@@ -27,6 +28,9 @@ if TYPE_CHECKING:
     import re
 
     from requests import PreparedRequest
+
+
+log = getLogger(__name__)
 
 
 _original_allowed_gai_family = urllib3_util_connection.allowed_gai_family  # type: ignore[attr-defined, ty:unresolved-attribute]
@@ -133,10 +137,22 @@ class HTTPSession(Session):
                         iface = interface
 
             if iface:
-                connection_pool_kw["socket_options"] = [
-                    *HTTPConnection.default_socket_options,
-                    (socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode()),
-                ]
+                if is_linux:
+                    connection_pool_kw["socket_options"] = [
+                        *HTTPConnection.default_socket_options,
+                        (socket.SOL_SOCKET, socket.SO_BINDTODEVICE, iface.encode()),
+                    ]
+                elif is_darwin:  # pragma: no branch
+                    try:
+                        idx = socket.if_nametoindex(iface)
+                    except OSError as err:
+                        log.error(err)
+                    else:
+                        connection_pool_kw["socket_options"] = [
+                            *HTTPConnection.default_socket_options,
+                            (socket.IPPROTO_IP, getattr(socket, "IP_BOUND_IF", 25), idx),
+                            (socket.IPPROTO_IPV6, getattr(socket, "IPV6_BOUND_IF", 125), idx),
+                        ]
             if host:
                 connection_pool_kw["source_address"] = (host, 0)
 

--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -71,6 +71,8 @@ _Exception: TypeAlias = type[Exception]
 
 # ----
 
+def urllib3_set_socket_options(sock: socket.socket, options: list[tuple[int, int, int | bytes]] | None) -> None: ...
+
 class SSLContextAdapter(HTTPAdapter):
     def get_ssl_context(self) -> ssl.SSLContext: ...
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 _TEST_CONDITION_MARKERS: Mapping[str, tuple[bool, str] | Callable[[Any], tuple[bool, str]]] = {
+    "linux_only": (sys.platform == "linux", "only applicable on Linux"),
+    "darwin_only": (sys.platform == "darwin", "only applicable on macOS"),
     "posix_only": (os.name == "posix", "only applicable on a POSIX OS"),
     "windows_only": (os.name == "nt", "only applicable on Windows"),
     "python": lambda *ver, **_: (  # pragma: no cover
@@ -41,6 +43,8 @@ _TEST_PRIORITIES = (
 
 
 def pytest_configure(config: pytest.Config):
+    config.addinivalue_line("markers", "linux_only: tests which are only applicable on Linux")
+    config.addinivalue_line("markers", "darwin_only: tests which are only applicable on macOS")
     config.addinivalue_line("markers", "posix_only: tests which are only applicable on a POSIX OS")
     config.addinivalue_line("markers", "windows_only: tests which are only applicable on Windows")
     config.addinivalue_line("markers", "python(version): tests which are only applicable on specific Python versions")

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -18,7 +18,13 @@ from urllib3.connection import HTTPConnection
 from urllib3.response import HTTPResponse
 
 from streamlink.exceptions import PluginError, StreamlinkDeprecationWarning
-from streamlink.session.http import HTTPSession, SSLContextAdapter, TLSNoDHAdapter, TLSSecLevel1Adapter
+from streamlink.session.http import (
+    HTTPSession,
+    SSLContextAdapter,
+    TLSNoDHAdapter,
+    TLSSecLevel1Adapter,
+    urllib3_set_socket_options,
+)
 from streamlink.session.http_useragents import DEFAULT
 
 
@@ -100,6 +106,45 @@ class TestUrllib3Overrides:
         req = requests.Request(method="GET", url=url)
         prep = httpsession.prepare_request(req)
         assert prep.url == expected
+
+    @pytest.mark.parametrize(
+        ("sock", "options", "expected"),
+        [
+            pytest.param(
+                {},
+                [],
+                [],
+                id="no-options",
+            ),
+            pytest.param(
+                {},
+                [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],
+                [(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)],
+                id="no-filters",
+            ),
+            # see set_interface() on darwin
+            pytest.param(
+                {},
+                [(socket.IPPROTO_IP, 25, 1), (socket.IPPROTO_IPV6, 125, 1)],
+                [(socket.IPPROTO_IP, 25, 1)],
+                id="inet-filter-ipproto-ipv6",
+            ),
+            # see set_interface() on darwin
+            pytest.param(
+                {"family": socket.AF_INET6},
+                [(socket.IPPROTO_IP, 25, 1), (socket.IPPROTO_IPV6, 125, 1)],
+                [(socket.IPPROTO_IPV6, 125, 1)],
+                id="inet6-filter-ipproto-ip",
+            ),
+        ],
+    )
+    def test_set_socket_options(self, sock: dict, options: list, expected: list):
+        sock.setdefault("family", socket.AF_INET)
+        sock.setdefault("type", socket.SOCK_STREAM)
+        sock.setdefault("proto", socket.IPPROTO_TCP)
+        mock_socket = Mock(**sock)
+        urllib3_set_socket_options(mock_socket, options)
+        assert mock_socket.setsockopt.call_args_list == [call(*item) for item in expected]
 
 
 class TestHTTPSession:

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -235,54 +235,98 @@ class TestHTTPSession:
         assert res.encoding == expected
         assert res.text == "Bär"
 
-    # not defined in stdlib on Windows
-    SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 0)
+    # Linux
+    SOL_SOCKET = getattr(socket, "SOL_SOCKET", 1)
+    SO_BINDTODEVICE = getattr(socket, "SO_BINDTODEVICE", 25)
+
+    # Darwin
+    IPPROTO_IP = getattr(socket, "IPPROTO_IP", 0)
+    IPPROTO_IPV6 = getattr(socket, "IPPROTO_IPV6", 41)
+    IP_BOUND_IF = getattr(socket, "IP_BOUND_IF", 25)
+    IPV6_BOUND_IF = getattr(socket, "IPV6_BOUND_IF", 125)
 
     @pytest.mark.parametrize(
-        ("interface", "source_address", "socket_options"),
+        ("interface", "source_address", "socket_options", "log"),
         [
             pytest.param(
                 None,
                 None,
                 None,
+                [],
                 id="none",
             ),
             pytest.param(
                 "",
                 None,
                 None,
+                [],
                 id="empty",
             ),
             pytest.param(
                 "0.0.0.0",
                 ("0.0.0.0", 0),
                 None,
+                [],
                 id="ipv4",
             ),
             pytest.param(
                 "::1",
                 ("::1", 0),
                 None,
+                [],
                 id="ipv6",
             ),
             pytest.param(
                 "my-interface",
                 None,
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
-                id="unix-iface",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"my-interface"),
+                ],
+                [],
+                id="linux-iface",
+                marks=pytest.mark.linux_only,
             ),
             pytest.param(
                 "if!my-interface",
                 None,
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
-                id="unix-iface-prefix",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"my-interface"),
+                ],
+                [],
+                id="linux-iface-prefix",
+                marks=pytest.mark.linux_only,
+            ),
+            pytest.param(
+                "my-interface",
+                None,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (IPPROTO_IP, IP_BOUND_IF, 1),
+                    (IPPROTO_IPV6, IPV6_BOUND_IF, 1),
+                ],
+                [],
+                id="darwin-iface",
+                marks=pytest.mark.darwin_only,
+            ),
+            pytest.param(
+                "if!my-interface",
+                None,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (IPPROTO_IP, IP_BOUND_IF, 1),
+                    (IPPROTO_IPV6, IPV6_BOUND_IF, 1),
+                ],
+                [],
+                id="darwin-iface-prefix",
+                marks=pytest.mark.darwin_only,
             ),
             pytest.param(
                 "host!0.0.0.0",
                 ("0.0.0.0", 0),
                 None,
+                [],
                 id="unix-host-prefix",
                 marks=pytest.mark.posix_only,
             ),
@@ -290,27 +334,59 @@ class TestHTTPSession:
                 "host!foo",
                 ("foo", 0),
                 None,
+                [],
                 id="unix-host-prefix-hostname",
                 marks=pytest.mark.posix_only,
             ),
             pytest.param(
                 "ifhost!my-interface!0.0.0.0",
                 ("0.0.0.0", 0),
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"my-interface")],
-                id="unix-ifhost-prefix",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"my-interface"),
+                ],
+                [],
+                id="linux-ifhost-prefix",
+                marks=pytest.mark.linux_only,
             ),
             pytest.param(
                 "ifhost!my-interface",
                 None,
-                [*HTTPConnection.default_socket_options, (socket.SOL_SOCKET, SO_BINDTODEVICE, b"ifhost!my-interface")],
-                id="unix-ifhost-prefix-invalid",
-                marks=pytest.mark.posix_only,
+                [
+                    *HTTPConnection.default_socket_options,
+                    (SOL_SOCKET, SO_BINDTODEVICE, b"ifhost!my-interface"),
+                ],
+                [],
+                id="linux-ifhost-prefix-invalid",
+                marks=pytest.mark.linux_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface!0.0.0.0",
+                ("0.0.0.0", 0),
+                [
+                    *HTTPConnection.default_socket_options,
+                    (IPPROTO_IP, IP_BOUND_IF, 1),
+                    (IPPROTO_IPV6, IPV6_BOUND_IF, 1),
+                ],
+                [],
+                id="darwin-ifhost-prefix",
+                marks=pytest.mark.darwin_only,
+            ),
+            pytest.param(
+                "ifhost!my-interface",
+                None,
+                None,
+                [
+                    ("streamlink.session.http", "error", "Invalid network interface name"),
+                ],
+                id="darwin-ifhost-prefix-invalid",
+                marks=pytest.mark.darwin_only,
             ),
             pytest.param(
                 "my-interface",
                 ("my-interface", 0),
                 None,
+                [],
                 id="win32-iface",
                 marks=pytest.mark.windows_only,
             ),
@@ -318,12 +394,30 @@ class TestHTTPSession:
                 "ifhost!my-interface!0.0.0.0",
                 ("ifhost!my-interface!0.0.0.0", 0),
                 None,
+                [],
                 id="win32-prefix",
                 marks=pytest.mark.windows_only,
             ),
         ],
     )
-    def test_set_interface(self, interface: str, source_address: tuple | None, socket_options: list[tuple] | None):
+    def test_set_interface(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        interface: str,
+        source_address: tuple | None,
+        socket_options: list[tuple] | None,
+        log: list,
+    ):
+        def _mock_socket_if_nametoindex(iface: str):
+            match iface:
+                case "my-interface":
+                    return 1
+                case _:
+                    raise OSError("Invalid network interface name")
+
+        monkeypatch.setattr("socket.if_nametoindex", _mock_socket_if_nametoindex)
+
         session = HTTPSession()
         session.mount("custom://", TLSNoDHAdapter())
 
@@ -341,6 +435,7 @@ class TestHTTPSession:
         for adapter in a_http, a_https, a_custom:
             assert adapter.poolmanager.connection_pool_kw.get("source_address") == source_address
             assert adapter.poolmanager.connection_pool_kw.get("socket_options") == socket_options
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == log
 
         session.set_interface(interface="")
         for adapter in a_http, a_https, a_custom:


### PR DESCRIPTION
Fixes #6903 
Closes #6906 
Closes #6907 

This combines #6906 and #6907, so that there are no failed CI jobs when merging into master separately.

Summary:

1. Add macos-latest runners for each version of Python
2. Update the temp dependencies script with newly built wheels
3. Add `is_linux` check in the compat module (to be able to exclude the BSDs)
4. Add test markers for linux/darwin in addition to the POSIX marker
5. Fix `HTTPSession.set_interface()` on macOS when using an interface name
6. Override urllib3's `util.connection._set_socket_options()` to be able to filter out options on macOS which can't be set depending on the socket's address family (when the connection is made/attempted)

As said in #6907, choosing an incorrect name only logs an error message and then continues using the default interface.

The macOS CI test runners *could be* ignored if we'd monkeypatch/mock the respective socket APIs and the `is_darwin` check, but I don't really like this idea. Should the CI test runners become too annoying due to being unable to spawn all of them at the same time, then I will maybe change this though.