### PR TITLE
plugins.goodgame: fix stream retrieval

### DIFF
--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -37,6 +37,9 @@ class GoodGame(Plugin):
     _API_PLAYER = "https://goodgame.ru/api/player"
     _API_STREAM = "https://goodgame.ru/api/4/users/{channel}/stream"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.session.set_option("hls-playlist-reload-time", "segment")
 
     def _get_channel_from_player(self):
         return self.session.http.get(

--- a/src/streamlink/plugins/goodgame.py
+++ b/src/streamlink/plugins/goodgame.py
@@ -9,12 +9,13 @@ $metadata title
 """
 
 import re
-import sys
+from urllib.parse import urlparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
+from streamlink.utils.parse import parse_qsd
 
 
 log = getLogger(__name__)
@@ -36,11 +37,6 @@ class GoodGame(Plugin):
     _API_PLAYER = "https://goodgame.ru/api/player"
     _API_STREAM = "https://goodgame.ru/api/4/users/{channel}/stream"
 
-    @classmethod
-    def stream_weight(cls, stream: str) -> tuple[float, str]:
-        if stream == "source":
-            return sys.maxsize, stream
-        return super().stream_weight(stream)
 
     def _get_channel_from_player(self):
         return self.session.http.get(
@@ -77,7 +73,7 @@ class GoodGame(Plugin):
                                 "username": str,
                             },
                             "sources": {
-                                str: validate.url(),
+                                "master": validate.url(),
                             },
                             "gameObj": {
                                 "title": validate.none_or_all(str),
@@ -90,7 +86,7 @@ class GoodGame(Plugin):
                             ("streamer", "username"),
                             ("gameObj", "title"),
                             "title",
-                            "sources",
+                            ("sources", "master"),
                         ),
                         validate.transform(lambda data: ("data", *data)),
                     ),
@@ -109,20 +105,14 @@ class GoodGame(Plugin):
             log.error(data[0] or "Unknown error")
             return
 
-        online, self.id, self.author, self.category, self.title, sources = data
+        online, self.id, self.author, self.category, self.title, stream_url = data
 
         if not online:
             return
 
-        streams = {}
-        for name, hls_url in sources.items():
-            if str.isnumeric(name):
-                name = f"{name}p"
-            elif name != "source":
-                continue
-            streams[name] = HLSStream(self.session, hls_url)
-
-        return streams
+        parsed = urlparse(stream_url)
+        params = parse_qsd(parsed.query)
+        return HLSStream.parse_variant_playlist(self.session, stream_url, params=params)
 
 
 __plugin__ = GoodGame


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

Closes: #7084 

```
$ ./script/test-plugin-urls.py goodgame -r CHANNELNAME AiBot -r CHANNELID 218490
:: https://goodgame.ru/AiBot
::  1080p60, worst, best
:: https://goodgame.ru/AiBot/
::  1080p60, worst, best
:: https://goodgame.ru/AiBot?foo=bar
::  1080p60, worst, best
:: https://goodgame.ru/player?218490
::  1080p60, worst, best
:: https://www.goodgame.ru/AiBot
::  1080p60, worst, best
:: https://www.goodgame.ru/player?218490
::  1080p60, worst, best
```

```
streamlink -l debug -o/dev/null --stream-segmented-duration 1 https://goodgame.ru/AiBot best
[session][debug] Loading plugin: goodgame
[cli][debug] OS:         Linux-6.18.33.2-microsoft-standard-WSL2-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.3
[cli][debug] OpenSSL:    OpenSSL 3.0.13 30 Jan 2024
[cli][debug] Streamlink: 8.5.0+48.gc9b69438.dirty
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.7.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.3
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.34.2
[cli][debug]  trio: 0.34.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.16.0
[cli][debug]  urllib3: 2.7.0
[cli][debug]  websocket-client: 1.9.2
[cli][debug] Arguments:
[cli][debug]  url=https://goodgame.ru/AiBot
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --output=/dev/null
[cli][debug]  --stream-segmented-duration=1.0
[cli][info] Found matching plugin goodgame for URL https://goodgame.ru/AiBot
[utils.l10n][debug] Language code: en_US
[stream.ffmpegmux][debug] ffmpeg version 6.1.1-3ubuntu5 Copyright (c) 2000-2023 the FFmpeg developers
[stream.ffmpegmux][debug]  built with gcc 13 (Ubuntu 13.2.0-23ubuntu3)
[stream.ffmpegmux][debug]  configuration: --prefix=/usr --extra-version=3ubuntu5 --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --disable-omx --enable-gnutls --enable-libaom --enable-libass --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libdav1d --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libglslang --enable-libgme --enable-libgsm --enable-libharfbuzz --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzimg --enable-openal --enable-opencl --enable-opengl --disable-sndio --enable-libvpl --disable-libmfx --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-ladspa --enable-libbluray --enable-libjack --enable-libpulse --enable-librabbitmq --enable-librist --enable-libsrt --enable-libssh --enable-libsvtav1 --enable-libx264 --enable-libzmq --enable-libzvbi --enable-lv2 --enable-sdl2 --enable-libplacebo --enable-librav1e --enable-pocketsphinx --enable-librsvg --enable-libjxl --enable-shared
[stream.ffmpegmux][debug]  libavutil      58. 29.100 / 58. 29.100
[stream.ffmpegmux][debug]  libavcodec     60. 31.102 / 60. 31.102
[stream.ffmpegmux][debug]  libavformat    60. 16.100 / 60. 16.100
[stream.ffmpegmux][debug]  libavdevice    60.  3.100 / 60.  3.100
[stream.ffmpegmux][debug]  libavfilter     9. 12.100 /  9. 12.100
[stream.ffmpegmux][debug]  libswscale      7.  5.100 /  7.  5.100
[stream.ffmpegmux][debug]  libswresample   4. 12.100 /  4. 12.100
[stream.ffmpegmux][debug]  libpostproc    57.  3.100 / 57.  3.100
[stream.hls][debug] Using external audio tracks for stream 1080p60 (language=None, name=Audio)
[cli][info] Available streams: 1080p60 (worst, best)
[cli][info] Opening stream: 1080p60 (hls-multi)
[cli][info] Writing output to
/dev/null
[cli][debug] Checking file output
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[stream.ffmpegmux][debug] Opening hls substream
[stream.hls][debug] Reloading playlist
[utils.named_pipe][info] Creating pipe streamlinkpipe-89378-1-1116
[utils.named_pipe][info] Creating pipe streamlinkpipe-89378-2-9376
[stream.ffmpegmux][debug] ffmpeg command: ['/usr/bin/ffmpeg', '-y', '-nostats', '-loglevel', 'info', '-i', '/tmp/streamlinkpipe-89378-1-1116', '-i', '/tmp/streamlinkpipe-89378-2-9376', '-c:v', 'copy', '-c:a', 'copy', '-map', '0:v?', '-map', '0:a?', '-map', '1:a', '-f', 'mpegts', 'pipe:1']
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-89378-1-1116
[stream.ffmpegmux][debug] Starting copy to pipe: /tmp/streamlinkpipe-89378-2-9376
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 20777; Last Sequence: 20780
[stream.hls][debug] First Sequence: 20777; Last Sequence: 20780
[stream.hls][debug] Start offset: -0.0; Duration: 1.0; Start Sequence: 20778; End Sequence: None
[stream.hls][debug] Start offset: -0.0; Duration: 1.0; Start Sequence: 20778; End Sequence: None
[stream.segmented][debug] Queuing HLSSegment(num=20778, init=False, discontinuity=False, duration=2.000, title=None, key=None, byterange=None, date=None, map=Map(key=None, byterange=None), fileext='m4s')
[stream.segmented][debug] Queuing HLSSegment(num=20778, init=False, discontinuity=False, duration=1.984, title=None, key=None, byterange=None, date=None, map=Map(key=None, byterange=None), fileext='m4s')
[stream.segmented][info] Stopping stream early after 1.00s
[stream.segmented][info] Stopping stream early after 1.00s
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 20778 to output
[stream.hls][debug] Segment initialization 20778 complete
[stream.hls][debug] Writing segment 20778 to output
[stream.hls][debug] Segment initialization 20778 complete
[stream.hls][debug] Writing segment 20778 to output
[stream.hls][debug] Segment 20778 complete
[stream.segmented][debug] Closing writer thread
[stream.hls][debug] Writing segment 20778 to output
[stream.hls][debug] Segment 20778 complete
[stream.segmented][debug] Closing writer thread
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-89378-2-9376
[cli][debug] Writing stream to output
[stream.ffmpegmux][debug] Pipe copy complete: /tmp/streamlinkpipe-89378-1-1116
[stream.ffmpegmux][debug] Closing ffmpeg thread
[stream.ffmpegmux][debug] Closed all the substreams
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[download] Written 1.49 MiB to /dev/null (0s)

```