### PR TITLE
chore: remove type-stub modules for urllib3 and requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ typing = [
   "lxml-stubs",
   "types-docutils",
   "types-freezegun",
-  "types-requests",
   "types-setuptools",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ typing = [
   "types-freezegun",
   "types-requests",
   "types-setuptools",
-  "types-urllib3",
 ]
 docs = [
   { include-group = "dev" },

--- a/src/streamlink/compat.py
+++ b/src/streamlink/compat.py
@@ -13,7 +13,7 @@ try:
 except ImportError:  # pragma: no cover
     from exceptiongroup import BaseExceptionGroup, ExceptionGroup  # type: ignore[import, ty:unresolved-import]
 
-from requests.compat import chardet as charset_normalizer  # type: ignore[attr-defined, ty:unresolved-import]
+from requests.compat import chardet as charset_normalizer
 
 from streamlink.exceptions import StreamlinkDeprecationWarning
 

--- a/src/streamlink/plugins/openrectv.py
+++ b/src/streamlink/plugins/openrectv.py
@@ -98,8 +98,8 @@ class OPENRECtv(Plugin):
         res = self.session.http.get(
             url,
             headers={
-                "access-token": self.session.http.cookies.get("access_token"),
-                "uuid": self.session.http.cookies.get("uuid"),
+                "access-token": self.session.http.cookies.get("access_token") or "",
+                "uuid": self.session.http.cookies.get("uuid") or "",
             },
         )
         data = self.session.http.json(res, schema=self._info_schema)
@@ -115,8 +115,8 @@ class OPENRECtv(Plugin):
         res = self.session.http.get(
             url,
             headers={
-                "access-token": self.session.http.cookies.get("access_token"),
-                "uuid": self.session.http.cookies.get("uuid"),
+                "access-token": self.session.http.cookies.get("access_token") or "",
+                "uuid": self.session.http.cookies.get("uuid") or "",
             },
         )
         data = self.session.http.json(res, schema=self._subscription_schema)

--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -79,9 +79,9 @@ class Radiko(Plugin):
         }
         self.session.http.headers.update(headers)
         r = self.session.http.get(self._api_auth_1)
-        token = r.headers.get("x-radiko-authtoken")
-        offset = int(r.headers.get("x-radiko-keyoffset"))
-        length = int(r.headers.get("x-radiko-keylength"))
+        token = r.headers.get("x-radiko-authtoken", "")
+        offset = int(r.headers.get("x-radiko-keyoffset", 0))
+        length = int(r.headers.get("x-radiko-keylength", 0))
         partial_key = base64.b64encode(self._auth_key[offset : offset + length].encode("ascii")).decode("utf-8")
         headers = {
             "x-radiko-authtoken": token,

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -995,7 +995,7 @@ class Twitch(Plugin):
         except OSError as err:
             # TODO: fix the "err" attribute set by HTTPSession.request()
             orig = getattr(err, "err", None)
-            if isinstance(orig, HTTPError) and orig.response.status_code >= 400:
+            if isinstance(orig, HTTPError) and orig.response is not None and orig.response.status_code >= 400:
                 # The playlist's error response may include JSON data with an error message
                 with suppress(PluginError):
                     error = validate.Schema(

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -7,7 +7,7 @@ import warnings
 from http.cookiejar import MozillaCookieJar
 from ipaddress import ip_address
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, runtime_checkable
 
 import urllib3
 import urllib3.util.connection as urllib3_util_connection
@@ -26,16 +26,30 @@ from streamlink.utils.parse import parse_json, parse_xml
 
 if TYPE_CHECKING:
     import re
-    from collections.abc import Iterator
+    from collections.abc import Iterable, Iterator, Mapping, Sequence
     from typing import TypeAlias
 
+    # noinspection PyProtectedMember
+    import requests._types as _rq_t
     from requests import PreparedRequest
     from requests.adapters import BaseAdapter
+    from requests.cookies import CookieJar, RequestsCookieJar
+
+    from streamlink.validate import Schema
 
     _TYPE_SOCKET_OPTION: TypeAlias = tuple[int, int, int | bytes]
 
 
 log = getLogger(__name__)
+
+
+_KT_co = TypeVar("_KT_co", covariant=True)
+_VT_co = TypeVar("_VT_co", covariant=True)
+
+
+@runtime_checkable
+class SupportsItems(Protocol[_KT_co, _VT_co]):
+    def items(self) -> Iterable[tuple[_KT_co, _VT_co]]: ...  # pragma: no cover
 
 
 _original_allowed_gai_family = urllib3_util_connection.allowed_gai_family
@@ -103,8 +117,6 @@ _VALID_REQUEST_ARGS = {"method", "url", "headers", "files", "data", "params", "a
 
 
 class HTTPSession(Session):
-    params: dict
-
     def __init__(self):
         super().__init__()
 
@@ -263,37 +275,68 @@ class HTTPSession(Session):
         # prepare request with the session context, which might add params, headers, cookies, etc.
         return self.prepare_request(request)
 
-    def request(self, method, url, *args, **kwargs):
-        acceptable_status = kwargs.pop("acceptable_status", [])
-        encoding = kwargs.pop("encoding", None)
-        exception = kwargs.pop("exception", PluginError)
-        headers = kwargs.pop("headers", None) or {}
-        params = kwargs.pop("params", None) or {}
-        proxies = kwargs.pop("proxies", self.proxies)
-        raise_for_status = kwargs.pop("raise_for_status", True)
-        schema = kwargs.pop("schema", None)
-        session = kwargs.pop("session", None)
-        timeout = kwargs.pop("timeout", self.timeout)
-        total_retries = kwargs.pop("retries", 0)
-        retry_backoff = kwargs.pop("retry_backoff", 0.3)
-        retry_max_backoff = kwargs.pop("retry_max_backoff", 10.0)
-        retries = 0
+    def request(
+        self,
+        method: str,
+        url: _rq_t.UriType,
+        params: _rq_t.ParamsType = None,
+        data: _rq_t.DataType = None,
+        headers: Mapping[str, str | bytes] | None = None,
+        cookies: RequestsCookieJar | CookieJar | dict[str, str] | None = None,
+        files: _rq_t.FilesType = None,
+        auth: _rq_t.AuthType = None,
+        timeout: _rq_t.TimeoutType = None,
+        allow_redirects: bool = True,
+        proxies: dict[str, str] | None = None,
+        hooks: _rq_t.HooksInputType | None = None,
+        stream: bool | None = None,
+        verify: _rq_t.VerifyType | None = None,
+        cert: _rq_t.CertType = None,
+        json: _rq_t.JsonType = None,
+        # streamlink options
+        acceptable_status: Sequence[int] | None = None,
+        encoding: str | None = None,
+        exception: type[Exception] | None = None,
+        raise_for_status: bool = True,
+        retries: int = 0,
+        retry_backoff: float = 0.3,
+        retry_max_backoff: float = 10.0,
+        schema: Schema | None = None,
+        session: HTTPSession | None = None,
+    ) -> Any:
+        acceptable_status = acceptable_status or []
+        exception = exception or PluginError
+        timeout = timeout or self.timeout
 
         if session:
-            headers.update(session.headers)
-            params.update(session.params)
+            headers = dict(headers or {}) | dict(session.headers or {})
+            if isinstance(params, SupportsItems):
+                params = dict(params.items()) | session.params  # type: ignore[ty:unsupported-operator]
+            elif params and not isinstance(params, (str, bytes)):
+                params = dict(params) | session.params  # type: ignore[ty:unsupported-operator]
+            else:
+                params = session.params
 
+        attempt = 0
         while True:
             try:
                 res = super().request(
                     method,
                     url,
-                    *args,
-                    headers=headers,
                     params=params,
+                    data=data,
+                    headers=headers,
+                    cookies=cookies,
+                    files=files,
+                    auth=auth,
                     timeout=timeout,
+                    allow_redirects=allow_redirects,
                     proxies=proxies,
-                    **kwargs,
+                    hooks=hooks,
+                    stream=stream,
+                    verify=verify,
+                    cert=cert,
+                    json=json,
                 )
                 if raise_for_status and res.status_code not in acceptable_status:
                     res.raise_for_status()
@@ -301,13 +344,13 @@ class HTTPSession(Session):
             except KeyboardInterrupt:
                 raise
             except Exception as rerr:
-                if retries >= total_retries:
+                if attempt >= retries:
                     err = exception(f"Unable to open URL: {url} ({rerr})")
-                    err.err = rerr
+                    err.err = rerr  # ty:ignore[unresolved-attribute]
                     raise err from None  # TODO: fix this
-                retries += 1
+                attempt += 1
                 # back off retrying, but only to a maximum sleep time
-                delay = min(retry_max_backoff, retry_backoff * (2 ** (retries - 1)))
+                delay = min(retry_max_backoff, retry_backoff * (2 ** (attempt - 1)))
                 time.sleep(delay)
 
         if encoding is not None:

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -14,7 +14,7 @@ import urllib3.util.connection as urllib3_util_connection
 from requests import Request, Session
 from requests.adapters import HTTPAdapter
 from urllib3.connection import HTTPConnection
-from urllib3.util import create_urllib3_context  # type: ignore[attr-defined, ty:unresolved-import]
+from urllib3.util import create_urllib3_context
 
 import streamlink.session.http_useragents as useragents
 from streamlink.compat import is_darwin, is_linux, is_win32
@@ -38,7 +38,15 @@ if TYPE_CHECKING:
 log = getLogger(__name__)
 
 
-_original_allowed_gai_family = urllib3_util_connection.allowed_gai_family  # type: ignore[attr-defined, ty:unresolved-attribute]
+_original_allowed_gai_family = urllib3_util_connection.allowed_gai_family
+
+
+def allowed_gai_family_inet() -> socket.AddressFamily:
+    return socket.AF_INET
+
+
+def allowed_gai_family_inet6() -> socket.AddressFamily:
+    return socket.AF_INET6
 
 
 # Never convert percent-encoded characters to uppercase in urllib3>=2.0.0.
@@ -53,7 +61,7 @@ _original_allowed_gai_family = urllib3_util_connection.allowed_gai_family  # typ
 # > encodings.
 class Urllib3UtilUrlPercentReOverride:
     # noinspection PyProtectedMember
-    _re_percent_encoding: re.Pattern = urllib3.util.url._PERCENT_RE  # type: ignore[attr-defined, ty:unresolved-attribute]
+    _re_percent_encoding: re.Pattern = urllib3.util.url._PERCENT_RE  # type: ignore[attr-defined]
 
     # noinspection PyUnusedLocal
     # https://github.com/urllib3/urllib3/blob/2.0.0/src/urllib3/util/url.py#L241-L243
@@ -62,7 +70,7 @@ class Urllib3UtilUrlPercentReOverride:
         return string, len(cls._re_percent_encoding.findall(string))
 
 
-urllib3.util.url._PERCENT_RE = Urllib3UtilUrlPercentReOverride  # type: ignore[attr-defined, ty:unresolved-attribute]
+urllib3.util.url._PERCENT_RE = Urllib3UtilUrlPercentReOverride  # type: ignore[assignment, ty:invalid-assignment]
 
 
 # Monkey-patch urllib3's set_socket_options,
@@ -87,7 +95,7 @@ def _filter_socket_options(sock: socket.socket, options: list[_TYPE_SOCKET_OPTIO
                 yield option
 
 
-urllib3.util.connection._set_socket_options = urllib3_set_socket_options  # type: ignore[attr-defined, ty:unresolved-attribute]
+urllib3.util.connection._set_socket_options = urllib3_set_socket_options  # type: ignore[ty:invalid-assignment]
 
 
 # requests.Request.__init__ keywords, except for "hooks"
@@ -206,11 +214,11 @@ class HTTPSession(Session):
     # noinspection PyMethodMayBeStatic
     def set_address_family(self, family: socket.AddressFamily | None = None) -> None:
         if family is None:
-            urllib3_util_connection.allowed_gai_family = _original_allowed_gai_family  # type: ignore[attr-defined, ty:unresolved-attribute]
+            urllib3_util_connection.allowed_gai_family = _original_allowed_gai_family
         elif family == socket.AF_INET:
-            urllib3_util_connection.allowed_gai_family = lambda: socket.AF_INET  # type: ignore[attr-defined, ty:unresolved-attribute]
+            urllib3_util_connection.allowed_gai_family = allowed_gai_family_inet  # type: ignore[ty:invalid-assignment]
         elif family == socket.AF_INET6:  # pragma: no branch
-            urllib3_util_connection.allowed_gai_family = lambda: socket.AF_INET6  # type: ignore[attr-defined, ty:unresolved-attribute]
+            urllib3_util_connection.allowed_gai_family = allowed_gai_family_inet6  # type: ignore[ty:invalid-assignment]
 
     def disable_dh(self, disable: bool = True) -> None:
         adapter: HTTPAdapter

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -201,10 +201,15 @@ class HTTPSession(Session):
             adapter.poolmanager.connection_pool_kw.pop("socket_options", None)
             adapter.poolmanager.connection_pool_kw.update(connection_pool_kw)
 
-    def mount(self, prefix: str | bytes, adapter: BaseAdapter) -> None:
+    def mount(self, prefix: str, adapter: BaseAdapter) -> None:
         # Update poolmanager connection kwargs for HTTPAdapters mounted after interface options were set
-        if isinstance(adapter, HTTPAdapter) and "http://" in self.adapters and "https://" in self.adapters:
-            default_adapter_connection_pool_kw = cast("HTTPAdapter", self.adapters["https://"]).poolmanager.connection_pool_kw
+        if (
+            isinstance(adapter, HTTPAdapter)
+            and "http://" in self.adapters
+            and (https_adapter := self.adapters.get("https://"))
+            and isinstance(https_adapter, HTTPAdapter)
+        ):
+            default_adapter_connection_pool_kw = https_adapter.poolmanager.connection_pool_kw
             adapter.poolmanager.connection_pool_kw.update({
                 "source_address": default_adapter_connection_pool_kw.get("source_address"),
                 "socket_options": default_adapter_connection_pool_kw.get("socket_options"),

--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -1,13 +1,14 @@
 import socket
 import ssl
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, TypedDict
+from typing import Any, TypedDict, overload
 
 # noinspection PyProtectedMember
 import requests._types as _requeststypes  # noqa: PLC2701
 from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
+from requests.cookies import CookieJar, RequestsCookieJar
 from typing_extensions import Unpack
 
 from streamlink.plugin.api.validate import Schema
@@ -20,19 +21,33 @@ class _StreamlinkKwargs(TypedDict, total=False):
     retries: float
     retry_backoff: float
     retry_max_backoff: float
-    schema: Schema
     session: HTTPSession
 
+class _SchemaKwargs(TypedDict):
+    schema: Schema
+
 class _RequestKwargs(_requeststypes.RequestKwargs, _StreamlinkKwargs):
+    pass
+
+class _RequestKwargsWithSchema(_requeststypes.RequestKwargs, _StreamlinkKwargs, _SchemaKwargs):
     pass
 
 class _GetKwargs(_requeststypes.GetKwargs, _StreamlinkKwargs):
     pass
 
+class _GetKwargsWithSchema(_requeststypes.GetKwargs, _StreamlinkKwargs, _SchemaKwargs):
+    pass
+
 class _PostKwargs(_requeststypes.PostKwargs, _StreamlinkKwargs):
     pass
 
+class _PostKwargsWithSchema(_requeststypes.PostKwargs, _StreamlinkKwargs, _SchemaKwargs):
+    pass
+
 class _DataKwargs(_requeststypes.DataKwargs, _StreamlinkKwargs):
+    pass
+
+class _DataKwargsWithSchema(_requeststypes.DataKwargs, _StreamlinkKwargs, _SchemaKwargs):
     pass
 
 # ----
@@ -81,50 +96,155 @@ class HTTPSession(Session):
     @staticmethod
     def valid_request_args(**req_keywords) -> dict[str, Any]: ...
     def prepare_new_request(self, **req_keywords) -> PreparedRequest: ...
+    @overload
     def request(
         self,
         method: str,
         url: _requeststypes.UriType,
-        *args,
-        **kwargs: Unpack[_RequestKwargs],
+        params: _requeststypes.ParamsType = None,
+        data: _requeststypes.DataType = None,
+        headers: Mapping[str, str | bytes] | None = None,
+        cookies: RequestsCookieJar | CookieJar | dict[str, str] | None = None,
+        files: _requeststypes.FilesType = None,
+        auth: _requeststypes.AuthType = None,
+        timeout: _requeststypes.TimeoutType = None,
+        allow_redirects: bool = True,
+        proxies: dict[str, str] | None = None,
+        hooks: _requeststypes.HooksInputType | None = None,
+        stream: bool | None = None,
+        verify: _requeststypes.VerifyType | None = None,
+        cert: _requeststypes.CertType = None,
+        json: _requeststypes.JsonType = None,
+        # streamlink options
+        acceptable_status: Sequence[int] | None = None,
+        encoding: str | None = None,
+        exception: type[Exception] | None = None,
+        raise_for_status: bool = True,
+        retries: int = 0,
+        retry_backoff: float = 0.3,
+        retry_max_backoff: float = 10.0,
+        schema: Schema | None = None,
+        session: HTTPSession | None = None,
     ) -> Any: ...
+    @overload
+    def request(
+        self,
+        url: _requeststypes.UriType,
+        params: _requeststypes.ParamsType = None,
+        data: _requeststypes.DataType = None,
+        headers: Mapping[str, str | bytes] | None = None,
+        cookies: RequestsCookieJar | CookieJar | dict[str, str] | None = None,
+        files: _requeststypes.FilesType = None,
+        auth: _requeststypes.AuthType = None,
+        timeout: _requeststypes.TimeoutType = None,
+        allow_redirects: bool = True,
+        proxies: dict[str, str] | None = None,
+        hooks: _requeststypes.HooksInputType | None = None,
+        stream: bool | None = None,
+        verify: _requeststypes.VerifyType | None = None,
+        cert: _requeststypes.CertType = None,
+        json: _requeststypes.JsonType = None,
+        # streamlink options
+        acceptable_status: Sequence[int] | None = None,
+        encoding: str | None = None,
+        exception: type[Exception] | None = None,
+        raise_for_status: bool = True,
+        retries: int = 0,
+        retry_backoff: float = 0.3,
+        retry_max_backoff: float = 10.0,
+        session: HTTPSession | None = None,
+    ) -> Response: ...
+    @overload
+    def get(
+        self,
+        url: _requeststypes.UriType,
+        params: _requeststypes.ParamsType | None = None,
+        **kwargs: Unpack[_GetKwargsWithSchema],
+    ) -> Any: ...
+    @overload
     def get(
         self,
         url: _requeststypes.UriType,
         params: _requeststypes.ParamsType | None = None,
         **kwargs: Unpack[_GetKwargs],
+    ) -> Response: ...
+    @overload
+    def options(
+        self,
+        url: _requeststypes.UriType,
+        **kwargs: Unpack[_RequestKwargsWithSchema],
     ) -> Any: ...
+    @overload
     def options(
         self,
         url: _requeststypes.UriType,
         **kwargs: Unpack[_RequestKwargs],
+    ) -> Response: ...
+    @overload
+    def head(
+        self,
+        url: _requeststypes.UriType,
+        **kwargs: Unpack[_RequestKwargsWithSchema],
     ) -> Any: ...
+    @overload
     def head(
         self,
         url: _requeststypes.UriType,
         **kwargs: Unpack[_RequestKwargs],
+    ) -> Response: ...
+    @overload
+    def post(
+        self,
+        url: _requeststypes.UriType,
+        data: _requeststypes.DataType = None,
+        json: _requeststypes.JsonType = None,
+        **kwargs: Unpack[_PostKwargsWithSchema],
     ) -> Any: ...
+    @overload
     def post(
         self,
         url: _requeststypes.UriType,
         data: _requeststypes.DataType = None,
         json: _requeststypes.JsonType = None,
         **kwargs: Unpack[_PostKwargs],
+    ) -> Response: ...
+    @overload
+    def put(
+        self,
+        url: _requeststypes.UriType,
+        data: _requeststypes.DataType = None,
+        **kwargs: Unpack[_DataKwargsWithSchema],
     ) -> Any: ...
+    @overload
     def put(
         self,
         url: _requeststypes.UriType,
         data: _requeststypes.DataType = None,
         **kwargs: Unpack[_DataKwargs],
+    ) -> Response: ...
+    @overload
+    def patch(
+        self,
+        url: _requeststypes.UriType,
+        data: _requeststypes.DataType = None,
+        **kwargs: Unpack[_DataKwargsWithSchema],
     ) -> Any: ...
+    @overload
     def patch(
         self,
         url: _requeststypes.UriType,
         data: _requeststypes.DataType = None,
         **kwargs: Unpack[_DataKwargs],
+    ) -> Response: ...
+    @overload
+    def delete(
+        self,
+        url: _requeststypes.UriType,
+        **kwargs: Unpack[_RequestKwargsWithSchema],
     ) -> Any: ...
+    @overload
     def delete(
         self,
         url: _requeststypes.UriType,
         **kwargs: Unpack[_RequestKwargs],
-    ) -> Any: ...
+    ) -> Response: ...

--- a/src/streamlink/session/http.pyi
+++ b/src/streamlink/session/http.pyi
@@ -1,73 +1,39 @@
 import socket
 import ssl
-from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, TypeAlias
+from typing import Any, TypedDict
 
-# noinspection PyUnresolvedReferences
-from _typeshed import SupportsItems, SupportsRead  # noqa: PLC2701
+# noinspection PyProtectedMember
+import requests._types as _requeststypes  # noqa: PLC2701
 from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
-from requests.auth import AuthBase
-from requests.cookies import RequestsCookieJar
+from typing_extensions import Unpack
 
 from streamlink.plugin.api.validate import Schema
-from streamlink.session import Streamlink
 
-# START: borrowed from typeshed / types-requests
-# https://github.com/python/typeshed/blob/b3db49abbd563a8543783fcd2b4d6765b32812b0/stubs/requests/requests/sessions.pyi
+class _StreamlinkKwargs(TypedDict, total=False):
+    acceptable_status: Sequence[int] | None
+    encoding: str | None
+    exception: type[Exception]
+    raise_for_status: bool
+    retries: float
+    retry_backoff: float
+    retry_max_backoff: float
+    schema: Schema
+    session: HTTPSession
 
-_Data: TypeAlias = (
-    # used in requests.models.PreparedRequest.prepare_body
-    #
-    # case: is_stream
-    # see requests.adapters.HTTPAdapter.send
-    # will be sent directly to http.HTTPConnection.send(...) (through urllib3)
-    Iterable[bytes]
-    # case: not is_stream
-    # will be modified before being sent to urllib3.HTTPConnectionPool.urlopen(body=...)
-    # see requests.models.RequestEncodingMixin._encode_params
-    # see requests.models.RequestEncodingMixin._encode_files
-    # note that keys&values are converted from Any to str by urllib.parse.urlencode
-    | str
-    | bytes
-    | SupportsRead[str | bytes]
-    | list[tuple[Any, Any]]
-    | tuple[tuple[Any, Any], ...]
-    | Mapping[Any, Any]
-)
-_Auth: TypeAlias = tuple[str, str] | AuthBase | Callable[[PreparedRequest], PreparedRequest]
-_Cert: TypeAlias = str | tuple[str, str]
-_FileName: TypeAlias = str | None
-_FileContent: TypeAlias = SupportsRead[str | bytes] | str | bytes
-_FileContentType: TypeAlias = str
-_FileCustomHeaders: TypeAlias = Mapping[str, str]
-_FileSpecTuple2: TypeAlias = tuple[_FileName, _FileContent]
-_FileSpecTuple3: TypeAlias = tuple[_FileName, _FileContent, _FileContentType]
-_FileSpecTuple4: TypeAlias = tuple[_FileName, _FileContent, _FileContentType, _FileCustomHeaders]
-_FileSpec: TypeAlias = _FileContent | _FileSpecTuple2 | _FileSpecTuple3 | _FileSpecTuple4
-_Files: TypeAlias = Mapping[str, _FileSpec] | Iterable[tuple[str, _FileSpec]]
-_Hook: TypeAlias = Callable[[Response], Any]
-_HooksInput: TypeAlias = Mapping[str, Iterable[_Hook] | _Hook]
+class _RequestKwargs(_requeststypes.RequestKwargs, _StreamlinkKwargs):
+    pass
 
-_ParamsMappingKeyType: TypeAlias = str | bytes | float
-_ParamsMappingValueType: TypeAlias = str | bytes | float | Iterable[str | bytes | float] | None
-_Params: TypeAlias = (
-    SupportsItems[_ParamsMappingKeyType, _ParamsMappingValueType]
-    | tuple[_ParamsMappingKeyType, _ParamsMappingValueType]
-    | Iterable[tuple[_ParamsMappingKeyType, _ParamsMappingValueType]]
-    | str
-    | bytes
-)
-_TextMapping: TypeAlias = MutableMapping[str, str]
-_HeadersUpdateMapping: TypeAlias = Mapping[str, str | bytes | None]
-_Timeout: TypeAlias = float | tuple[float | None, float | None]
-_Verify: TypeAlias = bool | str
+class _GetKwargs(_requeststypes.GetKwargs, _StreamlinkKwargs):
+    pass
 
-# END: borrowed from typeshed / types-requests
+class _PostKwargs(_requeststypes.PostKwargs, _StreamlinkKwargs):
+    pass
 
-_AcceptableStatus: TypeAlias = Sequence[int]
-_Exception: TypeAlias = type[Exception]
+class _DataKwargs(_requeststypes.DataKwargs, _StreamlinkKwargs):
+    pass
 
 # ----
 
@@ -90,7 +56,7 @@ class HTTPSession(Session):
         cls,
         res: Response,
         name: str | None = ...,
-        exception: _Exception | None = ...,
+        exception: type[Exception] | None = ...,
         schema: Schema | None = ...,
         *args,
         **kwargs,
@@ -102,7 +68,7 @@ class HTTPSession(Session):
         ignore_ns: bool | None = ...,
         invalid_char_entities: bool | None = ...,
         name: str | None = ...,
-        exception: _Exception | None = ...,
+        exception: type[Exception] | None = ...,
         schema: Schema | None = ...,
         *args,
         **kwargs,
@@ -117,232 +83,48 @@ class HTTPSession(Session):
     def prepare_new_request(self, **req_keywords) -> PreparedRequest: ...
     def request(
         self,
-        method: str | bytes,
-        url: str | bytes,
-        params: _Params | None = ...,
-        data: _Data | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        method: str,
+        url: _requeststypes.UriType,
+        *args,
+        **kwargs: Unpack[_RequestKwargs],
     ) -> Any: ...
     def get(
         self,
-        url: str | bytes,
-        *,
-        params: _Params | None = ...,
-        data: _Data | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        params: _requeststypes.ParamsType | None = None,
+        **kwargs: Unpack[_GetKwargs],
     ) -> Any: ...
     def options(
         self,
-        url: str | bytes,
-        *,
-        params: _Params | None = ...,
-        data: _Data | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        **kwargs: Unpack[_RequestKwargs],
     ) -> Any: ...
     def head(
         self,
-        url: str | bytes,
-        *,
-        params: _Params | None = ...,
-        data: _Data | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        **kwargs: Unpack[_RequestKwargs],
     ) -> Any: ...
     def post(
         self,
-        url: str | bytes,
-        data: _Data | None = ...,
-        json: Any | None = ...,
-        *,
-        params: _Params | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        data: _requeststypes.DataType = None,
+        json: _requeststypes.JsonType = None,
+        **kwargs: Unpack[_PostKwargs],
     ) -> Any: ...
     def put(
         self,
-        url: str | bytes,
-        data: _Data | None = ...,
-        *,
-        params: _Params | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        data: _requeststypes.DataType = None,
+        **kwargs: Unpack[_DataKwargs],
     ) -> Any: ...
     def patch(
         self,
-        url: str | bytes,
-        data: _Data | None = ...,
-        *,
-        params: _Params | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        data: _requeststypes.DataType = None,
+        **kwargs: Unpack[_DataKwargs],
     ) -> Any: ...
     def delete(
         self,
-        url: str | bytes,
-        *,
-        params: _Params | None = ...,
-        data: _Data | None = ...,
-        headers: _HeadersUpdateMapping | None = ...,
-        cookies: RequestsCookieJar | _TextMapping | None = ...,
-        files: _Files | None = ...,
-        auth: _Auth | None = ...,
-        timeout: _Timeout | None = ...,
-        allow_redirects: bool = ...,
-        proxies: _TextMapping | None = ...,
-        hooks: _HooksInput | None = ...,
-        stream: bool | None = ...,
-        verify: _Verify | None = ...,
-        cert: _Cert | None = ...,
-        json: Any | None = ...,
-        # Streamlink stuff
-        acceptable_status: _AcceptableStatus | None = ...,
-        encoding: str | None = ...,
-        exception: _Exception | None = ...,
-        raise_for_status: bool | None = ...,
-        session: Streamlink | None = ...,
-        schema: Schema | None = ...,
-        retries: float | None = ...,
-        retry_backoff: float | None = ...,
-        retry_max_backoff: float | None = ...,
+        url: _requeststypes.UriType,
+        **kwargs: Unpack[_RequestKwargs],
     ) -> Any: ...

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
     from streamlink import Streamlink
 
 
-_original_allowed_gai_family = urllib3.util.connection.allowed_gai_family  # type: ignore[attr-defined, ty:unresolved-attribute]
+_original_allowed_gai_family = urllib3.util.connection.allowed_gai_family
 
 
 class TestUrllib3Overrides:

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -5,7 +5,7 @@ import ssl
 from operator import itemgetter
 from socket import AF_INET, AF_INET6
 from ssl import SSLContext
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock, PropertyMock, call
 
 import freezegun
@@ -154,6 +154,63 @@ class TestHTTPSession:
         assert session.timeout == 20.0  # noqa: RUF069
         assert "file://" in session.adapters.keys()
 
+    @pytest.mark.parametrize("verb", ["get", "post", "head", "options", "put", "patch", "delete"])
+    def test_http_verbs(self, requests_mock: rm.Mocker, verb: str):
+        mocked = requests_mock.register_uri(verb, "http://localhost", text="OK")
+        session = HTTPSession()
+        method = getattr(session, verb)
+        assert callable(method)
+        res = method("http://localhost")
+        assert isinstance(res, requests.Response)
+        assert res.text == "OK"
+        assert mocked.called_once
+
+    @pytest.mark.parametrize(
+        ("params", "expected"),
+        [
+            pytest.param(
+                {"one": "three", "foo": "bar"},
+                "http://localhost/path?one=two&foo=bar",
+                id="mapping",
+            ),
+            pytest.param(
+                [("one", "three"), ("foo", "bar")],
+                "http://localhost/path?one=two&foo=bar",
+                id="list",
+            ),
+            pytest.param(
+                (("one", "three"), ("foo", "bar")),
+                "http://localhost/path?one=two&foo=bar",
+                id="tuple",
+            ),
+            pytest.param(
+                "one=three&foo=bar",
+                "http://localhost/path?one=two",
+                id="str",
+            ),
+            pytest.param(
+                b"one=three&foo=bar",
+                "http://localhost/path?one=two",
+                id="bytes",
+            ),
+        ],
+    )
+    def test_session_keyword(self, requests_mock: rm.Mocker, params: Any, expected: str):
+        session_one = HTTPSession()
+        session_two = HTTPSession()
+        requests_mock.register_uri("GET", "http://localhost/path")
+        session_two.headers.update({"User-Agent": "foo"})
+        session_two.params.update({"one": "two"})
+        res = session_one.get(
+            "http://localhost/path",
+            headers={"User-Agent": "bar", "X-Foo": "bar"},
+            params=params,
+            session=session_two,
+        )
+        assert res.request.headers["User-Agent"] == "foo"
+        assert res.request.headers["X-Foo"] == "bar"
+        assert res.request.url == expected
+
     def test_read_timeout(self, monkeypatch: pytest.MonkeyPatch):
         mock_sleep = Mock()
         mock_request = Mock(side_effect=requests.Timeout)
@@ -164,11 +221,25 @@ class TestHTTPSession:
         with pytest.raises(PluginError, match=r"^Unable to open URL: http://localhost/"):
             session.get("http://localhost/", timeout=123, retries=3, retry_backoff=2, retry_max_backoff=5)
 
-        assert mock_request.call_args_list == [
-            call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
-            call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
-            call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
-            call("GET", "http://localhost/", headers={}, params={}, timeout=123, proxies={}, allow_redirects=True),
+        assert mock_request.call_args_list == 4 * [
+            call(
+                "GET",
+                "http://localhost/",
+                params=None,
+                data=None,
+                headers=None,
+                cookies=None,
+                files=None,
+                auth=None,
+                timeout=123,
+                allow_redirects=True,
+                proxies=None,
+                hooks=None,
+                stream=None,
+                verify=None,
+                cert=None,
+                json=None,
+            ),
         ]
         assert mock_sleep.call_args_list == [
             call(2),


### PR DESCRIPTION
- [`types-urllib3` has already been removed from typeshed in 2023.](https://github.com/python/typeshed/commit/559d31c4a33045310a30843dd7fac88a62cc5915)
- [`types-requests` won't be needed anymore](https://github.com/python/typeshed/tree/bbb46e7939bfab4d4766a06457cd1f7f85206383/stubs/requests/requests) with the [release of `requests==2.34.0`](https://github.com/psf/requests/releases/tag/v2.34.0)

**Since these type-stub modules are incompatible with the inline typing annotations of both dependencies, `types-requests` and `types-urllib3` need to be removed from the Python environment**.

Otherwise, type checkers will automatically discover and use these modules, leading to the following errors:

```
src/streamlink/compat.py:16:29: error[unresolved-import] Module `requests.compat` has no member `chardet`
src/streamlink/session/http.py:17:26: error[unresolved-import] Module `urllib3.util` has no member `create_urllib3_context`
src/streamlink/session/http.py:41:32: error[unresolved-attribute] Module `urllib3.util.connection` has no member `allowed_gai_family`
src/streamlink/session/http.py:64:40: error[unresolved-attribute] Module `urllib3.util.url` has no member `_PERCENT_RE`
src/streamlink/session/http.py:73:1: error[unresolved-attribute] Unresolved attribute `_PERCENT_RE` on type `<module 'urllib3.util.url'>`.
src/streamlink/session/http.py:73:92: warning[unused-type-ignore-comment] Unused `type: ignore` directive: 'invalid-assignment'
src/streamlink/session/http.py:98:1: error[unresolved-attribute] Unresolved attribute `_set_socket_options` on type `<module 'urllib3.util.connection'>`.
src/streamlink/session/http.py:98:75: warning[unused-type-ignore-comment] Unused `type: ignore` directive
src/streamlink/session/http.py:204:9: error[invalid-method-override] Invalid override of method `mount`: Definition is incompatible with `Session.mount`
src/streamlink/session/http.py:222:13: error[unresolved-attribute] Unresolved attribute `allowed_gai_family` on type `<module 'urllib3.util.connection'>`.
src/streamlink/session/http.py:224:13: error[unresolved-attribute] Unresolved attribute `allowed_gai_family` on type `<module 'urllib3.util.connection'>`.
src/streamlink/session/http.py:224:83: warning[unused-type-ignore-comment] Unused `type: ignore` directive
src/streamlink/session/http.py:226:13: error[unresolved-attribute] Unresolved attribute `allowed_gai_family` on type `<module 'urllib3.util.connection'>`.
src/streamlink/session/http.py:226:84: warning[unused-type-ignore-comment] Unused `type: ignore` directive
src/streamlink/session/http.pyi:8:8: error[unresolved-import] Cannot resolve imported module `requests._types`
src/streamlink/session/http.pyi:87:9: error[invalid-method-override] Invalid override of method `request`: Definition is incompatible with `Session.request`
tests/session/test_http.py:37:32: error[unresolved-attribute] Module `urllib3.util.connection` has no member `allowed_gai_family`
Found 17 diagnostics
```

----

The biggest change is our `http.pyi` which now imports TypedDict typing data from `requests._types` and merges it with Streamlink's custom additions in our `HTTPSession.request()` method and various HTTP-verb methods. A huge simplification.

The third commit adds overloads for `request()` and the HTTP-verb methods, based on the `schema` keyword argument. If it's missing, then a regular `requests.Response` object is returned, `Any` otherwise.

The fourth one cleans up `request()`, fixes incorrect typing and adds some missing tests.