### PR TITLE
plugins: fix invalid protocol-plugin input URLs

### DIFF
--- a/src/streamlink/plugins/dash.py
+++ b/src/streamlink/plugins/dash.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
@@ -36,9 +37,14 @@ class MPEGDASH(Plugin):
 
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("https://", str(data.get("url", "")), force=False)
+        url = update_scheme("https://", data.get("url", ""), force=False)
         params = parse_params(data.get("params"))
-        log.debug(f"URL={url}; params={params}")
+        log.debug("URL=%s; params=%r", url, params)
+
+        parsed = urlparse(url)
+        if parsed.scheme != "file" and not parsed.netloc:
+            log.error("Input URL is missing a host or input file path is missing the file:// scheme")
+            return
 
         return DASHStream.parse_manifest(self.session, url, **params)
 

--- a/src/streamlink/plugins/hls.py
+++ b/src/streamlink/plugins/hls.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
@@ -24,9 +25,14 @@ log = getLogger(__name__)
 class HLSPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("https://", str(data.get("url", "")), force=False)
+        url = update_scheme("https://", data.get("url", ""), force=False)
         params = parse_params(data.get("params"))
-        log.debug(f"URL={url}; params={params}")
+        log.debug("URL=%s; params=%r", url, params)
+
+        parsed = urlparse(url)
+        if parsed.scheme != "file" and not parsed.netloc:
+            log.error("Input URL is missing a host or input file path is missing the file:// scheme")
+            return
 
         streams = HLSStream.parse_variant_playlist(self.session, url, **params)
 

--- a/src/streamlink/plugins/http.py
+++ b/src/streamlink/plugins/http.py
@@ -1,4 +1,5 @@
 import re
+from urllib.parse import urlparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
@@ -16,9 +17,14 @@ log = getLogger(__name__)
 class HTTPStreamPlugin(Plugin):
     def _get_streams(self):
         data = self.match.groupdict()
-        url = update_scheme("https://", str(data.get("url", "")), force=False)
+        url = update_scheme("https://", data.get("url", ""), force=False)
         params = parse_params(data.get("params"))
-        log.debug(f"URL={url}; params={params}")
+        log.debug("URL=%s; params=%r", url, params)
+
+        parsed = urlparse(url)
+        if parsed.scheme != "file" and not parsed.netloc:
+            log.error("Input URL is missing a host or input file path is missing the file:// scheme")
+            return
 
         return {"live": HTTPStream(self.session, url, **params)}
 

--- a/tests/plugins/test_dash.py
+++ b/tests/plugins/test_dash.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
@@ -92,6 +93,15 @@ def test_get_streams(monkeypatch: pytest.MonkeyPatch, session: Streamlink, url, 
     p.streams()
 
     assert mock_parse_manifest.call_args_list == [call(session, expected)]
+
+
+def test_missing_netloc(caplog: pytest.LogCaptureFixture, session: Streamlink):
+    caplog.set_level(logging.DEBUG, "streamlink")
+    assert not MPEGDASH(session, "dash:///foo/bar").streams()
+    assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+        ("streamlink.plugins.dash", "debug", "URL=https:///foo/bar; params={}"),
+        ("streamlink.plugins.dash", "error", "Input URL is missing a host or input file path is missing the file:// scheme"),
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/plugins/test_hls.py
+++ b/tests/plugins/test_hls.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
@@ -129,3 +130,12 @@ def test_get_streams(
     assert list(result.keys()) == streams
     assert all(isinstance(s, HLSStream) for s in result.values())
     assert mock_parse_variant_playlist.call_args_list == [call(session, expected)]
+
+
+def test_missing_netloc(caplog: pytest.LogCaptureFixture, session: Streamlink):
+    caplog.set_level(logging.DEBUG, "streamlink")
+    assert not HLSPlugin(session, "hls:///foo/bar").streams()
+    assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+        ("streamlink.plugins.hls", "debug", "URL=https:///foo/bar; params={}"),
+        ("streamlink.plugins.hls", "error", "Input URL is missing a host or input file path is missing the file:// scheme"),
+    ]

--- a/tests/plugins/test_http.py
+++ b/tests/plugins/test_http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import Mock, call
 
@@ -59,6 +60,15 @@ def test_get_streams(
     assert list(result.keys()) == ["live"]
     assert isinstance(result["live"], HTTPStream)
     assert mock_httpstream_init.call_args_list == [call(session, expected)]
+
+
+def test_missing_netloc(caplog: pytest.LogCaptureFixture, session: Streamlink):
+    caplog.set_level(logging.DEBUG, "streamlink")
+    assert not HTTPStreamPlugin(session, "httpstream:///foo/bar").streams()
+    assert [(record.name, record.levelname, record.message) for record in caplog.records] == [
+        ("streamlink.plugins.http", "debug", "URL=https:///foo/bar; params={}"),
+        ("streamlink.plugins.http", "error", "Input URL is missing a host or input file path is missing the file:// scheme"),
+    ]
 
 
 def test_parameters(monkeypatch: pytest.MonkeyPatch, session: Streamlink):


### PR DESCRIPTION
The protocol plugins need to check whether the input URL is correct or not. When providing a file path without the `file://` URL scheme, the implicit `https://` scheme is used, so `/foo/bar` becomes the URL path and the URL is lacking a netloc/host, which results in an error down the stack.

**master**
```
$ streamlink httpstream:///dev/zero best -o /dev/null
[cli][info] Found matching plugin http for URL httpstream:///dev/zero
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (http)
[cli][info] Writing output to
/dev/null
Traceback (most recent call last):
  File "/home/basti/repos/streamlink/src/streamlink/session/http.py", line 323, in request
    res = super().request(
        method,
    ...<14 lines>...
        json=json,
    )
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/sessions.py", line 635, in request
    prep = self.prepare_request(req)
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/sessions.py", line 541, in prepare_request
    p.prepare(
    ~~~~~~~~~^
        method=method.upper(),
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<10 lines>...
        hooks=merge_hooks(request.hooks, self.hooks),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/models.py", line 439, in prepare
    self.prepare_url(url, params)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/models.py", line 520, in prepare_url
    raise InvalidURL(f"Invalid URL {url!r}: No host supplied")
requests.exceptions.InvalidURL: Invalid URL 'https:///dev/zero': No host supplied

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 358, in open_stream
    stream_fd = stream.open()
  File "/home/basti/repos/streamlink/src/streamlink/stream/http.py", line 69, in open
    res = self.session.http.request(
        stream=True,
    ...<2 lines>...
        **reqargs,
    )
  File "/home/basti/repos/streamlink/src/streamlink/session/http.py", line 350, in request
    raise err from rerr
streamlink.exceptions.StreamError: Unable to open URL: https:///dev/zero (Invalid URL 'https:///dev/zero': No host supplied)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 411, in output_stream
    stream_fd, prebuffer = open_stream(stream)
                           ~~~~~~~~~~~^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 360, in open_stream
    raise StreamError(f"Could not open stream: {err}") from err
streamlink.exceptions.StreamError: Could not open stream: Unable to open URL: https:///dev/zero (Invalid URL 'https:///dev/zero': No host supplied)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/basti/.local/bin/streamlink", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 1037, in main
    exit_code = run(parser)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 1019, in run
    exit_code = handle_url_wrapper()
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 599, in handle_url_wrapper
    handle_url()
    ~~~~~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 662, in handle_url
    handle_stream(plugin, streams, stream_name)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 501, in handle_stream
    success = output_stream(stream, formatter)
  File "/home/basti/repos/streamlink/src/streamlink_cli/main.py", line 415, in output_stream
    log.error(f"Try {i + 1}/{args.retry_open}: Could not open stream {stream} ({err})")
                                                                     ^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/stream.py", line 40, in __repr__
    params.append(repr(method()))
                       ~~~~~~^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/http.py", line 55, in to_url
    return self.url
           ^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/stream/http.py", line 63, in url
    return self.session.http.prepare_new_request(**self.args).url  # type: ignore[return-value, ty:invalid-return-type]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/basti/repos/streamlink/src/streamlink/session/http.py", line 276, in prepare_new_request
    return self.prepare_request(request)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/sessions.py", line 541, in prepare_request
    p.prepare(
    ~~~~~~~~~^
        method=method.upper(),
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<10 lines>...
        hooks=merge_hooks(request.hooks, self.hooks),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/models.py", line 439, in prepare
    self.prepare_url(url, params)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/basti/venv/streamlink-314/lib/python3.14/site-packages/requests/models.py", line 520, in prepare_url
    raise InvalidURL(f"Invalid URL {url!r}: No host supplied")
requests.exceptions.InvalidURL: Invalid URL 'https:///dev/zero': No host supplied
```

**PR**
```
$ streamlink -l debug httpstream:///dev/zero best -o /dev/null
[cli][debug] OS:         Linux-7.1.10-1-git-x86_64-with-glibc2.44
[cli][debug] Python:     3.14.7
[cli][debug] OpenSSL:    OpenSSL 3.6.3 9 Jun 2026
[cli][debug] Streamlink: 8.5.0+32.g8ab777ac
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.7.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.1
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.34.2
[cli][debug]  trio: 0.34.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.16.0
[cli][debug]  urllib3: 2.7.0
[cli][debug]  websocket-client: 1.9.0
[cli][debug] Arguments:
[cli][debug]  url=httpstream:///dev/zero
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --output=/dev/null
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin http for URL httpstream:///dev/zero
[plugins.http][debug] URL=https:///dev/zero; params={}
[plugins.http][error] Input URL is missing a host or input file path is missing the file:// scheme
error: No playable streams found on this URL: httpstream:///dev/zero
```