### PR TITLE
plugins.douyu: re-introduce plugin with new implementation

### DIFF
--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -86,8 +86,47 @@ class Douyu(Plugin):
             f = hashlib.md5((f + key).encode("utf-8")).hexdigest()
         return hashlib.md5((f + key + suffix).encode("utf-8")).hexdigest()
 
-    def _request_stream(self, rid: str, rate: int, did: str, enc_data: dict, auth: str) -> dict | None:
+    def _get_encryption(self, did: str) -> dict | None:
+        enc_response = self.session.http.get(
+            self._URL_ENCRYPTION,
+            params={"did": did},
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "error": int,
+                    "data": validate.any(
+                        None,
+                        {
+                            "key": str,
+                            "rand_str": str,
+                            "enc_time": int,
+                            "enc_data": str,
+                            "is_special": int,
+                        },
+                    ),
+                },
+            ),
+        )
+        if enc_response["error"] != 0 or not enc_response["data"]:
+            return None
+        return enc_response["data"]
+
+    def _request_stream(self, rid: str, rate: int, did: str) -> dict | None:
+        enc_data = self._get_encryption(did)
+        if not enc_data:
+            log.error("Failed to get encryption parameters")
+            return None
+
         ts = int(time.time())
+        auth = self._compute_auth(
+            rid=rid,
+            ts=ts,
+            key=enc_data["key"],
+            rand_str=enc_data["rand_str"],
+            enc_time=enc_data["enc_time"],
+            is_special=enc_data["is_special"],
+        )
+
         play_data = self.session.http.post(
             self._URL_PLAY.format(rid=rid),
             data={
@@ -134,43 +173,7 @@ class Douyu(Plugin):
             log.info("Streamer is offline")
             return
 
-        enc_response = self.session.http.get(
-            self._URL_ENCRYPTION,
-            params={"did": did},
-            schema=validate.Schema(
-                validate.parse_json(),
-                {
-                    "error": int,
-                    "data": validate.any(
-                        None,
-                        {
-                            "key": str,
-                            "rand_str": str,
-                            "enc_time": int,
-                            "enc_data": str,
-                            "is_special": int,
-                        },
-                    ),
-                },
-            ),
-        )
-
-        if enc_response["error"] != 0 or not enc_response["data"]:
-            log.error("Failed to get encryption parameters")
-            return
-
-        enc_data = enc_response["data"]
-        ts = int(time.time())
-        auth = self._compute_auth(
-            rid=rid,
-            ts=ts,
-            key=enc_data["key"],
-            rand_str=enc_data["rand_str"],
-            enc_time=enc_data["enc_time"],
-            is_special=enc_data["is_special"],
-        )
-
-        first_data = self._request_stream(rid, 0, did, enc_data, auth)
+        first_data = self._request_stream(rid, 0, did)
         if not first_data:
             log.error("Failed to get stream URL")
             return
@@ -205,7 +208,7 @@ class Douyu(Plugin):
             if rate == 0:
                 data = first_data
             else:
-                data = self._request_stream(rid, rate, did, enc_data, auth)
+                data = self._request_stream(rid, rate, did)
 
             if data:
                 url = f"{data['rtmp_url']}/{data['rtmp_live']}"

--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -1,0 +1,237 @@
+"""
+$description 斗鱼直播 - 以游戏直播为主的弹幕式互动直播平台
+$url www.douyu.com
+$type live
+"""
+
+import hashlib
+import logging
+import re
+import time
+
+from streamlink.exceptions import NoStreamsError, PluginError
+from streamlink.plugin import Plugin, pluginargument, pluginmatcher
+from streamlink.plugin.api import validate
+from streamlink.stream.http import HTTPStream
+
+
+log = logging.getLogger(__name__)
+
+
+@pluginmatcher(
+    re.compile(
+        r"https?://(?:www\.)?douyu\.com/(?:topic/)?(?P<rid>\d+)(?:\?.*dyshid=(?P<dyshid>[^&]+))?",
+    ),
+)
+@pluginargument(
+    "rate",
+    metavar="RATE",
+    default="0",
+    help="Stream quality rate: 0=best (default), 1=smooth, 2=HD, 3=super HD, 4=4Mbps",
+)
+class Douyu(Plugin):
+    _URL_ENCRYPTION = "https://www.douyu.com/wgapi/livenc/liveweb/websec/getEncryption"
+    _URL_PLAY = "https://www.douyu.com/lapi/live/getH5PlayV1/{rid}"
+
+    DID = "10000000000000000000000000001501"
+
+    def _get_real_rid(self, rid: str) -> str:
+        """Get real room ID (URL room ID may differ from actual rid)"""
+        res = self.session.http.get(f"https://www.douyu.com/{rid}")
+
+        # Method 1: Extract from $ROOM.room_id
+        match = re.search(r"\$ROOM\.room_id\s*=\s*(\d+)", res.text)
+        if match:
+            return match.group(1)
+
+        # Method 2: Extract from roomID
+        match = re.search(r"roomID[\":\s]+(\d+)", res.text)
+        if match:
+            return match.group(1)
+
+        # Method 3: Extract from canonical link
+        match = re.search(r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\'][^"\']*/(\d+)', res.text)
+        if match:
+            return match.group(1)
+
+        # Method 4: Return input if it's already a number
+        if rid.isdigit():
+            return rid
+
+        raise PluginError(f"Cannot get real room ID: {rid}")
+
+    def _get_room_metadata(self, rid: str):
+        """Get room metadata (streamer name, title, category, etc.)"""
+        try:
+            data = self.session.http.get(
+                f"https://www.douyu.com/betard/{rid}",
+                schema=validate.Schema(
+                    validate.parse_json(),
+                    {
+                        "room": {
+                            "room_id": int,
+                            "room_name": str,
+                            "nickname": str,
+                            "cate_name": str,
+                            "show_status": int,  # 1=live, 2=offline
+                        },
+                    },
+                    validate.get("room"),
+                ),
+            )
+            self.id = str(data["room_id"])
+            self.title = data["room_name"]
+            self.author = data["nickname"]
+            self.category = data["cate_name"]
+            return data["show_status"] == 1
+        except Exception:
+            log.debug("Failed to get room metadata, continuing with stream extraction")
+            return True  # Assume live, let subsequent steps determine
+
+    @staticmethod
+    def _compute_auth(rid: str, did: str, ts: int, key: str, rand_str: str, enc_time: int, is_special: int) -> str:
+        """
+        Compute auth signature parameter.
+
+        Algorithm from douyuEx userscript:
+        1. If is_special != 1, append rid + ts as suffix
+        2. Start from rand_str, iterate enc_time times: md5(f + key)
+        3. Final: md5(f + key + suffix) is the auth
+        """
+        suffix = "" if is_special == 1 else f"{rid}{ts}"
+        f = rand_str
+        for _ in range(enc_time):
+            f = hashlib.md5((f + key).encode("utf-8")).hexdigest()
+        return hashlib.md5((f + key + suffix).encode("utf-8")).hexdigest()
+
+    def _get_stream_url(self, rid: str, rate: str, did: str | None = None) -> str | None:
+        """
+        Get actual live stream URL.
+
+        Process:
+        1. GET getEncryption to get encryption parameters
+        2. Compute auth signature
+        3. POST getH5PlayV1 to get stream URL
+        """
+        did = did or self.DID
+
+        # Step 1: Get encryption parameters
+        enc_data = self.session.http.get(
+            self._URL_ENCRYPTION,
+            params={"did": did},
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "error": int,
+                    "data": validate.any(
+                        None,
+                        {
+                            "key": str,
+                            "rand_str": str,
+                            "enc_time": int,
+                            "enc_data": str,
+                            "is_special": int,
+                        },
+                    ),
+                },
+            ),
+        )
+
+        if enc_data["error"] != 0 or not enc_data["data"]:
+            log.error("Failed to get encryption parameters")
+            return None
+
+        d = enc_data["data"]
+        ts = int(time.time())
+
+        # Step 2: Compute auth
+        auth = self._compute_auth(
+            rid=rid,
+            did=did,
+            ts=ts,
+            key=d["key"],
+            rand_str=d["rand_str"],
+            enc_time=d["enc_time"],
+            is_special=d["is_special"],
+        )
+
+        # Step 3: Request stream URL
+        play_data = self.session.http.post(
+            self._URL_PLAY.format(rid=rid),
+            data={
+                "enc_data": d["enc_data"],
+                "tt": str(ts),
+                "did": did,
+                "auth": auth,
+                "cdn": "",
+                "rate": rate,
+                "hevc": "0",
+                "fa": "0",
+                "ive": "0",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "error": int,
+                    "data": validate.any(
+                        None,
+                        {
+                            "rtmp_url": str,
+                            "rtmp_live": str,
+                        },
+                    ),
+                },
+            ),
+        )
+
+        if play_data["error"] != 0 or not play_data["data"]:
+            error_code = play_data["error"]
+            if error_code == 102:
+                log.error("Room does not exist")
+            elif error_code == 104:
+                log.info("Room is offline")
+            else:
+                log.error(f"Failed to get stream URL (error={error_code})")
+            return None
+
+        url = f"{play_data['data']['rtmp_url']}/{play_data['data']['rtmp_live']}"
+        return url
+
+    def _get_streams(self):
+        rid_input = self.match.group("rid")
+        # Extract user DID from URL if available
+        user_did = self.match.groupdict().get("dyshid")
+
+        # Get real room ID
+        real_rid = self._get_real_rid(rid_input)
+        log.debug(f"Real room ID: {real_rid}")
+
+        # Get room metadata
+        is_live = self._get_room_metadata(real_rid)
+        if not is_live:
+            log.info("Streamer is offline")
+            raise NoStreamsError
+
+        # Get stream quality parameter
+        rate = self.get_option("rate")
+
+        # Get stream URL (prefer user DID if available)
+        stream_url = self._get_stream_url(real_rid, rate, did=user_did)
+        if not stream_url:
+            raise NoStreamsError
+
+        log.debug(f"Stream URL: {stream_url}")
+
+        # Douyu CDN requires Referer header
+        yield (
+            "live",
+            HTTPStream(
+                self.session,
+                stream_url,
+                headers={"Referer": "https://www.douyu.com/"},
+            ),
+        )
+
+
+__plugin__ = Douyu

--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
+from streamlink.session.http import TLSSecLevel1Adapter
 from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_qsd
 
@@ -173,6 +174,11 @@ class Douyu(Plugin):
         if not first_data:
             log.error("Failed to get stream URL")
             return
+
+        # Mount TLSSecLevel1Adapter for CDN domains that may not be compatible
+        # with OpenSSL 3.0's default security level (SECLEVEL=2)
+        cdn_netloc = urlparse(first_data["rtmp_url"]).netloc
+        self.session.http.mount(f"https://{cdn_netloc}", TLSSecLevel1Adapter())
 
         multirates = first_data.get("multirates", [])
 

--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -1,18 +1,26 @@
 """
-$description 斗鱼直播 - 以游戏直播为主的弹幕式互动直播平台
+$description Chinese live-streaming platform for live video game broadcasts, operated by Douyu Technology.
 $url www.douyu.com
 $type live
+$metadata id
+$metadata author
+$metadata category
+$metadata title
 """
+
+from __future__ import annotations
 
 import hashlib
 import logging
 import re
+import sys
 import time
+from urllib.parse import urlparse
 
-from streamlink.exceptions import NoStreamsError, PluginError
-from streamlink.plugin import Plugin, pluginargument, pluginmatcher
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.http import HTTPStream
+from streamlink.utils.parse import parse_qsd
 
 
 log = logging.getLogger(__name__)
@@ -20,51 +28,32 @@ log = logging.getLogger(__name__)
 
 @pluginmatcher(
     re.compile(
-        r"https?://(?:www\.)?douyu\.com/(?:topic/)?(?P<rid>\d+)(?:\?.*dyshid=(?P<dyshid>[^&]+))?",
+        r"https?://(?:www\.)?douyu\.com/(?:topic/)?(?P<rid>\d+)",
     ),
-)
-@pluginargument(
-    "rate",
-    metavar="RATE",
-    default="0",
-    help="Stream quality rate: 0=best (default), 1=smooth, 2=HD, 3=super HD, 4=4Mbps",
 )
 class Douyu(Plugin):
     _URL_ENCRYPTION = "https://www.douyu.com/wgapi/livenc/liveweb/websec/getEncryption"
     _URL_PLAY = "https://www.douyu.com/lapi/live/getH5PlayV1/{rid}"
+    _URL_BETARD = "https://www.douyu.com/betard/{rid}"
 
     DID = "10000000000000000000000000001501"
+    HEVC = "0"
+    FA = "0"
+    IVE = "0"
 
-    def _get_real_rid(self, rid: str) -> str:
-        """Get real room ID (URL room ID may differ from actual rid)"""
-        res = self.session.http.get(f"https://www.douyu.com/{rid}")
+    QUALITY_WEIGHTS: dict[str, int] = {}
 
-        # Method 1: Extract from $ROOM.room_id
-        match = re.search(r"\$ROOM\.room_id\s*=\s*(\d+)", res.text)
-        if match:
-            return match.group(1)
+    @classmethod
+    def stream_weight(cls, stream: str) -> tuple[float, str]:
+        weight = cls.QUALITY_WEIGHTS.get(stream)
+        if weight:
+            return weight, "douyu"
+        return super().stream_weight(stream)
 
-        # Method 2: Extract from roomID
-        match = re.search(r"roomID[\":\s]+(\d+)", res.text)
-        if match:
-            return match.group(1)
-
-        # Method 3: Extract from canonical link
-        match = re.search(r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\'][^"\']*/(\d+)', res.text)
-        if match:
-            return match.group(1)
-
-        # Method 4: Return input if it's already a number
-        if rid.isdigit():
-            return rid
-
-        raise PluginError(f"Cannot get real room ID: {rid}")
-
-    def _get_room_metadata(self, rid: str):
-        """Get room metadata (streamer name, title, category, etc.)"""
+    def _get_room_metadata(self, rid: str) -> bool:
         try:
             data = self.session.http.get(
-                f"https://www.douyu.com/betard/{rid}",
+                self._URL_BETARD.format(rid=rid),
                 schema=validate.Schema(
                     validate.parse_json(),
                     {
@@ -72,8 +61,8 @@ class Douyu(Plugin):
                             "room_id": int,
                             "room_name": str,
                             "nickname": str,
-                            "cate_name": str,
-                            "show_status": int,  # 1=live, 2=offline
+                            validate.optional("cate_name"): validate.any(None, str),
+                            "show_status": int,
                         },
                     },
                     validate.get("room"),
@@ -82,41 +71,69 @@ class Douyu(Plugin):
             self.id = str(data["room_id"])
             self.title = data["room_name"]
             self.author = data["nickname"]
-            self.category = data["cate_name"]
+            self.category = data.get("cate_name")
             return data["show_status"] == 1
         except Exception:
-            log.debug("Failed to get room metadata, continuing with stream extraction")
-            return True  # Assume live, let subsequent steps determine
+            log.debug("Failed to get room metadata")
+            return True
 
     @staticmethod
-    def _compute_auth(rid: str, did: str, ts: int, key: str, rand_str: str, enc_time: int, is_special: int) -> str:
-        """
-        Compute auth signature parameter.
-
-        Algorithm from douyuEx userscript:
-        1. If is_special != 1, append rid + ts as suffix
-        2. Start from rand_str, iterate enc_time times: md5(f + key)
-        3. Final: md5(f + key + suffix) is the auth
-        """
+    def _compute_auth(rid: str, ts: int, key: str, rand_str: str, enc_time: int, is_special: int) -> str:
         suffix = "" if is_special == 1 else f"{rid}{ts}"
         f = rand_str
         for _ in range(enc_time):
             f = hashlib.md5((f + key).encode("utf-8")).hexdigest()
         return hashlib.md5((f + key + suffix).encode("utf-8")).hexdigest()
 
-    def _get_stream_url(self, rid: str, rate: str, did: str | None = None) -> str | None:
-        """
-        Get actual live stream URL.
+    def _request_stream(self, rid: str, rate: int, did: str, enc_data: dict, auth: str) -> dict | None:
+        ts = int(time.time())
+        play_data = self.session.http.post(
+            self._URL_PLAY.format(rid=rid),
+            data={
+                "enc_data": enc_data["enc_data"],
+                "tt": str(ts),
+                "did": did,
+                "auth": auth,
+                "cdn": "",
+                "rate": str(rate),
+                "hevc": self.HEVC,
+                "fa": self.FA,
+                "ive": self.IVE,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "error": int,
+                    "data": validate.any(
+                        None,
+                        "",
+                        {
+                            "rtmp_url": validate.url(scheme="https"),
+                            "rtmp_live": str,
+                            validate.optional("multirates"): [{"name": str, "rate": int, "bit": int}],
+                        },
+                    ),
+                },
+            ),
+        )
 
-        Process:
-        1. GET getEncryption to get encryption parameters
-        2. Compute auth signature
-        3. POST getH5PlayV1 to get stream URL
-        """
-        did = did or self.DID
+        if play_data["error"] != 0 or not play_data["data"]:
+            return None
 
-        # Step 1: Get encryption parameters
-        enc_data = self.session.http.get(
+        return play_data["data"]
+
+    def _get_streams(self):
+        rid = self.match.group("rid")
+
+        params = parse_qsd(urlparse(self.url).query)
+        did = params.get("dyshid") or self.DID
+
+        if not self._get_room_metadata(rid):
+            log.info("Streamer is offline")
+            return
+
+        enc_response = self.session.http.get(
             self._URL_ENCRYPTION,
             params={"did": did},
             schema=validate.Schema(
@@ -137,101 +154,65 @@ class Douyu(Plugin):
             ),
         )
 
-        if enc_data["error"] != 0 or not enc_data["data"]:
+        if enc_response["error"] != 0 or not enc_response["data"]:
             log.error("Failed to get encryption parameters")
-            return None
+            return
 
-        d = enc_data["data"]
+        enc_data = enc_response["data"]
         ts = int(time.time())
-
-        # Step 2: Compute auth
         auth = self._compute_auth(
             rid=rid,
-            did=did,
             ts=ts,
-            key=d["key"],
-            rand_str=d["rand_str"],
-            enc_time=d["enc_time"],
-            is_special=d["is_special"],
+            key=enc_data["key"],
+            rand_str=enc_data["rand_str"],
+            enc_time=enc_data["enc_time"],
+            is_special=enc_data["is_special"],
         )
 
-        # Step 3: Request stream URL
-        play_data = self.session.http.post(
-            self._URL_PLAY.format(rid=rid),
-            data={
-                "enc_data": d["enc_data"],
-                "tt": str(ts),
-                "did": did,
-                "auth": auth,
-                "cdn": "",
-                "rate": rate,
-                "hevc": "0",
-                "fa": "0",
-                "ive": "0",
-            },
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            schema=validate.Schema(
-                validate.parse_json(),
-                {
-                    "error": int,
-                    "data": validate.any(
-                        None,
-                        {
-                            "rtmp_url": str,
-                            "rtmp_live": str,
-                        },
-                    ),
-                },
-            ),
-        )
+        first_data = self._request_stream(rid, 0, did, enc_data, auth)
+        if not first_data:
+            log.error("Failed to get stream URL")
+            return
 
-        if play_data["error"] != 0 or not play_data["data"]:
-            error_code = play_data["error"]
-            if error_code == 102:
-                log.error("Room does not exist")
-            elif error_code == 104:
-                log.info("Room is offline")
+        multirates = first_data.get("multirates", [])
+
+        if not multirates:
+            url = f"{first_data['rtmp_url']}/{first_data['rtmp_live']}"
+            self.QUALITY_WEIGHTS["source"] = sys.maxsize
+            yield (
+                "source",
+                HTTPStream(
+                    self.session,
+                    url,
+                    headers={"Referer": "https://www.douyu.com/"},
+                ),
+            )
+            return
+
+        for rate_info in multirates:
+            rate = rate_info["rate"]
+            bit = rate_info["bit"]
+            name = f"{bit}k" if bit else "source"
+            weight = bit or sys.maxsize
+            self.QUALITY_WEIGHTS[name] = weight
+
+            if rate == 0:
+                data = first_data
             else:
-                log.error(f"Failed to get stream URL (error={error_code})")
-            return None
+                data = self._request_stream(rid, rate, did, enc_data, auth)
 
-        url = f"{play_data['data']['rtmp_url']}/{play_data['data']['rtmp_live']}"
-        return url
+            if data:
+                url = f"{data['rtmp_url']}/{data['rtmp_live']}"
+                yield (
+                    name,
+                    HTTPStream(
+                        self.session,
+                        url,
+                        headers={"Referer": "https://www.douyu.com/"},
+                    ),
+                )
 
-    def _get_streams(self):
-        rid_input = self.match.group("rid")
-        # Extract user DID from URL if available
-        user_did = self.match.groupdict().get("dyshid")
-
-        # Get real room ID
-        real_rid = self._get_real_rid(rid_input)
-        log.debug(f"Real room ID: {real_rid}")
-
-        # Get room metadata
-        is_live = self._get_room_metadata(real_rid)
-        if not is_live:
-            log.info("Streamer is offline")
-            raise NoStreamsError
-
-        # Get stream quality parameter
-        rate = self.get_option("rate")
-
-        # Get stream URL (prefer user DID if available)
-        stream_url = self._get_stream_url(real_rid, rate, did=user_did)
-        if not stream_url:
-            raise NoStreamsError
-
-        log.debug(f"Stream URL: {stream_url}")
-
-        # Douyu CDN requires Referer header
-        yield (
-            "live",
-            HTTPStream(
-                self.session,
-                stream_url,
-                headers={"Referer": "https://www.douyu.com/"},
-            ),
-        )
+        log.debug("QUALITY_WEIGHTS: %r", self.QUALITY_WEIGHTS)
 
 
 __plugin__ = Douyu

--- a/tests/plugins/test_douyu.py
+++ b/tests/plugins/test_douyu.py
@@ -9,18 +9,15 @@ class TestPluginCanHandleUrlDouyu(PluginCanHandleUrl):
         "https://www.douyu.com/12345",
         "https://www.douyu.com/topic/12345",
         "http://www.douyu.com/999",
-        "https://www.douyu.com/952595?dyshid=16793ba-595f1b40c7d47a73240bc10b26051701",
     ]
 
     should_match_groups = [
         ("https://www.douyu.com/288016", {"rid": "288016"}),
         ("https://www.douyu.com/topic/12345", {"rid": "12345"}),
-        ("https://www.douyu.com/952595?dyshid=abc123", {"rid": "952595", "dyshid": "abc123"}),
     ]
 
     should_not_match = [
         "https://www.douyu.com/",
         "https://www.douyu.com/member/cp",
         "https://www.douyu.com/abc_def",
-        "https://example.com/12345",
     ]

--- a/tests/plugins/test_douyu.py
+++ b/tests/plugins/test_douyu.py
@@ -1,0 +1,26 @@
+from streamlink.plugins.douyu import Douyu
+from tests.plugins import PluginCanHandleUrl
+
+
+class TestPluginCanHandleUrlDouyu(PluginCanHandleUrl):
+    __plugin__ = Douyu
+
+    should_match = [
+        "https://www.douyu.com/12345",
+        "https://www.douyu.com/topic/12345",
+        "http://www.douyu.com/999",
+        "https://www.douyu.com/952595?dyshid=16793ba-595f1b40c7d47a73240bc10b26051701",
+    ]
+
+    should_match_groups = [
+        ("https://www.douyu.com/288016", {"rid": "288016"}),
+        ("https://www.douyu.com/topic/12345", {"rid": "12345"}),
+        ("https://www.douyu.com/952595?dyshid=abc123", {"rid": "952595", "dyshid": "abc123"}),
+    ]
+
+    should_not_match = [
+        "https://www.douyu.com/",
+        "https://www.douyu.com/member/cp",
+        "https://www.douyu.com/abc_def",
+        "https://example.com/12345",
+    ]


### PR DESCRIPTION
## Description

Add a new plugin for douyu.com, a popular Chinese live streaming platform focused on gaming content.

This restores the Douyu plugin that was removed in 2020 (commit c905798a) due to JS engine requirements. The new implementation uses a different API endpoint (getH5PlayV1) with a pure Python MD5-based authentication mechanism — no JS engine required.

## Features

- URL matching: `www.douyu.com/{room_id}`, `www.douyu.com/topic/{room_id}`
- Optional `dyshid` parameter support via URL query string for user-specific DID
- Room metadata extraction (title, author, category) via betard API
- Multi-quality stream support (returns all available qualities, e.g. 9399k, 4000k, 2000k, 900k)
- Custom `stream_weight()` for proper quality ordering
- Referer header for CDN compatibility
- Graceful handling of offline rooms

## Verification

```
$ streamlink --loglevel debug https://www.douyu.com/952595
[cli][info] Found matching plugin douyu for URL https://www.douyu.com/952595
[plugins.douyu][debug] QUALITY_WEIGHTS: {'7805k': 7805, '4000k': 4000, '2000k': 2000, '900k': 900}
Available streams: 900k (worst), 2000k, 4000k, 7805k (best)

$ streamlink --loglevel debug https://www.douyu.com/2082749
[plugins.douyu][info] Streamer is offline
error: No playable streams found on this URL
```

## Tests

```
$ pytest tests/plugins/test_douyu.py -v
16 passed in 0.05s
```

## AI Assistance Disclosure

This plugin was developed with AI assistance (code generation and debugging). The author has full comprehension of all code submitted, including:
- The MD5-based auth algorithm (reversed from douyuEx userscript)
- The API flow (getEncryption → compute auth → getH5PlayV1)
- URL regex patterns and capture groups
- Streamlink plugin architecture conventions

All code has been manually verified and tested.
