### PR TITLE
plugins.okru: update metadata scheme

### DIFF
--- a/src/streamlink/plugins/okru.py
+++ b/src/streamlink/plugins/okru.py
@@ -74,9 +74,9 @@ class OKru(Plugin):
             self._canonicalize_mobile_url()
 
         schema_metadata = validate.Schema(
-            validate.parse_json(),
             {
                 validate.optional("author"): validate.all({validate.optional("name"): str}, validate.get("name")),
+                validate.optional("compilationTitle"): str,
                 validate.optional("movie"): validate.all(
                     {
                         validate.optional("id"): str,
@@ -108,7 +108,7 @@ class OKru(Plugin):
                 validate.parse_json(),
                 {
                     "flashvars": {
-                        validate.optional("metadata"): str,
+                        validate.optional("metadata"): dict,
                         validate.optional("metadataUrl"): validate.all(
                             validate.transform(unquote),
                             validate.url(),
@@ -129,7 +129,7 @@ class OKru(Plugin):
 
         data = schema_metadata.validate(metadata)
 
-        self.author = data.get("author")
+        self.author = data.get("author") or data.get("compilationTitle")
         self.id, self.title = data.get("movie", (None, None))
 
         for hls_url in data.get("hlsManifestUrl"), data.get("hlsMasterPlaylistUrl"):


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----
Closes: #7089

I also added `compilationTitle` property as an alternative to `author`. However, this property is missing for VODs embedded via `https://ok.ru/videoembed`
```
$ ./script/test-plugin-urls.py -m okru -r ID 3503444925978
:: https://m.ok.ru/video/3503444925978
::  240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '3503444925978', 'author': 'Прямой эфир ОТВ-Прим', 'category': None, 'title': 'Прямая трансляция телеканала "Общественное телевидение Приморья"'}
:: https://mobile.ok.ru/video/3503444925978
::  240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '3503444925978', 'author': 'Прямой эфир ОТВ-Прим', 'category': None, 'title': 'Прямая трансляция телеканала "Общественное телевидение Приморья"'}
:: https://ok.ru/live/3503444925978
::  240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '3503444925978', 'author': 'Прямой эфир ОТВ-Прим', 'category': None, 'title': 'Прямая трансляция телеканала "Общественное телевидение Приморья"'}
:: https://ok.ru/video/3503444925978
::  240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '3503444925978', 'author': 'Прямой эфир ОТВ-Прим', 'category': None, 'title': 'Прямая трансляция телеканала "Общественное телевидение Приморья"'}
:: https://ok.ru/videoembed/3503444925978
::  240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '3503444925978', 'author': 'Прямой эфир ОТВ-Прим', 'category': None, 'title': 'Прямая трансляция телеканала "Общественное телевидение Приморья"'}
:: https://www.ok.ru/video/3503444925978
::  240p, 360p, 480p, 720p, 1080p, worst, best
::   {'id': '3503444925978', 'author': 'Прямой эфир ОТВ-Прим', 'category': None, 'title': 'Прямая трансляция телеканала "Общественное телевидение Приморья"'}
```
```
$ streamlink -l debug -o/dev/null --stream-segmented-duration 1 https://ok.ru/live/3503444925978 best
[session][debug] Loading plugin: okru
[cli][debug] OS:         Linux-6.18.33.2-microsoft-standard-WSL2-x86_64-with-glibc2.39
[cli][debug] Python:     3.12.3
[cli][debug] OpenSSL:    OpenSSL 3.0.13 30 Jan 2024
[cli][debug] Streamlink: 8.5.0+61.g98b58b9b.dirty
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.7.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.3
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.34.2
[cli][debug]  trio: 0.34.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.16.0
[cli][debug]  urllib3: 2.7.0
[cli][debug]  websocket-client: 1.9.2
[cli][debug] Arguments:
[cli][debug]  url=https://ok.ru/live/3503444925978
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --output=/dev/null
[cli][debug]  --stream-segmented-duration=1.0
[cli][info] Found matching plugin okru for URL https://ok.ru/live/3503444925978
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)
[cli][info] Opening stream: 1080p (hls)
[cli][info] Writing output to
/dev/null
[cli][debug] Checking file output
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 843959; Last Sequence: 843981
[stream.hls][debug] Start offset: -0.0; Duration: 1.0; Start Sequence: 843979; End Sequence: None
[stream.segmented][debug] Queuing HLSSegment(num=843979, init=False, discontinuity=False, duration=2.000, title=None, key=None, byterange=None, date=None, map=None, fileext='ts')
[stream.segmented][info] Stopping stream early after 1.00s
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 843979 to output
[stream.hls][debug] Segment 843979 complete
[stream.segmented][debug] Closing writer thread
[cli][debug] Writing stream to output
[cli][info] Stream ended
[cli][info] Closing currently open stream...
[download] Written 2.15 MiB to /dev/null (0s)
```

