### PR TITLE
stream.hls: add support for packed audio streams

### DIFF
--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -328,7 +328,7 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
             # we defer the buffer writes by one read call and apply the unpad call only to the last read call.
             decrypted_chunk = decryptor.decrypt(encrypted_chunk)
             chunk = unpad(decrypted_chunk, AES.block_size, style="pkcs7")
-            self.reader.buffer.write(chunk)
+            self._write_into_buffer(iter([chunk]))
         except ValueError as err:
             log.error(f"Error while decrypting segment {segment.num}: {err}")
             return False
@@ -337,13 +337,17 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
 
     def _write_plain(self, segment: HLSSegment, response: Response) -> bool:
         try:
-            for chunk in self.iter_segment_content(segment, response):
-                self.reader.buffer.write(chunk)
+            self._write_into_buffer(self.iter_segment_content(segment, response))
         except (ChunkedEncodingError, ContentDecodingError, ConnectionError) as err:
             log.error(f"Download of segment {segment.num} failed: {err}")
             return False
 
         return True
+
+    def _write_into_buffer(self, iterator: Iterator[bytes]) -> None:
+        buffer = self.reader.buffer
+        for chunk in iterator:
+            buffer.write(chunk)
 
     # noinspection PyMethodMayBeStatic
     def get_segment_content(self, segment: HLSSegment, response: Response) -> bytes:

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import re
 import struct
 import warnings
+from dataclasses import dataclass
 from datetime import timedelta
+from struct import unpack
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar
 from urllib.parse import urlparse
 
@@ -26,6 +28,7 @@ from streamlink.stream.segmented import SegmentedStreamReader, SegmentedStreamWo
 from streamlink.utils.cache import LRUCache
 from streamlink.utils.crypto import AES, unpad
 from streamlink.utils.formatter import Formatter
+from streamlink.utils.id3v2 import ID3v2, ID3v2FrameError, parse_frame_priv
 from streamlink.utils.l10n import Language
 from streamlink.utils.num import to_float
 from streamlink.utils.times import now
@@ -45,6 +48,34 @@ if TYPE_CHECKING:
 
 
 log = getLogger(".".join(__name__.split(".")[:-1]))
+
+
+@dataclass
+class ID3v2FrameHLSPackedAudioTimestamp:
+    timestamp: float
+
+
+class ID3v2HLSPackedAudio(ID3v2):
+    @parse_frame_priv(b"com.apple.streaming.transportStreamTimestamp", ID3v2FrameHLSPackedAudioTimestamp)
+    def _parse_frame_priv_com_apple_streaming_transport_stream_timestamp(self, owner: bytes, data: bytearray):
+        if len(data) != 8:
+            raise ID3v2FrameError(f"Invalid data size for PRIV frame {owner.decode('ascii')}")
+        if data[0] & 0xFF or data[1] & 0xFF or data[2] & 0xFF or data[3] & 0xFE:
+            raise ID3v2FrameError(f"Invalid timestamp value for PRIV frame {owner.decode('ascii')}")
+
+        return unpack(">Q", data)[0] & 0x1FFFFFFFF
+
+
+def get_packed_audio_timestamp(tags: list[ID3v2HLSPackedAudio]) -> float | None:
+    return next(
+        (
+            frame.result.timestamp / 90000.0
+            for tag in tags
+            for frame in tag.frames
+            if type(frame.result) is ID3v2FrameHLSPackedAudioTimestamp
+        ),
+        None,
+    )
 
 
 class ByteRangeOffset:

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -31,6 +31,7 @@ from streamlink.utils.formatter import Formatter
 from streamlink.utils.id3v2 import ID3v2, ID3v2FrameError, parse_frame_priv
 from streamlink.utils.l10n import Language
 from streamlink.utils.num import to_float
+from streamlink.utils.thread import wait_for_all_events
 from streamlink.utils.times import now
 
 
@@ -685,6 +686,20 @@ class MuxedHLSStream(MuxedStream[TMuxedHLSStream_co]):
 
         super().__init__(session, *substreams, **ffmpeg_options)
         self.multivariant = multivariant if multivariant and multivariant.is_master else None
+
+    def _open_streams(self) -> list[HLSStreamReader]:  # type: ignore[override, ty:invalid-method-override]
+        fds: list[HLSStreamReader] = super()._open_streams()  # type: ignore[assignment, ty:invalid-assignment]
+        timeout = self.session.options.get("stream-timeout")
+
+        # wait for data to arrive in all streams
+        wait_for_all_events(*[fd.buffer.event_used for fd in fds], timeout=timeout)
+
+        itsoffset = [substream.packed_audio_timestamp for substream in self.substreams[1:]]
+        if any(o for o in itsoffset if o is not None):
+            self.options["itsoffset"] = [None, *itsoffset]
+            self.options["copyts"] = True
+
+        return fds
 
     def to_manifest_url(self):
         url = self.multivariant.uri if self.multivariant and self.multivariant.uri else None

--- a/src/streamlink/stream/hls/hls.py
+++ b/src/streamlink/stream/hls/hls.py
@@ -345,9 +345,25 @@ class HLSStreamWriter(SegmentedStreamWriter[HLSSegment, Response]):
         return True
 
     def _write_into_buffer(self, iterator: Iterator[bytes]) -> None:
+        if self.stream.parse_packed_audio:
+            iterator = self._parse_packed_audio_timestamp(iterator)
+
         buffer = self.reader.buffer
         for chunk in iterator:
             buffer.write(chunk)
+
+    def _parse_packed_audio_timestamp(self, iterator: Iterator[bytes]) -> Iterator[bytes]:
+        # strip and parse ID3v2 tags at the beginning of each segment
+        tags, iterator = ID3v2HLSPackedAudio.parse_tags(iterator)
+
+        # don't expect tags in any following segments if no tags were found, e.g. if it's no packed audio stream
+        if not tags:
+            self.stream.parse_packed_audio = False
+
+        elif self.stream.packed_audio_timestamp is None and (timestamp := get_packed_audio_timestamp(tags)):
+            self.stream.packed_audio_timestamp = timestamp
+
+        return iterator
 
     # noinspection PyMethodMayBeStatic
     def get_segment_content(self, segment: HLSSegment, response: Response) -> bytes:
@@ -716,6 +732,9 @@ class HLSStream(HTTPStream):
         self.force_restart = force_restart
         self.start_offset = start_offset
         self.duration = duration
+
+        self.parse_packed_audio: bool = True
+        self.packed_audio_timestamp: float | None = None
 
     def __json__(self):  # ruff: ignore[bad-dunder-method-name]
         json = super().__json__()

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import logging
 import os
+import struct
 import unittest
 from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
@@ -1973,3 +1974,45 @@ class TestID3v2HLSPackedAudio:
         assert tag.frames[0].result is None
         assert isinstance(tag.frames[0].error, ID3v2FrameError)
         assert str(tag.frames[0].error) == "Invalid data size for PRIV frame com.apple.streaming.transportStreamTimestamp"
+
+
+@patch("streamlink.stream.hls.hls.HLSStreamWorker.wait", Mock(return_value=True))
+class TestHlsPackedAudio(TestMixinStreamHLS, unittest.TestCase):
+    class PASegment(Segment):
+        def __init__(self, *args, ts: int = 0, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.audio_content = self.content
+            self.content = b"".join([
+                b"ID3\x04\x00\x00\x00\x00\x00\x3f",
+                b"PRIV\x00\x00\x00\x35\x00\x00",
+                b"com.apple.streaming.transportStreamTimestamp",
+                b"\x00",
+                struct.pack(">Q", ts),
+                self.content,
+            ])
+
+    def test_packed_audio_stream(self):
+        mocked_get_packed_audio_timestamp = Mock(side_effect=get_packed_audio_timestamp)
+        with patch("streamlink.stream.hls.hls.get_packed_audio_timestamp", mocked_get_packed_audio_timestamp):
+            segments = self.subject([
+                Playlist(0, [self.PASegment(0, ts=1234), self.PASegment(1, ts=1235)], end=True),
+            ])
+            data = self.await_read(read_all=True)
+
+        assert data == self.content(segments, prop="audio_content")
+        assert self.stream.packed_audio_timestamp == pytest.approx(1234 / 90000)
+        assert self.stream.parse_packed_audio
+        assert mocked_get_packed_audio_timestamp.call_count == 1
+
+    def test_no_packed_audio_stream(self):
+        mocked_get_packed_audio_timestamp = Mock(side_effect=get_packed_audio_timestamp)
+        with patch("streamlink.stream.hls.hls.get_packed_audio_timestamp", mocked_get_packed_audio_timestamp):
+            segments = self.subject([
+                Playlist(0, [Segment(0), Segment(1)], end=True),
+            ])
+            data = self.await_read(read_all=True)
+
+        assert data == self.content(segments, prop="content")
+        assert self.stream.packed_audio_timestamp is None
+        assert not self.stream.parse_packed_audio
+        assert mocked_get_packed_audio_timestamp.call_count == 0

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -2016,3 +2016,43 @@ class TestHlsPackedAudio(TestMixinStreamHLS, unittest.TestCase):
         assert self.stream.packed_audio_timestamp is None
         assert not self.stream.parse_packed_audio
         assert mocked_get_packed_audio_timestamp.call_count == 0
+
+
+@pytest.mark.parametrize(
+    ("timestamps", "itsoffset", "copyts"),
+    [
+        pytest.param([], [], None, id="no-packed-audio"),
+        pytest.param([None, 123], [None, 123, None], True, id="first"),
+        pytest.param([None, None, 123], [None, None, 123], True, id="second"),
+        pytest.param([None, 123, 456], [None, 123, 456], True, id="both"),
+    ],
+)
+def test_muxedhlsstream_packed_audio_ffmpeg_options(
+    monkeypatch: pytest.MonkeyPatch,
+    session: Streamlink,
+    timestamps: list,
+    itsoffset: list,
+    copyts: bool,
+):
+    def reader_open(reader: HLSStreamReader):
+        reader.buffer.event_used.set()
+
+    fake_streamio = object()
+    fake_ffmpegmuxer = Mock(open=Mock(return_value=fake_streamio))
+    monkeypatch.setattr("streamlink.stream.segmented.segmented.SegmentedStreamReader.open", reader_open)
+    monkeypatch.setattr("streamlink.stream.ffmpegmux.FFMPEGMuxer", Mock(return_value=fake_ffmpegmuxer))
+
+    packed_audio_stream = MuxedHLSStream[HLSStream](
+        session,
+        "mocked://video/1",
+        ["mocked://audio/1", "mocked://audio/2"],
+    )
+    assert len(packed_audio_stream.substreams) == 3
+
+    for idx, timestamp in enumerate(timestamps):
+        packed_audio_stream.substreams[idx].packed_audio_timestamp = timestamp
+
+    assert packed_audio_stream.open() is fake_streamio
+    assert packed_audio_stream.options.get("format") == "mpegts"
+    assert packed_audio_stream.options.get("itsoffset", []) == itsoffset
+    assert packed_audio_stream.options.get("copyts") is copyts

--- a/tests/stream/hls/test_hls.py
+++ b/tests/stream/hls/test_hls.py
@@ -28,13 +28,21 @@ from streamlink.stream.hls import (
     M3U8Parser,
     MuxedHLSStream,
 )
-from streamlink.stream.hls.hls import log
+from streamlink.stream.hls.hls import (
+    ID3v2FrameHLSPackedAudioTimestamp,
+    ID3v2HLSPackedAudio,
+    get_packed_audio_timestamp,
+    log,
+)
 from streamlink.utils.crypto import AES, pad
+from streamlink.utils.id3v2 import ID3v2FrameError
 from tests.mixins.stream_hls import EventedHLSStreamWorker, EventedHLSStreamWriter, Playlist, Segment, Tag, TestMixinStreamHLS
 from tests.resources import text
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from streamlink.session import Streamlink
 
 
@@ -1900,3 +1908,68 @@ class TestM3U8ParserLogging:
         parser.parse(data)
 
         assert bool(caplog.records) is has_logs
+
+
+class TestID3v2HLSPackedAudio:
+    @pytest.fixture()
+    def iterator(self):
+        return iter([
+            # first valid tag
+            b"ID3\x04\x00\x00\x00\x00\x00\x3f",
+            b"PRIV\x00\x00\x00\x35\x00\x00",
+            b"com.apple.streaming.transportStreamTimestamp",
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x01",
+            # second valid tag
+            b"ID3\x04\x00\x00\x00\x00\x00\x3f",
+            b"PRIV\x00\x00\x00\x35\x00\x00",
+            b"com.apple.streaming.transportStreamTimestamp",
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x02",
+            # packed audio data
+            b"remaining",
+        ])
+
+    def test_get_packed_audio_timestamp(self, iterator: Iterator[bytes]):
+        tags, iterator = ID3v2HLSPackedAudio.parse_tags(iterator)
+        assert get_packed_audio_timestamp(tags) == pytest.approx(1 / 90000)
+
+    def test_frames(self, iterator: Iterator[bytes]):
+        (first, second), iterator = ID3v2HLSPackedAudio.parse_tags(iterator)
+        assert b"".join(iterator) == b"remaining"
+
+        assert first.frames[0].ident == b"PRIV"
+        assert first.frames[0].result == ID3v2FrameHLSPackedAudioTimestamp(1)
+        assert first.frames[0].error is None
+
+        assert second.frames[0].ident == b"PRIV"
+        assert second.frames[0].result == ID3v2FrameHLSPackedAudioTimestamp(2)
+        assert second.frames[0].error is None
+
+    def test_invalid_timestamp(self):
+        iterator = iter([
+            b"ID3\x04\x00\x00\x00\x00\x00\x3f",
+            b"PRIV\x00\x00\x00\x35\x00\x00",
+            b"com.apple.streaming.transportStreamTimestamp",
+            b"\x00\x12\x34\x56\x78\x9a\xbc\xde\xf0",
+            b"remaining",
+        ])
+        (tag,), iterator = ID3v2HLSPackedAudio.parse_tags(iterator)
+        assert b"".join(iterator) == b"remaining"
+
+        assert tag.frames[0].result is None
+        assert isinstance(tag.frames[0].error, ID3v2FrameError)
+        assert str(tag.frames[0].error) == "Invalid timestamp value for PRIV frame com.apple.streaming.transportStreamTimestamp"
+
+    def test_invalid_size(self):
+        iterator = iter([
+            b"ID3\x04\x00\x00\x00\x00\x00\x40",
+            b"PRIV\x00\x00\x00\x36\x00\x00",
+            b"com.apple.streaming.transportStreamTimestamp",
+            b"\x00\x00\x00\x00\x00\x00\x00\x00\x03\x00",
+            b"remaining",
+        ])
+        (tag,), iterator = ID3v2HLSPackedAudio.parse_tags(iterator)
+        assert b"".join(iterator) == b"remaining"
+
+        assert tag.frames[0].result is None
+        assert isinstance(tag.frames[0].error, ID3v2FrameError)
+        assert str(tag.frames[0].error) == "Invalid data size for PRIV frame com.apple.streaming.transportStreamTimestamp"


### PR DESCRIPTION
Resolves #4721 
Enabled by #7082, #7081, #7059

This adds support for HLS packed audio streams.

- [x] First commits adds the ID3v2 `PRIV` frame parser for `com.apple.streaming.transportStreamTimestamp`.
- [x] Second commit refactors buffer write calls, so both decrypted and non-encrypted segments can be parsed
- [x] Third commit adds the `packed_audio_timestamp` attribute to `HLSStream` and makes the `HLSStreamWriter` parse (and discard) the ID3v2 tags at the beginning of each segment. If no tags were found, then no further attempts will be made to parse in follow-up segments. This avoids unnecessary work on regular streams.
- [x] Fourth commit updates the `HLSMuxedStream` and makes it set the `itsoffset` option with the parsed audio stream timestamp offsets. To do that, it first needs to wait for all substreams to have data in their buffers. When data is available, this means that the ID3v2 metadata was parsed, so it can then properly be set in the FFmpeg argv. If data was not available in time, then no `itsoffset` option value can be set for those particular substreams, but the `open()` call won't fail because of that.

----

**One important note:** (see #6472)

Since there's no segment synchronization between the individual `HLSStream`s in a `HLSMuxedStream` (unlike in Streamlink's DASH implementation where there's only one data manifest), this means that depending on the access time of each media playlist, the first downloaded segment might not match ones from other playlists.

This means that the beginning of the overall stream output might miss data from the other sub-streams, either the video or the audio stream. FFmpeg will be fed with the data of all streams immediately, but as it receives the correct PTS values for packed audio streams, the streams will be aligned properly. The end result is that there will be no audio for a short time at the beginning if the video stream started eariler, or if the audio stream started earlier than the video stream, the player will show a black screen or will wait with its output.

However, even if #6472 were resolved, syncing HLS segments accross media playlists (if program date time metadata is available) doesn't guarantee that the video+audio streams are fully/correctly aligned. There might still be a slight offset, still causing a tiny unnoticable delay with the packed audio stream implementation.