### PR TITLE
plugins.twitch: fix optional category metadata

### DIFF
--- a/src/streamlink/plugins/twitch.py
+++ b/src/streamlink/plugins/twitch.py
@@ -448,37 +448,34 @@ class TwitchAPI:
             queries,
             schema=validate.all(
                 validate.list(
-                    validate.all(
-                        {
-                            "data": {
-                                "userOrError": {
-                                    "displayName": str,
+                    {
+                        "data": {
+                            "userOrError": {
+                                "displayName": str,
+                            },
+                        },
+                    },
+                    {
+                        "data": {
+                            "user": {
+                                "lastBroadcast": {
+                                    "title": str,
+                                },
+                                "stream": {
+                                    "id": str,
+                                    "game": validate.none_or_all(
+                                        {"name": str},
+                                        validate.get("name"),
+                                    ),
                                 },
                             },
                         },
-                    ),
-                    validate.all(
-                        {
-                            "data": {
-                                "user": {
-                                    "lastBroadcast": {
-                                        "title": str,
-                                    },
-                                    "stream": {
-                                        "id": str,
-                                        "game": {
-                                            "name": str,
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    ),
+                    },
                 ),
                 validate.union_get(
                     (1, "data", "user", "stream", "id"),
                     (0, "data", "userOrError", "displayName"),
-                    (1, "data", "user", "stream", "game", "name"),
+                    (1, "data", "user", "stream", "game"),
                     (1, "data", "user", "lastBroadcast", "title"),
                 ),
             ),

--- a/tests/plugins/test_twitch.py
+++ b/tests/plugins/test_twitch.py
@@ -1110,7 +1110,9 @@ class TestTwitchMetadata:
 
     @pytest.fixture()
     def mock_request_channel(self, request: pytest.FixtureRequest, requests_mock: rm.Mocker):
-        data = getattr(request, "param", True)
+        param = getattr(request, "param", {})
+        data = param.get("data", True)
+        game = param.get("game", True)
 
         return requests_mock.post(
             "https://gql.twitch.tv/gql",
@@ -1134,7 +1136,9 @@ class TestTwitchMetadata:
                             },
                             "stream": {
                                 "id": "stream id",
-                                "game": {
+                                "game": None
+                                if not game
+                                else {
                                     "name": "channel game",
                                 },
                             },
@@ -1192,7 +1196,7 @@ class TestTwitchMetadata:
             },
         )
 
-    @pytest.mark.parametrize(("mock_request_channel", "metadata"), [(True, "https://twitch.tv/foo")], indirect=True)
+    @pytest.mark.parametrize(("mock_request_channel", "metadata"), [({}, "https://twitch.tv/foo")], indirect=True)
     def test_metadata_channel(self, mock_request_channel, metadata):
         assert metadata == ("stream id", "channel name", "channel game", "channel status")
         assert mock_request_channel.call_count == 1
@@ -1224,9 +1228,14 @@ class TestTwitchMetadata:
             },
         ]
 
-    @pytest.mark.parametrize(("mock_request_channel", "metadata"), [(False, "https://twitch.tv/foo")], indirect=True)
+    @pytest.mark.parametrize(("mock_request_channel", "metadata"), [({"data": False}, "https://twitch.tv/foo")], indirect=True)
     def test_metadata_channel_no_data(self, mock_request_channel, metadata):
         assert metadata == (None, None, None, None)
+        assert mock_request_channel.call_count == 1
+
+    @pytest.mark.parametrize(("mock_request_channel", "metadata"), [({"game": False}, "https://twitch.tv/foo")], indirect=True)
+    def test_metadata_channel_no_category(self, mock_request_channel, metadata):
+        assert metadata == ("stream id", "channel name", None, "channel status")
         assert mock_request_channel.call_count == 1
 
     @pytest.mark.parametrize(("mock_request_video", "metadata"), [(True, "https://twitch.tv/videos/1337")], indirect=True)


### PR DESCRIPTION
Fixes #7024 

```
$ streamlink -j https://www.twitch.tv/swngswer | jq .metadata
{
  "id": "316015306220",
  "author": "SwngSwer",
  "category": null,
  "title": "Zero Chill All Laughts Live!reaction"
}
```