### PR TITLE
stream.hls: refactor HLSStreamWriter

### DIFF
--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -18,23 +18,24 @@ from typing import TYPE_CHECKING
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
-from streamlink.stream.hls import HLSSegment, HLSStream, HLSStreamReader, HLSStreamWriter, M3U8Parser, parse_tag
+from streamlink.stream.hls import HLSSegment, HLSStream, M3U8Parser, parse_tag
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from requests import Response
 
 
 log = getLogger(__name__)
 
 
-class ResponseWrapper:
-    def __init__(self, response: Response, seed: int | None):
-        self.response = response
-        self.seed = seed
+@dataclass(kw_only=True)
+class BigoHLSSegment(HLSSegment):
+    seed: int | None = None
 
-    def iter_content(self, chunk_size: int):
-        iterator = self.response.iter_content(chunk_size)
+    def iter_content(self, response: Response, chunk_size: int) -> Iterator[bytes]:
+        iterator = response.iter_content(chunk_size)
         if self.seed is None:  # pragma: no cover
             yield from iterator
             return
@@ -60,7 +61,7 @@ class ResponseWrapper:
 
         self._decrypt_packets(packets, self.seed)
 
-        yield packets
+        yield bytes(packets)
         yield remainder
         yield from iterator
 
@@ -88,20 +89,6 @@ class ResponseWrapper:
                 packets[packet_offset + offset] ^= mask
 
 
-class BigoHLSStreamWriter(HLSStreamWriter):
-    def _write(self, segment: BigoHLSSegment, result: Response, is_map: bool):  # type: ignore[override, ty:invalid-method-override]
-        return super()._write(segment, ResponseWrapper(result, segment.seed), is_map)  # type: ignore[arg-type, ty:invalid-argument-type]
-
-
-class BigoHLSStreamReader(HLSStreamReader):
-    __writer__ = BigoHLSStreamWriter
-
-
-@dataclass(kw_only=True)
-class BigoHLSSegment(HLSSegment):
-    seed: int = -1
-
-
 class BigoM3U8Parser(M3U8Parser):
     __segment__ = BigoHLSSegment
 
@@ -122,7 +109,6 @@ class BigoM3U8Parser(M3U8Parser):
 
 
 class BigoHLSStream(HLSStream):
-    __reader__ = BigoHLSStreamReader
     __parser__ = BigoM3U8Parser
 
 

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -33,7 +33,7 @@ from streamlink.utils.times import now
 
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterator, Mapping
     from concurrent.futures import Future
     from datetime import datetime
 
@@ -286,7 +286,7 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
             return False
 
         try:
-            encrypted_chunk = response.content
+            encrypted_chunk = self.get_segment_content(segment, response)
         except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
             log.error(f"Download of segment {segment.num} failed: {err}")
             return False
@@ -307,13 +307,20 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
 
     def _write_plain(self, segment: HLSSegment, response: Response) -> bool:
         try:
-            for chunk in response.iter_content(self.WRITE_CHUNK_SIZE):
+            for chunk in self.iter_segment_content(segment, response):
                 self.reader.buffer.write(chunk)
         except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
             log.error(f"Download of segment {segment.num} failed: {err}")
             return False
 
         return True
+
+    # noinspection PyMethodMayBeStatic
+    def get_segment_content(self, segment: HLSSegment, response: Response) -> bytes:
+        return segment.get_content(response)
+
+    def iter_segment_content(self, segment: HLSSegment, response: Response) -> Iterator[bytes]:
+        yield from segment.iter_content(response, self.WRITE_CHUNK_SIZE)
 
 
 class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -233,7 +233,7 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
 
             written_once = self.reader.buffer.written_once
             try:
-                return self._write(segment, result, *data)
+                self._write(segment, result, *data)
             finally:
                 is_paused = self.reader.is_paused()
 
@@ -261,47 +261,59 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
                 log.info("Filtering out segments and pausing stream output")
                 self.reader.pause()
 
-    def _write(self, segment: HLSSegment, result: Response, is_map: bool):
+    def _write(self, segment: HLSSegment, response: Response, is_map: bool):
         # TODO: Rewrite HLSSegment, HLSStreamWriter and HLSStreamWorker based on independent initialization section segments,
         #       similar to the DASH implementation
         key = segment.map.key if is_map and segment.map else segment.key
 
         if key and key.method != "NONE" and not self.passthrough_encrypted:
-            try:
-                decryptor = self.create_decryptor(key, segment.num)
-            except (StreamError, ValueError) as err:
-                log.error(f"Failed to create decryptor: {err}")
-                self.close()
-                return
+            success = self._write_decrypt(segment, response, key)
+        else:
+            success = self._write_plain(segment, response)
 
-            try:
-                # Unlike plaintext segments, encrypted segments can't be written to the buffer in small chunks
-                # because of the byte padding at the end of the decrypted data, which means that decrypting in
-                # smaller chunks is unnecessary if the entire segment needs to be kept in memory anyway, unless
-                # we defer the buffer writes by one read call and apply the unpad call only to the last read call.
-                encrypted_chunk = result.content
-                decrypted_chunk = decryptor.decrypt(encrypted_chunk)
-                chunk = unpad(decrypted_chunk, AES.block_size, style="pkcs7")
+        if success:
+            if is_map:
+                log.debug(f"Segment initialization {segment.num} complete")
+            else:
+                log.debug(f"Segment {segment.num} complete")
+
+    def _write_decrypt(self, segment: HLSSegment, response: Response, key: Key) -> bool:
+        try:
+            decryptor = self.create_decryptor(key, segment.num)
+        except (StreamError, ValueError) as err:
+            log.error(f"Failed to create decryptor: {err}")
+            self.close()
+            return False
+
+        try:
+            encrypted_chunk = response.content
+        except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
+            log.error(f"Download of segment {segment.num} failed: {err}")
+            return False
+
+        try:
+            # Unlike plaintext segments, encrypted segments can't be written to the buffer in small chunks
+            # because of the byte padding at the end of the decrypted data, which means that decrypting in
+            # smaller chunks is unnecessary if the entire segment needs to be kept in memory anyway, unless
+            # we defer the buffer writes by one read call and apply the unpad call only to the last read call.
+            decrypted_chunk = decryptor.decrypt(encrypted_chunk)
+            chunk = unpad(decrypted_chunk, AES.block_size, style="pkcs7")
+            self.reader.buffer.write(chunk)
+        except ValueError as err:
+            log.error(f"Error while decrypting segment {segment.num}: {err}")
+            return False
+
+        return True
+
+    def _write_plain(self, segment: HLSSegment, response: Response) -> bool:
+        try:
+            for chunk in response.iter_content(self.WRITE_CHUNK_SIZE):
                 self.reader.buffer.write(chunk)
-            except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
-                log.error(f"Download of segment {segment.num} failed: {err}")
-                return
-            except ValueError as err:
-                log.error(f"Error while decrypting segment {segment.num}: {err}")
-                return
+        except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
+            log.error(f"Download of segment {segment.num} failed: {err}")
+            return False
 
-        else:
-            try:
-                for chunk in result.iter_content(self.WRITE_CHUNK_SIZE):
-                    self.reader.buffer.write(chunk)
-            except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
-                log.error(f"Download of segment {segment.num} failed: {err}")
-                return
-
-        if is_map:
-            log.debug(f"Segment initialization {segment.num} complete")
-        else:
-            log.debug(f"Segment {segment.num} complete")
+        return True
 
 
 class HLSStreamWorker(SegmentedStreamWorker[HLSSegment, Response]):

--- a/src/streamlink/stream/hls/segment.py
+++ b/src/streamlink/stream/hls/segment.py
@@ -11,7 +11,10 @@ from streamlink.utils.l10n import Language
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from datetime import datetime, timedelta
+
+    from requests import Response
 
 
 log = getLogger(".".join(__name__.split(".")[:-1]))
@@ -148,3 +151,10 @@ class HLSSegment(Segment):
     byterange: ByteRange | None
     date: datetime | None
     map: Map | None
+
+    # noinspection PyMethodMayBeStatic
+    def get_content(self, response: Response) -> bytes:
+        return response.content
+
+    def iter_content(self, response: Response, chunk_size: int) -> Iterator[bytes]:
+        yield from response.iter_content(chunk_size)

--- a/tests/plugins/test_bigo.py
+++ b/tests/plugins/test_bigo.py
@@ -105,7 +105,7 @@ class TestBigoHLSStream(TestMixinStreamHLS, unittest.TestCase):
         )
 
         for chunk_size in (16, 47):
-            with patch("streamlink.plugins.bigo.BigoHLSStreamWriter.WRITE_CHUNK_SIZE", chunk_size):
+            with patch("streamlink.stream.hls.HLSStreamWriter.WRITE_CHUNK_SIZE", chunk_size):
                 segment = BigoSegment(0, content=given)
                 self.subject([Playlist(0, [web_protection, segment], end=True)])
                 result = self.await_read(read_all=True)


### PR DESCRIPTION
The first commit refactors `HLSStreamWriter._write()` and splits it up into two more methods, one for regularly writing the segment into the buffer and one for decrypting it first.

The second commit then adds the `HLSSegment.{get,iter}_content()` methods and `HLSStreamWriter.{get,iter}_segment_content()` methods, so segment data can be altered before writing it to the buffer. This is intentional, so future implementations in subclasses can choose between them, based on what's needed.

Finally, the recently updated Bigo plugin now overrides the `HLSSegment.iter_content()` method instead of using the ugly `ResponseWrapper` hack. This amends #7056.

----

I'm not 100% happy with these changes, because of the current situation with the HLS segment-map (init section data) implementation, which still needs to be replaced. This will affect the writer's `_write()` method (and related), but refactoring this now and splitting it up shouldn't cause any future issues. These changes here should've been done a long time ago already.

I was also not sure whether to add the `HLSSegment` changes to the base `Segment` dataclass, since the DASH implementation could in theory also call these methods instead of calling the `Response.iter_content()` method directly. But since `Segment` is a generic segment dataclass which doesn't necessarily have to retrieve its data from a `requests.Response` object, it doesn't really make sense moving it there. We'd need another subclass which `HLSSegment` and `DASHSegment` inherit from, but that's currently a bit too much. This can be explored in the future should there be a need to modify DASH stream contents.

Now we have two "public" or rather non-private methods on the `HLSStreamWriter` and `HLSSegment` (none of these classes are actually public interfaces) for being able to modify stream data. I initially had the idea of a separate `StreamProcessor` class/thread when working on the HLS packed audio issue #4721, as it requires removing the ID3v2 data, so I'm not super confident with these two new methods, but I guess it should be fine. We have the segment and response objects as args, so lots of arbitrary data can be accessed, should it be needed. If it turns out that the writer thread which polls the segment queue and writes to the buffer is not suitable for segment content modifications, then we need to offload it to another thread, as initially planned.