### PR TITLE
ci.github: no dependabot test workflow on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - "automated/**"
+      - "dependabot/**"
     tags-ignore:
       - "**"
   pull_request: {}


### PR DESCRIPTION
The test workflow already runs on pull_request
