### PR TITLE
build: add Python 3.15 to package classifiers

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
     require_ci_to_pass: true
     # wait until at all test runners have uploaded a report (see the test job's build matrix)
     # otherwise, coverage failures may be shown while some reports are still missing
-    after_n_builds: 18
+    after_n_builds: 21
 comment:
   # this also configures the layout of PR check summaries / comments
   layout: "reach, diff, flags, files"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,17 @@ jobs:
           - "3.13"
           - "3.14"
           - "3.14t"
-        include:
-          - runs-on: ubuntu-latest
-            python-version: "3.15-dev"
-            continue: true
-          - runs-on: macos-latest
-            python-version: "3.15-dev"
-            continue: true
-          - runs-on: windows-latest
-            python-version: "3.15-dev"
-            continue: true
+          - "3.15-dev"
+#        include:
+#          - runs-on: ubuntu-latest
+#            python-version: "3.16-dev"
+#            continue: true
+#          - runs-on: macos-latest
+#            python-version: "3.16-dev"
+#            continue: true
+#          - runs-on: windows-latest
+#            python-version: "3.16-dev"
+#            continue: true
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 60
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Internet :: WWW/HTTP",
   "Topic :: Multimedia :: Sound/Audio",
   "Topic :: Multimedia :: Video",


### PR DESCRIPTION
Python 3.15rc1 has been released yesterday, so let's add 3.15 to the package classifiers metadata.

- https://peps.python.org/pep-0790/#release-schedule
- https://docs.python.org/3.15/whatsnew/changelog.html#python-3-15-0-release-candidate-1

CI runners should be available:
https://github.com/actions/python-versions/releases/tag/3.15.0-rc.1-30966273682

Locally everything was fine using an rc1 build. Only the beta 1 required a test bugfix.