### PR TITLE
plugins.bigo: fix token

### DIFF
--- a/src/streamlink/plugins/bigo.py
+++ b/src/streamlink/plugins/bigo.py
@@ -24,6 +24,7 @@ from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate
 from streamlink.stream.hls import HLSSegment, HLSStream, M3U8Parser, parse_tag
 from streamlink.utils.crypto import encrypt_openssl
+from streamlink.utils.random import CHOICES_HEX_LOWER, random_token
 
 
 if TYPE_CHECKING:
@@ -151,7 +152,7 @@ class Bigo(Plugin):
     def _get_token(self):
         timestamp = self._get_timestamp()
         payload = {
-            "dr": "00000000000000000000000000000000",
+            "dr": random_token(length=32, choices=CHOICES_HEX_LOWER),
             "business": "bigolive-video",
             "scene": "",
             "at_time": timestamp,


### PR DESCRIPTION
Resolves #7088 
https://github.com/streamlink/streamlink/issues/7088#issuecomment-5644348099

The zero hash parameter was chosen intentionally in the previous fix because of the very hash implementation, but apparently they are checking this now and return an "invalid" response. A random value works, surprisingly, implying all kinds of things.

If they restrict access again after a couple of hours or just a day, I will assume that someone on their end is monitoring this repo, because anything else doesn't make sense to me. I will not fight an uphill battle with a site like this and waste my time.

3 top streams at the moment:

```
$ streamlink https://www.bigo.tv/134143769
[cli][info] Found matching plugin bigo for URL https://www.bigo.tv/134143769
Available streams: live (worst, best)

$ streamlink https://www.bigo.tv/1084376509
[cli][info] Found matching plugin bigo for URL https://www.bigo.tv/1084376509
Available streams: live (worst, best)

$ streamlink https://www.bigo.tv/379741417
[cli][info] Found matching plugin bigo for URL https://www.bigo.tv/379741417
Available streams: live (worst, best)
```