### PR TITLE
tools: bump ruff+ty+mypy, replace docutils-stubs with types-docutils

### DIFF
--- a/docs/sphinxext/ext_argparse.py
+++ b/docs/sphinxext/ext_argparse.py
@@ -45,8 +45,7 @@ def indent(value, length=4):
 
 class ArgparseDirective(Directive):
     has_content = True
-    # noinspection PyClassVar
-    option_spec: ClassVar[dict[str, Callable[[str], Any]]] = {  # type: ignore[misc]
+    option_spec: ClassVar[dict[str, Callable[[str], Any]]] = {
         "module": unchanged,
         "attr": unchanged,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ typing = [
   { include-group = "test" },
   { include-group = "docs" },
   { include-group = "script" },
-  "ty ==0.0.30",
+  "ty ==0.0.33",
   "mypy[faster-cache] ==1.20.1",
   "typing-extensions >=4.0.0",
   "lxml-stubs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test = [
   "freezegun >=1.5.0",
 ]
 lint = [
-  "ruff ==0.15.10",
+  "ruff ==0.15.12",
 ]
 typing = [
   { include-group = "test" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ typing = [
   { include-group = "docs" },
   { include-group = "script" },
   "ty ==0.0.33",
-  "mypy[faster-cache] ==1.20.1",
+  "mypy[faster-cache] ==1.20.2",
   "typing-extensions >=4.0.0",
   "lxml-stubs",
   "trio-typing",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,11 +118,11 @@ typing = [
   "typing-extensions >=4.0.0",
   "lxml-stubs",
   "trio-typing",
+  "types-docutils",
   "types-freezegun",
   "types-requests",
   "types-setuptools",
   "types-urllib3",
-  "docutils-stubs",
 ]
 docs = [
   { include-group = "dev" },


### PR DESCRIPTION
Replacing `docutils-stubs` with `types-docutils` required setting `--reinstall` on pip in my local env, because both packages use the same internal toplevel package name and pip/uv didn't rewrite the entire package contents for some reason without `--reinstall`.