### PR TITLE
plugins.douyin: fix validation schema

### DIFF
--- a/src/streamlink/plugins/douyin.py
+++ b/src/streamlink/plugins/douyin.py
@@ -10,6 +10,7 @@ $metadata title
 from __future__ import annotations
 
 import re
+import sys
 import uuid
 
 from streamlink.logger import getLogger
@@ -30,7 +31,15 @@ log = getLogger(__name__)
 class Douyin(Plugin):
     _STATUS_LIVE = 2
 
-    QUALITY_WEIGHTS: dict[str, int] = {}
+    # There's no bitrate information in the JSON data available anymore.
+    # These weights are based on empirically measured video bitrates of a specific stream during plugin fixing.
+    # The values themselves don't matter, only the order.
+    QUALITY_WEIGHTS: dict[str, int] = {
+        "full_hd1": sys.maxsize,
+        "hd1": 8000,
+        "sd2": 2000,
+        "sd1": 1000,
+    }
 
     @classmethod
     def stream_weight(cls, stream: str) -> tuple[float, str]:
@@ -43,62 +52,32 @@ class Douyin(Plugin):
     SCHEMA_ROOM_STORE = validate.all(
         {
             "roomInfo": {
-                # "room" and "anchor" keys are missing on invalid channels
                 validate.optional("room"): validate.all(
                     {
-                        "id_str": str,
                         "status": int,
+                        "id_str": str,
                         "title": str,
+                        validate.optional("owner"): validate.all(
+                            {"nickname": str},
+                            validate.get("nickname"),
+                        ),
+                        validate.optional("stream_url"): {
+                            "flv_pull_url": {
+                                str: validate.url(),
+                            },
+                        },
                     },
                     validate.union_get(
                         "status",
                         "id_str",
                         "title",
+                        "owner",
+                        "stream_url",
                     ),
-                ),
-                validate.optional("anchor"): validate.all(
-                    {"nickname": str},
-                    validate.get("nickname"),
                 ),
             },
         },
-        validate.union_get(
-            ("roomInfo", "room"),
-            ("roomInfo", "anchor"),
-        ),
-    )
-
-    SCHEMA_STREAM_STORE = validate.all(
-        {
-            "streamData": {
-                "H264_streamData": {
-                    # "stream" value is `none` on offline/invalid channels
-                    "stream": validate.none_or_all(
-                        {
-                            str: validate.all(
-                                {
-                                    "main": {
-                                        # HLS stream URLs are multivariant streams but only with a single media playlist,
-                                        # so avoid using HLS in favor of having reduced stream lookup/start times
-                                        "flv": validate.any("", validate.url()),
-                                        "sdk_params": validate.all(
-                                            validate.parse_json(),
-                                            {"vbitrate": int},
-                                            validate.get("vbitrate"),
-                                        ),
-                                    },
-                                },
-                                validate.union_get(
-                                    ("main", "sdk_params"),
-                                    ("main", "flv"),
-                                ),
-                            ),
-                        },
-                    ),
-                },
-            },
-        },
-        validate.get(("streamData", "H264_streamData", "stream")),
+        validate.get(("roomInfo", "room")),
     )
 
     def _get_streams(self):
@@ -124,35 +103,21 @@ class Douyin(Plugin):
                     validate.get((0, "state")),
                     {
                         "roomStore": self.SCHEMA_ROOM_STORE,
-                        "streamStore": self.SCHEMA_STREAM_STORE,
                     },
-                    validate.union_get(
-                        "roomStore",
-                        "streamStore",
-                    ),
+                    validate.get("roomStore"),
                 ),
             ),
         )
         if not data:
             return
 
-        (room_info, self.author), stream_data = data
-        if not room_info:
-            return
-
-        status, self.id, self.title = room_info
+        status, self.id, self.title, self.author, streams = data
         if status != self._STATUS_LIVE:
             log.info("The channel is currently offline")
             return
 
-        for name, (vbitrate, url) in stream_data.items():
-            if not url:
-                continue
-            self.QUALITY_WEIGHTS[name] = vbitrate
-            url = update_scheme("https://", url, force=True)
-            yield name, HTTPStream(self.session, url)
-
-        log.debug("self.QUALITY_WEIGHTS=%r", self.QUALITY_WEIGHTS)
+        for name, flv_url in streams["flv_pull_url"].items():
+            yield name.lower(), HTTPStream(self.session, update_scheme("https://", flv_url, force=True))
 
 
 __plugin__ = Douyin


### PR DESCRIPTION
Fixes #6929 

@yoohot please have a look at the pull request changes and report back if this fixes the issue by testing a couple of streams. The live streams I've tested so far all seemed to be working, but I want to be sure.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

The retured data from their website unfortunately doesn't include bitrate information anymore, so the currently available qualities ("full_hd1" (best), "hd1", "sd2" and "sd1" (worst)) need to be hardcoded with custom weights. I don't know if there are streams with different quality names that are missing in the current version of this PR.

HLS streams were not working, so I kept the HTTP streams.

```
$ streamlink --json https://live.douyin.com/548845936731 | jq .metadata
{
  "id": "7641226847266638633",
  "author": "木森（大舞台）直播",
  "category": null,
  "title": "2026木森《月赛》总决赛"
}

$ streamlink -l debug https://live.douyin.com/548845936731 best
[cli][debug] OS:         Linux-7.0.7-1-git-x86_64-with-glibc2.43
[cli][debug] Python:     3.14.5
[cli][debug] OpenSSL:    OpenSSL 3.6.2 7 Apr 2026
[cli][debug] Streamlink: 8.4.0+15.gb4466531
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.4.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.0
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.34.2
[cli][debug]  trio: 0.33.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.15.0
[cli][debug]  urllib3: 2.7.0
[cli][debug]  websocket-client: 1.9.0
[cli][debug] Arguments:
[cli][debug]  url=https://live.douyin.com/548845936731
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin douyin for URL https://live.douyin.com/548845936731
[cli][info] Available streams: sd1 (worst), sd2, hd1, full_hd1 (best)
[cli][info] Opening stream: full_hd1 (http)
[cli][info] Starting player: mpv
[cli][debug] Pre-buffering 8192 bytes
[cli.output][debug] Opening subprocess: ['/home/basti/.local/bin/mpv', '--force-media-title=https://live.douyin.com/548845936731', '-']
[cli][debug] Writing stream to output
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

This is the quality data, but none of this maps to the given quality names:
```json
[
  {
    "name": "\\u6807\\u6e05",
    "sdk_key": "ld",
    "v_codec": "264",
    "resolution": "720x540",
    "level": 1,
    "v_bit_rate": 1000000,
    "additional_content": "",
    "fps": 25,
    "disable": 0
  },
  {
    "name": "\\u9ad8\\u6e05",
    "sdk_key": "sd",
    "v_codec": "264",
    "resolution": "960x720",
    "level": 2,
    "v_bit_rate": 2000000,
    "additional_content": "",
    "fps": 30,
    "disable": 0
  },
  {
    "name": "\\u8d85\\u6e05",
    "sdk_key": "hd",
    "v_codec": "264",
    "resolution": "960x720",
    "level": 3,
    "v_bit_rate": 6000000,
    "additional_content": "",
    "fps": 59,
    "disable": 0
  },
  {
    "name": "\\u84dd\\u5149",
    "sdk_key": "uhd",
    "v_codec": "264",
    "resolution": "1440x1080",
    "level": 4,
    "v_bit_rate": 14998528,
    "additional_content": "",
    "fps": 59,
    "disable": 0
  },
  {
    "name": "\\u539f\\u753b",
    "sdk_key": "origin",
    "v_codec": "264",
    "resolution": "",
    "level": 5,
    "v_bit_rate": 14998528,
    "additional_content": "",
    "fps": 59,
    "disable": 0
  }
]
```