### PR TITLE
ci.github: add lint checks for git PR branches

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  files:
-    name: Files
+  repo-integrity:
+    name: Repo integrity
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 300
+      - name: Fetch base branch ref
+        run: |
+          git fetch origin --depth=300 "+${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}"
       - name: File permissions
         if: ${{ !cancelled() }}
         run: "! grep -Ev '^644' <(git ls-files src/ tests/ | xargs stat '--format=%a %n')"
@@ -26,6 +32,20 @@ jobs:
       - name: No unicode bidirectional control characters
         if: ${{ !cancelled() }}
         run: "! git grep -EIn $'[\\u2066\\u2067\\u2068\\u2069\\u202A\\u202B\\u202C\\u202D\\u202E]'"
+      - name: Linear git history
+        if: ${{ !cancelled() }}
+        run: |
+          git log -z --format="%H%n%s" --min-parents=2 "origin/${{ github.base_ref }}..HEAD" \
+            | awk -v RS='\0' -F'\n' \
+              -f .github/workflows/scripts/lint-git-common.awk \
+              -f .github/workflows/scripts/lint-git-linear-history.awk
+      - name: Git commit messages
+        if: ${{ !cancelled() }}
+        run: |
+          git log -z --format="%H%n%B" "origin/${{ github.base_ref }}..HEAD" \
+            | awk -v RS='\0' -F'\n' \
+              -f .github/workflows/scripts/lint-git-common.awk \
+              -f .github/workflows/scripts/lint-git-commit-msg-format.awk
 
   style:
     name: Code style

--- a/.github/workflows/scripts/lint-git-commit-msg-format.awk
+++ b/.github/workflows/scripts/lint-git-commit-msg-format.awk
@@ -1,0 +1,45 @@
+NF > 1 {
+    hash = $1
+    subj = $2
+
+    if (length(subj) > MAX_LENGTH_SUBJ) {
+        printf "::error title=\"Commit %s\"::Subject >%d chars (%d)%%0A%s\n",
+            hash,
+            MAX_LENGTH_SUBJ,
+            length(subj),
+            gha_escape(subj)
+        err = 1
+    }
+    if (subj !~ /^[0-9]{4}$|^[a-z0-9_-]+(\.[a-z0-9_-]+)*: / || subj !~ /^[ -~]+$/ || subj ~ /[.?!:;]$/) {
+        printf "::error title=\"Commit %s\"::Invalid format%%0A%s\n",
+            hash,
+            gha_escape(subj)
+        err = 1
+    }
+
+    if (NF > 2 && $3 != "") {
+        printf "::error title=\"Commit %s\"::Line 2 must be blank\n",
+            hash
+        err = 1
+    }
+
+    body = ""
+    body_err = 0
+    for (i = 4; i <= NF; i++) {
+        body = body (i > 4 ? "\n" : "") $i
+
+        if (length($i) > MAX_LENGTH_BODY) {
+            body_err = 1
+        }
+    }
+
+    if (body_err == 1) {
+        printf "::error title=\"Commit %s\"::Body includes at least one line with >%d chars%%0A%s%%0A%%0A%s\n",
+            hash,
+            MAX_LENGTH_BODY,
+            gha_escape(subj),
+            gha_escape(body)
+        err = 1
+    }
+}
+END { exit err }

--- a/.github/workflows/scripts/lint-git-common.awk
+++ b/.github/workflows/scripts/lint-git-common.awk
@@ -1,0 +1,11 @@
+BEGIN {
+    MAX_LENGTH_SUBJ = 50
+    MAX_LENGTH_BODY = 72
+}
+
+function gha_escape(str) {
+    gsub(/%/, "%25", str)
+    gsub(/\r/, "%0D", str)
+    gsub(/\n/, "%0A", str)
+    return str
+}

--- a/.github/workflows/scripts/lint-git-common.awk
+++ b/.github/workflows/scripts/lint-git-common.awk
@@ -1,5 +1,5 @@
 BEGIN {
-    MAX_LENGTH_SUBJ = 50
+    MAX_LENGTH_SUBJ = 72
     MAX_LENGTH_BODY = 72
 }
 

--- a/.github/workflows/scripts/lint-git-linear-history.awk
+++ b/.github/workflows/scripts/lint-git-linear-history.awk
@@ -1,0 +1,10 @@
+NF {
+    hash = $1
+    subj = $2
+
+    printf "::error title=\"Commit %s\"::Disallowed merge commit%%0A%s\n",
+        hash,
+        gha_escape(subj)
+    err = 1
+}
+END { exit err }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,7 +139,7 @@ Adhering to the following process is the best way to get your work included in t
    git checkout -b TOPIC-BRANCH-NAME
    ```
 
-4. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines][howto-format-commits] or your code is unlikely be merged into the project. Use git's [interactive rebase][howto-rebase] feature to tidy up your commits before making them public.
+4. Commit your changes in logical chunks. Please adhere to our [git commit message style][howto-format-commits] or your code is unlikely be merged into the project. Use git's [interactive rebase][howto-rebase] feature to tidy up your commits before making them public.
 
 5. If your topic branch is based off an outdated commit on the master branch, then rebase first:
    ```bash
@@ -264,7 +264,7 @@ This contributing guide has been adapted from [HTML5 boilerplate's guide][ref-h5
   [mastering-markdown]: https://guides.github.com/features/mastering-markdown
   [howto-fork]: https://help.github.com/articles/fork-a-repo
   [howto-rebase]: https://help.github.com/articles/interactive-rebase
-  [howto-format-commits]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+  [howto-format-commits]: https://streamlink.github.io/developing.html#git-commit-style
   [howto-open-pull-requests]: https://help.github.com/articles/using-pull-requests
   [Git]: https://git-scm.com
   [license]: https://github.com/streamlink/streamlink/blob/master/LICENSE

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -150,7 +150,7 @@ To improve git history and changelog legibility, Streamlink enforces a specific 
 It is a variation of `conventional commits`_ using component/package prefixes instead of conventional types and scopes.
 
 Commit messages must begin with a lowercase prefix, followed by a colon and a space, and end with a subject description.
-The maximum line length is 50 characters.
+The target line length is 50 characters, with a hard maximum of 72 characters.
 
 The prefix must be a dot-separated pseudo-Python-import-path of the modified file path,
 ignoring the ``streamlink`` namespace (while renaming ``streamlink_cli`` to ``cli``).

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -143,6 +143,40 @@ structure should be compliant-ready for `linting <Validating changes_>`_.
 .. _pyproject.toml: https://github.com/streamlink/streamlink/blob/master/pyproject.toml
 
 
+Git commit style
+----------------
+
+To improve git history and changelog legibility, Streamlink enforces a specific commit message format.
+It is a variation of `conventional commits`_ using component/package prefixes instead of conventional types and scopes.
+
+Commit messages must begin with a lowercase prefix, followed by a colon and a space, and end with a subject description.
+The maximum line length is 50 characters.
+
+The prefix must be a dot-separated pseudo-Python-import-path of the modified file path,
+ignoring the ``streamlink`` namespace (while renaming ``streamlink_cli`` to ``cli``).
+Non-code changes should use an equivalent pseudo-path.
+If not applicable, standard conventional commit types must be used instead.
+If a commit affects multiple components, the primary one should be chosen, or a second prefix should be added
+using the same separator format.
+
+Subject descriptions must start with a lowercase imperative verb (e.g. "add", "remove", "refactor")
+communicating the nature of the change, and end without punctuation.
+
+For example:
+
+.. code-block:: text
+
+    session.http: fix set_interface on macOS
+    plugins.twitch: switch to usher v2 endpoints
+    ci.github: run preview-builds on uv.lock updates
+
+Optional message bodies must be separated from the subject by a blank line, with lines wrapped at 72 characters.
+Markdown formatting is supported. Standardized footers (e.g. ``Co-Authored-By: name <email-address>``)
+may be included at the end of the body.
+
+.. _conventional commits: https://www.conventionalcommits.org/
+
+
 Plugins
 -------
 


### PR DESCRIPTION
Not yet 100% sure about the 50->72 chars change. The 50 chars convention is a bit dated and annoying to work with in some cases when there are long prefixes. Lots of projects have switched to 72 a long time ago already...

I will also have to test the CI error message format first before merging. Will do that later...