### PR TITLE
tools: bump ruff to 0.15.15 and fix issues

### DIFF
--- a/build_backend/onbuild.py
+++ b/build_backend/onbuild.py
@@ -105,7 +105,7 @@ class Proxy(Generic[TProxyItem]):
 def update_file(file: Path) -> Generator[Proxy[str], None, None]:
     with file.open("r+", encoding="utf-8") as fh:
         proxy = Proxy(fh.read())
-        yield proxy
+        yield proxy  # noqa: RUF075
         fh.seek(0)
         fh.write(proxy.get())
         fh.truncate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ typing = [
   { include-group = "docs" },
   { include-group = "script" },
   # tools and typing dependencies
-  "ty ==0.0.38",
+  "ty ==0.0.43",
   "mypy[faster-cache] ==2.1.0",
   "typing-extensions >=4.0.0",
   # dependency overrides

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test = [
   "freezegun >=1.5.0",
 ]
 lint = [
-  "ruff ==0.15.13",
+  "ruff ==0.15.15",
 ]
 typing = [
   { include-group = "test" },

--- a/script/github-release.py
+++ b/script/github-release.py
@@ -477,7 +477,7 @@ class Release:
     @contextmanager
     def get_file_handles(assets: list[Path]) -> Generator[Mapping[str, IO[bytes]], None, None]:
         handles = {}
-        try:
+        try:  # noqa: PLW0717
             for asset in assets:
                 asset = ROOT / asset
                 if not asset.is_file():

--- a/script/update-user-agents.py
+++ b/script/update-user-agents.py
@@ -80,12 +80,13 @@ def main(api_key: str, file: Path):
         )
         if response.status_code != 200:
             response.raise_for_status()
-        data: Any = response.json()
-        result: dict = data and data.get("result") or {}
-        if result.get("code") != "success":
-            raise ValueError(result.get("message") or "Missing version_data in JSON response")
     except requests.exceptions.RequestException as err:
         raise ValueError("Error while querying API or parsing JSON response") from err
+
+    data: Any = response.json()
+    result: dict = data and data.get("result") or {}
+    if result.get("code") != "success":
+        raise ValueError(result.get("message") or "Missing version_data in JSON response")
 
     version_data: dict = data.get("version_data") or {}
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ if __name__ == "__main__":
     sys.path.insert(0, str(Path(__file__).parent))
 
     from build_backend.commands import cmdclass
-    from setuptools import Command, setup  # noqa: TC002
+    from setuptools import Command, setup
 
     try:
         # versioningit is only required when building from git (see pyproject.toml)

--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -179,7 +179,7 @@ class Kick(Plugin):
 
     def _get_cookies_from_webbrowser(self) -> bool:
         from streamlink.compat import BaseExceptionGroup  # noqa: PLC0415
-        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession  # noqa: PLC0415, TC001
+        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession  # noqa: PLC0415
         from streamlink.webbrowser.cdp.devtools import fetch  # noqa: PLC0415, TC001
 
         async def on_main(client_session: CDPClientSession, request: fetch.RequestPaused):

--- a/src/streamlink/plugins/nimotv.py
+++ b/src/streamlink/plugins/nimotv.py
@@ -75,7 +75,7 @@ class NimoTV(Plugin):
             return
 
         mStreamPkg = bytes.fromhex(mStreamPkg)
-        try:
+        try:  # noqa: PLW0717
             appid = self._re_appid.search(mStreamPkg).group(1).decode("utf-8")  # type: ignore[ty:unresolved-attribute]
             domain = self._re_domain.search(mStreamPkg).group(1).decode("utf-8")  # type: ignore[ty:unresolved-attribute]
             id_ = self._re_id.search(mStreamPkg).group(1).decode("utf-8")  # type: ignore[ty:unresolved-attribute]

--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -677,7 +677,7 @@ class TwitchClientIntegrity:
         device_id: str,
     ) -> tuple[str, int] | None:
         from streamlink.compat import BaseExceptionGroup  # noqa: PLC0415
-        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools  # noqa: PLC0415, TC001
+        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools  # noqa: PLC0415
 
         url = f"https://www.twitch.tv/{channel}"
         js_get_integrity_token = cls.JS_INTEGRITY_TOKEN \
@@ -887,7 +887,7 @@ class Twitch(Plugin):
             setattr(self, method, method_factory(getattr(parent, method)))
 
     def _get_metadata(self):
-        try:
+        with suppress(PluginError, TypeError):
             if self.video_id:
                 data = self.api.metadata_video(self.video_id)
             elif self.clip_id:
@@ -897,8 +897,6 @@ class Twitch(Plugin):
             else:  # pragma: no cover
                 return
             self.id, self.author, self.category, self.title = data
-        except (PluginError, TypeError):
-            pass
 
     def _client_integrity_token(self, channel: str) -> tuple[str, str] | None:
         if self.options.get("purge-client-integrity"):

--- a/src/streamlink/stream/dash/dash.py
+++ b/src/streamlink/stream/dash/dash.py
@@ -99,7 +99,7 @@ class DASHStreamWorker(SegmentedStreamWorker[DASHSegment, Response]):
         Do something and then wait for a given duration minus the time it took doing something
         """
         s = time()
-        yield
+        yield  # noqa: RUF075
         time_to_sleep = duration - (time() - s)
         if time_to_sleep > 0:
             self.wait(time_to_sleep)

--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -56,8 +56,10 @@ def count_dt(firstval: datetime | None = None, step: timedelta = ONE_SECOND) -> 
 @contextmanager
 def freeze_timeline(mpd):
     timelines = copy.copy(mpd.timelines)
-    yield
-    mpd.timelines = timelines
+    try:
+        yield
+    finally:
+        mpd.timelines = timelines
 
 
 _re_segment_template = re.compile(r"(.*?)\$(\w+)(?:%([\w.]+))?\$")

--- a/src/streamlink/stream/segmented/segmented.py
+++ b/src/streamlink/stream/segmented/segmented.py
@@ -274,7 +274,7 @@ class SegmentedStreamWorker(AwaitableMixin, NamedThread, Generic[TSegment, TResu
         iter_segments = self.iter_segments()
         queued: bool | None = None
 
-        try:
+        try:  # noqa: PLW0717
             while True:
                 if queued is None:
                     segment = next(iter_segments)

--- a/src/streamlink/webbrowser/cdp/client.py
+++ b/src/streamlink/webbrowser/cdp/client.py
@@ -408,7 +408,7 @@ class CDPClientSession:
             if b64encoded:  # pragma: no branch
                 body = base64.b64decode(body).decode()
         proxy = CMRequestProxy(body=body, response_code=response_code, response_headers=response_headers)
-        yield proxy
+        yield proxy  # noqa: RUF075
         await self.fulfill_request(
             request=request,
             response_code=proxy.response_code,

--- a/src/streamlink/webbrowser/webbrowser.py
+++ b/src/streamlink/webbrowser/webbrowser.py
@@ -87,7 +87,7 @@ class _WebbrowserLauncher:
 
     @asynccontextmanager
     async def launch(self) -> AsyncGenerator[trio.Nursery, None]:
-        try:
+        try:  # noqa: PLW0717
             headless = self.headless
             async with trio.open_nursery() as nursery:
                 log.info(f"Launching web browser: {self.executable} ({headless=})")

--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -266,7 +266,7 @@ def output_stream_http(
 
         stream_fd = prebuffer = None
         while not stream_fd and (not player or player.running):
-            try:
+            try:  # noqa: PLW0717
                 if not initial_streams_used:
                     streams = initial_streams
                     initial_streams_used = True
@@ -625,7 +625,7 @@ def handle_url():
 
     """
 
-    try:
+    try:  # noqa: PLW0717
         pluginname, pluginclass, resolved_url = streamlink.resolve_url(args.url)
         log.info(f"Found matching plugin {pluginname} for URL {args.url}")
 

--- a/src/streamlink_cli/streamrunner.py
+++ b/src/streamlink_cli/streamrunner.py
@@ -107,7 +107,7 @@ class StreamRunner:
 
         # TODO: Fix error messages (s/when/while/) and only log "Stream ended" when it ended on its own (data == b"").
         #       These are considered breaking changes of the CLI output, which is parsed by 3rd party tools.
-        try:
+        try:  # noqa: PLW0717
             write(prebuffer)
             progress(prebuffer)
             del prebuffer

--- a/tests/stream/dash/test_dash.py
+++ b/tests/stream/dash/test_dash.py
@@ -525,7 +525,7 @@ class TestDASHStreamWorker:
     @staticmethod
     def _iter_segments(iter_segments: Generator[DASHSegment, bool, None]) -> Iterator[DASHSegment]:
         queued: bool | None = None
-        try:
+        try:  # noqa: PLW0717
             while True:
                 if queued is None:
                     yield next(iter_segments)

--- a/tests/utils/test_module.py
+++ b/tests/utils/test_module.py
@@ -47,7 +47,7 @@ def test_load_module_importerror(name: str, path: Path, expected: ImportError):
 def test_load_module():
     name = __name__.split(".")[-1]
 
-    try:
+    try:  # noqa: PLW0717
         assert __name__ in sys.modules
         assert name not in sys.modules
 

--- a/tests/utils/test_named_pipe.py
+++ b/tests/utils/test_named_pipe.py
@@ -55,7 +55,7 @@ class ReadNamedPipeThreadPosix(ReadNamedPipeThread):
 class ReadNamedPipeThreadWindows(ReadNamedPipeThread):
     def read(self):
         handle = windll.kernel32.CreateFileW(str(self.path), GENERIC_READ, 0, None, OPEN_EXISTING, 0, None)
-        try:
+        try:  # noqa: PLW0717
             while True:
                 data = create_string_buffer(NamedPipeWindows.bufsize)
                 read = c_ulong(0)

--- a/tests/webbrowser/cdp/test_connection.py
+++ b/tests/webbrowser/cdp/test_connection.py
@@ -68,7 +68,7 @@ class FakeEvent(CDPEvent, event=None):
 
 @pytest.fixture()
 async def cdp_connection(websocket_connection: FakeWebsocketConnection):
-    try:
+    try:  # noqa: PLW0717
         async with CDPConnection.create("ws://localhost:1234/fake") as cdp_connection:
             assert isinstance(cdp_connection, CDPConnection)
             assert not websocket_connection.closed


### PR DESCRIPTION
Waiting for the next ruff release before merging, because that one will have a fix for `PLW0717` and try/finally blocks, which is why that rule is currently ignored.