### PR TITLE
plugins.bigo: get token via webbrowser API

### DIFF
--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -2,6 +2,7 @@
 $description Global live-streaming platform for live video game broadcasts and individual live streams.
 $url bigo.tv
 $type live
+$webbrowser Required for acquiring an API token for access to streams.
 $metadata id
 $metadata author
 $metadata category
@@ -116,14 +117,56 @@ class BigoHLSStream(HLSStream):
     re.compile(r"https?://(?:www\.)?bigo\.tv/(?P<site_id>[^/]+)$"),
 )
 class Bigo(Plugin):
+    _URL_TOKEN = "https://sec.bigo.sg/v1/webjs/status"
     _URL_API = "https://ta.bigo.tv/official_website/studio/getInternalStudioInfo"
 
+    def _acquire_token(self) -> str | None:
+        # ruff: disable[import-outside-top-level]
+        import trio
+
+        from streamlink.compat import BaseExceptionGroup
+        from streamlink.webbrowser.cdp import CDPClient, CDPClientSession, devtools
+        # ruff: enable[import-outside-top-level]
+
+        sender: trio.MemorySendChannel[str]
+        receiver: trio.MemoryReceiveChannel[str]
+        sender, receiver = trio.open_memory_channel(1)
+
+        async def on_token_response(client_session: CDPClientSession, response: devtools.fetch.RequestPaused):
+            async with client_session.alter_request(response) as cm:
+                await sender.send(cm.body)
+
+        async def intercept_token_response(client: CDPClient):
+            async with client.session() as client_session:
+                client_session.add_request_handler(on_token_response, url_pattern=f"{self._URL_TOKEN}?*", on_request=False)
+                async with client_session.navigate(self.url) as frame_id:
+                    await client_session.loaded(frame_id)
+                    return await receiver.receive()
+
+        try:
+            token = CDPClient.launch(self.session, intercept_token_response)
+        except BaseExceptionGroup:
+            log.exception("Failed intercepting token response")
+        except Exception as err:
+            log.error(err)
+        else:
+            return validate.Schema(
+                re.compile(r"jsonp\w+\((?P<json>.+?)\);"),
+                validate.get("json"),
+                validate.parse_json(),
+                {"token": str},
+                validate.get("token"),
+            ).validate(token)
+
     def _get_streams(self):
+        token = self._acquire_token()
+
         self.id, self.author, self.category, self.title, hls_url = self.session.http.post(
             self._URL_API,
             params={
                 "siteId": self.match["site_id"],
                 "verify": "",
+                "token": token,
             },
             schema=validate.Schema(
                 validate.parse_json(),


### PR DESCRIPTION
Resolves #7088 

This makes the plugin use Streamlink's webbrowser API for getting the API request `token` parameter which is required in order to get HLS playlist URLs, which means that a Chromium-based web browser is needed. I explained the reasons for this in #7088.

Tokens can only be used once and thus can't be cached. Without a token, the API response includes an empty HLS playlist URL string value, making the stream appear to be offline from the plugin's perspective. Unfortunately, the token request seems to be a bit flaky and sometimes the request is simply not made, so the API request afterwards will fail without a token.

As said in #7088, implementing authentication is out of scope, especially since a mobile app is involved. I don't like this plugin fix, because launching a web browser every time, even headlessly (`--webbrowser-headless`) and with most features disabled, is insanely stupid.

I have already spent lots of time since the last release reverting their even more stupid "web protection" HLS hack, where they obfuscate MPEG-TS headers in order to break playback in local players. See #7056. At least this got me motivated to work on HLS packed audio streams again...

Should there be any more plugin issues with this site, then I'm simply going to remove the plugin, as it's not worth it. It's a simp camsite anyway, and most of the streams don't appear to be live as well.

----

Some random streams:

```
$ streamlink -l debug https://www.bigo.tv/342871833 best
[cli][debug] OS:         Linux-7.1.10-1-git-x86_64-with-glibc2.44
[cli][debug] Python:     3.14.7
[cli][debug] OpenSSL:    OpenSSL 3.6.3 9 Jun 2026
[cli][debug] Streamlink: 8.5.0+70.g850ce6a33
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.7.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.3
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.34.2
[cli][debug]  trio: 0.34.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.16.0
[cli][debug]  urllib3: 2.7.0
[cli][debug]  websocket-client: 1.9.2
[cli][debug] Arguments:
[cli][debug]  url=https://www.bigo.tv/342871833
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin bigo for URL https://www.bigo.tv/342871833
[webbrowser.webbrowser][info] Launching web browser: /usr/bin/chromium (headless=True)
[webbrowser.webbrowser][debug] Waiting for web browser process to terminate
[cli][info] Available streams: live (worst, best)
[cli][info] Opening stream: live (hls)
[cli][info] Starting player: mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 0; Last Sequence: 1
[stream.hls][debug] Start offset: -0.0; Duration: 0.0; Start Sequence: 0; End Sequence: None
[stream.segmented][debug] Queuing BigoHLSSegment(num=0, init=False, discontinuity=True, duration=1.884, title=' no desc', key=None, byterange=None, date=2026-09-09T04:46:06.000000Z, map=None, seed=1330117166, fileext='ts')
[stream.segmented][debug] Queuing BigoHLSSegment(num=1, init=False, discontinuity=False, duration=1.877, title=' no desc', key=None, byterange=None, date=None, map=None, seed=1330117166, fileext='ts')
[stream.hls][debug] Writing segment 0 to output
[stream.hls][debug] Segment 0 complete
[stream.hls][warning] Encountered a stream discontinuity. This is unsupported and will result in incoherent output data.
[cli.output][debug] Opening subprocess: ['/home/basti/.local/bin/mpv', '--force-media-title=https://www.bigo.tv/342871833', '-']
[stream.hls][debug] Writing segment 1 to output
[stream.hls][debug] Segment 1 complete
[cli][debug] Writing stream to output
[stream.hls][debug] Reloading playlist
[stream.segmented][debug] Queuing BigoHLSSegment(num=2, init=False, discontinuity=False, duration=1.874, title=' no desc', key=None, byterange=None, date=None, map=None, seed=1330117166, fileext='ts')
[stream.segmented][debug] Queuing BigoHLSSegment(num=3, init=False, discontinuity=False, duration=1.946, title=' no desc', key=None, byterange=None, date=None, map=None, seed=1330117166, fileext='ts')
[stream.hls][debug] Writing segment 2 to output
[stream.hls][debug] Segment 2 complete
[stream.hls][debug] Writing segment 3 to output
[stream.hls][debug] Segment 3 complete
[stream.hls][debug] Reloading playlist
[stream.segmented][debug] Queuing BigoHLSSegment(num=4, init=False, discontinuity=False, duration=1.896, title=' no desc', key=None, byterange=None, date=None, map=None, seed=1330117166, fileext='ts')
[stream.hls][debug] Writing segment 4 to output
[stream.hls][debug] Segment 4 complete
[cli][info] Player closed
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```