### PR TITLE
ci.github: set workflow concurrency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
     tags:
       - "**"
 
+concurrency:
+  group: docs-deployment
+  cancel-in-progress: false
+
 jobs:
   documentation:
     name: Build and deploy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,10 @@ name: Lint
 on:
   pull_request: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   files:
     name: Files

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     name: Test


### PR DESCRIPTION
- still running test+lint PR workflows should be cancelled when a PR branch receives a new push
- tests on master should never be cancelled
- docs deployments should not run simultaneously (commit push and tag push)