### PR TITLE
stream.hls: fix duration_offset_start type

### DIFF
--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -318,7 +318,7 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
         self.playlist_segments: list[HLSSegment] = []
 
         self.live_edge = self.session.options.get("hls-live-edge")
-        self.duration_offset_start = int(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0))
+        self.duration_offset_start = float(self.stream.start_offset + (self.session.options.get("hls-start-offset") or 0.0))
         self.hls_live_restart = self.stream.force_restart or self.session.options.get("hls-live-restart")
 
         self.duration_limit = self.stream.duration or self.duration_limit
@@ -433,18 +433,18 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
     @staticmethod
     def duration_to_sequence(duration: float, segments: list[HLSSegment]) -> int:
         d = 0.0
-        default = -1
+        sequence = -1
 
-        segments_order = segments if duration >= 0 else reversed(segments)
+        segments_order = segments if duration >= 0.0 else reversed(segments)
+        duration = abs(duration)
 
         for segment in segments_order:
-            if d >= abs(duration):
-                return segment.num
+            sequence = segment.num
+            if d >= duration:
+                break
             d += segment.duration
-            default = segment.num
 
-        # could not skip far enough, so return the default
-        return default
+        return sequence
 
     @property
     def _queue_deadline_wait(self) -> float:
@@ -480,12 +480,12 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
             return
 
         if self.playlist_end is None:
-            if self.duration_offset_start > 0:
+            if self.duration_offset_start > 0.0:
                 log.debug(f"Time offsets negative for live streams, skipping back {self.duration_offset_start} seconds")
             # live playlist, force offset durations back to None
             self.duration_offset_start = -self.duration_offset_start
 
-        if self.duration_offset_start != 0:
+        if self.duration_offset_start:
             self.sequence = self.duration_to_sequence(self.duration_offset_start, self.playlist_segments)
 
         if self.playlist_segments:
@@ -626,7 +626,7 @@ class HLSStream(HTTPStream):
         multivariant: M3U8 | None = None,
         name: str | None = None,
         force_restart: bool = False,
-        start_offset: float = 0,
+        start_offset: float = 0.0,
         duration: float | None = None,
         **kwargs,
     ):
@@ -732,7 +732,7 @@ class HLSStream(HTTPStream):
         check_streams: bool | Literal["playlists", "segments"] = False,
         force_restart: bool = False,
         name_fmt: str | None = None,
-        start_offset: float = 0,
+        start_offset: float = 0.0,
         duration: float | None = None,
         **kwargs,
     ) -> dict[str, Self | MuxedHLSStream[Self]]:

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -785,6 +785,40 @@ class TestHLSStreamWorkerOptions:
         assert [(record.category, str(record.message)) for record in recwarn.list] == warning
 
 
+duration_to_segments_data = [1.0, 2.0, 3.0, 5.0, 7.0]
+
+
+@pytest.mark.parametrize(
+    ("duration", "durations", "expected"),
+    [
+        pytest.param(0.0, [], -1, id="empty"),
+        pytest.param(0.0, duration_to_segments_data, 0, id="no-duration"),
+        pytest.param(1.0, duration_to_segments_data, 1, id="one-segment"),
+        pytest.param(6.0, duration_to_segments_data, 3, id="multiple-segments-exact"),
+        pytest.param(6.1, duration_to_segments_data, 4, id="multiple-segments-partial"),
+        pytest.param(-7.0, duration_to_segments_data, 3, id="negative-one-segment-exact"),
+        pytest.param(-1.0, duration_to_segments_data, 3, id="negative-one-segment-partial"),
+        pytest.param(-12.0, duration_to_segments_data, 2, id="negative-multiple-segments-exact"),
+        pytest.param(-12.1, duration_to_segments_data, 1, id="negative-multiple-segments-partial"),
+    ],
+)
+def test_hlsstreamworker_duration_to_sequence(duration: float, durations: list[float], expected: int):
+    segments = [
+        HLSSegment(
+            num=num,
+            duration=d,
+            uri="",
+            title=None,
+            key=None,
+            byterange=None,
+            date=None,
+            map=None,
+        )
+        for num, d in enumerate(durations)
+    ]
+    assert HLSStreamWorker.duration_to_sequence(duration, segments) == expected
+
+
 class TestHLSStreamWorkerPlaylistSequenceWarning:
     warns = pytest.mark.parametrize(
         "_assert_warning",


### PR DESCRIPTION
- Turn `HLSStreamWorker.duration_offset_start` from an int into a float
- Refactor `HLSStreamWorker.duration_to_sequence()`
- Fix `start_offset` parameter value in `HLSStream`
- Add missing unit tests (one integration test already exists)