### PR TITLE
cli: fix bound ifaces of non-external HTTP output

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -166,7 +166,7 @@ def create_output(formatter: Formatter) -> FileOutput | PlayerOutput:
             except OSError as err:
                 raise StreamlinkCLIError(f"Failed to create pipe: {err}") from err
         elif args.player_http:
-            http = create_http_server()
+            http = create_http_server(host="127.0.0.1", port=0)
 
         if args.record:
             if args.record == "-":
@@ -230,7 +230,7 @@ def output_stream_http(
                 + " You must specify the path to a player executable with --player.",
             )
 
-        server = create_http_server()
+        server = create_http_server(host="127.0.0.1", port=0)
         player = output = PlayerOutput(
             path=args.player,
             args=args.player_args,
@@ -247,7 +247,7 @@ def output_stream_http(
         except OSError as err:
             raise StreamlinkCLIError(f"Failed to start player: {args.player} ({err})") from err
     else:
-        server = create_http_server(args.player_external_http_interface, port)
+        server = create_http_server(host=args.player_external_http_interface, port=port)
         player = None
 
         log.info("Starting server, access with one of:")

--- a/tests/cli/main/test_create_output.py
+++ b/tests/cli/main/test_create_output.py
@@ -13,7 +13,7 @@ from streamlink_cli.main import (
     create_output,
     setup_args,
 )
-from streamlink_cli.output import FileOutput, PlayerOutput
+from streamlink_cli.output import FileOutput, HTTPOutput, PlayerOutput
 
 
 ARGS_PLAYER_ENV = "--player-env=VAR1=abc", "--player-env=VAR2=def"
@@ -272,6 +272,16 @@ def test_incompatible_options(formatter: Formatter, argv: list, errormsg: str):
         create_output(formatter)
     assert str(excinfo.value) == errormsg
     assert excinfo.value.code == 1
+
+
+@pytest.mark.parametrize("argv", [pytest.param(["--player=mpv", "--player-http"])], indirect=["argv"])
+def test_player_http(monkeypatch: pytest.MonkeyPatch, formatter: Formatter, argv: list):
+    monkeypatch.setattr("streamlink_cli.output.http.HTTPOutput.start_server", Mock())
+    output = create_output(formatter)
+    assert isinstance(output, PlayerOutput)
+    assert isinstance(output.http, HTTPOutput)
+    assert output.http.host == "127.0.0.1"
+    assert output.http.port == 0
 
 
 @pytest.mark.parametrize("argv", [pytest.param([], id="default-player")], indirect=["argv"])


### PR DESCRIPTION
The local HTTP server for --player-http and --player-continuous-http should only bind to 127.0.0.1 and not all available interfaces.

The interface of --player-external-http remains customizable via --player-external-http-interface, but defaults to all interfaces.

----

Fixes #7050 

Since tests for `output_stream_http()` (`--player-continuous-http` / `--player-external-http`) were never written (this whole implementation was inherited from Livestreamer and is "not ideal"), there are no tests for the changes here. I've added a test for `--player-http` though.

**master**

```
$ streamlink -Q --player-http twitch.tv/dota2ti best & sleep 2 && ss -tpln | awk 'NR==1 || /streamlink/'
State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess
LISTEN 0      1                 0.0.0.0:45837      0.0.0.0:*    users:(("streamlink",pid=1474483,fd=6))
```

```
$ streamlink -Q --player-continuous-http twitch.tv/dota2ti best & sleep 2 && ss -tpln | awk 'NR==1 || /streamlink/'
State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess
LISTEN 1      1                 0.0.0.0:43035      0.0.0.0:*    users:(("streamlink",pid=1474826,fd=6))
```

**PR**

```
$ streamlink -Q --player-http twitch.tv/dota2ti best & sleep 2 && ss -tpln | awk 'NR==1 || /streamlink/'
State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess
LISTEN 1      1               127.0.0.1:46459      0.0.0.0:*    users:(("streamlink",pid=1475689,fd=6))
```

```
$ streamlink -Q --player-continuous-http twitch.tv/dota2ti best & sleep 2 && ss -tpln | awk 'NR==1 || /streamlink/'
State  Recv-Q Send-Q      Local Address:Port  Peer Address:PortProcess
LISTEN 1      1               127.0.0.1:45553      0.0.0.0:*    users:(("streamlink",pid=1475362,fd=6))
```