### PR TITLE
ci: ensure git fetch depth on all CI services

### DIFF
--- a/.github/workflows/scripts/fetch-tags.sh
+++ b/.github/workflows/scripts/fetch-tags.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+TARGET_DEPTH=300
+CURRENT_DEPTH=$(git rev-list --count HEAD)
+
+if [[ $(git rev-parse --is-shallow-repository) == "true" && CURRENT_DEPTH -lt TARGET_DEPTH ]]; then
+  git fetch --no-tags --deepen=$((TARGET_DEPTH - CURRENT_DEPTH))
+fi
+
 # Fetch only the tags within our shallow-clone depth (set to 300 commits by @actions/checkout),
 # so we can avoid fetching the entire repo, as it includes a BLOB that was committed years ago:
 # 1. Query the remote


### PR DESCRIPTION
RTD hardcodes a fetch depth of 50, which breaks the fetch tags script after just 50 commits, making the PR docs preview fail. The GH actions fetch depth on the other hand is configurable. It's set to 300 for many years and has thus never caused problems. The RTD issue has now occured because of the recent rewrite of the fetch tags script.