### PR TITLE
build: bump lxml to >=4.6.4,<8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "certifi",
   "exceptiongroup ; python_version<'3.11'",
   "isodate",
-  "lxml >=4.6.4,<7",
+  "lxml >=4.6.4,<8",
   "pycountry",
   "pycryptodome >=3.4.3,<4",
   "PySocks >=1.5.6,!=1.5.7",

--- a/uv.lock
+++ b/uv.lock
@@ -1891,7 +1891,7 @@ requires-dist = [
     { name = "certifi" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "isodate" },
-    { name = "lxml", specifier = ">=4.6.4,<7" },
+    { name = "lxml", specifier = ">=4.6.4,<8" },
     { name = "pycountry" },
     { name = "pycryptodome", specifier = ">=3.4.3,<4" },
     { name = "pysocks", specifier = ">=1.5.6,!=1.5.7" },


### PR DESCRIPTION
https://github.com/lxml/lxml/blob/lxml-7.0.0a1/CHANGES.txt

No breaking changes API-wise in the alpha 1 release of lxml 7. Tests are all passing.

Going to merge this once they've published a finalized release.