### PR TITLE
ci.github: fix fetch-tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,7 @@ jobs:
         with:
           fetch-depth: 300
       - name: Fetch tags
-        run: |
-          git ls-remote --tags --sort=version:refname 2>&- | awk 'END{printf "+%s:%s\n",$2,$2}' | git fetch origin --depth=300
-          git fetch origin --depth=300 --update-shallow
-          git describe --tags --long --dirty
+        run: ./.github/workflows/scripts/fetch-tags.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,7 @@ jobs:
         with:
           fetch-depth: 300
       - name: Fetch tags
-        run: |
-          git ls-remote --tags --sort=version:refname 2>&- | awk 'END{printf "+%s:%s\n",$2,$2}' | git fetch origin --depth=300
-          git fetch origin --depth=300 --update-shallow
-          git describe --tags --long --dirty
+        run: ./.github/workflows/scripts/fetch-tags.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
@@ -56,10 +53,7 @@ jobs:
         with:
           fetch-depth: 300
       - name: Fetch tags
-        run: |
-          git ls-remote --tags --sort=version:refname 2>&- | awk 'END{printf "+%s:%s\n",$2,$2}' | git fetch origin --depth=300
-          git fetch origin --depth=300 --update-shallow
-          git describe --tags --long --dirty
+        run: ./.github/workflows/scripts/fetch-tags.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"

--- a/.github/workflows/scripts/fetch-tags.sh
+++ b/.github/workflows/scripts/fetch-tags.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Fetch only the tags within our shallow-clone depth (set to 300 commits by @actions/checkout),
+# so we can avoid fetching the entire repo, as it includes a BLOB that was committed years ago:
+# 1. Query the remote
+# 2. Filter peeled/annotated tags and reformat output
+# 3. Query clone for known commit data
+# 4. Filter out tags with unknown commit data (tags outside our fetch depth)
+# 5. Fetch tags, so `git describe --tags` will work (assuming the fetch depth is large enough)
+git ls-remote --tags origin \
+  | awk '{ sub(/\^\{\}$/, "", $2); t[$2] = $1 } END { for (r in t) print t[r], "+" r ":" r }' \
+  | git cat-file --buffer --batch-check='%(rest)' \
+  | sed -n '/ missing$/!p' \
+  | git fetch origin --stdin
+
+git describe --tags --long --dirty

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,13 +52,7 @@ jobs:
           fetch-depth: 300
       - name: Fetch tags
         shell: bash
-        run: |
-          git ls-remote --tags --sort=version:refname 2>&- \
-            | awk 'END{printf "+%s:%s\n",$2,$2}' \
-            | git fetch origin --depth=300 \
-            || { ec=$?; [ $ec -eq 141 ] && true || (exit $ec); }
-          git fetch origin --depth=300 --update-shallow
-          git describe --tags --long --dirty
+        run: ./.github/workflows/scripts/fetch-tags.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -97,10 +91,7 @@ jobs:
         with:
           fetch-depth: 300
       - name: Fetch tags
-        run: |
-          git ls-remote --tags --sort=version:refname 2>&- | awk 'END{printf "+%s:%s\n",$2,$2}' | git fetch origin --depth=300
-          git fetch origin --depth=300 --update-shallow
-          git describe --tags --long --dirty
+        run: ./.github/workflows/scripts/fetch-tags.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"
@@ -133,10 +124,7 @@ jobs:
         with:
           fetch-depth: 300
       - name: Fetch tags
-        run: |
-          git ls-remote --tags --sort=version:refname 2>&- | awk 'END{printf "+%s:%s\n",$2,$2}' | git fetch origin --depth=300
-          git fetch origin --depth=300 --update-shallow
-          git describe --tags --long --dirty
+        run: ./.github/workflows/scripts/fetch-tags.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.14"


### PR DESCRIPTION
The old method was flaky and also not ideal:

1. It sometimes failed with "fatal: shallow file has changed since we read it"
2. It only tried to fetch the latest tag in semver sorting order, meaning that PR branches with an older merge-base on master could still end up without a valid tag for being able to run `git describe --tags`

This PR fixes the issues by fetching only the tags within our shallow-clone range of 300 commits. Remember that we don't fetch the entire repo because of the merge of the ~35 MiB FFmpeg binary into master years ago for the Windows installer that was part of this repo back then. Getting rid of that BLOB would've required rebasing and force-pushing the master branch, which we didn't do back then and surely won't do now.

So in order to figure out which tags to fetch, we query the remote for all tags, filter peeled/annotated tags, query the shallow clone for available/known commits, filter out everything unknown, and then finally fetch the tags with known commits in the shallow clone from the remote.

I've also moved the logic into a BASH script to avoid redundant code in the workflows.