### PR TITLE
plugins.youtube: rewrite plugin, solve n-challenge

### DIFF
--- a/src/streamlink/plugins/youtube.py
+++ b/src/streamlink/plugins/youtube.py
@@ -2,120 +2,297 @@
 $description Global live-streaming and video hosting social platform owned by Google.
 $url youtube.com
 $url youtu.be
-$type live
+$type live, vod
+$webbrowser Used as a fallback when the Deno JavaScript runtime is not installed on the system
 $metadata id
 $metadata author
 $metadata category
 $metadata title
-$notes VOD content and protected videos are not supported
+$notes Requires the yt_dlp_ejs package for access to higher quality streams and VODs.
+$notes Requires the Deno JavaScript runtime, or uses Streamlink's webbrowser API as a fallback.
 """
 
+from __future__ import annotations
+
+import json
 import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
 from urllib.parse import urlparse, urlunparse
 
-from streamlink.logger import getLogger
-from streamlink.plugin import Plugin, PluginError, pluginmatcher
-from streamlink.plugin.api import useragents, validate
-from streamlink.stream.ffmpegmux import MuxedStream
-from streamlink.stream.hls import HLSStream
-from streamlink.stream.http import HTTPStream
-from streamlink.utils.data import search_dict
-from streamlink.utils.parse import parse_json
+import trio
 
+from streamlink import PluginError, validate
+from streamlink.compat import BaseExceptionGroup
+from streamlink.logger import getLogger
+from streamlink.plugin import Plugin, pluginmatcher
+from streamlink.plugin.api import useragents
+from streamlink.stream.hls import HLSStream, MuxedHLSStream
+from streamlink.utils.deno import DenoProcessor
+from streamlink.utils.parse import parse_json, parse_qsd
+from streamlink.utils.times import hours_minutes_seconds_float
+from streamlink.webbrowser.cdp import CDPClient, devtools
+
+
+if TYPE_CHECKING:
+    from typing import Protocol
+
+    from streamlink.session.session import Streamlink
+    from streamlink.webbrowser.cdp import CDPClientSession
+
+    class SolverModule(Protocol):
+        def core(self) -> str: ...
+
+        def lib(self) -> str: ...
+
+
+yt_dlp_solver: SolverModule | None
+try:
+    from yt_dlp_ejs.yt import solver  # type: ignore # ty: ignore[unused-ignore-comment]
+
+    yt_dlp_solver = solver  # type: ignore
+except ImportError:
+    yt_dlp_solver = None
 
 log = getLogger(__name__)
 
 
-@pluginmatcher(
-    name="default",
-    pattern=re.compile(
-        r"https?://(?:\w+\.)?youtube\.com/(?:v/|live/|watch\?(?:.*&)?v=)(?P<video_id>[\w-]{11})",
-    ),
-)
-@pluginmatcher(
-    name="channel",
-    pattern=re.compile(
-        r"https?://(?:\w+\.)?youtube\.com/(?:@|c(?:hannel)?/|user/)?(?P<channel>[^/?]+)(?P<live>/live)?/?$",
-    ),
-)
-@pluginmatcher(
-    name="embed",
-    pattern=re.compile(
-        r"https?://(?:\w+\.)?youtube\.com/embed/(?:live_stream\?channel=(?P<live>[^/?&]+)|(?P<video_id>[\w-]{11}))",
-    ),
-)
-@pluginmatcher(
-    name="shorthand",
-    pattern=re.compile(
-        r"https?://youtu\.be/(?P<video_id>[\w-]{11})",
-    ),
-)
-class YouTube(Plugin):
-    _re_ytInitialData = re.compile(r"""var\s+ytInitialData\s*=\s*({.*?})\s*;\s*</script>""", re.DOTALL)
-    _re_ytInitialPlayerResponse = re.compile(r"""var\s+ytInitialPlayerResponse\s*=\s*({.*?});\s*var\s+\w+\s*=""", re.DOTALL)
+@dataclass(frozen=True)
+class NChallengeInput:
+    player_url: str
+    token: str
 
-    _url_canonical = "https://www.youtube.com/watch?v={video_id}"
-    _url_channelid_live = "https://www.youtube.com/channel/{channel_id}/live"
 
-    # There are missing itags
-    adp_video = {
-        137: "1080p",
-        299: "1080p60",  # HFR
-        264: "1440p",
-        308: "1440p60",  # HFR
-        266: "2160p",
-        315: "2160p60",  # HFR
-        138: "2160p",
-        302: "720p60",  # HFR
-        135: "480p",
-        133: "240p",
-        160: "144p",
+@dataclass(frozen=True)
+class NChallengeOutput:
+    solved: str | None = None
+
+
+class Solver(ABC):
+    def __init__(self, session: Streamlink):
+        self._code_cache: dict[str, str] = {}  # player_url -> raw JS source text
+        self.session = session
+
+    @abstractmethod
+    def _solve(self, js_input: str) -> dict | str | None:
+        pass
+
+    def solve(self, challenge: NChallengeInput) -> NChallengeOutput:
+        player = self._get_player(challenge.player_url)
+        if not player:
+            log.error("Could not retrieve player JS for URL: %s", challenge.player_url)
+            return NChallengeOutput()
+        js_input = self._construct_input(player, challenge)
+
+        output: dict | str | None = None
+        try:
+            output = self._solve(js_input)
+        except BaseExceptionGroup:
+            log.exception("n-challenge solving failed for token %r", challenge.token)
+        except Exception as err:
+            log.error(err)
+
+        return self.validate_output(output, challenge)
+
+    @staticmethod
+    def validate_output(output: dict | str | None, request: NChallengeInput) -> NChallengeOutput:
+        if output is None:
+            return NChallengeOutput()
+
+        def _filter_invalid_results(results: dict[str, str]) -> dict[str, str]:
+            # When the JS solver throws internally it returns the input token as the
+            # result, so a result that ends with the original challenge is a failure.
+            return {k: v for k, v in results.items() if not v.endswith(k)}
+
+        try:
+            responses = validate.Schema(
+                validate.any(
+                    validate.all(str, validate.parse_json()),
+                    dict,
+                ),
+                dict,
+                lambda d: d.get("type", "") != "error",
+            ).validate(output, name="solver output")
+
+            result = validate.Schema(
+                validate.get(("responses", 0)),
+                dict,
+                lambda d: d.get("type", "") != "error",
+                validate.get("data"),
+                {str: str},
+                validate.transform(_filter_invalid_results),
+                validate.get(request.token),
+                validate.any(str, None),
+                validate.transform(NChallengeOutput),
+            ).validate(responses, name="challenge result")
+            log.trace("Solver result: %r", result)
+        except PluginError as e:
+            log.error("Could not validate solver output: %s", e)
+            result = NChallengeOutput()
+
+        return result
+
+    @staticmethod
+    def _get_script(script_type: str) -> str:
+        if yt_dlp_solver is None:
+            raise ValueError("yt_dlp_ejs package is not installed")
+        try:
+            return yt_dlp_solver.core() if script_type == "core" else yt_dlp_solver.lib()
+        except Exception as exc:
+            raise ValueError(
+                f'Failed to load solver "{script_type}" script from package: {exc}',
+            ) from exc
+
+    def _construct_input(self, player: str, request: NChallengeInput) -> str:
+        data = {
+            "type": "player",
+            "player": player,
+            "requests": [{"type": "n", "challenges": [request.token]}],
+            "output_preprocessed": True,
+        }
+        return (
+            f"{self._get_script('lib')}\n"
+            + "Object.assign(globalThis, lib);\n"
+            + f"{self._get_script('core')}\n"
+            + f"console.log(JSON.stringify(jsc({json.dumps(data)})));\n"
+        )
+
+    def _get_player(self, player_url: str) -> str | None:
+        if player_url not in self._code_cache:
+            log.trace("Fetching player JS: %s", player_url)
+            code = self.session.http.get(player_url).text
+            if code:
+                self._code_cache[player_url] = code
+                log.trace("Player JS cached (%d chars)", len(code))
+            else:
+                log.warning("Empty response for player JS URL: %s", player_url)
+        return self._code_cache.get(player_url)
+
+
+class DenoSolver(Solver):
+    def __init__(self, session: Streamlink):
+        super().__init__(session)
+        self.deno = DenoProcessor()
+
+    def _solve(self, js_input: str) -> str | None:
+        self.deno.run(stdin=js_input.encode("utf-8"))
+        return self.deno.output
+
+
+class CDPSolver(Solver):
+    def _solve(self, js_input: str) -> dict | None:
+        sender, receiver = trio.open_memory_channel(1)
+
+        async def on_main(client_session: CDPClientSession, request: devtools.fetch.RequestPaused):
+            async with client_session.alter_request(request) as cm:
+                cm.body = "<!doctype html>"
+
+        async def collect_logs(client_session: CDPClientSession):
+            async for event in client_session.cdp_session.listen(devtools.runtime.ConsoleAPICalled):
+                for arg in event.args:
+                    if arg.value is None:
+                        continue
+                    try:
+                        # noinspection PyTypeChecker
+                        res = json.loads(arg.value)
+                    except (ValueError, TypeError, json.JSONDecodeError):
+                        continue
+                    if res.get("type"):
+                        await sender.send(res)
+                        return
+
+        async def solve_n_challenge(client: CDPClient):
+            async with client.session() as client_session:
+                client_session.add_request_handler(on_main, url_pattern="https://*", on_request=True)
+                async with client_session.navigate("https://www.youtube.com/") as frame_id:
+                    await client_session.loaded(frame_id)
+                    # Enable runtime to capture console events
+                    await client_session.cdp_session.send(devtools.runtime.enable())
+                    async with trio.open_nursery() as nursery:
+                        nursery.start_soon(collect_logs, client_session)
+                        await client_session.evaluate(js_input)
+                        return await receiver.receive()
+
+        return CDPClient.launch(self.session, solve_n_challenge)
+
+
+class YoutubeAPI:
+    SOLVERS: ClassVar[list[type[Solver]]] = [DenoSolver, CDPSolver]
+
+    # Default client configurations
+    # Each entry supplies default INNERTUBE_CONTEXT and the numeric client-name
+    CLIENTS: dict = {
+        "web_safari": {
+            "INNERTUBE_CONTEXT": {
+                "client": {
+                    "clientName": "WEB",
+                    "clientVersion": "2.20260114.08.00",
+                    "userAgent": (
+                        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
+                        + "(KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)"
+                    ),
+                },
+            },
+            "INNERTUBE_CONTEXT_CLIENT_NAME": 1,
+        },
+        "android_vr": {
+            "INNERTUBE_CONTEXT": {
+                "client": {
+                    "clientName": "ANDROID_VR",
+                    "clientVersion": "1.65.10",
+                    "deviceMake": "Oculus",
+                    "deviceModel": "Quest 3",
+                    "androidSdkVersion": 32,
+                    "userAgent": (
+                        "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; "
+                        + "eureka-user Build/SQ3A.220605.009.A1) gzip"
+                    ),
+                    "osName": "Android",
+                    "osVersion": "12L",
+                },
+            },
+            "INNERTUBE_CONTEXT_CLIENT_NAME": 28,
+        },
     }
-    adp_audio = {
-        140: 128,
-        141: 256,
-        171: 128,
-        249: 48,
-        250: 64,
-        251: 160,
-        256: 256,
-        258: 258,
-    }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        parsed = urlparse(self.url)
+    def __init__(self, session: Streamlink):
+        self.session = session
+        self.id: str | None = None
+        self.author: str | None = None
+        self.category: str | None = None
+        self.title: str | None = None
 
-        # translate input URLs to be able to find embedded data and to avoid unnecessary HTTP redirects
-        if parsed.netloc == "gaming.youtube.com":
-            self.url = urlunparse(parsed._replace(scheme="https", netloc="www.youtube.com"))
-        elif self.matches["shorthand"]:
-            self.url = self._url_canonical.format(video_id=self.match["video_id"])
-        elif self.matches["embed"] and self.match["video_id"]:
-            self.url = self._url_canonical.format(video_id=self.match["video_id"])
-        elif self.matches["embed"] and self.match["live"]:
-            self.url = self._url_channelid_live.format(channel_id=self.match["live"])
-        elif parsed.scheme != "https":
-            self.url = urlunparse(parsed._replace(scheme="https"))
+    def _get_solver(self) -> Solver | None:
+        for solverclass in self.SOLVERS:
+            try:
+                slvr = solverclass(session=self.session)
+            except Exception as err:
+                log.debug("Failed initializing n-challenge solver %s: %s", solverclass.__name__, err)
+                continue
+            else:
+                log.debug("Initialized n-challenge solver %s", solverclass.__name__)
+                return slvr
 
-        self.session.http.headers.update({"User-Agent": useragents.CHROME})
+        log.warning("Could not initialize any n-challenge solvers")
+        return None
 
-    @classmethod
-    def stream_weight(cls, stream: str) -> tuple[float, str]:
-        match_3d = re.match(r"(\w+)_3d", stream)
-        match_hfr = re.match(r"(\d+p)(\d+)", stream)
-        if match_3d:
-            weight, group = Plugin.stream_weight(match_3d.group(1))
-            weight -= 1
-            group = "youtube_3d"
-        elif match_hfr:
-            weight, group = Plugin.stream_weight(match_hfr.group(1))
-            weight += 1
-            group = "high_frame_rate"
-        else:
-            weight, group = Plugin.stream_weight(stream)
+    @staticmethod
+    def get_data_from_regex(data: str, regex: re.Pattern, descr: str):
+        if match := regex.search(data):
+            return parse_json(match.group(1))
+        raise PluginError(f"Pattern not found in response body: {descr}")
 
-        return weight, group
+    @staticmethod
+    def _schema_video_id(data) -> str | None:
+        return validate.Schema(
+            {
+                "currentVideoEndpoint": {
+                    "watchEndpoint": {"videoId": str},
+                },
+            },
+            validate.get(("currentVideoEndpoint", "watchEndpoint", "videoId")),
+        ).validate(data, name="_schema_video_id")
 
     @staticmethod
     def _schema_consent(data):
@@ -136,17 +313,182 @@ class YouTube(Plugin):
         )
         return schema_consent.validate(data)
 
-    def _schema_canonical(self, data):
-        schema_canonical = validate.Schema(
-            validate.parse_html(),
-            validate.xml_xpath_string(".//link[@rel='canonical'][1]/@href"),
-            validate.regex(self.matchers["default"].pattern),
-            validate.get("video_id"),
+    def _get_res(self, url: str, **kwargs):
+        res = self.session.http.get(url, **kwargs)
+        if urlparse(res.url).netloc == "consent.youtube.com":
+            target, elems = self._schema_consent(res.text)
+            c_data = {
+                elem.attrib.get("name"): elem.attrib.get("value")
+                for elem in elems
+            }  # fmt: skip
+            log.debug(f"consent target: {target}")
+            log.debug(f"consent data: {', '.join(c_data.keys())}")
+            res = self.session.http.post(target, data=c_data, **kwargs)
+        return res
+
+    def process_live_page(self, url: str) -> str:
+        res = self._get_res(url)
+        re_yt_initial_data = re.compile(r"""var\s+ytInitialData\s*=\s*({.*?})\s*;\s*</script>""", re.DOTALL)
+        initial = self.get_data_from_regex(res.text, re_yt_initial_data, "initial data")
+        video_id = self._schema_video_id(initial)
+        if not video_id:
+            raise ValueError("Unable to extract video ID from /live page")
+
+        log.debug("Resolved video ID %s", video_id)
+        return video_id
+
+    def _get_webpage_data(self, url: str) -> dict:
+        log.trace("Fetching watch page: %s", url)
+        re_ytcfg = re.compile(r"ytcfg\.set\s*\(\s*({.+?})\s*\)\s*;")
+        webpage = self._get_res(
+            url,
+            params={"bpctr": "9999999999", "has_verified": "1"},
+            headers={"User-Agent": self.CLIENTS["web_safari"]["INNERTUBE_CONTEXT"]["client"]["userAgent"]},
         )
-        return schema_canonical.validate(data)
+        self.extract_metadata(webpage.text)
+        return self.get_data_from_regex(webpage.text, re_ytcfg, "ytcfg")
+
+    @staticmethod
+    def _build_headers(client_config: dict, visitor_data: str, client_context: dict) -> dict:
+        default_client = client_config.get("INNERTUBE_CONTEXT", {}).get("client", {})
+        client_version = client_context.get("clientVersion") or default_client.get("clientVersion")
+        ua = client_context.get("userAgent") or default_client.get("userAgent")
+        return {
+            "X-YouTube-Client-Name": str(client_config.get("INNERTUBE_CONTEXT_CLIENT_NAME", "")),
+            "X-YouTube-Client-Version": client_version,
+            "Origin": "https://www.youtube.com",
+            "X-Goog-Visitor-Id": visitor_data,
+            "User-Agent": ua,
+            "content-type": "application/json",
+        }
+
+    @staticmethod
+    def _build_player_request_payload(client_context: dict, webpage_ytcfg: dict, video_id) -> dict:
+        return {
+            "context": client_context,
+            "videoId": video_id,
+            "playbackContext": {
+                "contentPlaybackContext": {
+                    "html5Preference": "HTML5_PREF_WANTS",
+                    **({"signatureTimestamp": sts} if (sts := webpage_ytcfg.get("STS")) else {}),
+                },
+            },
+            "contentCheckOk": True,
+            "racyCheckOk": True,
+        }
+
+    @staticmethod
+    def _schema_visitor_data(data) -> str:
+        return validate.Schema(
+            validate.any(
+                validate.all({"VISITOR_DATA": str}, validate.get("VISITOR_DATA")),
+                validate.all(
+                    {"INNERTUBE_CONTEXT": {"client": {"visitorData": str}}},
+                    validate.get(("INNERTUBE_CONTEXT", "client", "visitorData")),
+                ),
+            ),
+        ).validate(data, name="_schema_visitor_data")
+
+    @staticmethod
+    def _schema_player_url(data) -> str:
+        return validate.Schema(
+            validate.any(
+                validate.all({"PLAYER_JS_URL": str}, validate.get("PLAYER_JS_URL")),
+                validate.all(
+                    {"WEB_PLAYER_CONTEXT_CONFIGS": {str: {"jsUrl": str}}},
+                    validate.get("WEB_PLAYER_CONTEXT_CONFIGS"),
+                    validate.transform(lambda x: next(iter(x.values()))),
+                    validate.get("jsUrl"),
+                ),
+            ),
+            validate.transform(
+                lambda url: f"https://www.youtube.com/{url.removeprefix('https://www.youtube.com').removeprefix('/')}",
+            ),
+        ).validate(data, name="_schema_player_url")
+
+    def _extract_player_response(self, client: str, webpage_ytcfg: dict, visitor_data: str, video_id) -> dict:
+        # Prefer live page context; fall back to static client config.
+        client_config = self.CLIENTS[client].copy()
+        context = webpage_ytcfg.get("INNERTUBE_CONTEXT") or client_config.get("INNERTUBE_CONTEXT", {})
+        client_context = context.get("client", {})
+        client_context.update({"hl": "en", "timeZone": "UTC", "utcOffsetMinutes": 0})
+
+        headers = self._build_headers(client_config, visitor_data, client_context)
+        payload = self._build_player_request_payload(context, webpage_ytcfg, video_id)
+        return self.session.http.post(
+            "https://www.youtube.com/youtubei/v1/player",
+            params={"prettyPrint": "false"},
+            headers=headers,
+            json=payload,
+            schema=validate.Schema(
+                validate.parse_json(),
+                {"streamingData": dict},
+            ),
+        )
+
+    def _extract_hls(self, player_responses: list[dict], player_url: str) -> str:
+        slvr: Solver | None = None
+        for response in player_responses:
+            streaming_data = response.get("streamingData", {})
+
+            hls_manifest_url = streaming_data.get("hlsManifestUrl", "")
+            if not hls_manifest_url:
+                log.trace("No hlsManifestUrl in streamingData: %r", streaming_data)
+                continue
+
+            # Solve the n-parameter challenge embedded in the manifest path.
+            n_matches = re.findall(r"/n/([^/]+)/", urlparse(hls_manifest_url).path)
+            if not n_matches:
+                return hls_manifest_url
+            n_token = n_matches[0]
+
+            if yt_dlp_solver is None:
+                log.debug("External JS for n-challenge solving not found. Skipping solving n-challenge %r", n_token)
+                return hls_manifest_url
+
+            log.trace("Attempting to solve n-challenge token: %s", n_token)
+            if slvr is None:
+                slvr = self._get_solver()
+                if slvr is None:
+                    return hls_manifest_url
+
+            result = slvr.solve(NChallengeInput(token=n_token, player_url=player_url))
+            if not result.solved:
+                log.warning("Failed solving n-challenge token: %s", n_token)
+                continue
+
+            log.trace("n-challenge solved: %s -> %s", n_token, result.solved)
+            return hls_manifest_url.replace(f"/n/{n_token}", f"/n/{result.solved}")
+
+        return ""
+
+    def process_watch_page(self, url: str, video_id: str) -> str:
+        webpage_ytcfg = self._get_webpage_data(url)
+
+        player_responses = []
+        visitor_data = self._schema_visitor_data(webpage_ytcfg)
+        player_url = self._schema_player_url(webpage_ytcfg)
+        log.trace("Player JS URL: %s", player_url)
+        for client in reversed(list(self.CLIENTS)):
+            try:
+                response = self._extract_player_response(client, webpage_ytcfg, visitor_data, video_id)
+            except Exception as exc:
+                log.error("Player request failed for client %s: %s", client, exc)
+                continue
+
+            player_responses.append(response)
+
+        if not player_responses:
+            log.warning("Failed to extract any player response with streamingData")
+            return ""
+
+        if not (hls := self._extract_hls(player_responses, player_url)):
+            return ""
+
+        return hls
 
     @classmethod
-    def _schema_playabilitystatus(cls, data):
+    def _schema_playability_status(cls, data):
         schema = validate.Schema(
             {
                 "playabilityStatus": {
@@ -157,179 +499,31 @@ class YouTube(Plugin):
             validate.get("playabilityStatus"),
             validate.union_get("status", "reason"),
         )
-        return schema.validate(data)
-
-    @classmethod
-    def _schema_videodetails(cls, data):
-        schema = validate.Schema(
-            {
-                "videoDetails": {
-                    "videoId": str,
-                    "author": str,
-                    "title": str,
-                    validate.optional("isLive"): validate.transform(bool),
-                    validate.optional("isLiveContent"): validate.transform(bool),
-                    validate.optional("isLiveDvrEnabled"): validate.transform(bool),
-                    validate.optional("isLowLatencyLiveStream"): validate.transform(bool),
-                    validate.optional("isPrivate"): validate.transform(bool),
-                },
-                "microformat": validate.all(
-                    validate.any(
-                        validate.all(
-                            {"playerMicroformatRenderer": dict},
-                            validate.get("playerMicroformatRenderer"),
-                        ),
-                        validate.all(
-                            {"microformatDataRenderer": dict},
-                            validate.get("microformatDataRenderer"),
-                        ),
-                    ),
-                    {
-                        "category": str,
-                    },
-                ),
-            },
-            validate.union_get(
-                ("videoDetails", "videoId"),
-                ("videoDetails", "author"),
-                ("microformat", "category"),
-                ("videoDetails", "title"),
-                ("videoDetails", "isLive"),
-            ),
-        )
-        videoDetails = schema.validate(data)
-        log.trace("videoDetails = %r", videoDetails)
-        return videoDetails
+        return schema.validate(data, name="_schema_playability_status")
 
     @classmethod
     def _schema_streamingdata(cls, data):
-        schema = validate.Schema(
+        return validate.Schema(
             {
                 "streamingData": {
                     validate.optional("hlsManifestUrl"): str,
-                    validate.optional("formats"): [
-                        validate.all(
-                            {
-                                "itag": int,
-                                "qualityLabel": str,
-                                validate.optional("url"): validate.url(scheme="http"),
-                            },
-                            validate.union_get("url", "qualityLabel"),
-                        ),
-                    ],
-                    validate.optional("adaptiveFormats"): [
-                        validate.all(
-                            {
-                                "itag": int,
-                                "mimeType": validate.all(
-                                    str,
-                                    validate.regex(
-                                        re.compile(r"""^(?P<type>\w+)/(?P<container>\w+); codecs="(?P<codecs>.+)"$"""),
-                                    ),
-                                    validate.union_get("type", "codecs"),
-                                ),
-                                validate.optional("url"): validate.url(scheme="http"),
-                                validate.optional("qualityLabel"): str,
-                            },
-                            validate.union_get("url", "qualityLabel", "itag", "mimeType"),
-                        ),
-                    ],
                 },
             },
             validate.get("streamingData"),
-            validate.union_get("hlsManifestUrl", "formats", "adaptiveFormats"),
+            validate.get("hlsManifestUrl"),
+        ).validate(data, name="_schema_streamingdata")
+
+    def _get_data_from_api(self, url, video_id):
+        res = self._get_res(url)
+        re_innertube_api_key = re.compile(
+            r"""(?P<q1>["'])INNERTUBE_API_KEY(?P=q1)\s*:\s*(?P<q2>["'])(?P<data>.+?)(?P=q2)""",
+            re.DOTALL,
         )
-        hls_manifest, formats, adaptive_formats = schema.validate(data)
-        return hls_manifest, formats or [], adaptive_formats or []
-
-    def _create_adaptive_streams(self, adaptive_formats):
-        streams = {}
-        adaptive_streams = {}
-        audio_streams = {}
-        best_audio_itag = None
-
-        # Extract audio streams from the adaptive format list
-        for url, _label, itag, mimeType in adaptive_formats:
-            if url is None:
-                continue
-
-            # extract any high quality streams only available in adaptive formats
-            adaptive_streams[itag] = url
-            stream_type, stream_codec = mimeType
-            stream_codec = re.sub(r"^(\w+).*$", r"\1", stream_codec)
-
-            if stream_type == "audio" and itag in self.adp_audio:
-                audio_bitrate = self.adp_audio[itag]
-                if stream_codec not in audio_streams or audio_bitrate > self.adp_audio[audio_streams[stream_codec]]:
-                    audio_streams[stream_codec] = itag
-
-                # find the best quality audio stream m4a, opus or vorbis
-                if best_audio_itag is None or audio_bitrate > self.adp_audio[best_audio_itag]:
-                    best_audio_itag = itag
-
-        if (
-            not best_audio_itag
-            or self.session.http.head(adaptive_streams[best_audio_itag], raise_for_status=False).status_code >= 400
-        ):
-            return {}
-
-        streams.update({
-            f"audio_{stream_codec}": HTTPStream(self.session, adaptive_streams[itag])
-            for stream_codec, itag in audio_streams.items()
-        })
-
-        if best_audio_itag and adaptive_streams and MuxedStream.is_usable(self.session):
-            aurl = adaptive_streams[best_audio_itag]
-            for itag, name in self.adp_video.items():
-                if itag not in adaptive_streams:
-                    continue
-                vurl = adaptive_streams[itag]
-                log.debug(f"MuxedStream: v {itag} a {best_audio_itag} = {name}")
-                streams[name] = MuxedStream(
-                    self.session,
-                    HTTPStream(self.session, vurl),
-                    HTTPStream(self.session, aurl),
-                )
-
-        return streams
-
-    def _get_res(self, url):
-        res = self.session.http.get(url)
-        if urlparse(res.url).netloc == "consent.youtube.com":
-            target, elems = self._schema_consent(res.text)
-            c_data = {
-                elem.attrib.get("name"): elem.attrib.get("value")
-                for elem in elems
-            }  # fmt: skip
-            log.debug(f"consent target: {target}")
-            log.debug(f"consent data: {', '.join(c_data.keys())}")
-            res = self.session.http.post(target, data=c_data)
-        return res
-
-    @staticmethod
-    def _get_data_from_regex(res, regex, descr):
-        match = re.search(regex, res.text)
-        if not match:
-            log.debug(f"Missing {descr}")
-            return
-        return parse_json(match.group(1))
-
-    def _get_data_from_api(self, res):
-        try:
-            video_id = self.match["video_id"]
-        except IndexError:
-            video_id = None
-
-        if video_id is None:
-            try:
-                video_id = self._schema_canonical(res.text)
-            except (PluginError, TypeError):
-                return
-
-        if m := re.search(r"""(?P<q1>["'])INNERTUBE_API_KEY(?P=q1)\s*:\s*(?P<q2>["'])(?P<data>.+?)(?P=q2)""", res.text):
+        if m := re.search(re_innertube_api_key, res.text):
             api_key = m.group("data")
         else:
             api_key = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+            log.trace("Could not find API key in the page data. Applying a default key: %r", api_key)
 
         return self.session.http.post(
             "https://www.youtube.com/youtubei/v1/player",
@@ -357,74 +551,135 @@ class YouTube(Plugin):
             ),
         )
 
-    @staticmethod
-    def _data_video_id(data):
-        if not data:
+    def get_streams_from_api(self, url: str, video_id: str) -> str | None:
+        self.extract_metadata(url=url)
+        if not (data := self._get_data_from_api(url, video_id)):
             return None
-        for key in ("videoRenderer", "gridVideoRenderer"):
-            for videoRenderer in search_dict(data, key):
-                videoId = videoRenderer.get("videoId")
-                if videoId is not None:
-                    return videoId
+        status, reason = self._schema_playability_status(data)
 
-    def _get_streams(self):
-        res = self._get_res(self.url)
-
-        if self.matches["channel"] and not self.match["live"]:
-            initial = self._get_data_from_regex(res, self._re_ytInitialData, "initial data")
-            video_id = self._data_video_id(initial)
-            if video_id is None:
-                log.error("Could not find videoId on channel page")
-                return
-            self.url = self._url_canonical.format(video_id=video_id)
-            res = self._get_res(self.url)
-
-        # TODO: clean up the validation schemas and how they're applied
-
-        if not (data := self._get_data_from_api(res)):
-            return
-        status, reason = self._schema_playabilitystatus(data)
         # assume that there's an error if reason is set (status will still be "OK" for some reason)
         if status != "OK" or reason:
-            log.error(f"Could not get video info - {status}: {reason}")
+            log.error("Could not get video info - %s: %s", status, reason)
+            return None
+
+        if not (hls_url := self._schema_streamingdata(data)):
+            return None
+
+        return hls_url
+
+    @classmethod
+    def _schema_videodetails(cls, data):
+        schema = validate.Schema(
+            {
+                "videoDetails": {
+                    "videoId": str,
+                    "author": str,
+                    "title": str,
+                },
+                "microformat": validate.all(
+                    validate.any(
+                        validate.all(
+                            {"playerMicroformatRenderer": dict},
+                            validate.get("playerMicroformatRenderer"),
+                        ),
+                        validate.all(
+                            {"microformatDataRenderer": dict},
+                            validate.get("microformatDataRenderer"),
+                        ),
+                    ),
+                    {
+                        "category": str,
+                    },
+                ),
+            },
+            validate.union_get(
+                ("videoDetails", "videoId"),
+                ("videoDetails", "author"),
+                ("microformat", "category"),
+                ("videoDetails", "title"),
+            ),
+        )
+        return schema.validate(data)
+
+    def extract_metadata(self, data: str | None = None, url: str | None = None):
+        if not data and url is not None:
+            data = self._get_res(url).text
+        if not data:
             return
 
-        # the initial player response contains the category data, which the API response does not
-        init_player_response = self._get_data_from_regex(res, self._re_ytInitialPlayerResponse, "initial player response")
-        self.id, self.author, self.category, self.title, is_live = self._schema_videodetails(init_player_response)
-        log.debug(f"Using video ID: {self.id}")
+        re_yt_initial_player_response = re.compile(
+            r"var\s+ytInitialPlayerResponse\s*=\s*({.*?});\s*(?:var\s+\w+\s*=|</script>)",
+            re.DOTALL,
+        )
+        init_player_response = self.get_data_from_regex(data, re_yt_initial_player_response, "initial player response")
+        self.id, self.author, self.category, self.title = self._schema_videodetails(init_player_response)
 
-        if is_live:
-            log.debug("This video is live.")
 
-        # TODO: remove parsing of non-HLS stuff, as we don't support this
-        streams = {}
-        hls_manifest, formats, adaptive_formats = self._schema_streamingdata(data)
+@pluginmatcher(
+    name="default",
+    pattern=re.compile(
+        r"https?://(?:\w+\.)?youtube\.com/(?:v/|live/|embed/|watch\?(?:\S*&)?v=)(?P<video_id>[\w-]{11})",
+    ),
+)
+@pluginmatcher(
+    name="channel",
+    pattern=re.compile(
+        r"https?://(?:\w+\.)?youtube\.com/(?:@|c(?:hannel)?/|user/)?(?P<channel>[^/?]+)(?P<live>/live)?/?$",
+    ),
+)
+@pluginmatcher(
+    name="shorthand",
+    pattern=re.compile(
+        r"https?://youtu\.be/(?P<video_id>[\w-]{11})",
+    ),
+)
+class YouTube(Plugin):
+    _url_canonical: str = "https://www.youtube.com/watch?v={video_id}"
 
-        protected = any(url is None for url, *_ in formats + adaptive_formats)
-        if protected:
-            log.debug("This video may be protected.")
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.api = YoutubeAPI(self.session)
 
-        for url, label in formats:
-            if url is None:
-                continue
-            if self.session.http.head(url, raise_for_status=False).status_code >= 400:
-                break
-            streams[label] = HTTPStream(self.session, url)
+        if self.matches["channel"] and not self.match["live"]:
+            self.url = f"{self.url.removesuffix('/')}/live"
 
-        if not is_live:
-            streams.update(self._create_adaptive_streams(adaptive_formats))
+        parsed = urlparse(self.url)
+        params = parse_qsd(parsed.query)
 
-        if hls_manifest:
-            streams.update(HLSStream.parse_variant_playlist(self.session, hls_manifest, name_key="pixels"))
+        try:
+            self.time_offset = hours_minutes_seconds_float(params.get("t", "0"))
+        except ValueError:
+            self.time_offset = 0
 
-        if not streams:
-            if protected:
-                raise PluginError("This plugin does not support protected videos, try yt-dlp instead")
-            if formats or adaptive_formats:
-                raise PluginError("This plugin does not support VOD content, try yt-dlp instead")
+        if self.matches["default"] or self.matches["shorthand"]:
+            self.url = self._url_canonical.format(video_id=self.match["video_id"])
+        else:
+            self.url = urlunparse(parsed._replace(scheme="https", netloc="www.youtube.com"))
 
-        return streams
+        self.session.http.headers.update({"User-Agent": useragents.CHROME})
+
+    def _get_streams(self) -> dict[str, HLSStream | MuxedHLSStream[HLSStream]] | None:
+        if self.matches["channel"] and self.match["channel"]:
+            video_id = self.api.process_live_page(self.url)
+            self.url = self._url_canonical.format(video_id=video_id)
+
+        params: dict = dict(start_offset=self.time_offset)
+        try:
+            hls_url: str | None = self.api.process_watch_page(self.url, self.match["video_id"])
+            if not hls_url:
+                raise ValueError(f"No HLS URLs found for videoId={self.match['video_id']}")
+
+        except (PluginError, ValueError) as err:
+            log.error("Failed finding data, falling back to YouTube API: %s", err)
+            hls_url = self.api.get_streams_from_api(self.url, self.match["video_id"])
+            if not hls_url:
+                return None
+            params.update(name_key="pixels")
+
+        finally:
+            self.id, self.author, self.category, self.title = self.api.id, self.api.author, self.api.category, self.api.title
+
+        return HLSStream.parse_variant_playlist(self.session, hls_url, **params)
 
 
 __plugin__ = YouTube

--- a/src/streamlink/utils/deno.py
+++ b/src/streamlink/utils/deno.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import ClassVar
+
+from streamlink.logger import getLogger
+from streamlink.utils.path import resolve_executable
+from streamlink.utils.processoutput import ProcessOutput
+
+
+log = getLogger(__name__)
+
+
+class DenoProcessor(ProcessOutput):
+    """
+    Utility class for finding and launching Deno on the user's system and processing JavaScript via stdin/stdout.
+    """
+
+    # https://docs.deno.com/runtime/reference/cli/run/#usage
+    _RUN_FLAGS: ClassVar[frozenset[str]] = frozenset([
+        "--ext=js",
+        "--no-code-cache",
+        "--no-prompt",
+        "--no-remote",
+        "--no-lock",
+        "--node-modules-dir=none",
+        "--no-config",
+        "--no-npm",
+    ])
+
+    def __init__(
+        self,
+        executable_path: str | None = None,
+        **kwargs,
+    ) -> None:
+        if (exec_path := self.resolve_path(executable_path)) is None:
+            raise FileNotFoundError("Deno not found. Please install the Deno JavaScript runtime on your system.")
+
+        kwargs.pop("stdin", None)
+        super().__init__([exec_path, "run", *self._RUN_FLAGS, "-"], **kwargs)
+        self._output_lines: list[str] = []
+
+    # noinspection PyMethodOverriding
+    async def arun(self, stdin: bytes) -> bool:  # type: ignore[override, ty:invalid-method-override]
+        log.trace("Running Deno with a stdin payload of %d bytes: %r", len(stdin), self.command)
+        return await super().arun(stdin=stdin)
+
+    @property
+    def output(self) -> str:
+        return "\n".join(self._output_lines)
+
+    def onstdout(self, idx: int, line: str) -> bool | None:
+        self._output_lines.append(line)
+
+    def onstderr(self, idx: int, line: str) -> bool | None:
+        raise RuntimeError(f"Deno error: {line}")
+
+    @staticmethod
+    @lru_cache
+    def resolve_path(executable_path: str | None = None) -> str | None:
+        if not executable_path:
+            exec_path = resolve_executable(names=["deno"])
+        else:
+            exec_path = executable_path
+
+        if not exec_path:
+            return None
+
+        return str(exec_path)

--- a/tests/plugins/test_youtube.py
+++ b/tests/plugins/test_youtube.py
@@ -23,6 +23,10 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
             {"video_id": "aqz-KE-bpKQ"},
         ),
         (
+            ("default", "https://www.youtube.com/embed/aqz-KE-bpKQ"),
+            {"video_id": "aqz-KE-bpKQ"},
+        ),
+        (
             ("channel", "https://www.youtube.com/CHANNELNAME"),
             {"channel": "CHANNELNAME"},
         ),
@@ -63,14 +67,6 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
             {"channel": "CHANNELNAME", "live": "/live"},
         ),
         (
-            ("embed", "https://www.youtube.com/embed/aqz-KE-bpKQ"),
-            {"video_id": "aqz-KE-bpKQ"},
-        ),
-        (
-            ("embed", "https://www.youtube.com/embed/live_stream?channel=CHANNELNAME"),
-            {"live": "CHANNELNAME"},
-        ),
-        (
             ("shorthand", "https://youtu.be/aqz-KE-bpKQ"),
             {"video_id": "aqz-KE-bpKQ"},
         ),
@@ -95,8 +91,15 @@ class TestPluginCanHandleUrlYouTube(PluginCanHandleUrl):
         ("http://gaming.youtube.com/watch?v=0123456789A", "https://www.youtube.com/watch?v=0123456789A"),
         ("http://youtu.be/0123456789A", "https://www.youtube.com/watch?v=0123456789A"),
         ("http://youtube.com/embed/0123456789A", "https://www.youtube.com/watch?v=0123456789A"),
-        ("http://youtube.com/embed/live_stream?channel=CHANNELID", "https://www.youtube.com/channel/CHANNELID/live"),
         ("http://www.youtube.com/watch?v=0123456789A", "https://www.youtube.com/watch?v=0123456789A"),
+        ("http://youtube.com/@CHANNELNHANDLE", "https://www.youtube.com/@CHANNELNHANDLE/live"),
+        ("http://youtube.com/@CHANNELNHANDLE/", "https://www.youtube.com/@CHANNELNHANDLE/live"),
+        ("http://youtube.com/c/CHANNELNAME", "https://www.youtube.com/c/CHANNELNAME/live"),
+        ("http://youtube.com/c/CHANNELNAME/", "https://www.youtube.com/c/CHANNELNAME/live"),
+        ("http://youtube.com/channel/CHANNELID", "https://www.youtube.com/channel/CHANNELID/live"),
+        ("http://youtube.com/channel/CHANNELID/", "https://www.youtube.com/channel/CHANNELID/live"),
+        ("http://youtube.com/user/USERNAME", "https://www.youtube.com/user/USERNAME/live"),
+        ("http://youtube.com/user/USERNAME/", "https://www.youtube.com/user/USERNAME/live"),
     ],
 )
 def test_translate_url(url, expected):

--- a/tests/utils/test_deno.py
+++ b/tests/utils/test_deno.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from streamlink.utils.deno import DenoProcessor
+
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _clear_resolve_path_cache():
+    yield
+    DenoProcessor.resolve_path.cache_clear()
+
+
+@pytest.fixture()
+def fake_exe(tmp_path):
+    exe = tmp_path / "deno.exe"
+    exe.write_bytes(b"")
+    return exe
+
+
+class TestResolvePath:
+    @pytest.fixture()
+    def mock_resolve_executable(self, monkeypatch: pytest.MonkeyPatch, fake_exe: Path):
+        mock_resolve_executable = Mock(return_value=fake_exe)
+        monkeypatch.setattr("streamlink.utils.deno.resolve_executable", mock_resolve_executable)
+        yield mock_resolve_executable
+        assert mock_resolve_executable.call_count == 1
+
+    def test_explicit_path(self, fake_exe: Path):
+        assert DenoProcessor.resolve_path(str(fake_exe)) == str(fake_exe)
+
+    def test_not_found(self, mock_resolve_executable: Mock):
+        mock_resolve_executable.return_value = None
+        with pytest.raises(FileNotFoundError):
+            DenoProcessor()
+        with pytest.raises(FileNotFoundError):
+            DenoProcessor()
+
+    def test_auto_resolve(self, mock_resolve_executable: Mock, fake_exe: Path):
+        assert DenoProcessor.resolve_path() == str(fake_exe)
+        assert DenoProcessor.resolve_path() == str(fake_exe)
+
+
+class TestProcessOutputIntegration:
+    @pytest.fixture(autouse=True)
+    def _resolve(self, monkeypatch: pytest.MonkeyPatch, fake_exe: Path):
+        monkeypatch.setattr("streamlink.utils.deno.DenoProcessor.resolve_path", Mock(return_value=str(fake_exe)))
+
+    def test_process_args(self, fake_exe: Path):
+        proc = DenoProcessor(stdin="console.log('🐻');")
+        assert proc.command == [str(fake_exe), "run", *DenoProcessor._RUN_FLAGS, "-"]
+        assert proc.stdin == b""
+
+    @pytest.mark.trio()
+    async def test_log_command(self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, fake_exe: Path):
+        monkeypatch.setattr("streamlink.utils.deno.ProcessOutput.arun", AsyncMock(return_value=True))
+        caplog.set_level(1, "streamlink")
+        proc = DenoProcessor()
+        assert await proc.arun(stdin=b"foo")
+        assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+            (
+                "streamlink.utils.deno",
+                "trace",
+                f"Running Deno with a stdin payload of 3 bytes: {[str(fake_exe), 'run', *DenoProcessor._RUN_FLAGS, '-']!r}",
+            ),
+        ]
+
+    def test_output_collected(self):
+        proc = DenoProcessor()
+        proc.onstdout(0, "Hello")
+        proc.onstdout(0, "World!")
+        assert proc.output == "Hello\nWorld!"
+
+    def test_onstderr_raises(self):
+        proc = DenoProcessor()
+        with pytest.raises(RuntimeError, match="Deno error: some error"):
+            proc.onstderr(0, "some error")


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

The submitted solution adds support for YouTube's n-parameter challenge that's required to access HLS streams. The old plugin still works as a fallback if anything goes wrong.

## What changed

Added two solvers for n-challenges:
- DenoSolver - uses deno JS runtime for solving n-challenges
- CDPSolver - solves n-challenges using Chrome DevTools Protocol

Both use the yt_dlp_ejs package to solve the tokens.

Added extractors for handling different YouTube pages:
- `VideoExtractor` for `/watch?v=` URLs
- `LiveExtractor` for `/@channel/live` URLs  
- `StreamsExtractor` for `/@channel/streams` URLs

Added `--youtube-stream` CLI option to pick which stream from the `/streams` page to play. Options are `first`, `last`, `popular` (default), or a number like `1`, `2`, `3`.

Fixed _data_video_id to work with YouTube's new initial JSON format. Still works with the old format too.

If the new code fails for any reason, it falls back to the original plugin automatically.

## Requirements

Deno is optional. If it's not installed, the plugin uses CDP instead.

