### PR TITLE
session.http: also set interface on adapter mount

### DIFF
--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from requests import PreparedRequest
+    from requests.adapters import BaseAdapter
 
     _TYPE_SOCKET_OPTION: TypeAlias = tuple[int, int, int | bytes]
 
@@ -191,6 +192,16 @@ class HTTPSession(Session):
             adapter.poolmanager.connection_pool_kw.pop("source_address", None)
             adapter.poolmanager.connection_pool_kw.pop("socket_options", None)
             adapter.poolmanager.connection_pool_kw.update(connection_pool_kw)
+
+    def mount(self, prefix: str | bytes, adapter: BaseAdapter) -> None:
+        # Update poolmanager connection kwargs for HTTPAdapters mounted after interface options were set
+        if isinstance(adapter, HTTPAdapter) and "http://" in self.adapters and "https://" in self.adapters:
+            default_adapter_connection_pool_kw = cast("HTTPAdapter", self.adapters["https://"]).poolmanager.connection_pool_kw
+            adapter.poolmanager.connection_pool_kw.update({
+                "source_address": default_adapter_connection_pool_kw.get("source_address"),
+                "socket_options": default_adapter_connection_pool_kw.get("socket_options"),
+            })
+        super().mount(prefix, adapter)
 
     # noinspection PyMethodMayBeStatic
     def set_address_family(self, family: socket.AddressFamily | None = None) -> None:

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -482,13 +482,20 @@ class TestHTTPSession:
             assert adapter.poolmanager.connection_pool_kw.get("socket_options") == socket_options
         assert [(record.name, record.levelname, record.message) for record in caplog.records] == log
 
+        a_new = TLSNoDHAdapter()
+        assert a_new.poolmanager.connection_pool_kw.get("source_address") is None
+        assert a_new.poolmanager.connection_pool_kw.get("socket_options") is None
+        session.mount("new://", a_new)
+        assert a_new.poolmanager.connection_pool_kw.get("source_address") == source_address
+        assert a_new.poolmanager.connection_pool_kw.get("socket_options") == socket_options
+
         session.set_interface(interface="")
-        for adapter in a_http, a_https, a_custom:
+        for adapter in a_http, a_https, a_custom, a_new:
             assert adapter.poolmanager.connection_pool_kw.get("source_address") is None
             assert adapter.poolmanager.connection_pool_kw.get("socket_options") is None
 
         session.set_interface(interface=None)
-        for adapter in a_http, a_https, a_custom:
+        for adapter in a_http, a_https, a_custom, a_new:
             assert adapter.poolmanager.connection_pool_kw.get("source_address") is None
             assert adapter.poolmanager.connection_pool_kw.get("socket_options") is None
 


### PR DESCRIPTION
Amends #6862, #6907, #6908

`HTTPAdapter`s which are added to the `HTTPSession` after interface options were set also need to be updated. Some plugins mount custom adapters for example, and this is done after setting session options.