### PR TITLE
tools: disable ruff rule missing-trailing-comma

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,7 @@ ignore = [
   "compare-to-empty-string",
   "explicit-string-concatenation",
   "missing-f-string-syntax",
+  "missing-trailing-comma",  # already covered by ruff's formatter
   "parenthesize-chained-operators",
   "redefined-loop-name",
   "return-in-generator",


### PR DESCRIPTION
This linter rule (COM812) is redundant. I believe it was kept after adding the formatter because there were some issues when reformatting files. I don't see these issues anymore, so I'm going to ignore the rule now to suppress the warning message that's been shown ever since.