### PR TITLE
plugins.nos: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/nos.py
+++ b/src/streamlink/plugins/nos.py
@@ -31,22 +31,25 @@ class NOS(Plugin):
                 validate.none_or_all(
                     validate.parse_json(),
                     {
-                        "@type": validate.any(
-                            "VideoObject",
-                            validate.all(
-                                list,
-                                validate.contains("VideoObject"),
-                            ),
+                        "@graph": validate.all(
+                            [dict],
+                            validate.filter(lambda item: item.get("@type") == "VideoObject"),
+                            validate.filter(lambda item: item.get("encodingFormat") == "application/vnd.apple.mpegurl"),
                         ),
-                        "encodingFormat": "application/vnd.apple.mpegurl",
-                        "contentUrl": validate.url(),
-                        "identifier": validate.any(int, str),
-                        "name": str,
                     },
-                    validate.union_get(
-                        "contentUrl",
-                        "identifier",
-                        "name",
+                    validate.get("@graph"),
+                    validate.get(0),
+                    validate.none_or_all(
+                        {
+                            "contentUrl": validate.url(),
+                            "identifier": validate.any(int, str),
+                            "name": str,
+                        },
+                        validate.union_get(
+                            "contentUrl",
+                            "identifier",
+                            "name",
+                        ),
                     ),
                 ),
             ),
@@ -56,12 +59,16 @@ class NOS(Plugin):
 
         hls_url, self.id, self.title = data
 
-        res = self.session.http.get(hls_url, raise_for_status=False)
+        headers = {
+            "Origin": "https://nos.nl",
+            "Referer": self.url,
+        }
+        res = self.session.http.get(hls_url, headers=headers, raise_for_status=False)
         if res.status_code >= 400:
             log.error("Content is inaccessible or may have expired")
             return
 
-        return HLSStream.parse_variant_playlist(self.session, hls_url)
+        return HLSStream.parse_variant_playlist(self.session, hls_url, headers=headers)
 
 
 __plugin__ = NOS


### PR DESCRIPTION
Fixes #6953 

@ltguillaume please check and see if this fixes the plugin.
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

The plugin currently still matches `https://nos.nl/live`. However, no live streams are shown there, only a link to the canonical URL of a live stream. I wasn't sure if this changes sometimes, depending on the time of day, so I left it.

```
$ ./script/test-plugin-urls.py --interface tun0 -m nos
:: https://nos.nl/collectie/13951/video/2491092-dit-was-prinsjesdag
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2491092', 'author': None, 'category': None, 'title': 'Dit was Prinsjesdag'}
:: https://nos.nl/l/2490788
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2490788', 'author': None, 'category': None, 'title': 'Meteoor gespot boven noord Nederland'}
:: https://nos.nl/live
!! No streams found
:: https://nos.nl/livestream/2539164-schaatsen-wb-milwaukee-straks-de-massastart-m
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2539164', 'author': None, 'category': None, 'title': 'Schaatsen, WB Milwaukee: kijk mee naar de nabeschouwing'}
:: https://nos.nl/video/2490788-meteoor-gespot-boven-noord-nederland
::  360p, 480p, 720p, 1080p, worst, best
::   {'id': '2490788', 'author': None, 'category': None, 'title': 'Meteoor gespot boven noord Nederland'}
```