### PR TITLE
plugins.tiktok: rewrite and fix stream data schema

### DIFF
--- a/src/streamlink/plugins/tiktok.py
+++ b/src/streamlink/plugins/tiktok.py
@@ -10,12 +10,18 @@ $metadata title
 from __future__ import annotations
 
 import re
-import sys
+from typing import TYPE_CHECKING, ClassVar
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.http import HTTPStream
+
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from streamlink.stream.stream import Stream
 
 
 log = getLogger(__name__)
@@ -30,19 +36,85 @@ log = getLogger(__name__)
     pattern=re.compile(r"https?://(?:www\.)?tiktok\.com/@(?P<channel>[^/?]+)/video/(?P<id>\d+)"),
 )
 class TikTok(Plugin):
-    QUALITY_WEIGHTS: dict[str, int] = {}
+    QUALITY_WEIGHTS: ClassVar[dict[str, float]] = {
+        "ao": 0,
+        "auto": 200,
+        "ld": 300,
+        "sd": 400,
+        "hd": 500,
+        "hd_60": 600,
+        "uhd": 700,
+        "uhd_60": 800,
+        "origin": 1000000,
+    }
 
     _URL_API_LIVE = "https://www.tiktok.com/api-live/user/room"
 
     _STATUS_OFFLINE = 4
+    _PROTOCOL_ORDER = {"flv": 10}
+    _CODEC_ORDER = {"h264": 1, "h265": 2}
 
     @classmethod
     def stream_weight(cls, stream: str) -> tuple[float, str]:
-        weight = cls.QUALITY_WEIGHTS.get(stream)
-        if weight:
-            return weight, stream
+        try:
+            # protocol, codec, stream = stream.split("_", 2)
+            codec, stream = stream.split("_", 1)
+            if weight := cls.QUALITY_WEIGHTS.get(stream):
+                return weight + cls._PROTOCOL_ORDER.get("flv", 0) + cls._CODEC_ORDER.get(codec, 0), "tiktok"
+        except ValueError:
+            pass
 
         return super().stream_weight(stream)
+
+    _SCHEMA_STREAM_DATA = validate.Schema(
+        validate.none_or_all(
+            str,
+            validate.parse_json(),
+            {
+                "data": {
+                    str: validate.all(
+                        {
+                            "main": {
+                                "sdk_params": validate.all(
+                                    str,
+                                    validate.parse_json(),
+                                    {
+                                        validate.optional("VCodec"): validate.any(str, None),
+                                        validate.optional("v_codec"): validate.any(str, None),
+                                    },
+                                ),
+                                # HLS results in 403 HTTP responses
+                                # validate.optional("hls"): validate.any("", validate.url(scheme="https")),
+                                validate.optional("flv"): validate.any("", validate.url(scheme="https")),
+                            },
+                        },
+                        validate.get("main"),
+                    ),
+                },
+            },
+            validate.get("data"),
+        ),
+    )
+
+    def _get_stream_data(self, value: str | None, default_codec: str) -> Iterator[tuple[str, Stream]]:
+        data: dict[str, dict] | None
+        if not (data := self._SCHEMA_STREAM_DATA.validate(value)):
+            return
+
+        for quality, stream_data in data.items():
+            sdk_params = stream_data["sdk_params"]
+            codec = str(sdk_params.get("VCodec") or sdk_params.get("v_codec") or default_codec).lower()
+            codec = {"avc": "h264", "hevc": "h265"}.get(codec, codec)
+
+            for protocol in self._PROTOCOL_ORDER:
+                # name = f"{protocol}_{codec}_{quality}"
+                name = f"{codec}_{quality}"
+                if not (url := stream_data.get(protocol, "")):
+                    continue
+
+                match protocol:
+                    case "flv":
+                        yield name, HTTPStream(self.session, url)
 
     def _query_api(self, url, **kwargs):
         schema = kwargs.pop("schema")
@@ -57,13 +129,13 @@ class TikTok(Plugin):
                             "statusCode": 0,
                             "data": schema,
                         },
-                        validate.transform(lambda data: (True, data["data"])),
+                        validate.transform(lambda d: (True, d["data"])),
                     ),
                     validate.all(
                         {
                             "message": str,
                         },
-                        validate.transform(lambda data: (False, data["message"])),
+                        validate.transform(lambda d: (False, d["message"])),
                     ),
                 ),
             ),
@@ -77,14 +149,15 @@ class TikTok(Plugin):
         return data
 
     def _get_streams_live(self):
-        self.author = self.match["channel"]
+        self.author = author = self.match["channel"]
 
         data = self._query_api(
             self._URL_API_LIVE,
             params={
                 "aid": 1988,
                 "sourceType": 54,
-                "uniqueId": self.author,
+                "staleTime": 600000,
+                "uniqueId": author.lower(),
             },
             headers={
                 "Referer": self.url,
@@ -98,33 +171,15 @@ class TikTok(Plugin):
                         validate.optional("streamData"): validate.all(
                             {
                                 "pull_data": {
-                                    "stream_data": validate.all(
-                                        str,
-                                        validate.parse_json(),
-                                        {
-                                            "data": dict,
-                                        },
-                                        validate.get("data"),
-                                        {
-                                            str: validate.all(
-                                                {
-                                                    "main": {
-                                                        "flv": validate.url(),
-                                                        "sdk_params": validate.all(
-                                                            validate.parse_json(),
-                                                            {
-                                                                "vbitrate": int,
-                                                            },
-                                                        ),
-                                                    },
-                                                },
-                                                validate.union_get(
-                                                    ("main", "flv"),
-                                                    ("main", "sdk_params", "vbitrate"),
-                                                ),
-                                            ),
-                                        },
-                                    ),
+                                    "stream_data": str,
+                                },
+                            },
+                            validate.get(("pull_data", "stream_data")),
+                        ),
+                        validate.optional("hevcStreamData"): validate.all(
+                            {
+                                "pull_data": {
+                                    "stream_data": str,
                                 },
                             },
                             validate.get(("pull_data", "stream_data")),
@@ -137,29 +192,27 @@ class TikTok(Plugin):
                     "streamId",
                     "title",
                     "streamData",
+                    "hevcStreamData",
                 ),
             ),
         )
         if not data:
             return
 
-        status, self.id, self.title, stream_data = data
+        status, self.id, self.title, stream_data, hevc_stream_data = data
         if status == self._STATUS_OFFLINE:
             log.info("The channel is currently offline")
             return
 
-        if not stream_data:
-            log.error("The stream is inaccessible")
-            return
-
-        streams = {}
-        for name, (url, vbitrate) in stream_data.items():
-            self.QUALITY_WEIGHTS[name] = vbitrate
-            streams[name] = HTTPStream(self.session, url)
-
-        self.QUALITY_WEIGHTS["origin"] = sys.maxsize
-
-        return streams
+        seen = set()
+        for quality, stream in [
+            *self._get_stream_data(stream_data, "h264"),
+            *self._get_stream_data(hevc_stream_data, "h265"),
+        ]:
+            if quality in seen:
+                continue
+            seen.add(quality)
+            yield quality, stream
 
     def _get_streams_video(self):
         self.id = self.match["id"]
@@ -195,13 +248,13 @@ class TikTok(Plugin):
                                         ("author", "uniqueId"),
                                         ("video", "downloadAddr"),
                                     ),
-                                    validate.transform(lambda data: (True, data)),
+                                    validate.transform(lambda d: (True, d)),
                                 ),
                                 validate.all(
                                     {
                                         "statusMsg": str,
                                     },
-                                    validate.transform(lambda data: (False, data["statusMsg"])),
+                                    validate.transform(lambda d: (False, d["statusMsg"])),
                                 ),
                             ),
                         },

--- a/tests/plugins/test_tiktok.py
+++ b/tests/plugins/test_tiktok.py
@@ -1,3 +1,5 @@
+import json
+
 from streamlink.plugins.tiktok import TikTok
 from tests.plugins import PluginCanHandleUrl
 
@@ -14,3 +16,97 @@ class TestPluginCanHandleUrlTikTok(PluginCanHandleUrl):
     should_not_match = [
         "https://www.tiktok.com",
     ]
+
+
+def test_get_streams_live(session, requests_mock):
+    def stream_data(data):
+        return json.dumps({"data": data})
+
+    def endpoint(codec, bitrate, **urls):
+        return {
+            **urls,
+            "sdk_params": json.dumps({"VCodec": codec, "vbitrate": bitrate}),
+        }
+
+    requests_mock.get(
+        TikTok._URL_API_LIVE,
+        json={
+            "statusCode": 0,
+            "data": {
+                "liveRoom": {
+                    "status": 2,
+                    "streamId": "1234",
+                    "title": "Live title",
+                    "streamData": {
+                        "pull_data": {
+                            "stream_data": stream_data({
+                                "hd": {
+                                    "main": endpoint(
+                                        "h264",
+                                        1_800_000,
+                                        hls="https://example.com/h264/hd/main.m3u8",
+                                        flv="https://example.com/h264/hd/main.flv",
+                                        cmaf="https://example.com/h264/hd/main.mpd",
+                                    ),
+                                    "backup": endpoint(
+                                        "h264",
+                                        1_800_000,
+                                        hls="https://example.com/h264/hd/backup.m3u8",
+                                    ),
+                                },
+                                "ao": {
+                                    "main": endpoint("h264", 0, flv="https://example.com/h264/ao/main.flv"),
+                                },
+                            }),
+                        },
+                    },
+                    "hevcStreamData": {
+                        "pull_data": {
+                            "stream_data": stream_data({
+                                "origin": {
+                                    "main": endpoint("h264", 0, flv="https://example.com/origin/main.m3u8"),
+                                },
+                                "uhd_60": {
+                                    "main": endpoint("h265", 4_000_000, flv="https://example.com/h265/uhd60/main.m3u8"),
+                                },
+                                "hd": {
+                                    "main": endpoint("h265", 1_350_000, flv="https://example.com/h265/hd/main.m3u8"),
+                                },
+                                "sd": {
+                                    "main": endpoint("hevc", 1_000_000, flv="https://example.com/h265/sd/main.flv"),
+                                },
+                            }),
+                        },
+                    },
+                },
+            },
+        },
+    )
+
+    plugin = TikTok(session, "https://www.tiktok.com/@LIVE/live")
+    streams = plugin.streams()
+
+    assert plugin.id == "1234"
+    assert plugin.author == "LIVE"
+    assert plugin.title == "Live title"
+
+    assert list(streams.keys()) == [
+        "h264_ao",
+        "h265_sd",
+        "h264_hd",
+        "h265_hd",
+        "h265_uhd_60",
+        "h264_origin",
+        "worst",
+        "best",
+    ]
+    assert streams["worst"] is streams["h265_sd"]
+    assert streams["best"] is streams["h264_origin"]
+
+    request = requests_mock.request_history[0]
+    assert request.qs == {
+        "aid": ["1988"],
+        "sourcetype": ["54"],
+        "staletime": ["600000"],
+        "uniqueid": ["live"],
+    }


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

## Description
TikTok's live room API exposes stream information in both `streamData` and `hevcStreamData`. The existing implementation only parsed the main FLV URL from `streamData`, which caused additional qualities such as `origin`, `uhd_60`, `hd_60`, `sd`, and `ld` to be omitttted.

This change parses both stream containers and collects the available HLS and FLV endpoints for each quality.

## Stream selecttion

Only one primary stream is exposed for each quality, following Streamlink's existing stream naming conventions.

When multiple candidates exist for the same quality, they are prioritized in this order:

1. H.264 before H.265
2. Main CDN line before backup
3. HLS before FLV

This results in a concise stream list such as:

- `ao`
- `ld`
- `sd`
- `hd`
- `hd_60`
- `uhd_60`
- `origin`
- `worst`
- `best`

The `best` synonym resolves to `origin`, while `worst` resolves to the audio-only stream when available.

This PR also fixed for https://github.com/streamlink/streamlink/issues/6911