### PR TITLE
ci.github: run preview-builds on uv.lock updates

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -9,6 +9,7 @@ on:
       - "**"
     paths:
       - "pyproject.toml"
+      - "uv.lock"
       - "setup.py"
       - "MANIFEST.in"
       - "build_backend/**"


### PR DESCRIPTION
The Linux AppImages and Windows builds currently don't use the upstream uv.lock file yet, but once they do, updates to the lockfile should trigger new preview-builds.