### PR TITLE
session.http: fix request exception context

### DIFF
--- a/src/streamlink/plugins/nicolive.py
+++ b/src/streamlink/plugins/nicolive.py
@@ -148,10 +148,10 @@ class NicoLiveHLSStreamWriter(HLSStreamWriter):
         try:
             return super().create_decryptor(*args, **kwargs)
         except StreamError as err:
-            # TODO: fix HTTPSession.request()
             if (
-                not (orig_err := getattr(err, "err", None))
+                not (orig_err := err.__context__)
                 or not isinstance(orig_err, HTTPError)
+                or orig_err.response is None
                 or orig_err.response.status_code != 403
             ):
                 raise

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -993,8 +993,7 @@ class Twitch(Plugin):
                 **extra_params,
             )
         except OSError as err:
-            # TODO: fix the "err" attribute set by HTTPSession.request()
-            orig = getattr(err, "err", None)
+            orig = err.__context__
             if isinstance(orig, HTTPError) and orig.response is not None and orig.response.status_code >= 400:
                 # The playlist's error response may include JSON data with an error message
                 with suppress(PluginError):

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -347,7 +347,7 @@ class HTTPSession(Session):
                 if attempt >= retries:
                     err = exception(f"Unable to open URL: {url} ({rerr})")
                     err.err = rerr  # ty:ignore[unresolved-attribute]
-                    raise err from None  # TODO: fix this
+                    raise err from rerr
                 attempt += 1
                 # back off retrying, but only to a maximum sleep time
                 delay = min(retry_max_backoff, retry_backoff * (2 ** (attempt - 1)))

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -130,10 +130,8 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
                     **self.reader.request_params,
                 )
             except StreamError as err:
-                # FIXME: fix HTTPSession.request()
-                original_error = getattr(err, "err", None)
-                if isinstance(original_error, InvalidSchema):
-                    raise StreamError(f"Unable to find connection adapter for key URI: {key_uri}") from original_error
+                if isinstance(err.__context__, InvalidSchema):
+                    raise StreamError(f"Unable to find connection adapter for key URI: {key_uri}") from err.__context__
                 raise  # pragma: no cover
 
             res.encoding = "binary/octet-stream"

--- a/tests/session/test_http.py
+++ b/tests/session/test_http.py
@@ -218,8 +218,11 @@ class TestHTTPSession:
         monkeypatch.setattr("streamlink.session.http.Session.request", mock_request)
 
         session = HTTPSession()
-        with pytest.raises(PluginError, match=r"^Unable to open URL: http://localhost/"):
+        with pytest.raises(PluginError, match=r"^Unable to open URL: http://localhost/") as err:
             session.get("http://localhost/", timeout=123, retries=3, retry_backoff=2, retry_max_backoff=5)
+        oerr = getattr(err.value, "err", None)
+        assert isinstance(oerr, requests.Timeout)
+        assert err.value.__context__ is oerr
 
         assert mock_request.call_args_list == 4 * [
             call(


### PR DESCRIPTION
This fixes the missing exception context on HTTP requests failues. We've previously added the custom `err` attribute to the raised `Exception` object (based on the `exception` argument). This is kept for backward compatibility.

Fixing the overall situation with the exception types in HTTP requests (#5047) is still a difficult task considering the huge number of API calls in the entire codebase.