### PR TITLE
ci.github: add py315-dev test runners

### DIFF
--- a/.github/workflows/install-temp-dependencies.sh
+++ b/.github/workflows/install-temp-dependencies.sh
@@ -2,7 +2,7 @@
 set -euxo pipefail
 
 PY=$(python -c 'import platform,sysconfig;v="".join(platform.python_version_tuple()[:2]);t="t" if sysconfig.get_config_var("Py_GIL_DISABLED") else "";print(f"cp{v}-cp{v}{t}")')
-[[ "${PY}" == cp314-cp314 || "${PY}" == cp314-cp314t ]] || exit 0
+[[ "${PY}" == cp314-cp314t || "${PY}" == cp315-cp315 ]] || exit 0
 
 if [[ "$(uname)" == Linux ]]; then
     PLATFORM=linux_x86_64
@@ -18,27 +18,29 @@ fi
 BASE=https://github.com/streamlink/temp-dependency-builds-DO-NOT-USE/releases/download
 DEPS=()
 
-# individual platform dependencies
-if [[ "${PLATFORM}" == linux_x86_64 ]]; then
-    DEPS+=()
-elif [[ "${PLATFORM}" == macosx_10_15_universal2 ]]; then
-    DEPS+=()
-elif [[ "${PLATFORM}" == win_amd64 ]]; then
-    DEPS+=()
+if [[ "${PY}" == cp314-cp314t ]]; then
+    DEPS+=(
+        "brotli-20260523-1/brotli-1.2.0-${PY}-${PLATFORM}.whl"
+        "pycryptodome-20260424-1/pycryptodome-3.24.0b0-${PY}-${PLATFORM}.whl"
+    )
+
+elif [[ "${PY}" == cp315-cp315 ]]; then
+    DEPS+=(
+        "brotli-20260523-1/brotli-1.2.0-${PY}-${PLATFORM}.whl"
+        "lxml-20260523-1/lxml-6.1.1-${PY}-${PLATFORM}.whl"
+    )
+    if [[ "${PLATFORM}" == win_amd64 ]]; then
+        DEPS+=(
+            "cffi-20260523-1/cffi-2.0.0-${PY}-${PLATFORM}.whl"
+        )
+    fi
 fi
 
-# no-GIL / free-threaded dependencies
-if [[ "${PY}" == *t ]]; then
-    DEPS+=(
-        'brotli-20260424-1/brotli-1.2.0'
-        'pycryptodome-20260424-1/pycryptodome-3.24.0b0'
-    )
-fi
 
 if [[ ${#DEPS[@]} != 0 ]]; then
     deps=()
     for dep in "${DEPS[@]}"; do
-        deps+=("${BASE}/${dep}-${PY}-${PLATFORM}.whl")
+        deps+=("${BASE}/${dep}")
     done
 
     python -m pip install -U "${deps[@]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,16 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
-        # include:
-        #   - runs-on: ubuntu-latest
-        #     python-version: "3.15-dev"
-        #     continue: true
-        #   - runs-on: windows-latest
-        #     python-version: "3.15-dev"
-        #     continue: true
+        include:
+          - runs-on: ubuntu-latest
+            python-version: "3.15-dev"
+            continue: true
+          - runs-on: macos-latest
+            python-version: "3.15-dev"
+            continue: true
+          - runs-on: windows-latest
+            python-version: "3.15-dev"
+            continue: true
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
Python 3.15 beta 1 was released two weeks ago, so let's add CI test runners.
- https://docs.python.org/3.15/whatsnew/changelog.html
- https://peps.python.org/pep-0790/

----

For some strange reason, pytest locally fails when `sphinxcontrib-jsmath` is installed in the environment (pulled via the docs dependency group), but this won't be the case for the CI runners. This needs to be investigated, but I'm pretty sure that this was already reported on the respective issue trackers somewhere. We don't do anything with this package ourselves.

```
$ pytest
Error in import line from /home/basti/venv/streamlink-315/lib/python3.15/site-packages/sphinxcontrib_jsmath-1.0.1-py3.7-nspkg.pth: import sys, types, os;has_mfs = sys.version_info > (3, 5);p = os.path.join(sys._getframe(1).f_locals['sitedir'], *('sphinxcontrib',));importlib = has_mfs and __import__('importlib.util');has_mfs and __import__('importlib.machinery');m = has_mfs and sys.modules.setdefault('sphinxcontrib', importlib.util.module_from_spec(importlib.machinery.PathFinder.find_spec('sphinxcontrib', [os.path.dirname(p)])));m = m or sys.modules.setdefault('sphinxcontrib', types.ModuleType('sphinxcontrib'));mp = (m or []) and m.__dict__.setdefault('__path__',[]);(p not in mp) and mp.append(p)
  Traceback (most recent call last):
    File "<frozen site>", line 319, in _exec_imports
    File "<string>", line 1, in <module>
  KeyError: "local variable ''sitedir'' is not defined"
Error in import line from /home/basti/venv/streamlink-315/lib/python3.15/site-packages/sphinxcontrib_jsmath-1.0.1-py3.7-nspkg.pth: import sys, types, os;has_mfs = sys.version_info > (3, 5);p = os.path.join(sys._getframe(1).f_locals['sitedir'], *('sphinxcontrib',));importlib = has_mfs and __import__('importlib.util');has_mfs and __import__('importlib.machinery');m = has_mfs and sys.modules.setdefault('sphinxcontrib', importlib.util.module_from_spec(importlib.machinery.PathFinder.find_spec('sphinxcontrib', [os.path.dirname(p)])));m = m or sys.modules.setdefault('sphinxcontrib', types.ModuleType('sphinxcontrib'));mp = (m or []) and m.__dict__.setdefault('__path__',[]);(p not in mp) and mp.append(p)
  Traceback (most recent call last):
    File "<frozen site>", line 319, in _exec_imports
    File "<string>", line 1, in <module>
  KeyError: "local variable ''sitedir'' is not defined"
============================================================= test session starts ==============================================================
platform linux -- Python 3.15.0b1, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/basti/repos/streamlink
configfile: pyproject.toml
testpaths: build_backend, tests
plugins: trio-0.8.0, requests-mock-1.12.1
collected 7604 items
```

----

Also, before this can be merged, new cp315 wheels for Streamlink's dependencies will need to be built, or the CI runners have to build them every time. I'll have a look at this later.