### PR TITLE
build: bump min version req of lxml to 5.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   "certifi",
   "exceptiongroup ; python_version<'3.11'",
   "isodate",
-  "lxml >=4.6.4,<8",
+  "lxml >=5.0.0,<8",
   "pycountry",
   "pycryptodome >=3.4.3,<4",
   "PySocks >=1.5.6,!=1.5.7",

--- a/uv.lock
+++ b/uv.lock
@@ -1891,7 +1891,7 @@ requires-dist = [
     { name = "certifi" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "isodate" },
-    { name = "lxml", specifier = ">=4.6.4,<8" },
+    { name = "lxml", specifier = ">=5.0.0,<8" },
     { name = "pycountry" },
     { name = "pycryptodome", specifier = ">=3.4.3,<4" },
     { name = "pysocks", specifier = ">=1.5.6,!=1.5.7" },


### PR DESCRIPTION
lxml==5.0.0 changed the default value of its XMLParser's `resolve_entities` argument from True to "internal", which prevents access to remote resources by default.

Since Streamlink always uses the lxml defaults, the min-version of lxml should be bumped to avoid potential issues with older versions.

lxml 5.0.0 was released on 2023-12-29.
