### PR TITLE
utils.thread: add wait_for_all_events()

### DIFF
--- a/src/streamlink/utils/thread.py
+++ b/src/streamlink/utils/thread.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from itertools import count
-from threading import RLock, Thread
+from threading import Event, RLock, Thread
 from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from concurrent.futures import Future
+
+    from typing_extensions import Unpack
 
 
 _threadname_lock = RLock()
@@ -25,3 +29,12 @@ class NamedThread(Thread):
             kwargs["name"] = f"{newname}-{next(_threadname_counters[newname])}"
 
         super().__init__(*args, **kwargs)
+
+
+def wait_for_all_events(*events: Unpack[tuple[Event]], timeout: int | None = None) -> bool:
+    with ThreadPoolExecutor(max_workers=len(events)) as executor:
+        futures: list[Future[bool]] = [executor.submit(event.wait, timeout) for event in events]
+        # future result blocks until event is set or times out
+        results = [future.result(timeout=None) for future in futures]
+
+    return all(results)

--- a/tests/utils/test_thread.py
+++ b/tests/utils/test_thread.py
@@ -1,4 +1,14 @@
-from streamlink.utils.thread import NamedThread
+from __future__ import annotations
+
+from threading import Event, Thread
+from typing import TYPE_CHECKING
+
+from streamlink.utils.thread import NamedThread, wait_for_all_events
+from tests.testutils.handshake import Handshake
+
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_named_thread():
@@ -18,3 +28,63 @@ def test_named_thread():
     assert One(name="bar").name == "One-bar-0"
     assert One(name="bar").name == "One-bar-1"
     assert One().name == "One-2"
+
+
+class TestWaitForAllEvents:
+    def test_success(self) -> None:
+        handshake = Handshake()
+        result: bool | None = None
+        events = [Event() for _ in range(3)]
+
+        def producer():
+            nonlocal result
+            with handshake():
+                result = wait_for_all_events(*events, timeout=4)
+
+        thread = Thread(target=producer, daemon=True)
+        thread.start()
+
+        assert handshake.wait_ready(timeout=1)
+        assert result is None
+        assert [event.is_set() for event in events] == [False, False, False]
+
+        handshake.go()
+        for event in events[:-1]:
+            event.set()
+            assert not handshake.wait_done(timeout=0)
+            assert result is None
+
+        assert [event.is_set() for event in events] == [True, True, False]
+
+        events[-1].set()
+        assert handshake.wait_done(timeout=1)
+        assert result is True
+        assert [event.is_set() for event in events] == [True, True, True]
+
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+
+    def test_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        handshake = Handshake()
+        result: bool | None = None
+        event = Event()
+        # simulate an immediate timeout
+        monkeypatch.setattr(event, "wait", lambda *_: False)
+
+        def producer():
+            nonlocal result
+            with handshake():
+                result = wait_for_all_events(event, timeout=4)
+
+        thread = Thread(target=producer, daemon=True)
+        thread.start()
+
+        assert handshake.wait_ready(timeout=1)
+        assert result is None
+        assert not event.is_set()
+
+        handshake.step(timeout=1)
+        assert result is False
+
+        thread.join(timeout=1)
+        assert not thread.is_alive()


### PR DESCRIPTION
This is required for code refactorings for the HLS packed audio implementation I've been working on. Not all of this is fully finished yet, but I've got it working and in a somewhat decent shape already.

~~Going to try stacked PRs now that they are available. Let's see... Follow-up PRs based on this one will come when they are ready.~~ Stacked PRs don't work accross forks, which is a bit ridiculous. I'm not going to push my PR branches to the main repo.

Next will be the ID3v2 parser, then the HLS changes, and then the ffmpegmuxer changes.