### PR TITLE
cli: clean player inputs after pre-open failures

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -585,19 +585,24 @@ def format_valid_streams(plugin: Plugin, streams: Mapping[str, Stream]) -> str:
     return delimiter.join(validstreams)
 
 
+def close_output():
+    if not output:  # pragma: no cover
+        return
+    with suppress(KeyboardInterrupt):
+        output.close()
+
+
 def handle_url_wrapper() -> int:
     exit_code = 0
     try:
         handle_url()
     except KeyboardInterrupt:
-        # Close output
-        if output:
-            try:
-                output.close()
-            except KeyboardInterrupt:
-                pass
+        close_output()
         console.msg("Interrupted! Exiting...")
         exit_code = 128 + signal.SIGINT
+    except Exception:
+        close_output()
+        raise
     finally:
         if stream_fd:
             try:

--- a/src/streamlink_cli/output/player.py
+++ b/src/streamlink_cli/output/player.py
@@ -240,6 +240,7 @@ class PlayerOutput(Output):
         self.call = call
         self.quiet = quiet
 
+        self.player = None  # type: ignore[assignment, ty:invalid-assignment]
         self.filename = filename
         self.namedpipe = namedpipe
         self.http = http
@@ -348,16 +349,21 @@ class PlayerOutput(Output):
             self.http.accept_connection()
             self.http.open()
 
-    def _close(self):
-        # Close input to the player first to signal the end of the
-        # stream and allow the player to terminate of its own accord
+    def close(self):
+        # Close input to the player first to signal the end of the stream and allow the player to terminate on its own.
+        # Always close the player input, regardless whether the player was not launched yet
         if self.namedpipe:
             self.namedpipe.close()
+            self.namedpipe = None
         elif self.http:
             self.http.shutdown()
-        elif not self.filename and self.player.stdin:  # pragma: no branch
+            self.http = None
+        elif not self.filename and self.player and self.player.stdin:  # pragma: no branch
             self.player.stdin.close()
 
+        super().close()
+
+    def _close(self):
         if self.record:
             self.record.close()
 

--- a/tests/cli/main/test_handle_url.py
+++ b/tests/cli/main/test_handle_url.py
@@ -11,6 +11,7 @@ import streamlink_cli.main
 from streamlink.exceptions import FatalPluginError, PluginError
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.stream.stream import Stream
+from streamlink_cli.exceptions import StreamlinkCLIError
 
 
 if TYPE_CHECKING:
@@ -511,8 +512,7 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
     @pytest.fixture(autouse=True)
     def handle_url(self, request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch):
         mock_handle_url = Mock()
-        if getattr(request, "param", False):
-            mock_handle_url.side_effect = KeyboardInterrupt
+        mock_handle_url.side_effect = getattr(request, "param", None)
         monkeypatch.setattr(streamlink_cli.main, "handle_url", mock_handle_url)
 
     @staticmethod
@@ -542,7 +542,7 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
         ("handle_url", "output", "stream_fd", "exit_code", "stdout"),
         [
             pytest.param(
-                False,
+                None,
                 {},
                 {},
                 0,
@@ -550,7 +550,7 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
                 id="no-keyboardinterrupt",
             ),
             pytest.param(
-                True,
+                KeyboardInterrupt,
                 {},
                 {},
                 130,
@@ -558,7 +558,7 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
                 id="no-output",
             ),
             pytest.param(
-                True,
+                KeyboardInterrupt,
                 {"initialized": True},
                 {},
                 130,
@@ -566,7 +566,7 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
                 id="output",
             ),
             pytest.param(
-                True,
+                KeyboardInterrupt,
                 {"initialized": True},
                 {"initialized": True},
                 130,
@@ -574,7 +574,7 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
                 id="output-streamfd",
             ),
             pytest.param(
-                True,
+                KeyboardInterrupt,
                 {"initialized": True, "close_raises": True},
                 {"initialized": True},
                 130,
@@ -582,12 +582,28 @@ class TestHandleUrlKeyboardInterruptAndCleanup:
                 id="output-streamfd-outputclose-interrupted",
             ),
             pytest.param(
-                True,
+                KeyboardInterrupt,
                 {"initialized": True},
                 {"initialized": True, "close_raises": True},
                 130,
                 "Interrupted! Exiting...\n[cli][info] Closing currently open stream...\n",
                 id="output-streamfd-streamfdclose-interrupted",
+            ),
+            pytest.param(
+                StreamlinkCLIError("foo", code=1),
+                {"initialized": True},
+                {},
+                1,
+                "error: foo\n",
+                id="output-exception",
+            ),
+            pytest.param(
+                StreamlinkCLIError("foo", code=1),
+                {"initialized": True, "close_raises": True},
+                {},
+                1,
+                "error: foo\n",
+                id="output-exception-interrupted",
             ),
         ],
         indirect=["handle_url", "output", "stream_fd"],

--- a/tests/cli/output/test_player.py
+++ b/tests/cli/output/test_player.py
@@ -488,3 +488,16 @@ class TestPlayerOutput:
         with expected:
             playeroutput.open()
         assert any(record.category is StreamlinkWarning for record in recwarn.list) is warns
+
+    @pytest.mark.parametrize(
+        ("playeroutput", "input_attr", "close_method"),
+        [
+            pytest.param({"path": Path("player"), "namedpipe": Mock()}, "namedpipe", "close", id="namedpipe"),
+            pytest.param({"path": Path("player"), "http": Mock()}, "http", "shutdown", id="http"),
+        ],
+        indirect=["playeroutput"],
+    )
+    def test_close_unopened_player_input(self, playeroutput: PlayerOutput, input_attr: str, close_method: str):
+        playerinput: Mock = getattr(playeroutput, input_attr)
+        playeroutput.close()
+        assert getattr(playerinput, close_method).call_count == 1


### PR DESCRIPTION
- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

Fixes #4979

This follows up on #6933, but addresses the earlier root cause called out there: player input transports can be created before the stream is successfully opened. If stream opening fails before `output.open()`, the existing cleanup path is skipped.

Changes:
- close the created output before returning the stream-open failure
- let unopened `PlayerOutput.close()` release pre-created named pipe / HTTP input resources
- keep the existing opened-output shutdown path using the same player-input cleanup helper
- add regression coverage for stream-open failure cleanup and unopened player input cleanup

Validation:
- `python -m pytest tests/cli/main/test_output_stream.py::test_stream_failure_no_output_open -q`
- `python -m pytest tests/cli/output/test_player.py::TestPlayerOutput::test_close_unopened_player_input -q`
- `python -m pytest tests/cli/main/test_output_stream.py tests/cli/output/test_player.py -q`
- `python -m pytest tests/cli/main tests/cli/output -q`
- `python -m ruff check src/streamlink_cli/main.py src/streamlink_cli/output/player.py tests/cli/main/test_output_stream.py tests/cli/output/test_player.py`
- `python -m ruff format --check src/streamlink_cli/main.py src/streamlink_cli/output/player.py tests/cli/main/test_output_stream.py tests/cli/output/test_player.py`
- `git diff --check`

AI assistance disclosure:
- I used AI assistance while preparing this change. I reviewed the code path, wrote regression tests, and verified the result locally.