### PR TITLE
cli: clean player resources before output opens

### DIFF
--- a/src/streamlink_cli/output/player.py
+++ b/src/streamlink_cli/output/player.py
@@ -246,6 +246,7 @@ class PlayerOutput(Output):
         self.record = record
 
         self.title = title
+        self._closed = False
 
         self.playerargs = PlayerArgs(
             path=path,
@@ -267,6 +268,20 @@ class PlayerOutput(Output):
         else:
             self.stdout = sys.stdout
             self.stderr = sys.stderr
+
+    def close(self):
+        if self._closed:
+            return
+
+        if self.opened:
+            self._close()
+        else:
+            self._close_player_input()
+            if self.record:
+                self.record.close()
+
+        self.opened = False
+        self._closed = True
 
     @property
     def running(self):
@@ -348,14 +363,19 @@ class PlayerOutput(Output):
             self.http.accept_connection()
             self.http.open()
 
+    def _close_player_input(self) -> bool:
+        if self.namedpipe:
+            self.namedpipe.close()
+            return True
+        if self.http:
+            self.http.shutdown()
+            return True
+        return False
+
     def _close(self):
         # Close input to the player first to signal the end of the
         # stream and allow the player to terminate of its own accord
-        if self.namedpipe:
-            self.namedpipe.close()
-        elif self.http:
-            self.http.shutdown()
-        elif not self.filename and self.player.stdin:  # pragma: no branch
+        if not self._close_player_input() and not self.filename and self.player.stdin:  # pragma: no branch
             self.player.stdin.close()
 
         if self.record:

--- a/tests/cli/output/test_player.py
+++ b/tests/cli/output/test_player.py
@@ -488,3 +488,33 @@ class TestPlayerOutput:
         with expected:
             playeroutput.open()
         assert any(record.category is StreamlinkWarning for record in recwarn.list) is warns
+
+    @pytest.mark.parametrize(
+        ("playeroutput", "resource_attr", "close_method"),
+        [
+            pytest.param(
+                dict(path=Path("player"), namedpipe=Mock()),
+                "namedpipe",
+                "close",
+                id="namedpipe",
+            ),
+            pytest.param(
+                dict(path=Path("player"), http=Mock()),
+                "http",
+                "shutdown",
+                id="http",
+            ),
+        ],
+        indirect=["playeroutput"],
+    )
+    def test_close_without_open_cleans_player_input_resource(
+        self,
+        playeroutput: PlayerOutput,
+        resource_attr: str,
+        close_method: str,
+    ):
+        resource = getattr(playeroutput, resource_attr)
+
+        playeroutput.close()
+
+        assert getattr(resource, close_method).call_args_list == [call()]


### PR DESCRIPTION
- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

Fixes #4979

Summary:
- Clean named pipe and HTTP player-input resources when `PlayerOutput` is closed before `open()` has completed.
- Reuse the same player-input cleanup path for normal player shutdown.
- Add regression coverage for unopened named pipe and HTTP player outputs.

Validation:
- `python -m pytest tests/cli/output/test_player.py -q`
- `python -m pytest tests/cli -q`
- `python -m pytest -q`
- `python -m ruff check src/streamlink_cli/output/player.py tests/cli/output/test_player.py`
- `python -m ruff format --check src/streamlink_cli/output/player.py tests/cli/output/test_player.py`
- `git diff --check`

AI assistance disclosure:
- I used AI assistance while preparing this change. I reviewed the resulting code and verified it locally.