### PR TITLE
chore: set requests version range in typing group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,9 +113,13 @@ typing = [
   { include-group = "test" },
   { include-group = "docs" },
   { include-group = "script" },
+  # tools and typing dependencies
   "ty ==0.0.34",
   "mypy[faster-cache] ==2.0.0",
   "typing-extensions >=4.0.0",
+  # dependency overrides
+  "requests >=2.34.0,!=2.34.1",
+  # dependency type-stubs
   "lxml-stubs",
   "types-docutils",
   "types-freezegun",


### PR DESCRIPTION
Since we now rely on `requests`' inline typing annotations (#6924) which were added in `2.34.0`, we need to set a min version in the typing dependency group. `2.34.1` introduced a typing bug that will be fixed in their next version, so `2.34.1` is ignored.