### PR TITLE
plugins.douyu: no assert_hostname in HTTPAdapter

### DIFF
--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -19,12 +19,28 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.session.http import TLSPartialVerifyAdapter
+from streamlink.session.http import TLSSecLevel1Adapter
 from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_qsd
 
 
 log = logging.getLogger(__name__)
+
+
+class TLSPartialVerifyAdapter(TLSSecLevel1Adapter):
+    """
+    The base class SSLContextAdapter resets ssl_context.check_hostname to True when sending a request, so overriding get_ssl_context does not take effect.
+
+    Instead, assert_hostname is used to influence urllib3's internal decision logic,
+    ultimately achieving the effect of check_hostname=False to skip certificate hostname verification,
+    while still retaining certificate chain-related validation."
+    """
+
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = self.get_ssl_context()
+        kwargs["assert_hostname"] = False
+        return super().init_poolmanager(*args, **kwargs)
+
 
 @pluginmatcher(
     re.compile(

--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -37,7 +37,6 @@ class TLSPartialVerifyAdapter(TLSSecLevel1Adapter):
     """
 
     def init_poolmanager(self, *args, **kwargs):
-        kwargs["ssl_context"] = self.get_ssl_context()
         kwargs["assert_hostname"] = False
         return super().init_poolmanager(*args, **kwargs)
 

--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -29,7 +29,8 @@ log = logging.getLogger(__name__)
 
 class TLSPartialVerifyAdapter(TLSSecLevel1Adapter):
     """
-    The base class SSLContextAdapter resets ssl_context.check_hostname to True when sending a request, so overriding get_ssl_context does not take effect.
+    The base class SSLContextAdapter resets ssl_context.check_hostname to True when sending a request,
+    so overriding get_ssl_context does not take effect.
 
     Instead, assert_hostname is used to influence urllib3's internal decision logic,
     ultimately achieving the effect of check_hostname=False to skip certificate hostname verification,
@@ -192,7 +193,8 @@ class Douyu(Plugin):
             log.error("Failed to get stream URL")
             return
 
-        # Mount TLSPartialVerifyAdapter for CDN domains that may not be compatible with OpenSSL 3.0's default security level (SECLEVEL=2)
+        # Mount TLSPartialVerifyAdapter for CDN domains that may not be compatible
+        # with OpenSSL 3.0's default security level (SECLEVEL=2)
         # or domains with underscore
         self.session.http.mount("https://", TLSPartialVerifyAdapter())
 

--- a/src/streamlink/plugins/douyu.py
+++ b/src/streamlink/plugins/douyu.py
@@ -19,13 +19,12 @@ from urllib.parse import urlparse
 
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.session.http import TLSSecLevel1Adapter
+from streamlink.session.http import TLSPartialVerifyAdapter
 from streamlink.stream.http import HTTPStream
 from streamlink.utils.parse import parse_qsd
 
 
 log = logging.getLogger(__name__)
-
 
 @pluginmatcher(
     re.compile(
@@ -178,10 +177,9 @@ class Douyu(Plugin):
             log.error("Failed to get stream URL")
             return
 
-        # Mount TLSSecLevel1Adapter for CDN domains that may not be compatible
-        # with OpenSSL 3.0's default security level (SECLEVEL=2)
-        cdn_netloc = urlparse(first_data["rtmp_url"]).netloc
-        self.session.http.mount(f"https://{cdn_netloc}", TLSSecLevel1Adapter())
+        # Mount TLSPartialVerifyAdapter for CDN domains that may not be compatible with OpenSSL 3.0's default security level (SECLEVEL=2)
+        # or domains with underscore
+        self.session.http.mount("https://", TLSPartialVerifyAdapter())
 
         multirates = first_data.get("multirates", [])
 

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -415,5 +415,16 @@ class TLSSecLevel1Adapter(SSLContextAdapter):
 
         return ctx
 
+class TLSPartialVerifyAdapter(TLSSecLevel1Adapter):
+    def get_ssl_context(self) -> ssl.SSLContext:
+        ctx = super().get_ssl_context()
+        # not work, will be set to True in create_urllib3_context because verify_mode == ssl.CERT_REQUIRED
+        # ctx.check_hostname = False 
+        ctx.verify_mode = ssl.CERT_REQUIRED
+        return ctx
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = self.get_ssl_context()
+        kwargs["assert_hostname"] = False
+        return super().init_poolmanager(*args, **kwargs)
 
-__all__ = ["HTTPSession", "SSLContextAdapter", "TLSNoDHAdapter", "TLSSecLevel1Adapter"]
+__all__ = ["HTTPSession", "SSLContextAdapter", "TLSNoDHAdapter", "TLSSecLevel1Adapter", "TLSPartialVerifyAdapter"]

--- a/src/streamlink/session/http.py
+++ b/src/streamlink/session/http.py
@@ -415,16 +415,5 @@ class TLSSecLevel1Adapter(SSLContextAdapter):
 
         return ctx
 
-class TLSPartialVerifyAdapter(TLSSecLevel1Adapter):
-    def get_ssl_context(self) -> ssl.SSLContext:
-        ctx = super().get_ssl_context()
-        # not work, will be set to True in create_urllib3_context because verify_mode == ssl.CERT_REQUIRED
-        # ctx.check_hostname = False 
-        ctx.verify_mode = ssl.CERT_REQUIRED
-        return ctx
-    def init_poolmanager(self, *args, **kwargs):
-        kwargs["ssl_context"] = self.get_ssl_context()
-        kwargs["assert_hostname"] = False
-        return super().init_poolmanager(*args, **kwargs)
 
-__all__ = ["HTTPSession", "SSLContextAdapter", "TLSNoDHAdapter", "TLSSecLevel1Adapter", "TLSPartialVerifyAdapter"]
+__all__ = ["HTTPSession", "SSLContextAdapter", "TLSNoDHAdapter", "TLSSecLevel1Adapter"]


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [X] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [X] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

fix #7001 

set `kwargs["assert_hostname"] = False` to disable domain check.
