### PR TITLE
tests: fix can_colorize() monkeypatch on py315

### DIFF
--- a/tests/cli/main/test_logging.py
+++ b/tests/cli/main/test_logging.py
@@ -665,7 +665,7 @@ class TestPrint:
     @pytest.fixture()
     def _color(self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
         can_colorize = getattr(request, "param", False)
-        monkeypatch.setattr("_colorize.can_colorize", lambda: can_colorize)
+        monkeypatch.setattr("_colorize.can_colorize", Mock(return_value=can_colorize))
 
     @pytest.fixture()
     def stdout(self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture, session: Streamlink):


### PR DESCRIPTION
First py315 beta tomorrow:
https://peps.python.org/pep-0790/

This fixes failing tests due to changes in the stdlib that are incompatible with our monkeypatched test fixtures.

py315 CI runners will be added at a later stage