### PR TITLE
plugins.atresplayer: refactor stream retrieval

### DIFF
--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -24,6 +24,13 @@ log = getLogger(__name__)
 )
 class AtresPlayer(Plugin):
     _live_api_url = "https://api.atresplayer.com/client/v1/row/live"
+    _stream_priorities = {
+        "application/hls+legacy": 0,
+        "application/vnd.apple.mpegurl": 1,
+        "application/dash+xml": 2,
+        "application/hls+hevc": 3,
+        "application/dash+hevc": 4,
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -107,7 +114,11 @@ class AtresPlayer(Plugin):
             log.error(f"Player API error: {sources['error']} - {sources['error_description']}")
             return
 
-        for streamtype, streamsrc in sources.get("sourcesLive", []):
+        for streamtype, streamsrc in sorted(
+            sources.get("sourcesLive", []),
+            key=lambda source: self._stream_priorities.get(source[0], -1),
+            reverse=True,
+        ):
             log.debug(f"Stream source: {streamsrc} ({streamtype or 'n/a'})")
 
             if streamtype in (
@@ -125,14 +136,20 @@ class AtresPlayer(Plugin):
                 else:
                     yield from streams.items()
 
+                return
+
             elif streamtype in (
                 "application/dash+xml",
                 "application/dash+hevc",
             ):
-                yield from DASHStream.parse_manifest(
+                streams = DASHStream.parse_manifest(
                     self.session,
                     streamsrc,
-                ).items()
+                )
+
+                if streams:
+                    yield from streams.items()
+                    return
 
 
 __plugin__ = AtresPlayer

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -6,6 +6,7 @@ $region Spain
 """
 
 import re
+from urllib.parse import urlparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
@@ -22,37 +23,63 @@ log = getLogger(__name__)
     re.compile(r"https?://(?:www\.)?atresplayer\.com/directos/.+"),
 )
 class AtresPlayer(Plugin):
-    _channels_api_url = "https://api.atresplayer.com/client/v1/info/channels"
-    _player_api_url = "https://api.atresplayer.com/player/v1/live/{channel_id}?NODRM=true"
+    _live_api_url = "https://api.atresplayer.com/client/v1/row/live"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.url = update_scheme("https://", f"{self.url.rstrip('/')}/")
 
     def _get_streams(self):
-        channel_path = f"/{self.url.split('/')[-2]}/"
-        channel_data = self.session.http.get(
-            self._channels_api_url,
+        channel_path = urlparse(self.url).path
+
+        log.debug(f"Channel path: {channel_path}")
+
+        channels = self.session.http.get(
+            self._live_api_url,
             schema=validate.Schema(
                 validate.parse_json(),
-                [
-                    {
-                        "id": str,
-                        "link": {"url": str},
-                    },
-                ],
-                validate.filter(lambda item: item["link"]["url"] == channel_path),
+                {
+                    "itemRows": [
+                        {
+                            "link": {
+                                "url": str,
+                                "href": validate.url(),
+                            },
+                        },
+                    ],
+                },
+                validate.get("itemRows"),
             ),
         )
-        if not channel_data:
-            return
-        channel_id = channel_data[0]["id"]
 
-        player_api_url = self._player_api_url.format(channel_id=channel_id)
-        log.debug(f"Player API URL: {player_api_url}")
+        channel = next(
+            (item for item in channels if item["link"]["url"] == channel_path),
+            None,
+        )
+
+        if not channel:
+            log.error(f"Could not find live channel: {channel_path}")
+            return
+
+        page_api_url = channel["link"]["href"]
+
+        log.debug(f"Page API URL: {page_api_url}")
+
+        video_api_url = self.session.http.get(
+            page_api_url,
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "urlVideo": validate.url(),
+                },
+                validate.get("urlVideo"),
+            ),
+        )
+
+        log.debug(f"Video API URL: {video_api_url}")
 
         sources = self.session.http.get(
-            player_api_url,
+            video_api_url,
             acceptable_status=(200, 403),
             schema=validate.Schema(
                 validate.parse_json(),
@@ -75,21 +102,37 @@ class AtresPlayer(Plugin):
                 ),
             ),
         )
+
         if "error" in sources:
             log.error(f"Player API error: {sources['error']} - {sources['error_description']}")
             return
 
-        for streamtype, streamsrc in sources.get("sourcesLive"):
+        for streamtype, streamsrc in sources.get("sourcesLive", []):
             log.debug(f"Stream source: {streamsrc} ({streamtype or 'n/a'})")
 
-            if streamtype == "application/vnd.apple.mpegurl":
-                streams = HLSStream.parse_variant_playlist(self.session, streamsrc)
+            if streamtype in (
+                "application/vnd.apple.mpegurl",
+                "application/hls+legacy",
+                "application/hls+hevc",
+            ):
+                streams = HLSStream.parse_variant_playlist(
+                    self.session,
+                    streamsrc,
+                )
+
                 if not streams:
                     yield "live", HLSStream(self.session, streamsrc)
                 else:
                     yield from streams.items()
-            elif streamtype == "application/dash+xml":
-                yield from DASHStream.parse_manifest(self.session, streamsrc).items()
+
+            elif streamtype in (
+                "application/dash+xml",
+                "application/dash+hevc",
+            ):
+                yield from DASHStream.parse_manifest(
+                    self.session,
+                    streamsrc,
+                ).items()
 
 
 __plugin__ = AtresPlayer

--- a/src/streamlink/plugins/atresplayer.py
+++ b/src/streamlink/plugins/atresplayer.py
@@ -26,10 +26,13 @@ class AtresPlayer(Plugin):
     _live_api_url = "https://api.atresplayer.com/client/v1/row/live"
     _stream_priorities = {
         "application/hls+legacy": 0,
-        "application/vnd.apple.mpegurl": 1,
-        "application/dash+xml": 2,
-        "application/hls+hevc": 3,
-        "application/dash+hevc": 4,
+        "application/hls+legacyv3": 1,
+        "application/hls+ssai": 2,
+        "application/vnd.apple.mpegurl": 3,
+        "application/dash+ssai": 4,
+        "application/dash+xml": 5,
+        "application/hls+hevc": 6,
+        "application/dash+hevc": 7,
     }
 
     def __init__(self, *args, **kwargs):
@@ -124,6 +127,8 @@ class AtresPlayer(Plugin):
             if streamtype in (
                 "application/vnd.apple.mpegurl",
                 "application/hls+legacy",
+                "application/hls+legacyv3",
+                "application/hls+ssai",
                 "application/hls+hevc",
             ):
                 streams = HLSStream.parse_variant_playlist(
@@ -140,6 +145,7 @@ class AtresPlayer(Plugin):
 
             elif streamtype in (
                 "application/dash+xml",
+                "application/dash+ssai",
                 "application/dash+hevc",
             ):
                 streams = DASHStream.parse_manifest(


### PR DESCRIPTION

Atresplayer's live API exposes the live channel entries through:

```text
/client/v1/row/live
```

Each live entry provides a `link.href` endpoint. Resolving that endpoint returns `urlVideo`, whose response contains the `sourcesLive` stream sources.

This PR updates the Atresplayer plugin to follow this API flow instead of resolving the channel through `/client/v1/info/channels` and manually constructing `/player/v1/live/{channel_id}`.

The new resolution flow is:

```text
/client/v1/row/live
    -> link.href
    -> urlVideo
    -> sourcesLive
```

The channel is matched using `link.url` against the requested `/directos/.../` path.

### Verification

I checked all live entries currently returned by `/client/v1/row/live` and verified that their stream manifests can be parsed by Streamlink.

```text
[OK]   https://www.atresplayer.com/directos/antena3/ -> HLS (4 variants), HLS (4 variants), DASH (4 streams)
[OK]   https://www.atresplayer.com/directos/lasexta/ -> HLS (4 variants), HLS (4 variants), DASH (4 streams)
[OK]   https://www.atresplayer.com/directos/neox/ -> HLS (4 variants), HLS (4 variants), DASH (4 streams)
[OK]   https://www.atresplayer.com/directos/nova/ -> HLS (4 variants), HLS (4 variants), DASH (4 streams)
[OK]   https://www.atresplayer.com/directos/mega/ -> HLS (4 variants), HLS (4 variants), DASH (4 streams)
[OK]   https://www.atresplayer.com/directos/atreseries/ -> HLS (4 variants), HLS (4 variants), DASH (4 streams)
[OK]   https://www.atresplayer.com/directos/canal-flooxer/ -> HLS (5 variants), HLS (5 variants)
[OK]   https://www.atresplayer.com/directos/clasicos/ -> HLS (single stream), HLS (single stream)
[OK]   https://www.atresplayer.com/directos/canal-kidz/ -> HLS (5 variants), HLS (5 variants)
[OK]   https://www.atresplayer.com/directos/aqui-no-hay-quien-viva/ -> HLS (3 variants), HLS (3 variants)
[OK]   https://www.atresplayer.com/directos/el-hormiguero/ -> HLS (4 variants), HLS (4 variants)
[OK]   https://www.atresplayer.com/directos/equipo-de-investigacion/ -> HLS (5 variants), HLS (5 variants)
[OK]   https://www.atresplayer.com/directos/foq/ -> HLS (5 variants), HLS (5 variants)
[OK]   https://www.atresplayer.com/directos/el-club-de-la-comedia/ -> HLS (single stream), HLS (single stream)
[OK]   https://www.atresplayer.com/directos/multicine/ -> HLS (5 variants), HLS (5 variants)
[OK]   https://www.atresplayer.com/directos/comedia/ -> HLS (5 variants), HLS (5 variants)
[OK]   https://www.atresplayer.com/directos/mentes-inquietas/ -> HLS (5 variants), HLS (5 variants)
[FAIL] https://www.atresplayer.com/directos/atresplayer-premium/ -> required_paid: Required paid
```

I also tested the plugin directly with:

```console
streamlink --loglevel debug "https://www.atresplayer.com/directos/aqui-no-hay-quien-viva/" best
```

<details>
<summary>Debug log</summary>

```text
[cli][info] Found matching plugin atresplayer for URL https://www.atresplayer.com/directos/aqui-no-hay-quien-viva/

[plugins.atresplayer][debug] Channel path: /directos/aqui-no-hay-quien-viva/
[plugins.atresplayer][debug] Page API URL: https://api.atresplayer.com/client/v1/page/live/648ef3951756b0e425af83cc
[plugins.atresplayer][debug] Video API URL: https://api.atresplayer.com/player/v1/live/648ef3951756b0e425af83cc

[plugins.atresplayer][debug] Stream source: https://fast-channels.atresmedia.com/.../648ef3951756b0e425af83cc.m3u8 (application/vnd.apple.mpegurl)
[plugins.atresplayer][debug] Stream source: https://fast-channels.atresmedia.com/.../648ef3951756b0e425af83cc.m3u8 (application/hls+legacy)
[plugins.atresplayer][debug] Stream source: https://fast-channels.atresmedia.com/.../648ef3951756b0e425af83cc.m3u8 (application/hls+legacyv3)

[cli][info] Available streams: 404p_alt2_alt, 404p_alt2 (worst), 404p_alt, 404p (best)
[cli][info] Opening stream: 404p (hls)

[stream.hls][debug] Reloading playlist
[stream.hls][debug] First Sequence: 4198114; Last Sequence: 4198120

[stream.segmented][debug] Queuing HLSSegment(num=4198118, ...)
[stream.segmented][debug] Queuing HLSSegment(num=4198119, ...)
[stream.segmented][debug] Queuing HLSSegment(num=4198120, ...)

[stream.hls][debug] Writing segment 4198118 to output
[stream.hls][debug] Segment 4198118 complete
[stream.hls][debug] Writing segment 4198119 to output
[stream.hls][debug] Segment 4198119 complete
[stream.hls][debug] Writing segment 4198120 to output
[stream.hls][debug] Segment 4198120 complete
```

</details>

The actual `sourcesLive` URLs are dynamic, so they are not included individually in the summary above.

### Tested on

* Windows
* Streamlink built from this branch
* Atresplayer live streams returned by the current live API

AI assistance was used while investigating Atresplayer's current API flow

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)