### PR TITLE
Immutable releases and changelog linting in GH release script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,7 @@ jobs:
           python -m pip install -U
           -e .
           --group build
+          --group script
       - name: Build shell completions
         continue-on-error: ${{ matrix.continue || false }}
         run: bash ./script/build-shell-completions.sh
@@ -111,6 +112,10 @@ jobs:
           unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | grep -E '^\s*//'
           unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | grep -vE '^\s*//' | jq -e 'keys > 0'
           unzip -p ./dist/streamlink-*-any.whl 'streamlink/plugins/_plugins.json' | grep -vE '^\s*//' | jq
+      - name: Changelog
+        if: github.event_name == 'pull_request'
+        run: |
+          python ./script/github-release.py --check=${{ github.event.pull_request.head.sha }}
 
   documentation:
     name: Test docs

--- a/script/github-release.py
+++ b/script/github-release.py
@@ -194,7 +194,7 @@ class GitHubAPI:
     def call(
         self,
         host: str = "api.github.com",
-        method: Literal["GET", "POST", "PATCH"] = "GET",
+        method: Literal["GET", "POST", "PATCH", "DELETE"] = "GET",
         endpoint: str = "/",
         headers: dict[str, Any] | None = None,
         raise_failure: bool = True,
@@ -261,16 +261,17 @@ class GitHubAPI:
         )
         log.info(f"Successfully updated existing GitHub release {self.repo}#{self.tag}")
 
-    def create_or_update_release(self, **payload) -> int:
-        payload.update(tag_name=self.tag)
-        release_id = self.get_release_id()
+    def delete_release(self, release_id: int) -> None:
+        if not self.authenticated:
+            log.info(f"dry-run: Would have deleted GitHub release {self.repo}#{self.tag}")
+            return
 
-        if not release_id:
-            return self.create_release(payload)
-
-        self.update_release(release_id, payload)
-
-        return release_id
+        log.info(f"Deleting GitHub release {self.repo}#{self.tag}")
+        self.call(
+            method="DELETE",
+            endpoint=f"/repos/{self.repo}/releases/{release_id}",
+        )
+        log.info(f"Successfully deleted GitHub release {self.repo}#{self.tag}")
 
     def upload_asset(self, release_id: int, filename: str, filehandle: IO):
         if not self.authenticated:
@@ -288,13 +289,33 @@ class GitHubAPI:
         )
         log.info(f"Successfully uploaded '{filename}' to GitHub release {self.repo}#{self.tag}")
 
+    def publish_release(self, name: str, body: str, filehandles: Mapping[str, IO[bytes]]):
+        release_id = self.create_release({
+            "tag_name": self.tag,
+            "draft": True,
+            "name": name,
+            "body": body,
+        })
+
+        try:
+            for filename, filehandle in filehandles.items():
+                self.upload_asset(release_id, filename, filehandle)
+
+            self.update_release(
+                release_id,
+                {"draft": False},
+            )
+        except requests.RequestException as err:
+            log.error(f"Unable to publish release: {err}")
+            self.delete_release(release_id)
+
     def get_contributors(self, start: str, end: str) -> list[Author]:
         log.debug(f"Getting contributors of {self.repo} in commit range {start}...{end}")
 
         authors: dict[Email, Author] = {}
         co_authors: list[Email] = []
 
-        total_commits = None
+        total_commits: int | None = None
         parsed_commits = 0
         page = 0
 
@@ -332,7 +353,7 @@ class GitHubAPI:
                 # GitHub identifies its users by checking the commit-author's email address
                 commit_author_email = Email((commit.get("author") or {}).get("email", ""))
                 # The commit-author's name can differ from the GitHub user account name -> use the provided author login
-                author_name = (commitdata.get("author") or {}).get("login")
+                author_name: str | None = (commitdata.get("author") or {}).get("login")
                 if not commit_author_email or not author_name:
                     continue
 
@@ -410,7 +431,7 @@ class Release:
 
     @staticmethod
     @contextmanager
-    def get_file_handles(assets: list[Path]) -> Generator[Mapping[str, IO], None, None]:
+    def get_file_handles(assets: list[Path]) -> Generator[Mapping[str, IO[bytes]], None, None]:
         handles = {}
         try:
             for asset in assets:
@@ -457,7 +478,13 @@ class Release:
         return jinjatemplate.render(context)
 
 
-def main(args: argparse.Namespace):
+def main() -> None:
+    args: argparse.Namespace = get_args()
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+        format="[%(levelname)s] %(message)s",
+    )
+
     # if no tag was provided, get the current tag from `git describe --tags`
     tag = args.tag or Git.tag()
     if not tag:
@@ -469,7 +496,6 @@ def main(args: argparse.Namespace):
     release = Release(tag, args.template, args.changelog)
 
     # get file handles of release assets first, to prevent unnecessary API requests if input files can't be found
-    filehandles: Mapping[str, IO]
     with release.get_file_handles(args.assets) as filehandles:
         # initialize GitHub API
         api = GitHubAPI(args.repo, tag)
@@ -477,27 +503,24 @@ def main(args: argparse.Namespace):
         # prepare the release body with the changelog, contributors list and git shortlog
         body = release.get_body(api, args.no_contributors, args.no_shortlog)
 
-        # create a new release or update an existing one with the same tag
-        release_id = api.create_or_update_release(
+        # publish the new release
+        api.publish_release(
             name=f"Streamlink {tag}",
             body=body,
+            filehandles=filehandles,
         )
-
-        # upload assets
-        for filename, filehandle in filehandles.items():
-            api.upload_asset(release_id, filename, filehandle)
 
     log.info("Done")
 
 
 if __name__ == "__main__":
-    args = get_args()
-    logging.basicConfig(
-        level=logging.DEBUG if args.debug else logging.INFO,
-        format="[%(levelname)s] %(message)s",
-    )
-
+    # noinspection PyBroadException
     try:
-        main(args)
+        main()
     except KeyboardInterrupt:
         sys.exit(130)
+    except Exception:
+        log.exception("Error", exc_info=True)
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/script/github-release.py
+++ b/script/github-release.py
@@ -29,6 +29,7 @@ ROOT = Path(__file__).parents[1].resolve()
 DEFAULT_REPO = "streamlink/streamlink"
 
 
+RE_RELEASE_COMMIT_MESSAGE = re.compile(r"^release: (?P<version>\d+\.\d+\.\d+(?:-\S+)?)$")
 RE_CHANGELOG_DELIM = re.compile(r"\n## streamlink ")
 RE_CHANGELOG_CONTENT = re.compile(
     r"""
@@ -68,6 +69,15 @@ def get_args():
         "--dry-run",
         action="store_true",
         help="Don't make any GitHub API calls",
+    )
+    parser.add_argument(
+        "--check",
+        metavar="GITREF",
+        help=(
+            "Validate the changelog added by a specific git ref, usually HEAD.\n"
+            + f"Must be a release commit using the '{RE_RELEASE_COMMIT_MESSAGE.pattern}' format.\n"
+            + 'Implies --dry-run and --tag="".'
+        ),
     )
     parser.add_argument(
         "--repo",
@@ -148,6 +158,18 @@ class Git:
             )
         except subprocess.CalledProcessError as err:
             raise ValueError(f"Could not get tag from git:\n{err.stderr}") from err
+
+    @classmethod
+    def commit_msg(cls, ref: str = "HEAD") -> str:
+        try:
+            return cls._output(
+                "show",
+                "-s",
+                "--format=%s",
+                ref,
+            )
+        except subprocess.CalledProcessError as err:
+            raise ValueError(f"Could not get commit message from git:\n{err.stderr}") from err
 
     @classmethod
     def shortlog(cls, start: str, end: str) -> str:
@@ -399,8 +421,9 @@ class GitHubAPI:
 
 
 class Release:
-    def __init__(self, tag: str, template: Path, changelog: Path):
-        self.tag = tag
+    def __init__(self, ref: str, version: str, template: Path, changelog: Path):
+        self.ref = ref
+        self.version = version
         self.template = template
         self.changelog = changelog
 
@@ -445,10 +468,10 @@ class Release:
             if not (match := re.search(RE_CHANGELOG_CONTENT, section)):
                 raise ValueError(f"Invalid changelog format:\n{section}")
 
-            if match.group("version") == self.tag:
+            if match.group("version") == self.version:
                 return match.groupdict()
 
-        raise KeyError("Missing changelog for current release")
+        raise KeyError(f"Missing changelog for release {self.version}")
 
     @staticmethod
     @contextmanager
@@ -480,7 +503,7 @@ class Release:
 
         if not no_contributors or not no_shortlog:
             # don't include the tagged release commit
-            prev_commit = f"{self.tag}~1"
+            prev_commit = f"{self.ref}~1"
 
             # get the previous tag
             start = Git.tag(prev_commit)
@@ -506,27 +529,40 @@ def main() -> None:
         format="[%(levelname)s] %(message)s",
     )
 
-    # if no tag was provided, get the current tag from `git describe --tags`
-    tag = args.tag or Git.tag()
-    if not tag:
-        raise ValueError("Missing git tag")
+    dry_run = args.dry_run
+
+    if args.check:
+        dry_run = True
+        commit_msg = Git.commit_msg(args.check)
+        if not (match := RE_RELEASE_COMMIT_MESSAGE.search(commit_msg)):
+            log.warning(f"Git ref '{args.check}' is not a release commit, exiting...")
+            log.warning(commit_msg)
+            return
+
+        ref = args.check
+        version = match.group("version")
+    else:
+        ref = version = args.tag or Git.tag()
+        if not ref:
+            raise ValueError("Missing git tag")
 
     log.info(f"Repo: {args.repo}")
-    log.info(f"Tag: {tag}")
+    log.info(f"Ref: {ref}")
+    log.info(f"Version: {version}")
 
-    release = Release(tag, args.template, args.changelog)
+    release = Release(ref, version, args.template, args.changelog)
 
     # get file handles of release assets first, to prevent unnecessary API requests if input files can't be found
     with release.get_file_handles(args.assets) as filehandles:
         # initialize GitHub API
-        api = GitHubAPI(args.repo, tag, dry_run=args.dry_run)
+        api = GitHubAPI(args.repo, ref, dry_run=dry_run)
 
         # prepare the release body with the changelog, contributors list and git shortlog
         body = release.get_body(api, args.no_contributors, args.no_shortlog)
 
         # publish the new release
         api.publish_release(
-            name=f"Streamlink {tag}",
+            name=f"Streamlink {version}",
             body=body,
             filehandles=filehandles,
         )

--- a/script/github-release.py
+++ b/script/github-release.py
@@ -29,14 +29,15 @@ ROOT = Path(__file__).parents[1].resolve()
 DEFAULT_REPO = "streamlink/streamlink"
 
 
-RE_CHANGELOG = re.compile(
+RE_CHANGELOG_DELIM = re.compile(r"\n## streamlink ")
+RE_CHANGELOG_CONTENT = re.compile(
     r"""
-        ##\sstreamlink\s+
-        (?P<version>\d+\.\d+\.\d+(?:-\S+)?)\s+
+        ^
+        (?P<version>\d+\.\d+\.\d+(?:-\S+)?)\s
         \((?P<date>\d{4}-\d\d-\d\d)\)\n\n
         (?P<changelog>.+?)\n\n
-        \[Full\schangelog]\(\S+\)\n+
-        (?=\#\#\sstreamlink|$)
+        \[Full\ changelog]\(\S+\.\.\.(?P=version)\)\n\n
+        $
     """,
     re.VERBOSE | re.DOTALL | re.IGNORECASE,
 )
@@ -62,6 +63,11 @@ def get_args():
         "--debug",
         action="store_true",
         help="Enable debug logging",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Don't make any GitHub API calls",
     )
     parser.add_argument(
         "--repo",
@@ -161,7 +167,7 @@ class GitHubAPI:
     PER_PAGE = 100
     MAX_REQUESTS = 10
 
-    def __init__(self, repo: str, tag: str):
+    def __init__(self, repo: str, tag: str, dry_run: bool = False):
         self.authenticated = False
         self.repo = repo
         self.tag = tag
@@ -169,7 +175,10 @@ class GitHubAPI:
             "Accept": "application/vnd.github.v3+json",
             "User-Agent": repo,
         }
-        self._get_api_key()
+        if dry_run:
+            log.info("dry-run: Not making any GitHub API calls")
+        else:
+            self._get_api_key()
 
     def _get_api_key(self):
         github_token, releases_api_key = getenv("GITHUB_TOKEN"), getenv("RELEASES_API_KEY")
@@ -396,7 +405,7 @@ class Release:
         self.changelog = changelog
 
     @staticmethod
-    def _read_file(path: Path):
+    def _read_file(path: Path) -> str:
         with path.open("r", encoding="utf-8") as fh:
             contents = fh.read()
 
@@ -412,7 +421,7 @@ class Release:
         except OSError as err:
             raise OSError("Missing release template file") from err
 
-    def _read_changelog(self):
+    def _read_changelog(self) -> str:
         log.debug(f"Opening changelog file: {self.changelog}")
         try:
             return self._read_file(self.changelog)
@@ -423,7 +432,19 @@ class Release:
         changelog = self._read_changelog()
 
         log.debug("Parsing changelog file")
-        for match in re.finditer(RE_CHANGELOG, changelog):
+        sections = re.split(RE_CHANGELOG_DELIM, changelog)
+        num = len(sections)
+        for idx, section in enumerate(iter(sections)):
+            if idx == 0:
+                continue
+            elif idx == num - 1:
+                # workaround for whitespace at EOF,
+                # so we can have a sensible error message on missing changelog for current tag
+                section += "\n"
+
+            if not (match := re.search(RE_CHANGELOG_CONTENT, section)):
+                raise ValueError(f"Invalid changelog format:\n{section}")
+
             if match.group("version") == self.tag:
                 return match.groupdict()
 
@@ -498,7 +519,7 @@ def main() -> None:
     # get file handles of release assets first, to prevent unnecessary API requests if input files can't be found
     with release.get_file_handles(args.assets) as filehandles:
         # initialize GitHub API
-        api = GitHubAPI(args.repo, tag)
+        api = GitHubAPI(args.repo, tag, dry_run=args.dry_run)
 
         # prepare the release body with the changelog, contributors list and git shortlog
         body = release.get_body(api, args.no_contributors, args.no_shortlog)


### PR DESCRIPTION
Three commits:

1. In order to properly support GitHub's immutable releases feature, publish new releases as draft first, then upload release assets and then set the release's draft property to false
2. Rewrite the changelog parser and add `--dry-run` (dry run was implicit previously via missing env vars)
3. Add `--check=GITREF` and add a "Changelog" step to the CI build job, so properly formatted changelogs are detected in a PR

----

Test release (8.5.0) on my test account's test repo with immutable releases enabled:

```
[INFO] Repo: bastimeyer-test/streamlink-test
[INFO] Ref: 8.5.0
[INFO] Version: 8.5.0
[INFO] Found release asset 'streamlink-8.5.0.tar.gz'
[INFO] Creating new GitHub release bastimeyer-test/streamlink-test#8.5.0
[INFO] Successfully created new GitHub release bastimeyer-test/streamlink-test#8.5.0
[INFO] Uploading 'streamlink-8.5.0.tar.gz' to GitHub release bastimeyer-test/streamlink-test#8.5.0
[INFO] Successfully uploaded 'streamlink-8.5.0.tar.gz' to GitHub release bastimeyer-test/streamlink-test#8.5.0
[INFO] Updating existing GitHub release bastimeyer-test/streamlink-test#8.5.0
[INFO] Successfully updated existing GitHub release bastimeyer-test/streamlink-test#8.5.0
[INFO] Done
```

<img width="1060" height="256" alt="image" src="https://github.com/user-attachments/assets/234e6a8f-b177-4dd9-b396-dec900de8fa9" />

Successful changelog linting step on my test repo (the contributors number is always based on the master branch):

```
$ python ./script/github-release.py --check=HEAD
[INFO] Repo: bastimeyer-test/streamlink-test
[INFO] Ref: HEAD
[INFO] Version: 8.5.0
[INFO] dry-run: Not making any GitHub API calls
[INFO] dry-run: Would have created GitHub release bastimeyer-test/streamlink-test#HEAD with:
{'body': 'TESTRELEASE\n'
         '\n'
         '## 📦 Download and Installation\n'
         '\n'
         'Please see the [installation '
         'instructions](https://streamlink.github.io/install.html) for a list '
         'of available install methods and packages on the supported operating '
         'systems.\n'
         '\n'
         '## ⚙️ Configuration and Usage\n'
         '\n'
         'Please see the [CLI '
         'documentation](https://streamlink.github.io/cli.html) for how to '
         'configure and use Streamlink.\n'
         '\n'
         '## ❤️ Support\n'
         '\n'
         'If you think that Streamlink is useful and if you want to keep the '
         'project alive, then please consider supporting its maintainers by '
         'sending a small and optionally recurring tip via the [available '
         'options](https://streamlink.github.io/latest/support.html).  \n'
         'Your support is very much appreciated, thank you!\n'
         '\n'
         '## 🙏 Contributors\n'
         '\n'
         '- 10: @bastimeyer\n'
         '\n'
         '## 🗒️ Full changelog\n'
         '\n'
         '```text\n'
         'bastimeyer <mail@bastimeyer.de> (14):\n'
         '      tests: fix can_colorize() monkeypatch on py315\n'
         '      chore: remove trio-typing from typing dep group\n'
         '      tools: bump ty to 0.0.34 and fix warnings\n'
         '      tools: bump mypy to 2.0.0\n'
         '      session.http: fix default value of params kwarg\n'
         '      chore: remove types-urllib3 and fix issues\n'
         '      chore: remove types-requests and fix issues\n'
         '      session.http: add schema method overloads\n'
         '      session.http: refactor HTTPSession\n'
         '      session.http: fix request exception context\n'
         '      chore: set requests version range in typing group\n'
         '      script: create GitHub releases as draft first\n'
         '      script: update GitHub changelog parser\n'
         '      script: add --check to GitHub release script\n'
         '```',
 'draft': True,
 'name': 'Streamlink 8.5.0',
 'tag_name': 'HEAD'}
[INFO] dry-run: Would have updated GitHub release bastimeyer-test/streamlink-test#HEAD with:
{'draft': False}
[INFO] Done
```

`--check` on a non-release-commit (always succeeds):

```
$ ./script/github-release.py --check=HEAD
[WARNING] Git ref 'HEAD' is not a release commit, exiting...
[WARNING] script: add --check to GitHub release script
```

Invalid changelog format example:

```
$ ./script/github-release.py --check=8.1.2
[INFO] Repo: streamlink/streamlink
[INFO] Ref: 8.1.2
[INFO] Version: 8.1.2
[INFO] dry-run: Not making any GitHub API calls
[ERROR] Error
Traceback (most recent call last):
  File "/home/basti/repos/streamlink/./script/github-release.py", line 576, in <module>
    main()
    ~~~~^^
  File "/home/basti/repos/streamlink/./script/github-release.py", line 561, in main
    body = release.get_body(api, args.no_contributors, args.no_shortlog)
  File "/home/basti/repos/streamlink/./script/github-release.py", line 501, in get_body
    changelog = self._get_changelog()
  File "/home/basti/repos/streamlink/./script/github-release.py", line 469, in _get_changelog
    raise ValueError(f"Invalid changelog format:\n{section}")
ValueError: Invalid changelog format:
8.1.2 (2026-01-18)

- Fixed: warnings when parsing HLS playlists with private-use language subtags ([#6780](https://github.com/streamlink/streamlink/pull/6780))
- Updated plugins:
  - youtube: fixed live streams ([#6777](https://github.com/streamlink/streamlink/pull/6777))

[Full changelog](https://github.com/streamlink/streamlink/compare/8.1.1...invalid)
```