### PR TITLE
stream.ffmpegmux: add itsoffset option

### DIFF
--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from contextlib import suppress
 from functools import lru_cache
+from itertools import zip_longest
 from pathlib import Path
 from shutil import which
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TextIO, TypeVar
@@ -210,6 +211,7 @@ class FFMPEGMuxer(StreamIO):
         audiocodec = session.options.get("ffmpeg-audio-transcode") or options.pop("acodec", self.DEFAULT_AUDIO_CODEC)
         metadata = options.pop("metadata", {})
         maps = options.pop("maps", [])
+        itsoffset = options.get("itsoffset", [])
         copyts = session.options.get("ffmpeg-copyts") or options.pop("copyts", False)
         start_at_zero = session.options.get("ffmpeg-start-at-zero") or options.pop("start_at_zero", False)
 
@@ -221,7 +223,12 @@ class FFMPEGMuxer(StreamIO):
             loglevel,
         ]
 
-        for np in self.pipes:
+        for np, itsoffset_item in zip_longest(self.pipes, itsoffset, fillvalue=None):
+            if np is None:
+                break
+            # align tracks by provided PTS
+            if itsoffset_item is not None:
+                self._cmd.extend(["-itsoffset", f"{itsoffset_item}"])
             self._cmd.extend(["-i", str(np.path)])
 
         self._cmd.extend(["-c:v", videocodec])

--- a/src/streamlink/stream/ffmpegmux.py
+++ b/src/streamlink/stream/ffmpegmux.py
@@ -57,29 +57,33 @@ class MuxedStream(Stream, Generic[TSubstreams_co]):
         self.subtitles: dict[str, Stream] = options.pop("subtitles", {})
         self.options: dict[str, Any] = options
 
-    def open(self):
-        fds = []
+    def _open_streams(self) -> list[StreamIO]:
+        fds: list[StreamIO] = []
         metadata = self.options.get("metadata", {})
         maps = self.options.get("maps", [])
         # only update the maps values if they haven't been set
         update_maps = not maps
-        for substream in self.substreams:
-            log.debug("Opening %s substream", substream.shortname())
+        for stream in self.substreams:
+            log.debug("Opening %s substream", stream.shortname())
             if update_maps:
                 maps.append(len(fds))
-            fds.append(substream and substream.open())
+            fds.append(stream.open())
 
         for i, subtitle in enumerate(self.subtitles.items()):
-            language, substream = subtitle
-            log.debug("Opening %s subtitle stream", substream.shortname())
+            language, subtitle_stream = subtitle
+            log.debug("Opening %s subtitle stream", subtitle_stream.shortname())
             if update_maps:
                 maps.append(len(fds))
-            fds.append(substream and substream.open())
+            fds.append(subtitle_stream.open())
             metadata[f"s:s:{i}"] = [f"language={language}"]
 
         self.options["metadata"] = metadata
         self.options["maps"] = maps
 
+        return fds
+
+    def open(self):
+        fds = self._open_streams()
         return FFMPEGMuxer(self.session, *fds, **self.options).open()
 
     @classmethod

--- a/tests/stream/test_ffmpegmux.py
+++ b/tests/stream/test_ffmpegmux.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, call
 import pytest
 
 from streamlink.stream.ffmpegmux import FFMPEGMuxer, FFmpegVersionOutput
+from streamlink.stream.stream import StreamIO
 
 
 if TYPE_CHECKING:
@@ -226,6 +227,7 @@ class TestFFmpegVersionOutput:
 class TestOpen:
     FFMPEG_ARGS_DEFAULT_BASE = ["-y", "-nostats"]
     FFMPEG_ARGS_DEFAULT_LOGLEVEL = ["-loglevel", "info"]
+    FFMPEG_ARGS_DEFAULT_INPUTS = ["-i", "one", "-i", "two", "-i", "three"]
     FFMPEG_ARGS_DEFAULT_CODECS = ["-c:v", FFMPEGMuxer.DEFAULT_VIDEO_CODEC, "-c:a", FFMPEGMuxer.DEFAULT_AUDIO_CODEC]
     FFMPEG_ARGS_DEFAULT_FORMAT = ["-f", FFMPEGMuxer.DEFAULT_OUTPUT_FORMAT]
     FFMPEG_ARGS_DEFAULT_OUTPUT = ["pipe:1"]
@@ -236,6 +238,21 @@ class TestOpen:
         monkeypatch.setattr("streamlink.stream.ffmpegmux.which", mock)
 
         return mock
+
+    @pytest.fixture(autouse=True)
+    def _fake_named_pipe(self, monkeypatch: pytest.MonkeyPatch):
+        class FakeNamedPipe:
+            paths = iter(["one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten"])
+
+            @property
+            def path(self) -> str:
+                return next(self.paths, "")
+
+        monkeypatch.setattr("streamlink.stream.ffmpegmux.NamedPipe", FakeNamedPipe)
+
+    @pytest.fixture(autouse=True)
+    def _no_copy_to_pipe_thread(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr("streamlink.stream.ffmpegmux.threading", Mock())
 
     @pytest.fixture()
     def popen(self, monkeypatch: pytest.MonkeyPatch):
@@ -253,6 +270,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
                     *FFMPEG_ARGS_DEFAULT_OUTPUT,
@@ -266,6 +284,7 @@ class TestOpen:
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     "-loglevel",
                     "verbose",
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
                     *FFMPEG_ARGS_DEFAULT_OUTPUT,
@@ -279,6 +298,7 @@ class TestOpen:
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     "-loglevel",
                     "error",
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
                     *FFMPEG_ARGS_DEFAULT_OUTPUT,
@@ -291,6 +311,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-f",
                     "mpegts",
@@ -304,6 +325,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-f",
                     "avi",
@@ -317,6 +339,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -330,6 +353,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -343,6 +367,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -356,6 +381,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -369,6 +395,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     "-start_at_zero",
@@ -383,6 +410,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     "-start_at_zero",
@@ -397,6 +425,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -410,6 +439,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     *FFMPEG_ARGS_DEFAULT_FORMAT,
@@ -423,6 +453,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     "-start_at_zero",
@@ -437,6 +468,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-copyts",
                     "-start_at_zero",
@@ -451,6 +483,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     "-c:v",
                     "avc",
                     "-c:a",
@@ -466,6 +499,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     "-c:v",
                     "divx",
                     "-c:a",
@@ -481,6 +515,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     "-c:v",
                     FFMPEGMuxer.DEFAULT_VIDEO_CODEC,
                     "-c:a",
@@ -496,6 +531,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     "-c:v",
                     FFMPEGMuxer.DEFAULT_VIDEO_CODEC,
                     "-c:a",
@@ -511,6 +547,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     "-c:v",
                     "avc",
                     "-c:a",
@@ -526,6 +563,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     "-c:v",
                     "divx",
                     "-c:a",
@@ -541,6 +579,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-map",
                     "test",
@@ -557,6 +596,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-metadata:s:a:0",
                     "language=eng",
@@ -571,6 +611,7 @@ class TestOpen:
                 [
                     *FFMPEG_ARGS_DEFAULT_BASE,
                     *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *FFMPEG_ARGS_DEFAULT_INPUTS,
                     *FFMPEG_ARGS_DEFAULT_CODECS,
                     "-metadata",
                     "title=test",
@@ -578,6 +619,34 @@ class TestOpen:
                     *FFMPEG_ARGS_DEFAULT_OUTPUT,
                 ],
                 id="metadata-title",
+            ),
+            pytest.param(
+                {},
+                {"itsoffset": [None, 1.2]},
+                [
+                    *FFMPEG_ARGS_DEFAULT_BASE,
+                    *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *["-i", "one"],
+                    *["-itsoffset", "1.2", "-i", "two"],
+                    *["-i", "three"],
+                    *FFMPEG_ARGS_DEFAULT_CODECS,
+                    *FFMPEG_ARGS_DEFAULT_FORMAT,
+                    *FFMPEG_ARGS_DEFAULT_OUTPUT,
+                ],
+                id="itsoffset",
+            ),
+            pytest.param(
+                {},
+                {"itsoffset": [None, None, None, None]},
+                [
+                    *FFMPEG_ARGS_DEFAULT_BASE,
+                    *FFMPEG_ARGS_DEFAULT_LOGLEVEL,
+                    *["-i", "one", "-i", "two", "-i", "three"],
+                    *FFMPEG_ARGS_DEFAULT_CODECS,
+                    *FFMPEG_ARGS_DEFAULT_FORMAT,
+                    *FFMPEG_ARGS_DEFAULT_OUTPUT,
+                ],
+                id="itsoffset-more-values-than-pipes",
             ),
         ],
     )
@@ -590,7 +659,7 @@ class TestOpen:
         expected: list,
     ):
         session.options.update(options)
-        streamio = FFMPEGMuxer(session, **muxer_args)
+        streamio = FFMPEGMuxer(session, *(StreamIO() for _ in range(3)), **muxer_args)
 
         streamio.open()
         assert popen.call_args_list == [


### PR DESCRIPTION
This is required for #4721

This PR adds support to the `FFMPEGMuxer` for [FFmpeg's `-itsoffset` parameter](https://ffmpeg.org/ffmpeg.html#Main-options), which allows shifting the PTS of stream inputs. The `itsoffset` option is a sequence of optional `float`s for the stream PTS offsets, matching the respective `StreamIO` object in the `streams` tuple.

The first commit is a simple refactor of `MuxedStream.open()`, so the file descriptors can be accessed before making the `FFMPEGMuxer.open()`. The reason for this is that packed audio stream timestamps need to be extracted from the stream data first (ID3v2 metadata). This will all come in the follow-up PRs which implement HLS packed audio.

As said many times, the whole `stream.ffmpexmux` module needs to be rewritten from scratch eventually, so changes like this unfortunately always make the code even worse.