### PR TITLE
utils.processoutput: refactor stdin argument

### DIFF
--- a/src/streamlink/utils/processoutput.py
+++ b/src/streamlink/utils/processoutput.py
@@ -5,13 +5,18 @@ import math
 from contextlib import aclosing, suppress
 from functools import partial
 from subprocess import PIPE
-from typing import TYPE_CHECKING, BinaryIO
+from typing import TYPE_CHECKING, BinaryIO, TypedDict
 
 import trio
 
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator, Callable
+
+    from typing_extensions import Unpack
+
+    class TRunArgs(TypedDict, total=False):
+        stdin: int | bytes | BinaryIO | None
 
 
 class ProcessOutput:
@@ -23,7 +28,7 @@ class ProcessOutput:
         command: list[str],
         timeout: float = math.inf,
         wait_terminate: float = 2.0,
-        stdin: int | bytes | BinaryIO | None = PIPE,
+        stdin: int | bytes | BinaryIO = b"",
     ):
         self.command = command
         self.timeout = timeout
@@ -32,10 +37,11 @@ class ProcessOutput:
         self._send_channel, self._receive_channel = trio.open_memory_channel(1)
         self._receive_max_bytes: int | None = None
 
-    def run(self) -> bool:  # pragma: no cover
-        return trio.run(self.arun)
+    def run(self, **kwargs: Unpack[TRunArgs]) -> bool:  # pragma: no cover
+        return trio.run(partial(self.arun, **kwargs))
 
-    async def arun(self) -> bool:
+    async def arun(self, **kwargs: Unpack[TRunArgs]) -> bool:
+        stdin = kwargs.get("stdin")
         with trio.move_on_after(self.timeout):
             async with trio.open_nursery() as nursery:
                 run_process = partial(
@@ -44,7 +50,7 @@ class ProcessOutput:
                     check=False,
                     capture_stdout=False,
                     capture_stderr=False,
-                    stdin=self.stdin,
+                    stdin=self.stdin if stdin is None else stdin,
                     stdout=PIPE,
                     stderr=PIPE,
                     deliver_cancel=self._deliver_cancel,

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -112,7 +112,7 @@ class TestCommand:
         session.options.update({"ffmpeg-no-validation": False})
 
         class MyFFmpegVersionOutput(FFmpegVersionOutput):
-            def run(self):
+            def run(self, *_, **__):
                 self.onstdout(0, "ffmpeg version 0.0.0 suffix")
                 self.onstdout(1, "foo")
                 self.onstdout(2, "bar")
@@ -148,7 +148,7 @@ class TestCommand:
         })
 
         class MyFFmpegVersionOutput(FFmpegVersionOutput):
-            def run(self):
+            def run(self, *_, **__):
                 self.onstdout(0, "ffmpeg version 0.0.0 custom")
                 return True
 
@@ -166,7 +166,7 @@ class TestCommand:
         session.options.update({"ffmpeg-no-validation": False})
 
         class MyFFmpegVersionOutput(FFmpegVersionOutput):
-            def run(self):
+            def run(self, *_, **__):
                 return False
 
         mock_versionoutput = Mock(side_effect=MyFFmpegVersionOutput)

--- a/tests/utils/test_processoutput.py
+++ b/tests/utils/test_processoutput.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from subprocess import PIPE
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
@@ -52,6 +53,7 @@ class FakeProcessOutput(ProcessOutput):
         if ignoresigterm:
             command.append("ignoresigterm")
         kwargs.setdefault("command", command)
+        kwargs.setdefault("stdin", PIPE)
 
         super().__init__(*args, **kwargs)
         self.stream_receive_some_event = trio.Event()
@@ -345,6 +347,45 @@ async def test_output_exception(get_process: Callable[[], Awaitable[trio.Process
     assert process
     assert process.poll() is not None
     assert exc_info.group_contains(ZeroDivisionError)
+
+
+@pytest.mark.trio()
+@pytest.mark.parametrize(
+    ("kwargs_constructor", "kwargs_arun"),
+    [
+        pytest.param(
+            {"stdin": b"exit:123\n"},
+            {},
+            id="constructor",
+        ),
+        pytest.param(
+            {},
+            {"stdin": b"exit:123\n"},
+            id="arun",
+        ),
+    ],
+)
+async def test_stdin_arg(get_process: Callable[[], Awaitable[trio.Process]], kwargs_constructor: dict, kwargs_arun: dict):
+    class CustomProcessOutput(ProcessOutput):
+        def onexit(self, code: int) -> bool:
+            return code == 123
+
+    class CustomFakeProcessOutput(FakeProcessOutput, CustomProcessOutput):
+        pass
+
+    po = CustomFakeProcessOutput(timeout=4, **kwargs_constructor)
+    result = None
+
+    async def run():
+        nonlocal result
+        result = await po.arun(**kwargs_arun)
+
+    async with trio.open_nursery() as nursery:
+        nursery.start_soon(run)
+        process = await get_process()
+        assert process.stdin is None
+
+    assert result
 
 
 @pytest.mark.posix_only()


### PR DESCRIPTION
- Change default value from `subprocess.PIPE` to empty bytes object
- Add `stdin` keyword to `run()` and `arun()`
- Add tests for stdin keyword on class constructor and `arun()`

----

This will help with #6922 