### PR TITLE
Add Lurkiti and Clippiti apps to the third party list.

### DIFF
--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -95,4 +95,21 @@ Lurkiti
   per-stream quality, notification, Streamlink and player option overrides.
   Quick install from PyPi.
 
+Clippiti
+--------
+
+.. image:: https://raw.githubusercontent.com/tarzasai/clippiti/v0.1.16/doc/media/main-window.png
+  :align: center
+  :alt: Clippiti main window with OSD help and pinned toolbar
+
+:Description: Livestream player with a rolling buffer, clipping, and recording
+:Type: GUI (graphical user interface)
+:OS: :fab:`windows;fa-xl` :fab:`apple;fa-xl` :fab:`linux;fa-xl`
+:Author: `tarzasai <https://github.com/tarzasai>`_
+:Website: https://github.com/tarzasai/clippiti
+:Info: Clippiti is a PyQt6 desktop player that opens a livestream and keeps a
+  rolling local HLS buffer, letting you take snapshots, save past moments as
+  clips, and record with optional auto-remux to MP4. It uses the Streamlink
+  Python API for stream resolution and ffmpeg for buffering and export.
+
 .. content list end

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -79,7 +79,7 @@ OBS-Streamlink
 Lurkiti
 -------
 
-.. image:: https://raw.githubusercontent.com/tarzasai/Lurkiti/v1.0.22/media/settings1.png
+.. image:: https://github.com/user-attachments/assets/25ae6d3c-f2d1-4303-b686-d9d703d38661
   :align: center
   :alt: Lurkiti settings window
 
@@ -98,7 +98,7 @@ Lurkiti
 Clippiti
 --------
 
-.. image:: https://raw.githubusercontent.com/tarzasai/clippiti/v0.1.16/doc/media/main-window.png
+.. image:: https://github.com/user-attachments/assets/de6bed0e-dfa1-4119-8f37-ffac7e3f6470
   :align: center
   :alt: Clippiti main window with OSD help and pinned toolbar
 

--- a/docs/thirdparty.rst
+++ b/docs/thirdparty.rst
@@ -76,4 +76,23 @@ OBS-Streamlink
   embedding streams directly as a scene source. This is useful for broadcasters of
   multi-platform live streams and for live commentators.
 
+Lurkiti
+-------
+
+.. image:: https://raw.githubusercontent.com/tarzasai/Lurkiti/v1.0.22/media/settings1.png
+  :align: center
+  :alt: Lurkiti settings window
+
+:Description: Monitors livestreams from the system tray and opens them with
+  Streamlink
+:Type: GUI (system tray application)
+:OS: :fab:`windows;fa-xl` :fab:`apple;fa-xl` :fab:`linux;fa-xl`
+:Author: `tarzasai <https://github.com/tarzasai>`_
+:Website: https://github.com/tarzasai/Lurkiti
+:Info: Lurkiti is a system-tray app that monitors a list of livestreams (Twitch,
+  YouTube and any other Streamlink-supported site) and notifies you when they go
+  live. Streams open in your preferred player (mpv, VLC, Clippiti, etc.) with
+  per-stream quality, notification, Streamlink and player option overrides.
+  Quick install from PyPi.
+
 .. content list end


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

Re-proposing my apps in 2 separate commits as requested - sorry for the different title styles, you would think that Github suggests consistent titles, but it doesn't.

I also updated both the app to create a better Streamlink session, even more in Clippiti as it was spawning a separate process instead of using the Streamlink python module. A big thank you to @bastimeyer for pointing it out.