### PR TITLE
plugins.kick: fix VODs

### DIFF
--- a/src/streamlink/plugins/kick.py
+++ b/src/streamlink/plugins/kick.py
@@ -32,6 +32,7 @@ from streamlink.stream.hls import (
     M3U8Parser,
     parse_tag,
 )
+from streamlink.utils.data import search_dict
 
 
 log = getLogger(__name__)
@@ -138,7 +139,7 @@ class KickAdapter(SSLContextAdapter):
 )
 @pluginmatcher(
     name="vod",
-    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/(?:video/|[^/]+/videos/)(?P<vod>[^/?]+)"),
+    pattern=re.compile(r"https?://(?:\w+\.)?kick\.com/(?P<channel>[^/?]+)/videos/(?P<vod>[^/?]+)"),
 )
 @pluginmatcher(
     name="clip",
@@ -166,7 +167,7 @@ class Kick(Plugin):
     _CACHE_EXPIRATION = 3600 * 24 * 30
 
     _URL_API_LIVESTREAM = "https://kick.com/api/v2/channels/{channel}/livestream"
-    _URL_API_VOD = "https://kick.com/api/v1/video/{vod}"
+    _URL_API_VOD = "https://web.kick.com/api/v1/channels/{channel}/videos/{vod}"
     _URL_API_CLIP = "https://kick.com/api/v2/clips/{clip}"
 
     def __init__(self, *args, **kwargs):
@@ -260,7 +261,9 @@ class Kick(Plugin):
             validate.any(
                 validate.all(
                     {"message": str},
-                    validate.transform(lambda obj: ("error", obj["message"])),
+                    validate.get("message"),
+                    lambda msg: msg.lower() != "success",
+                    validate.transform(lambda msg: ("error", msg)),
                 ),
                 validate.all(
                     {"data": None},
@@ -310,24 +313,47 @@ class Kick(Plugin):
     def _get_streams_vod(self):
         self.id = self.match["vod"]
 
-        hls_url, self.author, self.title = self._query_api(
-            self._URL_API_VOD.format(vod=self.id),
+        channel_id = self.session.http.get(
+            self.url,
+            schema=validate.Schema(
+                validate.parse_html(),
+                validate.xml_xpath_string(".//script[contains(text(),'channel_id')][1]/text()"),
+                validate.none_or_all(
+                    validate.regex(re.compile(r"""self\.__next_f\.push\(\[\d+,\s*(?P<data>".+?")]\)""")),
+                    validate.get("data"),
+                    validate.parse_json(),
+                    validate.transform(lambda s: s.split("\n")),
+                    validate.map(lambda s: re.sub(r"^[^\[]+", "", s)),
+                    validate.filter(bool),
+                    [validate.parse_json()],
+                    validate.transform(lambda data: next(search_dict(data, "channel_id"), None)),
+                ),
+            ),
+        )
+        if not channel_id:
+            return
+
+        hls_url, self.author, self.category, self.title = self._query_api(
+            self._URL_API_VOD.format(channel=channel_id, vod=self.id),
             schema=validate.Schema(
                 {
-                    "source": validate.url(path=validate.endswith(".m3u8")),
-                    "livestream": {
-                        "session_title": str,
+                    "data": {
+                        "recording_url": validate.url(path=validate.endswith(".m3u8")),
                         "channel": {
-                            "user": {
-                                "username": str,
-                            },
+                            "username": str,
                         },
+                        "category": {
+                            "name": str,
+                        },
+                        "title": str,
                     },
                 },
+                validate.get("data"),
                 validate.union_get(
-                    "source",
-                    ("livestream", "channel", "user", "username"),
-                    ("livestream", "session_title"),
+                    "recording_url",
+                    ("channel", "username"),
+                    ("category", "name"),
+                    "title",
                 ),
             ),
         )

--- a/tests/plugins/test_kick.py
+++ b/tests/plugins/test_kick.py
@@ -17,12 +17,8 @@ class TestPluginCanHandleUrlKick(PluginCanHandleUrl):
             {"channel": "LIVE_CHANNEL"},
         ),
         (
-            ("vod", "https://kick.com/video/VIDEO_ID"),
-            {"vod": "VIDEO_ID"},
-        ),
-        (
             ("vod", "https://kick.com/VIDEO_CHANNEL/videos/VIDEO_ID"),
-            {"vod": "VIDEO_ID"},
+            {"channel": "VIDEO_CHANNEL", "vod": "VIDEO_ID"},
         ),
         (
             ("clip", "https://kick.com/CLIP_CHANNEL?clip=CLIP_ID&foo=bar"),


### PR DESCRIPTION
Resolves #7107 

In order to be able to access VODs on their "web" API, the channel ID needs to be retrieved first. This is embedded in the DOM rehydration data. By now, it's probably worth adding a dedicated validation function for this, as the validation schema logic is repeated several times now throughout various plugins.

VOD URLs without the channel name now return 404, so the matcher also needed to be updated.

@ffbw4hwj please check and see if some VODs are not working with this change
https://github.com/streamlink/streamlink/blob/master/CONTRIBUTING.md#pull-request-feedback

```
$ ./script/test-plugin-urls.py -m kick -r LIVE_CHANNEL eslcs -r VIDEO_CHANNEL eslcs -r VIDEO_ID 01a08cc5-b7b8-7947-b2cd-023a8be5a775 -r CLIP_CHANNEL eslcs -r CLIP_ID clip_01M1R0YVQAES586QS5QAQWYSTG
:: https://kick.com/eslcs
::  160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '126640734', 'author': 'eslcs', 'category': 'Counter-Strike 2', 'title': 'RERUN: IEM Cologne Major 2026'}
:: https://kick.com/eslcs/clips/clip_01M1R0YVQAES586QS5QAQWYSTG?clip=CLIP_ID_FROM_QUERY_STRING&foo=bar
::  clip, worst, best
::   {'id': 'clip_01M1R0YVQAES586QS5QAQWYSTG', 'author': 'eslcs', 'category': 'Counter-Strike 2', 'title': 'ronda corta!!'}
:: https://kick.com/eslcs/clips/clip_01M1R0YVQAES586QS5QAQWYSTG?foo=bar
::  clip, worst, best
::   {'id': 'clip_01M1R0YVQAES586QS5QAQWYSTG', 'author': 'eslcs', 'category': 'Counter-Strike 2', 'title': 'ronda corta!!'}
:: https://kick.com/eslcs/videos/01a08cc5-b7b8-7947-b2cd-023a8be5a775
::  160p, 360p, 480p, 720p60, 1080p60, worst, best
::   {'id': '01a08cc5-b7b8-7947-b2cd-023a8be5a775', 'author': 'ESLCS', 'category': 'Counter-Strike 2', 'title': 'RERUN: IEM Cologne Major 2026'}
:: https://kick.com/eslcs?clip=clip_01M1R0YVQAES586QS5QAQWYSTG&foo=bar
::  clip, worst, best
::   {'id': 'clip_01M1R0YVQAES586QS5QAQWYSTG', 'author': 'eslcs', 'category': 'Counter-Strike 2', 'title': 'ronda corta!!'}
```

```
$ streamlink -l debug --stream-segmented-duration=10 https://kick.com/eslcs/videos/01a08cc5-b7b8-7947-b2cd-023a8be5a775 best
[cli][debug] OS:         Linux-7.2.4-1-git-x86_64-with-glibc2.44
[cli][debug] Python:     3.14.7
[cli][debug] OpenSSL:    OpenSSL 3.6.4 25 Aug 2026
[cli][debug] Streamlink: 8.5.0+74.g0578a1b57
[cli][debug] Dependencies:
[cli][debug]  certifi: 2026.7.22
[cli][debug]  isodate: 0.7.2
[cli][debug]  lxml: 6.1.3
[cli][debug]  pycountry: 26.2.16
[cli][debug]  pycryptodome: 3.23.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.34.2
[cli][debug]  trio: 0.34.0
[cli][debug]  trio-websocket: 0.12.2
[cli][debug]  typing-extensions: 4.16.0
[cli][debug]  urllib3: 2.7.0
[cli][debug]  websocket-client: 1.9.2
[cli][debug] Arguments:
[cli][debug]  url=https://kick.com/eslcs/videos/01a08cc5-b7b8-7947-b2cd-023a8be5a775
[cli][debug]  stream=['best']
[cli][debug]  --loglevel=debug
[cli][debug]  --player=mpv
[cli][debug]  --stream-segmented-duration=10.0
[cli][debug]  --webbrowser-headless=True
[cli][info] Found matching plugin kick for URL https://kick.com/eslcs/videos/01a08cc5-b7b8-7947-b2cd-023a8be5a775
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 160p (worst), 360p, 480p, 720p60, 1080p60 (best)
[cli][info] Opening stream: 1080p60 (hls)
[cli][info] Starting player: mpv
[stream.hls][debug] Reloading playlist
[cli][debug] Pre-buffering 8192 bytes
[stream.hls][debug] First Sequence: 0; Last Sequence: 6326
[stream.hls][debug] Start offset: 0.0; Duration: 10.0; Start Sequence: 0; End Sequence: 6326
[stream.segmented][debug] Queuing HLSSegment(num=0, init=False, discontinuity=False, duration=10.000, title=None, key=None, byterange=None, date=2026-09-10T19:22:30.160000Z, map=None, fileext='ts')
[stream.segmented][info] Stopping stream early after 10.00s
[stream.segmented][debug] Closing worker thread
[stream.hls][debug] Writing segment 0 to output
[stream.hls][debug] Segment 0 complete
[stream.segmented][debug] Closing writer thread
[cli.output][debug] Opening subprocess: ['/home/basti/.local/bin/mpv', '--force-media-title=https://kick.com/eslcs/videos/01a08cc5-b7b8-7947-b2cd-023a8be5a775', '-']
[cli][debug] Writing stream to output
[cli][info] Stream ended
[cli][info] Closing currently open stream...
```