### PR TITLE
plugins.pluto: fetching graphql hash

### DIFF
--- a/src/streamlink/plugins/pluto.py
+++ b/src/streamlink/plugins/pluto.py
@@ -88,6 +88,14 @@ class PlutoHLSStream(HLSStream):
     ),
 )
 class Pluto(Plugin):
+    RE_GQL_HASH = re.compile(
+        r"""
+                    __meta__:\{hash:"(?P<hash>[0-9a-f]{64})"},kind:"Document",definitions:\[\{kind:"OperationDefinition"
+                    ,operation:"(?:query|mutation|subscription)"(?:,name:\{kind:"Name",value:"(?P<op>[\w$]+)"})?
+                """,
+        re.VERBOSE,
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.session.http.headers.update({"User-Agent": useragents.FIREFOX})
@@ -142,11 +150,36 @@ class Pluto(Plugin):
             schema=schema,
         )
 
+    def _get_gql_hash(self, operation: str) -> dict[str, str]:
+        app_chunk_src = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[contains(@src,'/_next/static/chunks/pages/_app-')][1]/@src"),
+            ),
+        )
+        if not app_chunk_src:
+            raise PluginError("Could not find the Pluto TV app chunk URL")
+
+        gql_hash = self.session.http.get(
+            urljoin(self.url, app_chunk_src),
+            schema=validate.Schema(
+                validate.all(
+                    validate.regex(self.RE_GQL_HASH, method="findall"),
+                    [(str, str)],
+                    validate.filter(lambda match: match[1] == operation),
+                    validate.get((0, 0)),
+                ),
+            ),
+        )
+        log.trace("Found hash for %s: %s", operation, gql_hash)
+        return gql_hash
+
     def _get_series_metadata(self) -> dict:
         data = self._graphql_request(
             "https://pluto.tv/api/tn/hubs/graphql/",
             "FullEpisodesData",
-            {"tnPersistedDocumentHash": "c42c1d0736825cd1f43e28b71dfa6f4955a1b3003a92e42edf99fcae885ea1fe"},
+            {"tnPersistedDocumentHash": self._get_gql_hash("FullEpisodesData")},
             {
                 "showId": self.match["id_s"],
                 "apiRawContentId": None,
@@ -184,7 +217,7 @@ class Pluto(Plugin):
         return self._graphql_request(
             "https://pluto.tv/api/tn/video/graphql/",
             "ChannelsOne",
-            {"tnPersistedDocumentHash": "b9c2b93c341345b0c990fa85bd9b596944c7f343d11ed066d2e1e2db42b1f7ca"},
+            {"tnPersistedDocumentHash": self._get_gql_hash("ChannelsOne")},
             {
                 "params": {
                     "userRegistrationCountry": "US",

--- a/tests/plugins/test_pluto.py
+++ b/tests/plugins/test_pluto.py
@@ -47,10 +47,10 @@ class TestPluginCanHandleUrlPluto(PluginCanHandleUrl):
         (
             (
                 "movies",
-                "https://pluto.tv/us/movies/6925771d1a8e9be91b1b7d22/#open",
+                "https://pluto.tv/us/movies/5ed28c8cefbd62001b280de6/#open",
             ),
             {
-                "id": "6925771d1a8e9be91b1b7d22",
+                "id": "5ed28c8cefbd62001b280de6",
             },
         ),
         (


### PR DESCRIPTION
<!--
Thank you very much for opening a pull request!

Before you continue, please make sure that you have read and understood the contribution guidelines, including our plugin rules, as well as our rules about AI-assisted contributions. Otherwise, your changes may be rejected.

Please mark the checkboxes below before submitting (replace `- [ ]` with `- [x]`)
-->

- [x] [I have read the contribution guidelines](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#contributing-to-streamlink)
- [x] [I have read the rules about AI-assisted contributions](https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#ai-assisted-contributions)

----

## Changes
- Fetching GraphQL `tnPersistedDocumentHash` hashes for a specified operation
- Replaced a dead link with a valid one in the test  

## AI
- helped with analyzing the HAR files and building the regex

## Tests:
```
[1]> # US IP
[1]> ./script/test-plugin-urls.py pluto -m
NoTagError: `git describe --long --dirty --always --tags` could not find a tag
:: https://pluto.tv/en/live-tv/61409f8d6feb30000766b675
!! No streams found
:: https://pluto.tv/en/on-demand/movies/5ed28c8cefbd62001b280de6
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '5ed28c8cefbd62001b280de6', 'author': None, 'category': 'Comedy', 'title': 'South Park: Bigger, Longer & Uncut'}
:: https://pluto.tv/en/on-demand/series/5e00cd538e67b0dcb2cf3bcd/season/1/episode/60dee91cfc802600134b886d
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '60dee91cfc802600134b886d', 'author': None, 'category': None, 'title': None}
:: https://pluto.tv/fr/watch/live-tv/31528/
!! No streams found
:: https://pluto.tv/gsa/shows/2740225/episode/60dee91cfc802600134b886d/
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '60dee91cfc802600134b886d', 'author': None, 'category': None, 'title': None}
:: https://pluto.tv/us/movies/5ed28c8cefbd62001b280de6/#open
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '5ed28c8cefbd62001b280de6', 'author': None, 'category': 'Comedy', 'title': 'South Park: Bigger, Longer & Uncut'}
```
```
[1]> # German IP
[1]> ./script/test-plugin-urls.py pluto -m
NoTagError: `git describe --long --dirty --always --tags` could not find a tag
:: https://pluto.tv/en/live-tv/61409f8d6feb30000766b675
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '61409f8d6feb30000766b675', 'author': None, 'category': None, 'title': 'Pluto TV Space'}
:: https://pluto.tv/en/on-demand/movies/5ed28c8cefbd62001b280de6
!! Error while fetching streams
:: https://pluto.tv/en/on-demand/series/5e00cd538e67b0dcb2cf3bcd/season/1/episode/60dee91cfc802600134b886d
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '60dee91cfc802600134b886d', 'author': None, 'category': None, 'title': None}
:: https://pluto.tv/fr/watch/live-tv/31528/
!! Error while fetching streams
:: https://pluto.tv/gsa/shows/2740225/episode/60dee91cfc802600134b886d/
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '60dee91cfc802600134b886d', 'author': 'South Park', 'category': 'Comedy', 'title': 'Cartman und die Analsonde'}
:: https://pluto.tv/us/movies/5ed28c8cefbd62001b280de6/#open
!! Error while fetching streams
```
```
[1]> # French IP
[1]> ./script/test-plugin-urls.py pluto -m
NoTagError: `git describe --long --dirty --always --tags` could not find a tag
:: https://pluto.tv/en/live-tv/61409f8d6feb30000766b675
!! Error while fetching streams
:: https://pluto.tv/en/on-demand/movies/5ed28c8cefbd62001b280de6
!! Error while fetching streams
:: https://pluto.tv/en/on-demand/series/5e00cd538e67b0dcb2cf3bcd/season/1/episode/60dee91cfc802600134b886d
!! Error while fetching streams
:: https://pluto.tv/fr/watch/live-tv/31528/
::  640k, 1000k, 1600k, 2300k, 3300k, worst, best
::   {'id': '5f8eb66537867f0007146953', 'author': None, 'category': None, 'title': 'CATFISH TV'}
:: https://pluto.tv/gsa/shows/2740225/episode/60dee91cfc802600134b886d/
!! Error while fetching streams
:: https://pluto.tv/us/movies/5ed28c8cefbd62001b280de6/#open
!! Error while fetching streams
```
