### PR TITLE
stream.dash: fix t attr in SegmentTimeline

### DIFF
--- a/src/streamlink/stream/dash/manifest.py
+++ b/src/streamlink/stream/dash/manifest.py
@@ -1041,7 +1041,9 @@ class SegmentTimeline(MPDNode):
     def segments(self) -> Iterator[TimelineSegment]:
         t = 0
         for tsegment in self.timeline_segments:
-            if t == 0 and tsegment.t is not None:
+            # An explicit @t overrides the running time on any segment, not just
+            # the first one, which is how a SegmentTimeline signals a gap.
+            if tsegment.t is not None:
                 t = tsegment.t
             # check the start time from MPD
             for _ in range(tsegment.r + 1):

--- a/tests/resources/dash/test_timeline_gap.mpd
+++ b/tests/resources/dash/test_timeline_gap.mpd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MPD type="static" xmlns="urn:mpeg:dash:schema:mpd:2011"
+  minBufferTime="PT2S" mediaPresentationDuration="PT18S"
+  profiles="urn:mpeg:dash:profile:isoff-live:2011">
+  <Period id="0" start="PT0S">
+    <AdaptationSet id="0" mimeType="video/mp4" contentType="video">
+      <Representation id="v" bandwidth="128000">
+        <SegmentTemplate initialization="init.m4s" media="seg-$Number$.m4s?t=$Time$" timescale="1000" startNumber="1">
+          <SegmentTimeline>
+            <S t="0" d="4000" r="1"/>
+            <S t="10000" d="4000"/>
+          </SegmentTimeline>
+        </SegmentTemplate>
+      </Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>

--- a/tests/stream/dash/test_manifest.py
+++ b/tests/stream/dash/test_manifest.py
@@ -201,6 +201,22 @@ class TestMPDParser:
                 "http://test.se/video/250kbit/segment_5.m4s",
             ]
 
+    def test_segments_timeline_gap(self):
+        with xml("dash/test_timeline_gap.mpd") as mpd_xml:
+            mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")
+
+            segments = mpd.periods[0].adaptationSets[0].representations[0].segments()
+            init_segment = next(segments)
+            assert init_segment.uri == "http://test.se/init.m4s"
+
+            # The second `<S t="10000">` signals a gap: its explicit @t must be
+            # honoured instead of continuing the running time from 8000.
+            assert [segment.uri for segment in itertools.islice(segments, 3)] == [
+                "http://test.se/seg-1.m4s?t=0",
+                "http://test.se/seg-2.m4s?t=4000",
+                "http://test.se/seg-3.m4s?t=10000",
+            ]
+
     def test_segments_dynamic_time(self):
         with xml("dash/test_3.mpd") as mpd_xml:
             mpd = MPD(mpd_xml, base_url="http://test.se/", url="http://test.se/manifest.mpd")


### PR DESCRIPTION
- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

`SegmentTimeline.segments` only honoured an `<S>` element's explicit `@t` when the running time was still `0`:

```python
t = 0
for tsegment in self.timeline_segments:
    if t == 0 and tsegment.t is not None:
        t = tsegment.t
    ...
```

So `@t` was applied on the first segment only. In a `SegmentTimeline`, a later `<S t="...">` sets a new start time to signal a **gap / discontinuity** (per ISO/IEC 23009-1). That start time was ignored and the segment was placed at the accumulated time instead, producing wrong `$Time$` values — and therefore requests for the wrong segments.

Example: `<S t="0" d="4000" r="1"/>` followed by `<S t="10000" d="4000"/>` should produce `$Time$` = 0, 4000, **10000**, but produced 0, 4000, **8000**.

### Fix

Apply `@t` whenever an `<S>` carries it, not only on the first segment. Contiguous timelines (no `@t` on later segments) are unaffected.

### Test

Added `test_segments_timeline_gap` with a fixture MPD (`dash/test_timeline_gap.mpd`). On `master` the third segment is `?t=8000`; with this change it is `?t=10000`. The existing DASH segment tests stay green and ruff is clean.

### AI-assisted contributions

I used an AI assistant (Claude Code) to help find this and draft the test. I verified it myself — reproduced the wrong `$Time$` red→green through the real `MPD` parser, ran the DASH test suite, and confirmed ruff passes. I understand the change and take responsibility for it.
