### PR TITLE
utils.id3v2: add basic ID3v2 parser

### DIFF
--- a/src/streamlink/utils/id3v2.py
+++ b/src/streamlink/utils/id3v2.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import chain
+from struct import unpack
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
+
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+
+    from typing_extensions import Self
+
+    TFrameParser: TypeAlias = "Callable[[ID3v2, bytes, bytearray], Any]"
+
+
+class ID3v2Error(Exception):
+    def __hash__(self) -> int:  # pragma: no cover
+        return hash((type(self), self.args))
+
+    def __eq__(self, other: object) -> bool:
+        if type(other) is not type(self) or not isinstance(other, Exception):  # pragma: no cover
+            return NotImplemented
+        return self.args == other.args
+
+
+class ID3v2NotEnoughDataError(ID3v2Error):
+    pass
+
+
+class ID3v2NoID3v2Error(ID3v2Error):
+    pass
+
+
+class ID3v2FrameError(ID3v2Error):
+    pass
+
+
+@dataclass(kw_only=True)
+class ID3v2Header:
+    major: int
+    revision: int
+    unsynchronization: bool
+    extended: bool
+    experimental: bool
+    footer: bool
+    size: int
+    data: bytearray
+
+
+@dataclass(kw_only=True)
+class ID3v2Frame:
+    ident: bytes
+    size: int
+    data: bytearray
+    result: Any
+    error: ID3v2FrameError | None
+
+    # frame status flags
+    # tag_alter_preservation: bool = False
+    # file_alter_preservation: bool = False
+    # read_only: bool = False
+
+    # frame format flags
+    grouping_identity: bool = False
+    compression: bool = False
+    encryption: bool = False
+    unsynchronization: bool = False
+    data_length_indicator: bool = False
+
+
+_SYMBOL_FRAME_PARSER = "__PARSE_ID3v2_FRAME"
+_FRAME_PARSERS = "_FRAME_PARSERS"
+_FRAME_PARSERS_PRIV = "_FRAME_PARSERS_PRIV"
+
+
+def _parse_frame_factory(frame_type: str):
+    def _decorator(frame_name: bytes, frame_result_class: type | None = None):
+        def decorator(func: TFrameParser) -> TFrameParser:
+            setattr(func, _SYMBOL_FRAME_PARSER, (frame_type, frame_name, frame_result_class))
+            return func
+
+        return decorator
+
+    return _decorator
+
+
+parse_frame = _parse_frame_factory(_FRAME_PARSERS)
+parse_frame_priv = _parse_frame_factory(_FRAME_PARSERS_PRIV)
+
+
+class _ID3v2Meta(type):
+    def __init__(cls, name, bases, namespace, **kwargs):
+        super().__init__(name, bases, namespace, **kwargs)
+
+        frame_types = {_FRAME_PARSERS, _FRAME_PARSERS_PRIV}
+        for frame_type in frame_types:
+            setattr(cls, frame_type, dict(getattr(cls, frame_type, {})))
+        for member in namespace.values():
+            frame_type, frame_name, frame_result_class = getattr(member, _SYMBOL_FRAME_PARSER, (None, None, None))
+            if frame_type not in frame_types or type(frame_name) is not bytes:
+                continue
+            getattr(cls, frame_type)[frame_name] = member, frame_result_class
+
+
+class ID3v2(metaclass=_ID3v2Meta):
+    """
+    A very basic ID3v2.4.0 parser.
+    The main goal of this parser is to be able to parse ID3v2 tags in HLS packed audio streams.
+
+    Not all ID3v2 features are therefore implemented, like support for
+    unsynch bytes, extended headers, frame group idents, frame compression or frame encryption.
+    """
+
+    MAGICBYTES_HEADER = b"ID3"
+    MAGICBYTES_FOOTER = b"3DI"
+    SUPPORTED_VERSION = 4, 0
+
+    _FRAME_PARSERS: ClassVar[Mapping[bytes, tuple[TFrameParser, type | None]]]
+    _FRAME_PARSERS_PRIV: ClassVar[Mapping[bytes, tuple[TFrameParser, type | None]]]
+
+    def __init__(self, iterator: Iterator[bytes]):
+        self._bytes_read = 0
+        self._iterator = iterator
+        self.parsed = False
+        self.header: ID3v2Header = None  # type: ignore[assignment, ty:invalid-assignment]
+        self.frames: list[ID3v2Frame] = []
+
+    @classmethod
+    def parse_tags(cls, iterator: Iterator[bytes]) -> tuple[list[Self], Iterator[bytes]]:
+        tags = []
+        while True:
+            parser = cls(iterator)
+            try:
+                parser.parse()
+            except (ID3v2NoID3v2Error, ID3v2NotEnoughDataError):
+                break
+            finally:
+                iterator = iter(parser)
+            tags.append(parser)
+
+        return tags, iterator
+
+    @property
+    def bytes_read(self):
+        return self._bytes_read
+
+    def parse(self) -> None:
+        if self.parsed:
+            return
+
+        self.header = self._parse_header()
+        self._parse_extended_header()
+        self.frames.extend(self._parse_frames())
+
+        self._consume_padding()
+        self._parse_footer()
+
+        self.parsed = True
+
+    def __iter__(self):
+        yield from self._iterator
+
+    def _prepend_iterator(self, data: bytes | bytearray):
+        if data:
+            self._iterator = chain((bytes(data),), self._iterator)
+
+    def _read(self, size: int, *, check_boundary: bool = True, increment_counter: bool = True) -> bytearray:
+        if check_boundary and self._bytes_read + size > self.header.size:
+            raise ID3v2Error("Attempting to read more ID3v2 than allowed")
+
+        buffer = bytearray()
+        needed = size
+
+        for chunk in self._iterator:
+            if not chunk:
+                continue
+
+            chunk_len = len(chunk)
+            if chunk_len < needed:
+                buffer.extend(chunk)
+                needed -= chunk_len
+            else:
+                buffer.extend(chunk[:needed])
+                leftover = chunk[needed:]
+                if leftover:
+                    self._prepend_iterator(leftover)
+                break
+
+        if increment_counter:
+            self._bytes_read += len(buffer)
+
+        return buffer
+
+    def _parse_header(self) -> ID3v2Header:
+        data = self._read(10, check_boundary=False, increment_counter=False)
+        if len(data) < 10:
+            # add data back to the iterator if not enough data could be read
+            self._prepend_iterator(data)
+            raise ID3v2NotEnoughDataError("Not enough data for header")
+
+        ident, major, revision, flags, size_bytes = unpack(">3sBBB4s", data)
+
+        try:  # ruff: ignore[too-many-statements-in-try-clause]
+            if ident != self.MAGICBYTES_HEADER:
+                raise ID3v2NoID3v2Error
+            if (major, revision) != self.SUPPORTED_VERSION:
+                raise ID3v2Error("Incompatible ID3v2 version")
+            if flags & 0x0F:
+                raise ID3v2Error("Invalid ID3v2 flags")
+
+            unsynchronization = bool(flags & 0x80)
+            extended = bool(flags & 0x40)
+            experimental = bool(flags & 0x20)
+            footer = bool(flags & 0x10)
+            size = self._parse_syncsafe_integer(size_bytes)
+
+        except:
+            # add data back to the iterator if parsing the header fails
+            self._prepend_iterator(data)
+            raise
+
+        return ID3v2Header(
+            major=major,
+            revision=revision,
+            unsynchronization=unsynchronization,
+            extended=extended,
+            experimental=experimental,
+            footer=footer,
+            size=size,
+            data=data,
+        )
+
+    def _parse_extended_header(self):
+        if not self.header.extended:
+            return
+
+        data = self._read(4)
+        if len(data) < 4:
+            raise ID3v2Error("Not enough data for extended header")
+
+        size = self._parse_syncsafe_integer(data)
+        if size < 6:
+            raise ID3v2Error(f"Invalid extended header size: {size}")
+
+        size -= 4
+
+        # discard extended header bytes
+        if len(self._read(size)) < size:
+            raise ID3v2Error(f"Could not read {size} bytes of ID3v2 extended header")
+
+    def _parse_frames(self) -> Iterator[ID3v2Frame]:
+        while self._bytes_read + 10 <= self.header.size:
+            if (frame := self._parse_frame()) is None:
+                break
+            yield frame
+
+    def _parse_frame(self) -> ID3v2Frame | None:
+        header = self._read(10)
+        ident, size_bytes, _status_flags, format_flags = unpack(">4s4s2B", header)
+
+        # potential padding bytes at the end of the tag
+        if ident == b"\x00\x00\x00\x00":
+            return None
+
+        grouping_identity = bool(format_flags & 0x40)
+        compression = bool(format_flags & 0x08)
+        encryption = bool(format_flags & 0x04)
+        data_length_indicator = bool(format_flags & 0x01)
+
+        offset = int(grouping_identity) + int(encryption) + 4 * int(data_length_indicator or compression)
+
+        size = self._parse_syncsafe_integer(size_bytes)
+        data = self._read(size)
+        if len(data) < size or offset >= len(data):
+            raise ID3v2NotEnoughDataError("Not enough data for frame data")
+
+        if offset > 0:
+            data = data[offset:]
+
+        result: Any = None
+        error: ID3v2FrameError | None = None
+        try:
+            result = self._get_parser_result(self._FRAME_PARSERS, ident, data)
+        except ID3v2FrameError as err:
+            error = err
+
+        return ID3v2Frame(
+            ident=ident,
+            size=size,
+            data=data,
+            result=result,
+            error=error,
+            grouping_identity=grouping_identity,
+            compression=compression,
+            encryption=encryption,
+            data_length_indicator=data_length_indicator,
+        )
+
+    def _consume_padding(self):
+        if (remaining := self.header.size - self._bytes_read) > 0:
+            self._read(remaining)
+
+    def _parse_footer(self):
+        if not self.header.footer:
+            return
+
+        data = self._read(10, check_boundary=False)
+        if len(data) == 10:
+            ident, major, revision, flags, size_bytes = unpack(">3sBBB4s", data)
+            size = self._parse_syncsafe_integer(size_bytes)
+            if (
+                ident == self.MAGICBYTES_FOOTER
+                and (major, revision) == (self.header.major, self.header.revision)
+                and flags == self.header.data[5]
+                and size == self.header.size
+            ):
+                return
+
+        self._bytes_read -= len(data)
+        self._prepend_iterator(data)
+
+    @staticmethod
+    def _parse_syncsafe_integer(data: bytes | bytearray):
+        size_a, size_b, size_c, size_d = unpack(">4B", data)
+        if size_a & 0x80 or size_b & 0x80 or size_c & 0x80 or size_d & 0x80:
+            raise ID3v2Error("Invalid ID3v2 size value")
+
+        return size_a << 21 | size_b << 14 | size_c << 7 | size_d
+
+    def _get_parser_result(self, parsers: Mapping[bytes, tuple[TFrameParser, type | None]], ident: bytes, data: bytearray):
+        if not (parser := parsers.get(ident)):
+            return None
+        callback, frame_result_class = parser
+        result = callback(self, ident, data)
+        if frame_result_class:
+            result = frame_result_class(result)
+
+        return result
+
+    @parse_frame(b"PRIV")
+    def _parse_frame_priv(self, _ident: bytes, data: bytearray):
+        try:
+            owner, data = data.split(b"\0", 1)
+        except ValueError:
+            raise ID3v2FrameError("Invalid PRIV frame data") from None
+
+        return self._get_parser_result(self._FRAME_PARSERS_PRIV, bytes(owner), data)

--- a/tests/utils/test_id3v2.py
+++ b/tests/utils/test_id3v2.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from streamlink.utils.id3v2 import (
+    ID3v2,
+    ID3v2Error,
+    ID3v2Frame,
+    ID3v2FrameError,
+    ID3v2NoID3v2Error,
+    ID3v2NotEnoughDataError,
+    parse_frame,
+    parse_frame_priv,
+)
+
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def ss_int(value: int) -> bytes:
+    return bytes([
+        (value >> 21) & 0x7F,
+        (value >> 14) & 0x7F,
+        (value >> 7) & 0x7F,
+        value & 0x7F,
+    ])
+
+
+class TestID3v2SyncsafeInteger:
+    def test_valid(self):
+        assert ID3v2._parse_syncsafe_integer(b"\x00\x00\x00\x00") == 0
+        assert ID3v2._parse_syncsafe_integer(b"\x00\x00\x00\x7f") == 0x7F
+        assert ID3v2._parse_syncsafe_integer(b"\x00\x00\x01\x00") == 0x80
+        assert ID3v2._parse_syncsafe_integer(b"\x00\x02\x00\x00") == 0x8000
+        assert ID3v2._parse_syncsafe_integer(b"\x7f\x7f\x7f\x7f") == 0xFFFFFFF
+
+    @pytest.mark.parametrize("pos", range(4))
+    def test_invalid(self, pos: int):
+        with pytest.raises(ID3v2Error, match="Invalid ID3v2 size value"):
+            ID3v2._parse_syncsafe_integer(pos * b"\x00" + b"\x80" + (3 - pos) * b"\x00")
+
+
+class TestNoID3v2:
+    @pytest.mark.parametrize("data", [(b"",), (b"foo",), (b"foo", b"bar")])
+    def test_insufficient(self, data: Sequence[bytes]):
+        iterator = iter(data)
+        parser = ID3v2(iterator)
+        with pytest.raises(ID3v2NotEnoughDataError, match=r"Not enough data for header"):
+            parser.parse()
+        assert parser.bytes_read == 0
+        assert not parser.parsed
+        assert b"".join(parser) == b"".join(data)
+        assert next(iterator, None) is None
+
+    def test_invalid(self):
+        parser = ID3v2(iter((b"not ID3v2!",)))
+        with pytest.raises(ID3v2NoID3v2Error):
+            parser.parse()
+        assert parser.bytes_read == 0
+        assert not parser.parsed
+        assert b"".join(parser) == b"not ID3v2!"
+
+
+class TestID3v2Header:
+    def test_valid_no_frames(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00\x00\x00\x00\x00remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 0
+
+        header = parser.header
+        assert header.major == 4
+        assert header.revision == 0
+        assert not header.extended
+        assert not header.unsynchronization
+        assert not header.experimental
+        assert not header.footer
+        assert header.size == 0
+
+        assert b"".join(parser) == b"remaining"
+
+    @pytest.mark.parametrize(
+        ("data", "error_msg"),
+        [
+            pytest.param(b"ID3\x03\x00\x00\x00\x00\x00\x00", "Incompatible ID3v2 version"),
+            pytest.param(b"ID3\x04\x00\x01\x00\x00\x00\x00", "Invalid ID3v2 flags"),
+        ],
+    )
+    def test_invalid(self, data: bytes, error_msg: str):
+        parser = ID3v2(iter([data]))
+        with pytest.raises(ID3v2Error, match=error_msg):
+            parser.parse()
+        assert parser.bytes_read == 0
+        assert b"".join(parser) == data
+
+
+class TestID3v2ExtendedHeader:
+    def test_discards(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x40", ss_int(24), ss_int(20), 20 * b"\x00", b"remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 24
+        assert parser.header.extended
+        assert b"".join(parser) == b"remaining"
+
+    def test_not_enough_data(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x40", ss_int(10), 3 * b"\x00"]))
+        with pytest.raises(ID3v2Error, match=r"Not enough data for extended header"):
+            parser.parse()
+        assert parser.bytes_read == 3
+        assert b"".join(parser) == b""
+
+    def test_insufficient(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x40", ss_int(10), ss_int(10), 5 * b"\x00"]))
+        with pytest.raises(ID3v2Error, match=r"Could not read 6 bytes of ID3v2 extended header"):
+            parser.parse()
+        assert parser.bytes_read == 9
+        assert b"".join(parser) == b""
+
+    def test_invalid_header_size(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x40", ss_int(10), ss_int(5), 6 * b"\x00"]))
+        with pytest.raises(ID3v2Error, match=r"Invalid extended header size: 5"):
+            parser.parse()
+        assert parser.bytes_read == 4
+        assert b"".join(parser) == 6 * b"\x00"
+
+
+class TestID3v2Footer:
+    def test_discards(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x10", ss_int(10), 10 * b"\x00", b"3DI\x04\x00\x10", ss_int(10), b"remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 20
+        assert parser.header.footer
+        assert b"".join(parser) == b"remaining"
+
+    def test_mismatch(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x10", ss_int(10), 10 * b"\x00", b"3DI\x04\x00\x00", ss_int(10), b"remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 10
+        assert parser.header.footer
+        assert b"".join(parser) == b"".join([b"3DI\x04\x00\x00", ss_int(10), b"remaining"])
+
+    def test_insufficient(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x10", ss_int(10), 10 * b"\x00", b"remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 10
+        assert parser.header.footer
+        assert b"".join(parser) == b"remaining"
+
+
+class TestID3v2Frames:
+    def test_not_enough_header_data(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00", ss_int(9), 9 * b"\x00", b"remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 9
+        assert not parser.frames
+        assert b"".join(parser) == b"remaining"
+
+    def test_not_a_frame(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00", ss_int(10), 4 * b"\x00", 6 * b"\x01", b"remaining"]))
+        parser.parse()
+        assert parser.bytes_read == 10
+        assert not parser.frames
+        assert b"".join(parser) == b"remaining"
+
+    def test_check_boundary_on_read(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00", ss_int(10), b"PRIV", ss_int(100), b"\x00\x00remaining"]))
+        with pytest.raises(ID3v2Error, match=r"Attempting to read more ID3v2 than allowed"):
+            parser.parse()
+        assert parser.bytes_read == 10
+        assert not parser.frames
+        assert b"".join(parser) == b"remaining"
+
+    def test_not_enough_frame_data(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00", ss_int(20), b"PRIV", ss_int(10), b"\x00\x00", 9 * b"\x00"]))
+        with pytest.raises(ID3v2Error, match=r"Not enough data for frame data"):
+            parser.parse()
+        assert parser.bytes_read == 19
+        assert b"".join(parser) == b""
+
+    def test_not_enough_frame_data_with_offsets(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00", ss_int(11), b"PRIV", ss_int(1), b"\x00\x40\x00"]))
+        with pytest.raises(ID3v2Error, match=r"Not enough data for frame data"):
+            parser.parse()
+        assert parser.bytes_read == 11
+        assert b"".join(parser) == b""
+
+    def test_offsets(self):
+        parser = ID3v2(
+            iter([
+                b"ID3\x04\x00\x00",
+                ss_int(21),
+                b"PRIV",
+                ss_int(11),
+                # grouping identity | compression | encryption | data length indicator
+                b"\x00\x4d",
+                b"\xf0\xf1\xf2\xf3\xf4\xf5",
+                b"\x01\x23\x00\x45\x67",
+                b"remaining",
+            ]),
+        )
+        parser.parse()
+        assert parser.bytes_read == 21
+        assert parser.frames == [
+            ID3v2Frame(
+                ident=b"PRIV",
+                size=11,
+                data=bytearray(b"\x01\x23\x00\x45\x67"),
+                result=None,
+                error=None,
+                grouping_identity=True,
+                compression=True,
+                encryption=True,
+                unsynchronization=False,
+                data_length_indicator=True,
+            ),
+        ]
+        assert b"".join(parser) == b"remaining"
+
+    def test_frame_error(self):
+        parser = ID3v2(
+            iter([
+                b"ID3\x04\x00\x00",
+                ss_int(14),
+                b"PRIV",
+                ss_int(4),
+                b"\x00\x00",
+                b"\x01\x23\x45\x67",
+                b"remaining",
+            ]),
+        )
+        parser.parse()
+        assert parser.bytes_read == 14
+        assert parser.frames == [
+            ID3v2Frame(
+                ident=b"PRIV",
+                size=4,
+                data=bytearray(b"\x01\x23\x45\x67"),
+                result=None,
+                error=ID3v2FrameError("Invalid PRIV frame data"),
+                grouping_identity=False,
+                compression=False,
+                encryption=False,
+                unsynchronization=False,
+                data_length_indicator=False,
+            ),
+        ]
+        assert b"".join(parser) == b"remaining"
+
+
+class TestID3v2FrameCallbacks:
+    @dataclass
+    class Result:
+        my_result_value: bool
+
+    @pytest.mark.parametrize(
+        ("value", "resultclass", "expected"),
+        [
+            (b"abcd", None, True),
+            (b"wxyz", None, False),
+            (b"abcd", Result, Result(True)),
+            (b"wxyz", Result, Result(False)),
+        ],
+    )
+    def test_frame(self, value: bytes, resultclass: type | None, expected: bool | Result):
+        class CustomID3v2(ID3v2):
+            @parse_frame(b"ABCD", resultclass)
+            def _parse_frame_asdf(self, ident: bytes, data: bytearray):
+                return data.decode("ascii") == ident.decode("ascii").lower()
+
+        assert ID3v2._FRAME_PARSERS.get(b"ABCD") is None
+        assert ID3v2._FRAME_PARSERS_PRIV.get(b"ABCD") is None
+        assert CustomID3v2._FRAME_PARSERS.get(b"ABCD") is not None
+        assert CustomID3v2._FRAME_PARSERS_PRIV.get(b"ABCD") is None
+
+        parser = CustomID3v2(iter([b"ID3\x04\x00\x00", ss_int(14), b"ABCD", ss_int(4), b"\x00\x00", value]))
+        parser.parse()
+        assert parser.bytes_read == 14
+        assert parser.frames == [
+            ID3v2Frame(
+                ident=b"ABCD",
+                size=4,
+                data=bytearray(value),
+                result=expected,
+                error=None,
+                grouping_identity=False,
+                compression=False,
+                encryption=False,
+                unsynchronization=False,
+                data_length_indicator=False,
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        ("value", "resultclass", "expected"),
+        [
+            (b"ABCD", None, True),
+            (b"WXYZ", None, False),
+            (b"ABCD", Result, Result(True)),
+            (b"WXYZ", Result, Result(False)),
+        ],
+    )
+    def test_priv_frame(self, value: bytes, resultclass: type | None, expected: bool | Result):
+        class CustomID3v2(ID3v2):
+            @parse_frame_priv(b"abcd", resultclass)
+            def _parse_frame_asdf(self, ident: bytes, data: bytearray):
+                return data.decode("ascii") == ident.decode("ascii").upper()
+
+        assert ID3v2._FRAME_PARSERS.get(b"abcd") is None
+        assert ID3v2._FRAME_PARSERS_PRIV.get(b"abcd") is None
+        assert CustomID3v2._FRAME_PARSERS.get(b"abcd") is None
+        assert CustomID3v2._FRAME_PARSERS_PRIV.get(b"abcd") is not None
+
+        parser = CustomID3v2(iter([b"ID3\x04\x00\x00", ss_int(19), b"PRIV", ss_int(9), b"\x00\x00abcd\x00", value]))
+        parser.parse()
+        assert parser.bytes_read == 19
+        assert parser.frames == [
+            ID3v2Frame(
+                ident=b"PRIV",
+                size=9,
+                data=bytearray(b"abcd\x00" + value),
+                result=expected,
+                error=None,
+                grouping_identity=False,
+                compression=False,
+                encryption=False,
+                unsynchronization=False,
+                data_length_indicator=False,
+            ),
+        ]
+
+
+class TestID3v2Parse:
+    def test_parse_tags(self):
+        tags, iterator = ID3v2.parse_tags(iter([b"ID3\x04\x00\x00", ss_int(0), b"ID3\x04\x00\x00", ss_int(0), b"remaining"]))
+        assert len(tags) == 2
+        assert b"".join(iterator) == b"remaining"
+        assert all(tag.parsed for tag in tags)
+        assert all(not tag.frames for tag in tags)
+
+    def test_parse_twice(self):
+        parser = ID3v2(iter([b"ID3\x04\x00\x00", ss_int(0), b"remaining"]))
+        assert not parser.parsed
+        parser.parse()
+        assert parser.parsed
+        assert parser.bytes_read == 0
+        parser.parse()
+        assert parser.bytes_read == 0
+        assert b"".join(parser) == b"remaining"


### PR DESCRIPTION
Required for #4721 (HLS packed audio streams)

----

This implements a basic ID3v2 parser from a stream iterator input, which parses an ID3v2 payload at the start of the stream, and which then returns the parsed ID3v2 tags (can be multiple) as well as the updated iterator with the tags removed.

ID3v2 parser packages on PyPI were either dead, or not suited for our needs.

The implementation is only doing the bare minium for what's needed for HLS packed audio streams, namely parsing the ID3v2 header with an optional extended header and parsing a list of data frames. Only the `PRIV` data frame is supported with all other frames silently being discarded (as no parser callback is implemented). `PRIV` frames have another hashmap of parser callbacks that need to be registed by a subclass. This will be done by the HLS implementation, where logic for the `com.apple.streaming.transportStreamTimestamp` `PRIV` frame will be added.

Other ID3v2 features like unsynchronization bytes, frame grouping, frame compression or frame encryption are not supported, because they are not needed.