### PR TITLE
plugins.zdf_mediathek: rewrite and fix plugin

### DIFF
--- a/src/streamlink/plugins/zdf_mediathek.py
+++ b/src/streamlink/plugins/zdf_mediathek.py
@@ -2,118 +2,231 @@
 $description Live TV channels and video on-demand service from ZDF, a German public, independent broadcaster.
 $url zdf.de
 $type live, vod
+$metadata id
+$metadata title
 $region Germany
 """
 
+from __future__ import annotations
+
 import re
-from urllib.parse import urlparse, urlunparse
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSStream
-from streamlink.utils.url import url_concat
+from streamlink.stream.http import HTTPStream
 
 
 log = getLogger(__name__)
 
 
 @pluginmatcher(
-    re.compile(r"https?://(\w+\.)?(zdf\.de|3sat\.de)/"),
+    re.compile(r"https?://(?:\w+\.)?zdf\.de/play/(?P<category>[^/]+)/[^/]+/(?P<video_id>[^\s?#]+)"),
 )
 class ZDFMediathek(Plugin):
-    PLAYER_ID = "ngplayer_2_4"
+    _URL_CONFIGURATION = "https://ngp.zdf.de/configs/zdf/zdfmt25/configuration.json"
+    _URL_API = "https://api.zdf.de/{path}"
 
-    def _get_streams(self):
-        zdf_json = self.session.http.get(
-            self.url,
-            schema=validate.Schema(
-                validate.parse_html(),
-                validate.xml_xpath_string(".//*[@data-zdfplayer-jsb][1]/@data-zdfplayer-jsb"),
-                validate.none_or_all(
-                    validate.parse_json(),
-                    {
-                        "apiToken": str,
-                        "content": validate.url(),
-                    },
-                    validate.union_get("apiToken", "content"),
-                ),
-            ),
-        )
-        if zdf_json is None:
-            return
-
-        apiToken, apiUrl = zdf_json
-
-        headers = {
-            "Accept": "application/vnd.de.zdf.v1.0+json;charset=UTF-8",
-            "Api-Auth": f"Bearer {apiToken}",
-            "Referer": self.url,
+    # noinspection GraphQLUnresolvedReference
+    # language=graphql
+    _QUERY_VIDEO_BY_CANONICAL = """
+        query VideoByCanonical($canonical: String!) {
+            videoByCanonical(canonical: $canonical) {
+                id
+                title
+                currentMedia {
+                    nodes {
+                        ptmdTemplate
+                        ... on LiveMedia {
+                            liveMediaType
+                        }
+                        ... on VodMedia {
+                            vodMediaType
+                        }
+                    }
+                }
+            }
         }
+    """
 
-        pApiUrl = urlparse(apiUrl)
-        apiUrlBase = urlunparse((pApiUrl.scheme, pApiUrl.netloc, "", "", "", ""))
-        apiUrlPath = self.session.http.get(
-            apiUrl,
-            headers=headers,
+    def _video_by_canonical(self, auth: str, canonical: str):
+        return self.session.http.post(
+            self._URL_API.format(path="graphql"),
+            headers={
+                "Api-Auth": f"Bearer {auth}",
+            },
+            json={
+                "operationName": "VideoByCanonical",
+                "query": re.sub(r"\s+", " ", self._QUERY_VIDEO_BY_CANONICAL).strip(),
+                "variables": {
+                    "canonical": canonical,
+                },
+            },
             schema=validate.Schema(
                 validate.parse_json(),
                 {
-                    "mainVideoContent": {
-                        "http://zdf.de/rels/target": {
-                            "http://zdf.de/rels/streams/ptmd-template": str,
-                        },
+                    "data": {
+                        "videoByCanonical": validate.none_or_all(
+                            {
+                                "id": str,
+                                "title": str,
+                                "currentMedia": validate.all(
+                                    {
+                                        "nodes": [
+                                            validate.all(
+                                                {
+                                                    "ptmdTemplate": str,
+                                                    validate.optional("liveMediaType"): str,
+                                                    validate.optional("vodMediaType"): str,
+                                                },
+                                                validate.union_get(
+                                                    "ptmdTemplate",
+                                                    "liveMediaType",
+                                                    "vodMediaType",
+                                                ),
+                                            ),
+                                        ],
+                                    },
+                                    validate.get("nodes"),
+                                ),
+                            },
+                            validate.union_get(
+                                "id",
+                                "title",
+                                "currentMedia",
+                            ),
+                        ),
                     },
                 },
-                validate.get(("mainVideoContent", "http://zdf.de/rels/target", "http://zdf.de/rels/streams/ptmd-template")),
-                validate.transform(lambda template: template.format(playerId=self.PLAYER_ID).replace(" ", "")),
+                validate.get(("data", "videoByCanonical")),
             ),
         )
 
-        stream_request_url = url_concat(apiUrlBase, apiUrlPath)
-        data = self.session.http.get(
-            stream_request_url,
-            headers=headers,
+    def _get_stream_data(self, auth: str, path: str):
+        return self.session.http.get(
+            self._URL_API.format(path=path.lstrip("/")),
+            headers={
+                "Api-Auth": f"Bearer {auth}",
+            },
             schema=validate.Schema(
                 validate.parse_json(),
                 {
                     "priorityList": [
-                        {
-                            "formitaeten": validate.all(
-                                [
-                                    {
-                                        "type": str,
-                                        "qualities": validate.all(
-                                            [
-                                                {
-                                                    "quality": str,
-                                                    "audio": {
-                                                        "tracks": [
-                                                            {
-                                                                "uri": validate.url(),
-                                                            },
-                                                        ],
+                        validate.all(
+                            {
+                                "formitaeten": [
+                                    validate.all(
+                                        {
+                                            "mimeType": str,
+                                            "qualities": [
+                                                validate.all(
+                                                    {
+                                                        "quality": str,
+                                                        validate.optional("highestVerticalResolution"): int,
+                                                        "audio": {
+                                                            "tracks": [
+                                                                validate.all(
+                                                                    {
+                                                                        "class": str,
+                                                                        "uri": validate.url(),
+                                                                    },
+                                                                    validate.union_get(
+                                                                        "class",
+                                                                        "uri",
+                                                                    ),
+                                                                ),
+                                                            ],
+                                                        },
                                                     },
-                                                },
+                                                    validate.union_get(
+                                                        "quality",
+                                                        "highestVerticalResolution",
+                                                        ("audio", "tracks"),
+                                                    ),
+                                                ),
                                             ],
-                                            validate.filter(lambda obj: obj["quality"] == "auto"),
+                                        },
+                                        validate.union_get(
+                                            "mimeType",
+                                            "qualities",
                                         ),
-                                    },
+                                    ),
                                 ],
-                                validate.filter(lambda obj: obj["type"] == "h264_aac_ts_http_m3u8_http"),
-                            ),
-                        },
+                            },
+                            validate.get("formitaeten", []),
+                        ),
                     ],
                 },
-                validate.get("priorityList"),
+                validate.get(("priorityList", 0), []),
             ),
         )
 
-        for priority in data:
-            for formitaeten in priority["formitaeten"]:
-                for quality in formitaeten["qualities"]:
-                    for audio in quality["audio"]["tracks"]:
-                        yield from HLSStream.parse_variant_playlist(self.session, audio["uri"], headers=headers).items()
+    def _get_api_token(self):
+        return self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[contains(text(),'apiAuthToken')][1]/text()"),
+                validate.none_or_all(
+                    validate.regex(re.compile(r"""self\.__next_f\.push\(\[\d+,\s*(?P<data>".+?")]\)""")),
+                    validate.get("data"),
+                    validate.parse_json(),
+                    validate.regex(re.compile(r'''"apiAuthToken":"(?P<token>.+?)"''')),
+                    validate.get("token"),
+                ),
+            ),
+        )
+
+    def _get_player_id(self):
+        return self.session.http.get(
+            self._URL_CONFIGURATION,
+            schema=validate.Schema(
+                validate.parse_json(),
+                {
+                    "ptmdPlayerId": str,
+                },
+                validate.get("ptmdPlayerId"),
+            ),
+        )
+
+    def _get_streams(self) -> dict | None:
+        if self.match["category"] == "zapping":
+            log.error("Zapping video URLs are not supported")
+            return None
+
+        player_id = self._get_player_id()
+        api_token = self._get_api_token()
+
+        data = self._video_by_canonical(auth=api_token, canonical=self.match["video_id"])
+        if not data:
+            return None
+
+        media: list[tuple[str, str | None, str | None]]
+        self.id, self.title, media = data
+
+        path: str | None = next(
+            (path for path, *media_types in media if "DEFAULT" in media_types),
+            next((path for path, *_ in media), None),
+        )
+        if not path:
+            return None
+
+        stream_data = self._get_stream_data(auth=api_token, path=path.replace("{playerId}", player_id, 1))
+
+        result = {}
+        for stream_type, qualities in stream_data:
+            for quality, resolution, streams in qualities:
+                for stream_class, url in streams:
+                    if stream_class != "main":
+                        continue
+                    match stream_type:
+                        case "application/x-mpegURL" if quality == "auto":
+                            return HLSStream.parse_variant_playlist(self.session, url)
+                        case _ if stream_type.startswith("video/"):
+                            result[f"{resolution}p"] = HTTPStream(self.session, url)
+
+        return result
 
 
 __plugin__ = ZDFMediathek

--- a/tests/plugins/test_zdf_mediathek.py
+++ b/tests/plugins/test_zdf_mediathek.py
@@ -5,16 +5,25 @@ from tests.plugins import PluginCanHandleUrl
 class TestPluginCanHandleUrlZDFMediathek(PluginCanHandleUrl):
     __plugin__ = ZDFMediathek
 
-    should_match = [
-        "http://www.zdf.de/live-tv",
-        "https://www.zdf.de/sender/zdf/zdf-live-beitrag-100.html",
-        "https://www.zdf.de/sender/zdfneo/zdfneo-live-beitrag-100.html",
-        "https://www.zdf.de/sender/3sat/3sat-live-beitrag-100.html",
-        "https://www.zdf.de/sender/phoenix/phoenix-live-beitrag-100.html",
-        "https://www.zdf.de/sender/arte/arte-livestream-100.html",
-        "https://www.zdf.de/sender/kika/kika-live-beitrag-100.html",
-        "https://www.zdf.de/dokumentation/zdfinfo-doku/zdfinfo-live-beitrag-100.html",
-        "https://www.zdf.de/comedy/heute-show/videos/diy-hazel-habeck-100.html",
-        "https://www.zdf.de/nachrichten/heute-sendungen/so-wird-das-wetter-102.html",
-        "https://www.3sat.de/wissen/nano",
+    should_match_groups = [
+        (
+            "https://www.zdf.de/play/live-tv/sender/zdf-live-beitrag-100",
+            {"category": "live-tv", "video_id": "zdf-live-beitrag-100"},
+        ),
+        (
+            "https://www.zdf.de/play/live-tv/sender/zdfinfo-live-beitrag-100",
+            {"category": "live-tv", "video_id": "zdfinfo-live-beitrag-100"},
+        ),
+        (
+            "https://www.zdf.de/play/live-tv/sender/arte-livestream-100",
+            {"category": "live-tv", "video_id": "arte-livestream-100"},
+        ),
+        (
+            "https://www.zdf.de/play/magazine/heute-106/260906-heute-sendung-17-uhr-100",
+            {"category": "magazine", "video_id": "260906-heute-sendung-17-uhr-100"},
+        ),
+        (
+            "https://www.zdf.de/play/dokus/terra-x-unsere-waelder-100/unsere-waelder-ein-jahr-unter-baeumen-100",
+            {"category": "dokus", "video_id": "unsere-waelder-ein-jahr-unter-baeumen-100"},
+        ),
     ]


### PR DESCRIPTION
Resolves #6508

Similar to the ard\_mediathek plugin, fixing is now possible with the added support for packed audio streams.

"Zapping" input URLs are not supported. These include a "non-canonical" video ID which matches a single item of a large nested list of VODs queried from the GQL API. This nested list is categorized by "clusters" and each item has a timestamp value which cycles throughout the day. Not worth the effort to implement this.

```
$ ./script/test-plugin-urls.py -m zdf_mediathek
:: https://www.zdf.de/play/dokus/terra-x-unsere-waelder-100/unsere-waelder-ein-jahr-unter-baeumen-100
::  176p, 272p, 360p, 480p, 576p, 720p, worst, best
::   {'id': 'b7f22e4e-11fb-4d63-bf2e-3e60306ceb88', 'author': None, 'category': None, 'title': 'Ein Jahr unter Bäumen'}
:: https://www.zdf.de/play/live-tv/sender/arte-livestream-100
::  180p_alt, 180p, 240p_alt, 240p, 360p_alt, 360p, 540p_alt, 540p, 720p_alt, 720p, worst, best
::   {'id': '539f547e-8e8f-47c5-8593-340b27190a2a', 'author': None, 'category': None, 'title': 'ARTE Livestream'}
:: https://www.zdf.de/play/live-tv/sender/zdf-live-beitrag-100
::  360p_alt, 360p, 540p_alt, 540p, 720p50_alt, 720p50, worst, best
::   {'id': '607dd5e3-e054-446a-b315-efac92aa7ae9', 'author': None, 'category': None, 'title': 'ZDF Livestream'}
:: https://www.zdf.de/play/live-tv/sender/zdfinfo-live-beitrag-100
::  360p_alt, 360p, 540p_alt, 540p, 720p50_alt, 720p50, worst, best
::   {'id': '7a7fa4c5-aef7-4598-98f3-ec8163dad9bd', 'author': None, 'category': None, 'title': 'ZDFinfo Livestream'}
:: https://www.zdf.de/play/magazine/heute-106/260906-heute-sendung-17-uhr-100
::  270p, 540p, 720p, 1080p, worst, best
::   {'id': '6a3d947e-c61d-47ef-9844-04e9cf2948e0', 'author': None, 'category': None, 'title': 'ZDF heute Sendung vom 06.09.2026'}
```

```
$ streamlink https://www.zdf.de/play/live-tv/sender/zdf-live-beitrag-100 best
[cli][info] Found matching plugin zdf_mediathek for URL https://www.zdf.de/play/live-tv/sender/zdf-live-beitrag-100
[cli][info] Available streams: 360p_alt (worst), 360p, 540p_alt, 540p, 720p50_alt, 720p50 (best)
[cli][info] Opening stream: 720p50 (hls-multi)
[cli][info] Starting player: mpv
[utils.named_pipe][info] Creating pipe streamlinkpipe-3546819-1-7778
[utils.named_pipe][info] Creating pipe streamlinkpipe-3546819-2-8624
[cli][info] Player closed
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```

```
$ streamlink -QO https://www.zdf.de/play/live-tv/sender/zdf-live-beitrag-100 best | ffprobe -v error -i - -of json -show_streams | jq '.streams[] | {codec_type, time_base, start_pts, start_time}'
{
  "codec_type": "video",
  "time_base": "1/90000",
  "start_pts": 8140529980,
  "start_time": "90450.333111"
}
{
  "codec_type": "audio",
  "time_base": "1/90000",
  "start_pts": 8140530819,
  "start_time": "90450.342433"
}
```