### PR TITLE
Add support for reading namespaced attributes in manifests

### DIFF
--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -227,9 +227,9 @@ class MPDNode:
         self.attributes.add(key)
         value = self.attrib.get(key)
         if value is None and match_local_name:
-            matches = [v for k, v in self.attrib.items() if _local_name(k) == key]
+            matches = [k for k in self.attrib if _local_name(k) == key]
             if len(matches) == 1:
-                value = matches[0]
+                value = self.attrib[matches[0]]
             elif len(matches) > 1:
                 log.debug("Ambiguous local name lookup for attribute %r on <%s>: %s", key, self.__tag__, matches)
         if value is not None:

--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -220,15 +220,24 @@ class MPDNode:
         inherited: TAttrInherited = None,
     ) -> TAttrParseResult | TAttrDefault: ...  # pragma: no cover
 
-    def attr(self, key, parser=None, default=None, required=False, inherited=None):
+    def attr(self, key, parser=None, default=None, required=False, inherited=None, match_local_name=True):
+        def _local_name(name):
+            return name.split("}", 1)[1] if name.startswith("{") else name
+
         self.attributes.add(key)
-        if key in self.attrib:
-            value = self.attrib.get(key)
+        value = self.attrib.get(key)
+        if value is None and match_local_name:
+            matches = [v for k, v in self.attrib.items() if _local_name(k) == key]
+            if len(matches) == 1:
+                value = matches[0]
+            elif len(matches) > 1:
+                raise MPDParsingError(f"Multiple namespaced attributes found matching {key} ")
+        if value is not None:
             if parser and callable(parser):
                 return parser(value)
             else:
                 return value
-        elif inherited:
+        if inherited:
             value = self.walk_back_get_attr(key, inherited)
             if value is not None:
                 return value

--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -231,7 +231,7 @@ class MPDNode:
             if len(matches) == 1:
                 value = matches[0]
             elif len(matches) > 1:
-                raise MPDParsingError(f"Multiple namespaced attributes found matching {key} ")
+                log.debug("Ambiguous local name lookup for attribute %r on <%s>: %s", key, self.__tag__, matches)
         if value is not None:
             if parser and callable(parser):
                 return parser(value)


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

Currently, the default namespace is being ignored when parsing a manifest:
https://github.com/streamlink/streamlink/blob/a47fc7a74786ffcb196f65b24e95f37e30937241/src/streamlink/stream/dash/dash.py#L285
https://github.com/streamlink/streamlink/blob/a47fc7a74786ffcb196f65b24e95f37e30937241/src/streamlink/utils/parse.py#L99-L100

However, this leaves prefixed namespaces untouched.

In class ContentProtection, we expect a `default_KID` attribute to be written. However this is often prefixed by a namespace in the manifest, e.g. prefixed with the `cenc` namespace:
```
<?xml version="1.0" encoding="UTF-8"?>
<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" xmlns:cenc="urn:mpeg:cenc:2013" xmlns:ck="http://dashif.org/guidelines/clearKey" xmlns:dashif="https://dashif.org/" xmlns:mas="urn:marlin:mas:1-0:services:schemas:mpd" xmlns:mspr="urn:microsoft:playready" xmlns:xlink="http://www.w3.org/1999/xlink" maxSegmentDuration="PT0H0M3.840S" mediaPresentationDuration="PT0H7M44.000S" minBufferTime="PT1.500S" profiles="urn:dvb:dash:profile:dvb-dash:2014,urn:dvb:dash:profile:dvb-dash:isoff-ext-live:2014" type="static">
 <Period duration="PT0H7M44.000S" id="p0">

  <AdaptationSet contentType="video" id="1" lang="en" maxFrameRate="25" maxHeight="2160" maxWidth="3840" par="16:9" segmentAlignment="true" startWithSAP="1">
   <ContentProtection cenc:default_KID="43215678-1234-1234-1234-123412341237" schemeIdUri="urn:mpeg:dash:mp4protection:2011" value="cenc"/>
   <ContentProtection schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95" value="MSPR 2.0">
...
```
When parsed by lxml, the attrib key will be `{urn:mpeg:cenc:2013}default_KID` rather than the expected `default_KID`, and therefore `default_KID` will incorrectly be `None`.

This pull request adds support for reading namespaced attributes. The `attr` class method in `MPDNode` has an additional param `match_local_name` (`True` by default) which allows the namespace prefix of the attribute to be ignored. This will allow for `default_KID` to be set as intended.

Fixes #6985 