### PR TITLE
plugins.bigo: add "token" API parameter

### DIFF
--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -12,13 +12,18 @@ from __future__ import annotations
 
 import ctypes
 import re
+from base64 import b64encode
 from dataclasses import dataclass
+from json import dumps as json_dumps
+from random import randint
+from time import time
 from typing import TYPE_CHECKING
 
 from streamlink.logger import getLogger
 from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSSegment, HLSStream, M3U8Parser, parse_tag
+from streamlink.utils.crypto import encrypt_openssl
 
 
 if TYPE_CHECKING:
@@ -117,13 +122,67 @@ class BigoHLSStream(HLSStream):
 )
 class Bigo(Plugin):
     _URL_API = "https://ta.bigo.tv/official_website/studio/getInternalStudioInfo"
+    _URL_TOKEN_T = "https://sec.bigo.sg/v1/webjs/t"
+    _URL_TOKEN_STATUS = "https://sec.bigo.sg/v1/webjs/status"
+
+    _TOKEN_ENCRYPTION_KEY = b"undefinedval0x01"
+
+    _SCHEMA_JSONP = validate.Schema(
+        validate.regex(re.compile(r"jsonp\w+\((?P<json>.+?)\);")),
+        validate.get("json"),
+        validate.parse_json(),
+    )
+
+    @staticmethod
+    def _fake_jsonp_callback():
+        return f"jsonpcallback_{int(time() * 1000)}_{randint(0, 1000000)}"
+
+    def _get_timestamp(self):
+        return self.session.http.get(
+            self._URL_TOKEN_T,
+            params={"callback": self._fake_jsonp_callback()},
+            schema=validate.Schema(
+                self._SCHEMA_JSONP,
+                {"code": int, "time": str},
+                validate.get("time"),
+            ),
+        )
+
+    def _get_token(self):
+        timestamp = self._get_timestamp()
+        payload = {
+            "dr": "00000000000000000000000000000000",
+            "business": "bigolive-video",
+            "scene": "",
+            "at_time": timestamp,
+            "ver": "2.0",
+        }
+        stringified = json_dumps(payload, separators=(",", ":")).encode("utf-8")
+        encrypted = encrypt_openssl(stringified, self._TOKEN_ENCRYPTION_KEY)
+        data = b64encode(encrypted)
+
+        return self.session.http.get(
+            self._URL_TOKEN_STATUS,
+            params={
+                "callback": self._fake_jsonp_callback(),
+                "data": data,
+            },
+            schema=validate.Schema(
+                self._SCHEMA_JSONP,
+                {"token": str},
+                validate.get("token"),
+            ),
+        )
 
     def _get_streams(self):
+        token = self._get_token()
+
         self.id, self.author, self.category, self.title, hls_url = self.session.http.post(
             self._URL_API,
             params={
                 "siteId": self.match["site_id"],
                 "verify": "",
+                "token": token,
             },
             schema=validate.Schema(
                 validate.parse_json(),

--- a/src/streamlink/plugins/streann.py
+++ b/src/streamlink/plugins/streann.py
@@ -92,7 +92,7 @@ class Streann(Plugin):
         log.debug("passphrase")
         res = self.session.http.get(self.url)
         passphrase_m = self.passphrase_re.search(res.text)
-        return passphrase_m and passphrase_m.group("passphrase").encode("utf8")
+        return passphrase_m.group("passphrase").encode("utf8") if passphrase_m else None
 
     def get_token(self, **config):
         log.debug("get_token")
@@ -165,7 +165,8 @@ class Streann(Plugin):
         passphrase = self.passphrase()
         if passphrase:
             log.debug("Found passphrase")
-            params = decrypt_openssl(data, passphrase)
+            if not (params := decrypt_openssl(data, passphrase)):
+                return
             config = parse_qsd(params.decode("utf8"))
             log.trace("config: %r", config)
             token = self.get_token(**config)

--- a/src/streamlink/utils/crypto.py
+++ b/src/streamlink/utils/crypto.py
@@ -1,5 +1,7 @@
 # ruff: file-ignore[unused-import]
-import hashlib
+from __future__ import annotations
+
+from os import urandom
 
 
 # re-export pycryptodome / pycryptodomex stuff in a single place
@@ -7,18 +9,18 @@ import hashlib
 try:
     # pycryptodome (drop-in replacement for the old PyCrypto library)
     from Crypto.Cipher import AES, PKCS1_v1_5
-    from Crypto.Hash import SHA256
+    from Crypto.Hash import MD5, SHA256
     from Crypto.PublicKey import RSA
     from Crypto.Util.Padding import pad, unpad
 except ImportError:  # pragma: no cover
     # pycryptodomex (independent of the old PyCrypto library)
     from Cryptodome.Cipher import AES, PKCS1_v1_5  # type: ignore
-    from Cryptodome.Hash import SHA256  # type: ignore
+    from Cryptodome.Hash import MD5, SHA256  # type: ignore
     from Cryptodome.PublicKey import RSA  # type: ignore
     from Cryptodome.Util.Padding import pad, unpad  # type: ignore
 
 
-def evp_bytestokey(password, salt, key_len, iv_len):
+def evp_bytestokey(password: bytes, salt: bytes, key_len: int, iv_len: int) -> tuple[bytes, bytes]:
     """
     Python implementation of OpenSSL's EVP_BytesToKey()
     :param password: or passphrase
@@ -29,18 +31,36 @@ def evp_bytestokey(password, salt, key_len, iv_len):
     """
     d = d_i = b""
     while len(d) < key_len + iv_len:
-        d_i = hashlib.md5(d_i + password + salt).digest()
+        d_i = MD5.new(d_i + password + salt).digest()
         d += d_i
     return d[:key_len], d[key_len : key_len + iv_len]
 
 
-def decrypt_openssl(data, passphrase, key_length=32):
-    if data.startswith(b"Salted__"):
-        salt = data[len(b"Salted__") : AES.block_size]
-        key, iv = evp_bytestokey(passphrase, salt, key_length, AES.block_size)
-        d = AES.new(key, AES.MODE_CBC, iv)
-        out = d.decrypt(data[AES.block_size :])
-        return unpad_pkcs5(out)
+def encrypt_openssl(data: bytes, passphrase: bytes, key_length: int = 32) -> bytes:
+    salt = urandom(8)
+    key, iv = evp_bytestokey(passphrase, salt, key_length, AES.block_size)
+    padded = pad_pkcs5(data, AES.block_size)
+    cipher = AES.new(key, AES.MODE_CBC, iv)
+    encrypted = cipher.encrypt(padded)
+
+    return b"Salted__" + salt + encrypted
+
+
+def decrypt_openssl(data: bytes, passphrase: bytes, key_length: int = 32) -> bytes | None:
+    if not data.startswith(b"Salted__"):
+        return None
+
+    salt = data[len(b"Salted__") : AES.block_size]
+    key, iv = evp_bytestokey(passphrase, salt, key_length, AES.block_size)
+    d = AES.new(key, AES.MODE_CBC, iv)
+    out = d.decrypt(data[AES.block_size :])
+
+    return unpad_pkcs5(out)
+
+
+def pad_pkcs5(data: bytes, block_size: int = AES.block_size) -> bytes:
+    padding_len = block_size - (len(data) % block_size)
+    return data + bytes(padding_len * [padding_len])
 
 
 def unpad_pkcs5(padded):

--- a/tests/utils/test_crypto.py
+++ b/tests/utils/test_crypto.py
@@ -1,17 +1,44 @@
 import base64
 
-from streamlink.utils.crypto import decrypt_openssl, evp_bytestokey
+import pytest
+
+from streamlink.utils.crypto import decrypt_openssl, encrypt_openssl, evp_bytestokey
 
 
-class TestUtil:
-    def test_evp_bytestokey(self):
-        assert evp_bytestokey(b"hello", b"", 16, 16) == (
-            b"]A@*\xbcK*v\xb9q\x9d\x91\x10\x17\xc5\x92",
-            b"(\xb4n\xd3\xc1\x11\xe8Q\x02\x90\x9b\x1c\xfbP\xea\x0f",
-        )
+def test_evp_bytestokey():
+    assert evp_bytestokey(b"hello", b"", 16, 16) == (
+        b"]A@*\xbcK*v\xb9q\x9d\x91\x10\x17\xc5\x92",
+        b"(\xb4n\xd3\xc1\x11\xe8Q\x02\x90\x9b\x1c\xfbP\xea\x0f",
+    )
 
-    def test_decrpyt(self):
-        # data generated with:
-        #   echo "this is a test" | openssl enc -aes-256-cbc -pass pass:"streamlink" -base64
-        data = base64.b64decode("U2FsdGVkX18nVyJ6Y+ksOASMSHKuRoQ9b4DKHuPbyQc=")
-        assert decrypt_openssl(data, b"streamlink") == b"this is a test\n"
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        # Old fixture data
+        # > echo "this is a test" | openssl enc -aes-256-cbc -pass pass:streamlink -base64
+        pytest.param(b"U2FsdGVkX18nVyJ6Y+ksOASMSHKuRoQ9b4DKHuPbyQc=", id="random-salt"),
+        # Custom KDF salt: no prefix with -S since OpenSSL 3.0
+        # > (
+        # >   printf 'Salted__\x01\x23\x45\x67\x89\xab\xcd\xef'
+        # >   echo "this is a test" | openssl enc -aes-256-cbc -md md5 -S 0123456789abcdef -pass pass:streamlink
+        # > ) | base64
+        pytest.param(b"U2FsdGVkX18BI0VniavN772AmBz3M35evEFhaFfFvQo=", id="null-byte-salt"),
+    ],
+)
+def test_decrypt_openssl(data: str):
+    decoded = base64.b64decode(data, validate=True)
+    assert decrypt_openssl(decoded, b"streamlink") == b"this is a test\n"
+
+
+def test_encrypt_openssl(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr("streamlink.utils.crypto.urandom", lambda *_, **__: b"\x01\x23\x45\x67\x89\xab\xcd\xef")
+    encrypted = encrypt_openssl(b"this is a test\n", b"streamlink")
+    assert base64.b64encode(encrypted) == b"U2FsdGVkX18BI0VniavN772AmBz3M35evEFhaFfFvQo="
+
+
+@pytest.mark.parametrize("key_length", range(16, 32 + 1, 8))
+def test_encrypt_decrypt_openssl(key_length: int):
+    message = b"this is a test\n"
+    passphrase = b"streamlink"
+    assert decrypt_openssl(encrypt_openssl(message, passphrase, key_length), passphrase, key_length) == message


### PR DESCRIPTION
Resolves #7088 
Closes #7098

----

First commit adds the necessary `encrypt_openssl` crypto function with hardcoded legacy KDF and hardcoded cipher function, similar to the already existing `decrypt_openssl` function. These can be updated in the future.

----

The Bigo nonsense is explained [here](https://github.com/streamlink/streamlink/issues/7088#issuecomment-5626117245), which was a lot of effort figuring this out. I only did this because it was a little bit of a challenge, same as #7056, otherwise I had dumped the plugin immediately, because its utter trash content IS NOT worth the effort.

Random example stream:

```sh
streamlink -QO https://www.bigo.tv/922443379 best \
  | ffprobe -i - -v error -of json -show_format -show_streams \
  | jq
```
```json
{
  "streams": [
    {
      "index": 0,
      "codec_name": "aac",
      "codec_long_name": "AAC (Advanced Audio Coding)",
      "profile": "HE-AACv2",
      "codec_type": "audio",
      "codec_tag_string": "[15][0][0][0]",
      "codec_tag": "0x000f",
      "mime_codec_string": "mp4a.40.29",
      "sample_fmt": "fltp",
      "sample_rate": "44100",
      "channels": 2,
      "channel_layout": "stereo",
      "bits_per_sample": 0,
      "initial_padding": 0,
      "ts_id": "1",
      "ts_packetsize": "188",
      "id": "0x101",
      "r_frame_rate": "0/0",
      "avg_frame_rate": "0/0",
      "time_base": "1/90000",
      "start_pts": 3498786630,
      "start_time": "38875.407000",
      "bit_rate": "96008",
      "disposition": {
        "default": 0,
        "dub": 0,
        "original": 0,
        "comment": 0,
        "lyrics": 0,
        "karaoke": 0,
        "forced": 0,
        "hearing_impaired": 0,
        "visual_impaired": 0,
        "clean_effects": 0,
        "attached_pic": 0,
        "timed_thumbnails": 0,
        "non_diegetic": 0,
        "captions": 0,
        "descriptions": 0,
        "metadata": 0,
        "dependent": 0,
        "still_image": 0,
        "multilayer": 0
      }
    },
    {
      "index": 1,
      "codec_name": "h264",
      "codec_long_name": "H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10",
      "profile": "High",
      "codec_type": "video",
      "codec_tag_string": "[27][0][0][0]",
      "codec_tag": "0x001b",
      "mime_codec_string": "avc1.640028",
      "width": 1080,
      "height": 1920,
      "coded_width": 1080,
      "coded_height": 1920,
      "has_b_frames": 0,
      "pix_fmt": "yuv420p",
      "level": 40,
      "color_range": "tv",
      "color_space": "bt470bg",
      "color_transfer": "smpte170m",
      "color_primaries": "bt470bg",
      "chroma_location": "left",
      "field_order": "progressive",
      "is_avc": "false",
      "nal_length_size": "0",
      "ts_id": "1",
      "ts_packetsize": "188",
      "id": "0x100",
      "r_frame_rate": "24/1",
      "avg_frame_rate": "24/1",
      "time_base": "1/90000",
      "start_pts": 3498791220,
      "start_time": "38875.458000",
      "bits_per_raw_sample": "8",
      "extradata_size": 28,
      "disposition": {
        "default": 0,
        "dub": 0,
        "original": 0,
        "comment": 0,
        "lyrics": 0,
        "karaoke": 0,
        "forced": 0,
        "hearing_impaired": 0,
        "visual_impaired": 0,
        "clean_effects": 0,
        "attached_pic": 0,
        "timed_thumbnails": 0,
        "non_diegetic": 0,
        "captions": 0,
        "descriptions": 0,
        "metadata": 0,
        "dependent": 0,
        "still_image": 0,
        "multilayer": 0
      }
    }
  ],
  "format": {
    "filename": "fd:",
    "nb_streams": 2,
    "nb_programs": 1,
    "nb_stream_groups": 0,
    "format_name": "mpegts",
    "format_long_name": "MPEG-TS (MPEG-2 Transport Stream)",
    "start_time": "38875.407000",
    "size": "0",
    "probe_score": 100
  }
}
```