### PR TITLE
stream.hls: fix reload-time float user overrides

### DIFF
--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -23,6 +23,7 @@ from streamlink.utils.cache import LRUCache
 from streamlink.utils.crypto import AES, unpad
 from streamlink.utils.formatter import Formatter
 from streamlink.utils.l10n import Language
+from streamlink.utils.num import to_float
 from streamlink.utils.times import now
 
 
@@ -325,12 +326,19 @@ class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):
 
         self.reload_attempts = self.session.options.get("hls-playlist-reload-attempts")
         self.reload_time = self.session.options.get("hls-playlist-reload-time")
-        if str(self.reload_time).isnumeric() and float(self.reload_time) >= self._RELOAD_TIME_MIN:
-            self.reload_time = float(self.reload_time)
-        elif self.reload_time not in ("segment", "live-edge"):
+        if self.reload_time in (None, "default"):
             self.reload_time = 0.0
+        elif self.reload_time not in ("segment", "live-edge"):
+            try:
+                self.reload_time = to_float(self.reload_time, raise_on_error=True)
+                if self.reload_time < self._RELOAD_TIME_MIN:
+                    self.reload_time = 0.0
+            except Exception as err:
+                log.error(f"Failed parsing hls-playlist-reload-time value: {err}")
+                self.reload_time = 0.0
         self._reload_time: float = self._RELOAD_TIME_DEFAULT
         self._reload_last: datetime = now()
+
         self.passthrough_encrypted = self.session.options.get("stream-passthrough-encrypted")
 
     def _warn_playlist_sequence(self):

--- a/src/streamlink/utils/num.py
+++ b/src/streamlink/utils/num.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import math
+from typing import Any, Literal, overload
+
+
+@overload
+def to_float(
+    value: Any,
+    *,
+    allow_nan: bool = False,
+    allow_inf: bool = False,
+) -> float | None: ...  # pragma: no cover
+
+
+@overload
+def to_float(
+    value: Any,
+    *,
+    allow_nan: bool = False,
+    allow_inf: bool = False,
+    raise_on_error: Literal[True] = True,
+) -> float: ...  # pragma: no cover
+
+
+@overload
+def to_float(
+    value: Any,
+    *,
+    allow_nan: bool = False,
+    allow_inf: bool = False,
+    raise_on_error: bool = False,
+) -> float | None: ...  # pragma: no cover
+
+
+def to_float(value: Any, *, allow_nan: bool = False, allow_inf: bool = False, raise_on_error: bool = False) -> float | None:
+    try:
+        num = float(value)
+    except (ValueError, TypeError, OverflowError):
+        if raise_on_error:
+            raise
+        return None
+
+    if not allow_nan and math.isnan(num):
+        if raise_on_error:
+            raise ValueError("NaN values are not allowed")
+        return None
+
+    if not allow_inf and math.isinf(num):
+        if raise_on_error:
+            raise ValueError("Infinity values are not allowed")
+        return None
+
+    return num

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -1631,13 +1631,25 @@ class TestHlsReloadTime(TestMixinStreamHLS, unittest.TestCase):
         time = self.subject([Playlist(0, [], end=True, targetduration=0)], reload_time="live-edge")
         assert time == 6, "sets reload time to 6 seconds when no segments and no targetduration are available"
 
-    def test_number(self):
+    def test_number_int(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="2")
         assert time == 2, "number values override the reload time"
+
+    def test_number_float(self):
+        time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="2.5")
+        assert time == pytest.approx(2.5), "number values override the reload time"
 
     def test_number_invalid(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="0")
         assert time == 4, "invalid number values set the reload time to the playlist's targetduration"
+
+    @patch("streamlink.stream.hls.hls.log")
+    def test_number_error(self, mock_log: Mock):
+        time = self.subject([Playlist(0, self.segments, end=True, targetduration=4)], reload_time="foo")
+        assert time == 4, "invalid number values set the reload time to the playlist's targetduration"
+        assert mock_log.error.call_args_list == [
+            call("Failed parsing hls-playlist-reload-time value: could not convert string to float: 'foo'"),
+        ]
 
     def test_no_target_duration(self):
         time = self.subject([Playlist(0, self.segments, end=True, targetduration=0)], reload_time="default")

--- a/tests/utils/test_num.py
+++ b/tests/utils/test_num.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import math
+from contextlib import nullcontext
+from typing import Any
+
+import pytest
+
+from streamlink.utils.num import to_float
+
+
+class TestToFloat:
+    class Pi:
+        def __float__(self):
+            return math.pi
+
+    raises_typeerror = pytest.raises(TypeError)
+    raises_overflowerror = pytest.raises(OverflowError)
+    raises_valueerror_convert_str = pytest.raises(ValueError, match=r"could not convert string to float")
+    raises_valueerror_nan = pytest.raises(ValueError, match=r"^NaN values are not allowed$")
+    raises_valueerror_inf = pytest.raises(ValueError, match=r"^Infinity values are not allowed$")
+
+    @pytest.mark.parametrize(
+        ("value", "raises"),
+        [
+            pytest.param(None, raises_typeerror, id="none"),
+            pytest.param({}, raises_typeerror, id="TypeError"),
+            pytest.param(10**9999, raises_overflowerror, id="OverflowError"),
+            pytest.param("", raises_valueerror_convert_str, id="empty"),
+            pytest.param("invalid", raises_valueerror_convert_str, id="ValueError-1"),
+            pytest.param("foo123", raises_valueerror_convert_str, id="ValueError-2"),
+            pytest.param("123foo", raises_valueerror_convert_str, id="ValueError-3"),
+            pytest.param("True", raises_valueerror_convert_str, id="bool-as-str"),
+            pytest.param("0b11", raises_valueerror_convert_str, id="no-binary"),
+            pytest.param("0o11", raises_valueerror_convert_str, id="no-octal"),
+            pytest.param("0x11", raises_valueerror_convert_str, id="no-hexadecimal"),
+            pytest.param("NaN", raises_valueerror_nan, id="nan-disallowed"),
+            pytest.param("-NaN", raises_valueerror_nan, id="nan-negative-disallowed"),
+            pytest.param(math.nan, raises_valueerror_nan, id="nan-obj-disallowed"),
+            pytest.param("Infinity", raises_valueerror_inf, id="infinity-disallowed"),
+            pytest.param("-Infinity", raises_valueerror_inf, id="infinity-negative-disallowed"),
+            pytest.param(math.inf, raises_valueerror_inf, id="infinity-obj-disallowed"),
+            pytest.param("1e9999", raises_valueerror_inf, id="rounded-to-infinity-disallowed"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "raise_on_error",
+        [
+            pytest.param(True, id="raise-on-error"),
+            pytest.param(False, id="no-raise-on-error"),
+        ],
+    )
+    def test_invalid(self, value: Any, raises: nullcontext, raise_on_error: bool):
+        if not raise_on_error:
+            raises = nullcontext()
+        with raises:
+            assert to_float(value, raise_on_error=raise_on_error) is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            pytest.param(" 123 ", 123.0, id="int"),
+            pytest.param(" 123.45 ", 123.45, id="float"),
+            pytest.param(" .123 ", 0.123, id="float-no-whole-number"),
+            pytest.param(" 123. ", 123.0, id="float-no-decimal-place"),
+            pytest.param(" -123 ", -123.0, id="int-negative"),
+            pytest.param(" -123.45 ", -123.45, id="float-negative"),
+            pytest.param(" +123 ", 123.0, id="int-positive"),
+            pytest.param(" +123.45 ", 123.45, id="float-positive"),
+            pytest.param(" 1e10 ", 1e10, id="exponent-notation"),
+            pytest.param(" 1e-10 ", 1e-10, id="exponent-notation-negative"),
+            pytest.param(" 1e+10 ", 1e10, id="exponent-notation-positive"),
+            pytest.param("011", 11, id="leading-zero"),
+            pytest.param("1_2.3_4", 12.34, id="digit-separators"),
+            pytest.param(123, 123.0, id="obj-int"),
+            pytest.param(123.45, 123.45, id="obj-float"),
+            pytest.param(Pi(), math.pi, id="__float__"),
+        ],
+    )
+    def test_floats(self, value: Any, expected: float):
+        res = to_float(value)
+        assert type(res) is float
+        assert res == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("NaN"),
+            pytest.param("-NaN"),
+            pytest.param(math.nan),
+        ],
+    )
+    def test_nan(self, value: str):
+        res = to_float(value, allow_nan=True)
+        assert res is not None
+        assert math.isnan(res)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("Infinity"),
+            pytest.param("-Infinity"),
+            pytest.param("Inf"),
+            pytest.param("-Inf"),
+            pytest.param("1e9999"),
+            pytest.param(math.inf),
+        ],
+    )
+    def test_inf(self, value: str):
+        res = to_float(value, allow_inf=True)
+        assert res is not None
+        assert math.isinf(res)


### PR DESCRIPTION
Fixes #6955 

As said, the reload-time logic should be rewritten at some point.