### PR TITLE
script: rm uv deps from update-user-agents.py

### DIFF
--- a/script/update-user-agents.py
+++ b/script/update-user-agents.py
@@ -1,9 +1,4 @@
 #!/usr/bin/env python
-# /// script
-# dependencies = [
-#   "requests",
-# ]
-# ///
 
 from __future__ import annotations
 


### PR DESCRIPTION
Streamlink's dev/build scripts use the `script` dependency group declared in pyproject.toml, along with the global uv.lock file.

The CI runs `uv run --frozen --only-group script ./script/update-user-agents.py`, which conflicts with embedded script dependencies, as it requires individual script lockfiles.

https://github.com/streamlink/streamlink/actions/runs/28485299534/job/84430340441#step:5:1

> error: Unable to find lockfile for Python script, but `--frozen` was provided. To create a lockfile, run `uv lock --script`.