### PR TITLE
cli: fix status code on setup error

### DIFF
--- a/src/streamlink_cli/main.py
+++ b/src/streamlink_cli/main.py
@@ -1029,7 +1029,8 @@ def main():
         parser = build_parser()
         setup(parser)
     except StreamlinkCLIError as err:
-        sys.stderr.write(f"{err}\n")
+        if sys.stderr:
+            sys.stderr.write(f"{err}\n")
         raise SystemExit(err.code) from None
 
     try:

--- a/tests/cli/main/test_main.py
+++ b/tests/cli/main/test_main.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+import streamlink_cli.main
+from streamlink_cli.exceptions import StreamlinkCLIError
+
+
+@pytest.mark.parametrize(
+    ("stdio", "expected"),
+    [
+        pytest.param({}, "foo\n", id="has-stderr"),
+        pytest.param({"sys.stderr": None}, "", id="no-stderr"),
+    ],
+)
+def test_setup_error(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    stdio: dict[str, Any],
+    expected: str,
+):
+    monkeypatch.setattr("streamlink_cli.main.setup", Mock(side_effect=StreamlinkCLIError("foo", code=123)))
+    for k, v in stdio.items():
+        monkeypatch.setattr(k, v)
+
+    with pytest.raises(SystemExit) as exc_info:
+        streamlink_cli.main.main()
+
+    stdout, stderr = capsys.readouterr()
+    assert exc_info.value.code == 123
+    assert not stdout
+    assert stderr == expected


### PR DESCRIPTION
This fixes the process status code being silently swallowed by an `AttributeError` if `sys.stderr` is `None`, when the stderr file descriptor was closed via `2>&-`.

For example, if the error for an invalid log file had a dedicated status code, this would've overridden it with a simple 1, `streamlink --logfile / -l debug 2>&-; echo $?`.

The error code paths are already tested and fully covered, but their tests are scattered around the `tests.cli.main` package (logging tests and session option tests for example), so I added a new `test_main` module for this.