### PR TITLE
plugins.radiko: fix live_url value

### DIFF
--- a/src/streamlink/plugins/radiko.py
+++ b/src/streamlink/plugins/radiko.py
@@ -40,7 +40,7 @@ class Radiko(Plugin):
         yield from HLSStream.parse_variant_playlist(self.session, url).items()
 
     def _live(self, station_id):
-        live_url = f"http://f-radiko.smartstream.ne.jp/{station_id}/_definst_/simul-stream.stream/playlist.m3u8"
+        live_url = "https://alliance-stream-radiko.smartstream.ne.jp/so/playlist.m3u8"
         token, _area_id = self._authorize()
         lsid = hashlib.md5(str(random.random()).encode("utf-8")).hexdigest()
         live_params = {


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

Radiko webpage changed the host streaming server. Old `http://f-radiko.smartstream.ne.jp` returned a timeout error. 
New `live_url` has been extracted from `http://radiko.jp/v2/station/stream_smh_multi/{station_id}.xml`.

This fixes #6960 .