### PR TITLE
session.http: fix default value of params kwarg

### DIFF
--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -254,8 +254,8 @@ class HTTPSession(Session):
         acceptable_status = kwargs.pop("acceptable_status", [])
         encoding = kwargs.pop("encoding", None)
         exception = kwargs.pop("exception", PluginError)
-        headers = kwargs.pop("headers", {})
-        params = kwargs.pop("params", {})
+        headers = kwargs.pop("headers", None) or {}
+        params = kwargs.pop("params", None) or {}
         proxies = kwargs.pop("proxies", self.proxies)
         raise_for_status = kwargs.pop("raise_for_status", True)
         schema = kwargs.pop("schema", None)


### PR DESCRIPTION
[requests==2.34.0](https://github.com/psf/requests/releases/tag/v2.34.0) fixed the signature of Session.get() after adding inline typing annotations, leading to an incorrect default value in our request() method override that resulted in test failures.