### PR TITLE
docs: add trovo plugin removal to migrations guide

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -1,6 +1,25 @@
 Migrations
 ==========
 
+streamlink 8.5.0
+----------------
+
+plugins.trovo
+^^^^^^^^^^^^^
+
+The ``trovo`` plugin has been removed, as Trovo has discontinued its live-streaming platform.
+
+| :octicon:`x-circle` #6998
+| :octicon:`git-pull-request` #6999
+
+.. admonition:: Migration
+   :class: hint
+
+   Trovo's live-streaming service ceased operation on June 30, 2026, so the ``trovo`` plugin
+   no longer serves any working streams. Please switch to a different streaming service or
+   platform that is supported by Streamlink.
+
+
 streamlink 8.0.0
 ----------------
 


### PR DESCRIPTION
Adds the missing `streamlink 8.5.0` section to the migrations guide documenting the removal of the `trovo` plugin (streamlink/streamlink#6999).

The plugin was removed in 8.5.0 because Trovo discontinued its live-streaming platform on June 30, 2026. The changelog entry exists, but the migrations guide is the place users hit when upgrading — it currently has no 8.5.0 section at all.

## Testing
- `sphinx-build -b dummy -W -t no_intersphinx -t no_acknowledgements .` — passes (warnings as errors)
- `sphinx-build -b html -W ...` — renders correctly (section, octicon refs, Migration admonition)

## AI-assisted contribution disclosure
This change was prepared with the assistance of an AI agent (draft authored and verified by an automated contributor, per the [AI-assisted contributions rules](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)). The change is a small docs-only addition; every line is understood and verified against the upstream changelog and PR streamlink/streamlink#6999.