### PR TITLE
chore: remove custom blank GH issue template link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: "📝 New empty issue (maintainers only)"
-    about: "Create an empty issue without using a form/template. Only accessible by maintainers."
-    url: https://github.com/streamlink/streamlink/issues/new
   - name: "❓ Help"
     about: "The issue tracker is only meant for bug reports, feature/plugin requests and plugin issues. Please ask your questions on the discussions forum and look for already existing answers. If you're unsure whether XYZ is a bug or plugin issue, please just open a regular issue thread."
     url: https://github.com/streamlink/streamlink/discussions


### PR DESCRIPTION
Blank issues are available automatically for everyone with write access when `blank_issues_enabled: false` is set. The option only affects accounts with read access.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser