### PR TITLE
plugins.goltelevision: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/goltelevision.py
+++ b/src/streamlink/plugins/goltelevision.py
@@ -6,30 +6,63 @@ $region Spain
 """
 
 import re
+from urllib.parse import urlparse
 
+from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream.hls import HLSStream
+
+
+log = getLogger(__name__)
 
 
 @pluginmatcher(
     re.compile(r"https?://(?:www\.)?goltelevision\.com/en-directo"),
 )
 class GOLTelevision(Plugin):
-    def _get_streams(self):
-        self.session.http.headers.update({
-            "Origin": "https://goltelevision.com",
-            "Referer": "https://goltelevision.com/",
-        })
-        url = self.session.http.get(
-            "https://play.goltelevision.com/api/stream/live",
+    _provider_dailymotion = "https://www.dailymotion.com/embed/video/{video}"
+
+    def _get_stream_data(self):
+        return self.session.http.get(
+            self.url,
             schema=validate.Schema(
-                validate.parse_json(),
-                {"manifest": validate.url()},
-                validate.get("manifest"),
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[@id='__NEXT_DATA__'][@type='application/json'][1]/text()"),
+                validate.none_or_all(
+                    validate.parse_json(),
+                    {
+                        "props": {
+                            "pageProps": {
+                                "channel": {
+                                    "stream": {
+                                        "dataVideo": str,
+                                        "key": str,
+                                        "metaContent": validate.url(),
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    validate.get(("props", "pageProps", "channel", "stream")),
+                    validate.union_get("dataVideo", "key", "metaContent"),
+                ),
             ),
         )
-        return HLSStream.parse_variant_playlist(self.session, url)
+
+    def _get_streams(self):
+        if not (data := self._get_stream_data()):
+            log.error("No stream data found")
+            return
+
+        data_video, key, meta_content = data
+
+        match urlparse(meta_content).netloc.split("."), data_video, key:
+            case host, *_ if host[-2:] == ["dailymotion", "com"] or host == ["dai", "ly"]:
+                log.info("Found embedded dailymotion stream")
+                return self.session.streams(self._provider_dailymotion.format(video=data_video))
+            case _:
+                log.error("No matching stream provider found for the embedded stream")
+                return
 
 
 __plugin__ = GOLTelevision


### PR DESCRIPTION
Fixes #6914 

This site has switched to dailymotion streams. Their API still returns HLS streams hosted on cloudflare with a working multivariant playlist, but the hostname of the media playlist doesn't exist. They probably didn't remove the API endpoint after switching the streaming provider.

According to their JS code, there's support for different streaming providers, but since I can't validate any of this, it's only dailymotion (for now). The changes should make it easy to implement more if needed.

----

German IP-address (geo blocked)

```
$ streamlink -l debug -o /dev/null --stream-segmented-duration=10 https://www.goltelevision.com/en-directo best
[cli][debug] OS:         Linux-6.19.13-1-git-x86_64-with-glibc2.43
[cli][debug] Python:     3.14.4
[cli][debug] OpenSSL:    OpenSSL 3.6.2 7 Apr 2026
[cli][debug] Streamlink: 8.3.0+23.gc94b509f
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.4.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.0
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.33.1
[cli][debug]  trio: 0.33.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.15.0
[cli][debug]  urllib3: 2.6.3
[cli][debug]  websocket-client: 1.9.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.goltelevision.com/en-directo
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --output=/dev/null
[cli][debug]  --stream-segmented-duration=10.0
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin goltelevision for URL https://www.goltelevision.com/en-directo
[plugins.goltelevision][info] Found embedded dailymotion stream
[plugins.dailymotion][debug] Found media ID: k5cyQ3rl70nCl7Fhb5W
[plugins.dailymotion][error] Failed to get stream: Video mit geografischer Einschränkung.
error: No playable streams found on this URL: https://www.goltelevision.com/en-directo
```

With VPN from Spain

```
$ streamlink -l debug --interface=tun0 -o /dev/null --stream-segmented-duration=10 https://www.goltelevision.com/en-directo best
[cli][debug] OS:         Linux-6.19.13-1-git-x86_64-with-glibc2.43
[cli][debug] Python:     3.14.4
[cli][debug] OpenSSL:    OpenSSL 3.6.2 7 Apr 2026
[cli][debug] Streamlink: 8.3.0+23.gc94b509f
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.4.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.0
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.33.1
[cli][debug]  trio: 0.33.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.15.0
[cli][debug]  urllib3: 2.6.3
[cli][debug]  websocket-client: 1.9.0
[cli][debug] Arguments:
[cli][debug]  url=https://www.goltelevision.com/en-directo
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --interface=tun0
[cli][debug]  --player=mpv
[cli][debug]  --output=/dev/null
[cli][debug]  --stream-segmented-duration=10.0
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin goltelevision for URL https://www.goltelevision.com/en-directo
[plugins.goltelevision][info] Found embedded dailymotion stream
[plugins.dailymotion][debug] Found media ID: k5cyQ3rl70nCl7Fhb5W
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 180p (worst), 477p, 720p (best)
[cli][info] Opening stream: 720p (hls)
[cli][info] Writing output to
/dev/null
[cli][debug] Checking file output
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 1777575554; Last Sequence: 1777580353
[stream.hls][debug] Start offset: 0; Duration: 10.0; Start Sequence: 1777580351; End Sequence: None
[stream.segmented][debug] Queuing HLSSegment(num=1777580351, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-05-02T15:59:29.271000Z, map=None, fileext='ts')
[stream.segmented][debug] Queuing HLSSegment(num=1777580352, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-05-02T15:59:32.271000Z, map=None, fileext='ts')
[stream.segmented][debug] Queuing HLSSegment(num=1777580353, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-05-02T15:59:35.271000Z, map=None, fileext='ts')
[stream.hls][debug] Writing segment 1777580351 to output
[stream.hls][debug] Segment 1777580351 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Writing segment 1777580352 to output
[stream.hls][debug] Segment 1777580352 complete
[stream.hls][debug] Writing segment 1777580353 to output
[stream.hls][debug] Segment 1777580353 complete
[stream.hls][debug] Reloading playlist
[stream.segmented][debug] Queuing HLSSegment(num=1777580354, init=False, discontinuity=False, duration=3.000, title=None, key=None, byterange=None, date=2026-05-02T15:59:38.271000Z, map=None, fileext='ts')
[stream.segmented][info] Stopping stream early after 10.00s
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 1777580354 to output
[stream.hls][debug] Segment 1777580354 complete
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[download] Written 3.35 MiB to /dev/null (2s @ 1.41 MiB/s)
```